### PR TITLE
BB7 Protocol Refinement — Sorted Sets, Audit Guard, Data-Driven Compat

### DIFF
--- a/grimoires/loa/a2a/gpt-review/sprint-findings-1.json
+++ b/grimoires/loa/a2a/gpt-review/sprint-findings-1.json
@@ -1,24 +1,36 @@
 {
   "verdict": "CHANGES_REQUIRED",
-  "summary": "This plan is close, but two items (trust-boundary enforcement scope and an untestable integration test setup) can realistically cause the sprint to fail to deliver the intended security hardening.",
+  "summary": "The plan covers the three BB7 findings, but two tasks contain acceptance criteria/approaches that are either impossible as written or likely to break production packaging/runtime, which can cause the sprint to fail at integration time.",
   "blocking_issues": [
     {
-      "location": "Sprint 1 – Task 1.3 + Acceptance Criteria AC-H1.5; Sprint 2 – Task 2.4/AC-H2.5-2.6",
-      "issue": "F-5 requires loa-finn to re-validate pool claims, but the sprint only implements Arrakis-side validation (warn-only) and does not include any loa-finn work item or a concrete cross-repo dependency/handshake to ensure the security fix actually lands.",
-      "why_blocking": "The high-severity finding is explicitly about the trust boundary: loa-finn must independently verify. If the sprint ships only Arrakis warn-logs, the core vulnerability remains and the sprint’s stated purpose (“trust boundary fixes”) is not met. This is a classic confused-deputy gap: the relying party (loa-finn) still trusts convenience claims without re-derivation.",
-      "fix": "Add an explicit deliverable/task (and dependency) for loa-finn: implement `validatePoolClaims`-equivalent enforcement in loa-finn’s JWT intake/routing path with a defined behavior (e.g., reject 403 on mismatch). If cross-repo work cannot be done in this cycle, change scope/wording to “Arrakis-side detection only” and add a tracked blocking dependency (issue + owner + target date) so the sprint can be considered complete without claiming the trust-boundary fix is done."
+      "location": "Task 1.1: Migrate Circuit Breaker Failure Tracking from CSV to Sorted Sets (AC-1.1 vs proposed Lua snippet)",
+      "issue": "Acceptance criteria requires `ZRANGEBYSCORE`, but the proposed implementation uses `ZREMRANGEBYSCORE` + `ZCARD` and does not actually call `ZRANGEBYSCORE`.",
+      "why_blocking": "You cannot satisfy AC-1.1 with the described implementation; this will fail the sprint’s own DoD/AC gate even if the code is correct and performant.",
+      "fix": "Either (a) update AC-1.1 to match the intended algorithm (`ZREMRANGEBYSCORE` + `ZADD` + `ZCARD`), or (b) change the script to use `ZRANGEBYSCORE` (e.g., `local failures = redis.call('ZRANGEBYSCORE', ...)` then `#failures`)—but that’s typically worse than `ZCARD` after trimming."
     },
     {
-      "location": "Sprint 2 – Task 2.4 (Contract integration tests) and AC-H2.5/AC-H2.6",
-      "issue": "The proposed integration tests depend on being able to create a “forged inconsistent claims” JWT that still passes S2S verification, but the plan does not specify how the test will sign it (key material/JWKS injection) nor how logs are captured deterministically.",
-      "why_blocking": "Without a test seam to sign tokens with a test key that the verifier trusts (or to inject a JWKS), the test cannot reach the validation code path because JWS verification will fail earlier. Similarly, asserting “warning is logged” is flaky unless the logger is injectable/spied in the test harness. This can stall Sprint 2 or lead to non-deterministic CI failures.",
-      "fix": "Add a prerequisite task to create a deterministic test harness: (1) inject JWKS/JWT verifier keyset for tests (e.g., in-memory JWKS or env-configured test keypair) so the usage receiver accepts the token; (2) make logger injectable or expose a test sink so assertions can reliably detect warning/no-warning. Update AC-H2.5/2.6 to assert on a structured log event or counter rather than free-text logs."
+      "location": "Task 1.1: Migration logic in `LUA_FAILURE`",
+      "issue": "Zero-downtime migration is underspecified for mixed-fleet concurrency: old code may still be writing the CSV hash field while new code migrates/deletes it, causing lost/duplicated failure records and inconsistent breaker state during rollout.",
+      "why_blocking": "Fleet-wide circuit breaking is a critical requirement; inconsistent failure counts during deployment can cause either false opens (outage) or failure to open (cascading failures). Without a defined mixed-version strategy, the rollout itself can break production behavior.",
+      "fix": "Add an explicit mixed-fleet compatibility plan: either (1) two-phase deploy (phase A: new code writes both CSV+ZSET; phase B: after full rollout, stop CSV and delete field), or (2) keep the CSV field as a shadow for one window duration before deletion, or (3) version the keyspace (e.g., `:failures_v2`) and have new code read both during transition. Add AC to prove mixed-version safety (simulate old+new writers)."
     },
     {
-      "location": "Sprint 1 – Task 1.2 validatePoolClaims() + AC-H1.3/AC-H1.4",
-      "issue": "Acceptance criteria and function contract are internally inconsistent: AC says “returns true/false”, but the task defines `{ valid: boolean; reason?: string }`. Also the validation rule “allowed_pools matches tier exactly” is underspecified about ordering/representation, which can cause false negatives and churn.",
-      "why_blocking": "Engineers won’t know what to implement/test against, and tests may fail depending on array ordering or serialization differences between systems. This is especially risky because the function is intended as a cross-system contract; ambiguity here can block completion or create brittle behavior.",
-      "fix": "Normalize the contract: update AC-H1.3/H1.4 to match `{ valid, reason }` (or change function to boolean). Specify canonicalization: treat `allowed_pools` as a set (order-independent) and define exact expected set per access level (e.g., compare sorted unique arrays). Add explicit AC for ordering-insensitivity and duplicate handling."
+      "location": "Task 1.3: Make Compatibility Matrix Data-Driven (implementation approach: `readFileSync` at module init)",
+      "issue": "`readFileSync` from a relative path at runtime is brittle in Node package distribution (compiled `dist/` layout, ESM/CJS differences, bundlers, pnpm workspace symlinks). The JSON may not be resolvable at runtime even if it is included in `npm pack`.",
+      "why_blocking": "This can cause startup failures in production (explicitly called out in your “What to Verify” #5). A fail-fast throw (AC-1.15) combined with a path-resolution mistake will hard-fail services after deploy.",
+      "fix": "Define a robust loading strategy and add a test for it: e.g., import JSON as a module (Node supports JSON imports with proper config) or resolve via `new URL('../schema/compatibility.json', import.meta.url)` (ESM) / `path.join(__dirname, '../schema/...')` (CJS) depending on build output. Alternatively, copy JSON into `dist/` during build and reference it relative to the compiled file. Add AC: “works when installed as a packed tarball and executed from dist output” (integration test using `npm pack` + install in a temp dir)."
+    },
+    {
+      "location": "Task 1.3: AC-1.19",
+      "issue": "AC-1.19 claims “Adding a new compatibility entry requires only a JSON file change (no TS recompile for data changes)”, but the proposed approach loads JSON at module init from the package filesystem. In typical deployments, changing a file inside an installed package still requires rebuilding/redeploying the artifact; and if you ship compiled JS, you still need to publish a new package version for consumers.",
+      "why_blocking": "As written, AC-1.19 is not realistically testable/true in the normal npm/package release model, so the sprint can fail its own acceptance criteria even if the feature is implemented correctly.",
+      "fix": "Reword AC-1.19 to something testable and accurate, e.g., “Adding a new compatibility entry requires editing only `compatibility.json` (no TS code changes)” and/or “matrix updates do not require changing TypeScript source beyond the JSON file.” If you truly need runtime-updatable data without republish, that’s a different design (external config source) and should be explicitly scoped."
+    },
+    {
+      "location": "Task 1.2: Add Runtime Schema Enforcement for Audit Events (testing coverage)",
+      "issue": "No explicit task/AC to add or update tests for the new runtime validation behavior (warn + skip). Existing tests may pass without modification even if the guard is broken or never triggered, and there’s no defined way to verify CloudWatch-filter-safe structure beyond local logs.",
+      "why_blocking": "This change is specifically to prevent silent drops in CloudWatch; without a deterministic test asserting the guard behavior and emitted structure, you can ship a regression that still silently drops events, failing the purpose of the sprint.",
+      "fix": "Add explicit AC and a unit test: (1) invalid event → `log.warn` called with `audit_event_validation_failure` and `log.info` not called; (2) valid event → `log.info` called with required fields present. If you have a log-shape contract, assert the JSON keys exactly (snake_case vs camelCase)."
     }
   ],
   "question": "",

--- a/grimoires/loa/a2a/gpt-review/sprint-findings-2.json
+++ b/grimoires/loa/a2a/gpt-review/sprint-findings-2.json
@@ -1,23 +1,40 @@
 {
-  "verdict": "APPROVED",
-  "summary": "All previously blocking issues are addressed: the plan now explicitly scopes Arrakis vs. loa-finn enforcement with a tracked cross-repo dependency, and the integration tests are made feasible via an existing JWKS/key + injectable logger seam; the validatePoolClaims contract/ACs are now consistent and canonicalized.",
+  "verdict": "CHANGES_REQUIRED",
+  "summary": "Most prior blockers were addressed (sorted-set AC alignment, audit validation tests, and safer JSON loading), but the mixed-fleet migration fix introduces a truly blocking correctness risk for fleet-wide circuit breaking during rollout.",
   "previous_issues_status": [
     {
-      "original_issue": "F-5 trust-boundary enforcement scope: sprint claimed trust-boundary fix but had no loa-finn deliverable/dependency, leaving confused-deputy gap",
+      "original_issue": "AC-1.1 required `ZRANGEBYSCORE` but implementation used `ZREMRANGEBYSCORE` + `ZCARD` (AC/implementation mismatch)",
       "status": "fixed",
-      "notes": "The plan now clearly states Arrakis is detection-only (warn-only) and adds a Blocking Dependencies section plus an explicit Sprint 2 task (2.6) to file a loa-finn enforcement issue, and SDD language (2.2) that loa-finn MUST re-validate and SHOULD reject. This resolves the scope/handshake problem without pretending the vulnerability is fully closed in Arrakis alone."
+      "notes": "AC-1.1 is now aligned to the intended algorithm (`ZREMRANGEBYSCORE` + `ZADD` + `ZCARD`)."
     },
     {
-      "original_issue": "Integration tests were untestable: no specified way to sign a forged-but-verifiable JWT and no deterministic log assertion seam",
-      "status": "fixed",
-      "notes": "Task 2.4 now anchors on existing test infrastructure: JWKS test server + deterministic key generation/signing helpers, and a createPipeline/logger helper with spyable warn/info. AC-H2.5/2.6 assertions are on structured log events rather than free-text, removing flakiness and making the test path reachable past JWS verification."
+      "original_issue": "Zero-downtime migration underspecified for mixed-fleet concurrency; risk of lost/duplicated failures during rollout",
+      "status": "not_fixed",
+      "notes": "A mixed-fleet strategy was added, but it explicitly allows old and new fleets to write to different stores and not see each other’s failures. That breaks the core requirement of fleet-wide circuit breaking during the rollout window."
     },
     {
-      "original_issue": "validatePoolClaims contract inconsistency (boolean vs {valid, reason}) and underspecified ordering/representation rules for allowed_pools",
+      "original_issue": "Compatibility matrix loading via `readFileSync` at module init is brittle in packaged/bundled Node environments",
       "status": "fixed",
-      "notes": "AC-H1.3/H1.4 now match the `{ valid: boolean; reason?: string }` return type, and the canonicalization rule is explicitly defined (sorted + deduped set comparison; order-independent membership). This makes implementation/test expectations unambiguous and stable across systems."
+      "notes": "Switched to JSON module import with `resolveJsonModule`, avoiding runtime path resolution and file I/O."
+    },
+    {
+      "original_issue": "AC-1.19 was unrealistic as written (implied no rebuild/redeploy needed for data changes)",
+      "status": "fixed",
+      "notes": "Reworded to a testable claim: only `compatibility.json` needs editing (no TS source changes). This is reasonable in a normal publish/redeploy model."
+    },
+    {
+      "original_issue": "Audit runtime validation lacked explicit tests to prove warn+skip behavior and log shape",
+      "status": "fixed",
+      "notes": "Added AC-1.21 and AC-1.22 to require unit tests for invalid/valid events and to assert warn/info behavior."
     }
   ],
-  "new_blocking_concerns": [],
+  "new_blocking_concerns": [
+    {
+      "location": "Task 1.1: Mixed-Fleet Deployment Strategy (new containers write only ZSET; old containers write only CSV hash field)",
+      "description": "During a rolling deploy, failure events are split across two independent stores, so neither version observes the full fleet failure rate. This violates fleet-wide circuit breaking semantics at the exact time you most need them (deploys), and can prevent the breaker from opening under real cascading failure conditions.",
+      "why_blocking": "Fleet-wide circuit breaking is a critical requirement. The proposed strategy knowingly degrades correctness (not just sensitivity) for ~deployment duration, and the failure mode is dangerous: the breaker may stay closed when it should open, enabling cascading failures and budget/accounting blowups. This is not a minor tradeoff; it undermines the core safety mechanism during rollout.",
+      "fix": "Adopt a mixed-version compatible write/read strategy for at least one window duration:\n- Two-phase deploy: Phase A (compat mode): new code writes to BOTH CSV hash field and ZSET, and reads/counts from ZSET (or reads both and takes max) while leaving CSV intact. Phase B (after full rollout + >windowMs): stop writing CSV and perform cleanup (HDEL) safely.\nOR\n- Dual-read during transition: new code counts failures from ZSET plus (if present) parses CSV as a fallback and uses the maximum/union count, then gradually removes CSV after rollout.\nAdd/adjust AC-1.20 to require a mixed-fleet simulation test (old-writer + new-writer) proving the breaker opens at the same threshold as single-version behavior."
+    }
+  ],
   "iteration": 2
 }

--- a/grimoires/loa/a2a/gpt-review/sprint-findings-3.json
+++ b/grimoires/loa/a2a/gpt-review/sprint-findings-3.json
@@ -1,31 +1,31 @@
 {
   "verdict": "APPROVED",
-  "summary": "The two previously-blocking items (req_hash canonicalization ambiguity and IPv6 normalization) are now specified in a single, implementable way, and the earlier race-condition fix remains correct without introducing new blocking issues.",
+  "summary": "All previously raised blockers are now addressed, and the mixed-fleet circuit breaker migration is corrected to preserve fleet-wide semantics during rolling deploys without introducing new blocking risks.",
   "previous_issues_status": [
     {
-      "original_issue": "req_hash binding uses non-canonical/unstable JSON.stringify(request) and may hash the wrong object; need one canonicalization shared by minter+verifier",
+      "original_issue": "AC-1.1 required `ZRANGEBYSCORE` but implementation used `ZREMRANGEBYSCORE` + `ZCARD` (AC/implementation mismatch)",
       "status": "fixed",
-      "notes": "S8-T1 now picks one unambiguous binding scheme: hash the exact raw HTTP body bytes that Arrakis forwards upstream, and require loa-finn to hash the received body bytes. This removes JSON canonicalization pitfalls entirely and is precise/testable (same bytes => same hash; tamper => mismatch)."
+      "notes": "AC-1.1 is aligned to the intended sliding-window algorithm (`ZREMRANGEBYSCORE` + `ZADD` + `ZCARD`) and the plan text matches it."
     },
     {
-      "original_issue": "Finalize/Reaper race condition fix was underspecified and risked impossible Redis ops; need an implementable atomic claim mechanism guaranteeing exactly-once decrement",
+      "original_issue": "Zero-downtime migration underspecified for mixed-fleet concurrency; risk of lost/duplicated failures during rollout",
       "status": "fixed",
-      "notes": "S8-T3 keeps the claim-via-DEL approach with clear semantics (DEL return value as the claim signal) and adds an explicit concurrent finalize+reaper test in S9-T3 to validate exactly-once reserved decrement. This is implementable with Redis EVALSHA atomicity and addresses the double-DECRBY window."
+      "notes": "Task 1.1 now specifies a two-phase rollout where new code dual-writes (ZSET + CSV) and also migrates CSV→ZSET on each call, plus clears both on success. This ensures old and new containers observe the same fleet-wide failure stream during the rollout window, which resolves the prior correctness risk. AC-1.20 and AC-1.23 explicitly cover mixed-fleet safety and require a simulation test."
     },
     {
-      "original_issue": "IPv6 normalization: lowercasing alone insufficient; need real canonicalization and address trust proxy/XFF correctness",
+      "original_issue": "Compatibility matrix loading via `readFileSync` at module init is brittle in packaged/bundled Node environments",
       "status": "fixed",
-      "notes": "S8-T4 replaces string-prefix logic with ipaddr.js parsing + normalization, converts IPv4-mapped IPv6 to IPv4, and adds tests for equivalent IPv6 textual forms mapping to the same bucket. It also explicitly tests that req.ip (trust proxy mediated) is used rather than raw XFF, preventing spoofing."
+      "notes": "The plan uses TS JSON module import with `resolveJsonModule`, avoiding runtime file I/O and path resolution issues."
     },
     {
-      "original_issue": "getAvailableModels() abstraction leak: proposed fix didn’t resolve overrides; acceptance said 'correct' aliases per access level",
-      "status": "rejected_with_valid_reason",
-      "notes": "S9-T1 explicitly constrains getAvailableModels() to defaults-only because the port lacks communityId, and documents that overrides are applied per-request via context.allowedModelAliases. This is a reasonable resolution given the interface constraint and stays within 'fixes only' scope."
+      "original_issue": "AC-1.19 was unrealistic as written (implied no rebuild/redeploy needed for data changes)",
+      "status": "fixed",
+      "notes": "AC-1.19 is now scoped to 'edit only compatibility.json (no TS source changes)', which is testable and reasonable under normal publish/redeploy."
     },
     {
-      "original_issue": "Property-based budget tests: plan didn’t ensure it can observe interleaving invariants given Redis scripts are atomic; needed a deterministic concurrency harness or a direct exactly-once test",
+      "original_issue": "Audit runtime validation lacked explicit tests to prove warn+skip behavior and log shape",
       "status": "fixed",
-      "notes": "S9-T3 adds between-batch invariant checks and, critically, a dedicated concurrent finalize+reaper test that directly exercises the prior race. Using fast-check scheduler for Node-level interleavings is acceptable as an additional exploration mechanism."
+      "notes": "AC-1.21 and AC-1.22 require unit tests for invalid/valid events asserting warn+skip vs info emission, matching the non-blocking audit requirement."
     }
   ],
   "new_blocking_concerns": [],

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "next_sprint_number": 213,
-  "active_cycle": "cycle-019",
+  "next_sprint_number": 214,
+  "active_cycle": "cycle-020",
   "cycles": [
     {
       "id": "cycle-001",
@@ -280,16 +280,29 @@
     {
       "id": "cycle-019",
       "label": "The Capability Mesh — Per-Model Accounting & Protocol Architecture (BB6)",
-      "status": "active",
+      "status": "archived",
       "created": "2026-02-12T12:00:00Z",
+      "archived": "2026-02-12T23:30:00Z",
       "prd": "grimoires/loa/prd-hounfour-endgame.md",
       "sdd": "grimoires/loa/sdd-hounfour-endgame.md",
       "sprint_plan": "grimoires/loa/sprint.md",
       "sprints": [
-        {"global_id": 209, "local_label": "sprint-1", "status": "pending"},
-        {"global_id": 210, "local_label": "sprint-2", "status": "pending"},
-        {"global_id": 211, "local_label": "sprint-3", "status": "pending"},
-        {"global_id": 212, "local_label": "sprint-4", "status": "pending"}
+        {"global_id": 209, "local_label": "sprint-1", "status": "completed"},
+        {"global_id": 210, "local_label": "sprint-2", "status": "completed"},
+        {"global_id": 211, "local_label": "sprint-3", "status": "completed"},
+        {"global_id": 212, "local_label": "sprint-4", "status": "completed"}
+      ]
+    },
+    {
+      "id": "cycle-020",
+      "label": "Bridgebuilder Round 7 — Protocol Refinement (BB7)",
+      "status": "active",
+      "created": "2026-02-12T23:45:00Z",
+      "prd": "grimoires/loa/prd-hounfour-endgame.md",
+      "sdd": "grimoires/loa/sdd-hounfour-endgame.md",
+      "sprint_plan": "grimoires/loa/sprint.md",
+      "sprints": [
+        {"global_id": 213, "local_label": "sprint-1", "status": "pending"}
       ]
     }
   ]

--- a/grimoires/loa/sprint.md
+++ b/grimoires/loa/sprint.md
@@ -1,10 +1,10 @@
-# Sprint Plan: The Capability Mesh — Per-Model Accounting & Protocol Architecture
+# Sprint Plan: Bridgebuilder Round 7 — Protocol Refinement
 
-**Version**: 1.1.0
+**Version**: 1.0.0
 **Date**: February 12, 2026
-**Cycle**: cycle-019
-**Codename**: The Capability Mesh
-**Source**: Bridgebuilder Round 6 findings ([PR #53](https://github.com/0xHoneyJar/arrakis/pull/53))
+**Cycle**: cycle-020
+**Codename**: The Refinement
+**Source**: Bridgebuilder Round 7 findings ([PR #55](https://github.com/0xHoneyJar/arrakis/pull/55))
 **PRD**: `prd-hounfour-endgame.md` v1.2.0 (extended)
 **SDD**: `sdd-hounfour-endgame.md` v1.2.0 (extended)
 **RFC**: [0xHoneyJar/loa-finn#31](https://github.com/0xHoneyJar/loa-finn/issues/31)
@@ -15,604 +15,156 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Total Sprints** | 4 |
-| **Sprint Timebox** | 1 day per sprint (solo AI-assisted); hard stop + scope cut if exceeded |
+| **Total Sprints** | 1 |
+| **Sprint Timebox** | 1 day (solo AI-assisted) |
 | **Developer** | Solo (AI-assisted) |
 | **Repos** | arrakis (primary) |
-| **Critical Path** | Sprint 1 → Sprint 4 (per-model accounting flows into dashboard metrics) |
-| **Parallel Work** | Sprints 2 & 3 are independent of each other |
-| **Global Sprint IDs** | 209–212 |
+| **Global Sprint IDs** | 213 |
 
 ### Context
 
-PR #53 consolidated cycles 015–018 (Hounfour Endgame + Bridgebuilder Rounds 3–4), delivering 15 commits across 65 files. The Bridgebuilder Round 6 review identified 7 architectural findings that advance the system from "feature-complete" to "protocol-grade." This cycle implements all 7.
+PR #55 delivered The Capability Mesh (cycle-019): per-model ensemble accounting, contract protocol promotion, fleet-wide Redis circuit breaker, API key isolation boundary, token estimator calibration, and incremental fallback reservation. Bridgebuilder Round 7 reviewed that work and identified 3 critical refinements plus 3 praise items. This cycle implements the 3 critical findings.
 
 ### Goals
 
-| ID | Goal | BB6 Finding | Metric |
+| ID | Goal | BB7 Finding | Metric |
 |----|------|-------------|--------|
-| G-1 | Per-model-invocation accounting in ensemble results | #6 (Ensemble Budget) | Usage reports include `model_breakdown` array with per-model costs |
-| G-2 | Contract package promoted to standalone shared protocol | #2 (Contract Protocol Nucleus) | `@arrakis/loa-finn-contract` importable from root workspace |
-| G-3 | POOL_PROVIDER_HINT as configurable routing policy | #5 (Provider Policy) | Provider hints loaded from env/config, not hardcoded |
-| G-4 | API key string persistence eliminated from V8 heap | #3 (Security) | Auth headers set via Buffer, no string conversion |
-| G-5 | Fleet-wide circuit breaker via Redis | #4 (Circuit Breaker) | CB state shared across ECS containers |
-| G-6 | Gateway lifecycle externalized as protocol | #1 (State Machine) | `RequestLifecycle` class drives invoke/stream |
-| G-7 | Ensemble fallback incremental reservation release | #6 (Budget Optimization) | Fallback releases reservation capacity per attempt |
+| G-1 | Redis sorted set failure tracking | R7-1 (Scalability) | `LUA_FAILURE` uses `ZREMRANGEBYSCORE`/`ZADD`/`ZCARD` instead of CSV parsing |
+| G-2 | Runtime schema enforcement for audit events | R7-3 (Reliability) | Required fields validated before `log.info()` emission |
+| G-3 | Data-driven compatibility matrix | R7-4 (Maintainability) | Matrix loaded from `compatibility.json`, not hardcoded in TS |
 
-### Definition of Done (per sprint)
+### Findings Not Addressed (Praise / Future)
+
+| Finding | Type | Reason |
+|---------|------|--------|
+| R7-2: Request lifecycle state machine | Praise | No changes needed — future distributed tracing direction noted |
+| R7-5: Fallback 1x budget optimization | Praise | No changes needed — budget invariant confirmed correct |
+| R7-3 evolution: Branded types for API keys | Future | Deferred to Hounfour ensemble orchestrator (loa-finn#31) |
+| R7-3 evolution: undici zero-copy path | Future | Tracked as enhancement, awaiting undici dependency addition |
+
+### Definition of Done
 
 1. All acceptance criteria marked as passing
-2. Unit tests pass (`vitest`)
-3. E2E tests pass (13/13 minimum, new scenarios added)
-4. No new lint/type errors introduced
-5. Code committed to feature branch with sprint prefix
-6. `/review-sprint` + `/audit-sprint` quality gates passed
+2. No new lint/type errors introduced (`npx tsc --noEmit`)
+3. Code committed to feature branch with sprint prefix
+4. `/review-sprint` + `/audit-sprint` quality gates passed
 
 ---
 
-## Sprint 1: Per-Model Ensemble Accounting (G-1)
+## Sprint 1: Protocol Refinement (G-1, G-2, G-3)
 
-**Global ID**: 209
-**Goal**: Decompose ensemble cost attribution to per-model granularity, enabling hybrid BYOK/platform accounting within a single ensemble request.
-
-**Why First**: This is the user's primary request and the highest-value architectural advance. It extends the existing ensemble system without breaking it, and the contract schema changes must land before other sprints can extend the protocol.
+**Global ID**: 213
+**Goal**: Address all 3 critical Bridgebuilder Round 7 findings — scalable failure tracking, audit event validation, and data-driven compatibility.
 
 ### Tasks
 
-#### Task 1.1: `ModelInvocationResult` Type + Ensemble Decomposition
+#### Task 1.1: Migrate Circuit Breaker Failure Tracking from CSV to Sorted Sets
 
-**New File**: `packages/adapters/agent/ensemble-accounting.ts`
-**Modified**: `packages/core/ports/agent-gateway.ts`
+**Modified**: `packages/adapters/agent/redis-circuit-breaker.ts`
 
-- Define `ModelInvocationResult` type:
-  ```typescript
-  interface ModelInvocationResult {
-    model_id: string;         // Pool ID or model alias used
-    provider: string;         // 'openai' | 'anthropic'
-    succeeded: boolean;       // Whether this invocation completed
-    input_tokens: number;
-    output_tokens: number;
-    cost_micro: number;       // Cost in micro-USD for this model
-    accounting_mode: 'PLATFORM_BUDGET' | 'BYOK_NO_BUDGET';
-    latency_ms: number;       // Per-model latency
-    error_code?: string;      // If failed, the error code
-  }
-  ```
-- Define `EnsembleAccountingResult` type:
-  ```typescript
-  interface EnsembleAccountingResult {
-    strategy: EnsembleStrategy;
-    n_requested: number;
-    n_succeeded: number;
-    n_failed: number;
-    model_breakdown: ModelInvocationResult[];
-    total_cost_micro: number;           // Sum of succeeded model costs
-    platform_cost_micro: number;        // Sum of PLATFORM_BUDGET costs only
-    byok_cost_micro: number;            // Sum of BYOK_NO_BUDGET costs only
-    reserved_cost_micro: number;        // Original N× reservation
-    savings_micro: number;              // reserved - total (unused capacity)
-  }
-  ```
-- Add `ensemble_accounting` optional field to `AgentInvokeResponse` port type
+The `LUA_FAILURE` script currently stores failure timestamps as a comma-separated string in a Redis hash field. Every `onFailure()` call parses the entire CSV, filters by time window, and rebuilds the string — O(n) per call where n = failures in window.
 
-**Acceptance Criteria**:
-- [ ] AC-1.1: `ModelInvocationResult` type exported from `@arrakis/core/ports`
-- [ ] AC-1.2: `EnsembleAccountingResult` type exported from `@arrakis/core/ports`
-- [ ] AC-1.3: Types support mixed accounting modes (BYOK + platform in same ensemble)
-- [ ] AC-1.4: `savings_micro` correctly computes unused reservation capacity
+**Fix**: Replace CSV-in-hash with Redis sorted sets (`ZREMRANGEBYSCORE` + `ZADD` + `ZCARD`):
+```lua
+-- Remove expired failures (trim window)
+redis.call('ZREMRANGEBYSCORE', key..':failures', '-inf', nowMs - windowMs)
+-- Add new failure timestamp as both score and member
+redis.call('ZADD', key..':failures', nowMs, nowMs)
+-- Count remaining failures in window
+local count = redis.call('ZCARD', key..':failures')
+```
 
-#### Task 1.2: Contract Schema Extension — `model_breakdown` in Usage Reports
+O(log n) insert + O(log n) range trim instead of O(n) string parsing.
 
-**Modified**: `tests/e2e/contracts/schema/loa-finn-contract.json`, `tests/e2e/contracts/src/index.ts`
+**Mixed-Fleet Deployment Strategy (Two-Phase)**:
 
-- Extend `usage_report` schema with optional `model_breakdown` array:
-  ```json
-  "model_breakdown": {
-    "type": "array",
-    "items": {
-      "type": "object",
-      "required": ["model_id", "provider", "succeeded", "cost_micro", "accounting_mode"],
-      "properties": {
-        "model_id": { "type": "string" },
-        "provider": { "type": "string", "enum": ["openai", "anthropic"] },
-        "succeeded": { "type": "boolean" },
-        "input_tokens": { "type": "integer", "minimum": 0 },
-        "output_tokens": { "type": "integer", "minimum": 0 },
-        "cost_micro": { "type": "integer", "minimum": 0 },
-        "accounting_mode": { "type": "string", "enum": ["PLATFORM_BUDGET", "BYOK_NO_BUDGET"] },
-        "latency_ms": { "type": "integer", "minimum": 0 },
-        "error_code": { "type": "string" }
-      }
-    }
-  }
-  ```
-- Bump contract package version to `1.1.0` (minor — backward-compatible addition)
-- Add TypeScript types for `ModelBreakdownEntry` to contract package
-- Extend `TestVectorUsageReport` type with optional `model_breakdown`
+**Phase A — Compatibility mode (during rolling deploy)**:
+New Lua scripts write to BOTH the sorted set AND the legacy CSV hash field, and read/count from the sorted set:
+- `LUA_FAILURE`: On each call, first check for CSV hash field `failures`. If present, parse timestamps, `ZADD` them into sorted set, then `HDEL` the CSV field (one-time migration per call). Then perform normal sorted set ops (`ZREMRANGEBYSCORE` + `ZADD` + `ZCARD`). Finally, write back a CSV representation to the hash field for old containers still reading it.
+- `LUA_SUCCESS`: Clear both sorted set (`DEL key:failures`) and CSV hash field (`HDEL key failures`).
+- **Result**: Old containers see new failures via CSV. New containers see old failures via CSV→ZSET migration. Fleet-wide failure count is consistent across both code versions.
+
+**Phase B — Cleanup (after full rollout + 1 window duration)**:
+Remove CSV write-back from Lua scripts in a follow-up PR. The hash field `failures` will be stale/empty at this point. This is a non-urgent cleanup — the dual-write overhead is ~1 extra `HSET` per failure.
+
+**Changes**:
+- Rewrite `LUA_FAILURE` to use sorted set operations on `key:failures` sorted set key
+- Rewrite `LUA_SUCCESS` to clear sorted set with `DEL key:failures`
+- Add cleanup: `LUA_FAILURE` checks for old hash field `failures` and deletes it if present (one-time)
+- Update `LUA_CHECK` if it reads failure count (currently does not — no change needed)
+- Update process-local fallback to match (already uses `number[]` array — no change)
 
 **Acceptance Criteria**:
-- [ ] AC-1.5: Contract schema validates with `model_breakdown` present
-- [ ] AC-1.6: Contract schema validates without `model_breakdown` (backward-compatible)
-- [ ] AC-1.7: Contract version bumped to `1.1.0`
-- [ ] AC-1.8: TypeScript types re-exported from contract package
+- [ ] AC-1.1: `LUA_FAILURE` uses `ZREMRANGEBYSCORE` + `ZADD` + `ZCARD` instead of CSV string manipulation
+- [ ] AC-1.2: `LUA_SUCCESS` clears sorted set with `DEL key:failures`
+- [ ] AC-1.3: Phase A dual-write: new `LUA_FAILURE` migrates CSV→ZSET on each call and writes back CSV for old readers
+- [ ] AC-1.4: O(log n) complexity for failure recording (no string parsing)
+- [ ] AC-1.5: Process-local fallback behavior unchanged (already uses `number[]`)
+- [ ] AC-1.6: All existing circuit breaker tests pass without modification
+- [ ] AC-1.7: Sorted set entries auto-expire via `ZREMRANGEBYSCORE` on each call (no TTL needed)
+- [ ] AC-1.20: Mixed-fleet safety: dual-write ensures old+new containers observe consistent fleet failure counts during rolling deployment
+- [ ] AC-1.23: Unit test: simulate old-writer (CSV only) + new-writer (dual-write) — breaker opens at same threshold as single-version behavior
 
-#### Task 1.3: Hybrid BYOK/Platform Accounting Per Model
+#### Task 1.2: Add Runtime Schema Enforcement for Audit Events
 
-**Modified**: `packages/adapters/agent/agent-gateway.ts`, `packages/adapters/agent/ensemble-mapper.ts`
+**Modified**: `packages/adapters/agent/capability-audit.ts`
 
-- Extend `AgentGateway.invoke()` and `stream()` to decompose ensemble cost by model:
-  - For each model in the ensemble request, check BYOK eligibility via `resolveByokProvider()`
-  - Models with BYOK key → `BYOK_NO_BUDGET` (cost_micro = 0 for platform)
-  - Models without BYOK key → `PLATFORM_BUDGET` (normal cost accounting)
-  - Budget reservation only for PLATFORM_BUDGET models: `multiplier = count(non-BYOK models)`
-- Extend `EnsembleMapper.computePartialCost()` to return per-model breakdown
-- Update `checkBudgetDrift()` to use `platform_cost_micro` (not total) for drift detection
+The `CapabilityAuditEvent` type is well-structured at compile time, but CloudWatch Log Metric Filters will silently drop events that don't match expected field names. There's no runtime validation between the TypeScript interface and the emitted JSON.
 
-**Acceptance Criteria**:
-- [ ] AC-1.9: Ensemble with 3 models, 1 BYOK + 2 platform → budget reserves 2× (not 3×)
-- [ ] AC-1.10: Usage report `model_breakdown` shows correct `accounting_mode` per model
-- [ ] AC-1.11: Budget drift detection uses only platform costs
-- [ ] AC-1.12: BYOK models tracked in `model_breakdown` with `cost_micro: 0`
-- [ ] AC-1.13: Unit test: mixed BYOK/platform ensemble with partial failure — committed ≤ reserved
-- [ ] AC-1.22: EMF metric emitted: `PerModelCost` with dimensions `{model_id, provider, accounting_mode}` (unit: micro-USD)
-- [ ] AC-1.23: EMF metric emitted: `EnsembleSavings` with `savings_micro` value (unit: micro-USD)
+**Fix**: Add a lightweight required-fields guard before `this.log.info()`. Not full JSON Schema — just assert that the 4 critical fields (`trace_id`, `community_id`, `event_type`, `pool_id`) are non-empty strings.
 
-#### Task 1.4: E2E Test Vectors for Per-Model Accounting
-
-**Modified**: `tests/e2e/contracts/vectors/loa-finn-test-vectors.json`, `tests/e2e/agent-gateway-e2e.test.ts`, `tests/e2e/loa-finn-e2e-stub.ts`
-
-- Add `invoke_ensemble_hybrid_byok` test vector:
-  - 3-model best_of_n: model A (BYOK/anthropic), model B (platform), model C (platform)
-  - Expected: `model_breakdown` with 3 entries, mixed `accounting_mode`
-  - Expected: `platform_cost_micro` = sum of B + C, `byok_cost_micro` = 0
-- Add `invoke_ensemble_per_model_partial` test vector:
-  - 3-model consensus: model A succeeds, model B fails, model C succeeds
-  - Expected: `model_breakdown` with 3 entries, `n_succeeded: 2`, `n_failed: 1`
-  - Expected: `total_cost_micro` = A + C (failed model excluded)
-- Update E2E stub to return `model_breakdown` in usage reports
-- Update E2E tests to validate per-model cost attribution
+**Changes**:
+- Add private `validateRequiredFields()` method to `CapabilityAuditLogger`
+- Call it at the top of `emit()` before the `log.info()` call
+- On validation failure: log a warning (don't throw — audit events should not crash requests) and skip emission
+- Add `audit_event_validation_failure` structured log for observability of the guard itself
 
 **Acceptance Criteria**:
-- [ ] AC-1.14: E2E test validates hybrid BYOK/platform ensemble accounting
-- [ ] AC-1.15: E2E test validates per-model partial failure with correct cost attribution
-- [ ] AC-1.16: All existing E2E tests still pass (backward compatibility)
-- [ ] AC-1.17: E2E count ≥ 15 (up from 13)
+- [ ] AC-1.8: `emit()` validates `trace_id`, `community_id`, `event_type`, and `pool_id` are non-empty strings before emission
+- [ ] AC-1.9: Missing required field → warning logged with field name, event skipped (not thrown)
+- [ ] AC-1.10: `audit_event_validation_failure` structured log emitted on guard trigger
+- [ ] AC-1.11: All existing audit event emission paths still work (no false positives)
+- [ ] AC-1.12: Convenience methods (`emitPoolAccess`, `emitByokUsage`, `emitEnsembleInvocation`) pass validation (they always supply required fields)
+- [ ] AC-1.21: Unit test: event with empty `trace_id` → `log.warn` called with `audit_event_validation_failure`, `log.info` NOT called
+- [ ] AC-1.22: Unit test: valid event → `log.info` called with all required fields present in `audit` object, `log.warn` NOT called
 
-#### Task 1.5: loa-finn Contract v1.1.0 Compatibility Verification
+#### Task 1.3: Make Compatibility Matrix Data-Driven
 
-**Modified**: `tests/e2e/loa-finn-e2e-stub.ts`, `tests/e2e/agent-gateway-e2e.test.ts`
+**Modified**: `packages/contracts/src/compatibility.ts`
+**New File**: `packages/contracts/schema/compatibility.json`
 
-- Verify loa-finn tolerates the new `model_breakdown` field (additive schema):
-  - Update E2E stub to simulate loa-finn receiving usage reports with `model_breakdown`
-  - Test that loa-finn stub correctly ignores unknown fields (JSON Schema `additionalProperties: true`)
-  - Test that loa-finn stub works with contract v1.0.0 payloads (no `model_breakdown`) AND v1.1.0 (with `model_breakdown`)
-- If loa-finn is strict about schema validation, document the required loa-finn change as a cross-repo dependency in NOTES.md
-- Add E2E scenario: arrakis sends v1.1.0 usage report → loa-finn stub validates and accepts
+The hardcoded `COMPATIBILITY_MATRIX` array in TypeScript works for 2 entries but won't scale. The contract package was promoted to a standalone protocol artifact (BB6 #2) specifically so it could evolve independently. Data that changes at a different cadence than code should live in a different file.
 
-**Acceptance Criteria**:
-- [ ] AC-1.18: E2E stub simulates loa-finn receiving `model_breakdown` in usage reports
-- [ ] AC-1.19: Stub accepts both v1.0.0 (no `model_breakdown`) and v1.1.0 (with `model_breakdown`) payloads
-- [ ] AC-1.20: If loa-finn requires changes, cross-repo dependency documented in NOTES.md with PR reference
-- [ ] AC-1.21: Contract backward-compatibility proven by E2E (not just schema validation)
+**Fix**: Move compatibility data to `packages/contracts/schema/compatibility.json`. Import as a TypeScript JSON module (no `readFileSync`). Validate required fields at load time.
 
----
-
-## Sprint 2: Contract Protocol Promotion + Provider Policy (G-2, G-3)
-
-**Global ID**: 210
-**Goal**: Promote the contract package to a standalone shared protocol artifact and make provider routing configurable.
-
-**Why Second**: The contract schema was updated in Sprint 1. This sprint elevates it to protocol status and addresses the routing policy hardcoding.
-
-### Tasks
-
-#### Task 2.1: Contract Package Promotion to Workspace Root
-
-**Modified**: `package.json` (root), `tests/e2e/contracts/package.json`
-
-- Move `@arrakis/loa-finn-contract` from `tests/e2e/contracts/` to `packages/contracts/` (workspace root level)
-- Update all imports across the codebase:
-  - `tests/e2e/agent-gateway-e2e.test.ts`
-  - `packages/adapters/agent/contract-version.ts`
-  - Any other references
-- Add `packages/contracts` to pnpm workspace configuration
-- Ensure `npm pack` produces a publishable artifact
-- Add README documenting the package as a protocol specification (not a test utility)
+**Changes**:
+- Create `packages/contracts/schema/compatibility.json` with the current 2 entries
+- Modify `compatibility.ts` to import JSON using TypeScript JSON module import (`import matrixData from '../schema/compatibility.json'` with `resolveJsonModule: true` in tsconfig). This avoids `readFileSync` path-resolution issues across ESM/CJS/bundlers and ensures the data is resolved at compile time.
+- Add lightweight load-time validation: each entry must have `arrakis_version`, `loa_finn_version`, `contract_version`, `status`
+- Export `COMPATIBILITY_MATRIX` as readonly for consumers that need direct access
+- Ensure `packages/contracts/tsconfig.json` has `"resolveJsonModule": true` and `"esModuleInterop": true`
+- Update `packages/contracts/package.json` to include `schema/` in `files` array (for `npm pack`)
 
 **Acceptance Criteria**:
-- [ ] AC-2.1: Package lives at `packages/contracts/` (not `tests/e2e/contracts/`)
-- [ ] AC-2.2: All existing imports still resolve
-- [ ] AC-2.3: `pnpm build` succeeds with new package location
-- [ ] AC-2.4: Package README describes it as protocol specification
-- [ ] AC-2.5: `npm pack` in `packages/contracts/` produces valid tarball
-
-#### Task 2.2: Compatibility Matrix + Version Negotiation
-
-**New File**: `packages/contracts/src/compatibility.ts`
-**Modified**: `packages/contracts/src/index.ts`
-
-- Create `CompatibilityMatrix` class:
-  ```typescript
-  interface CompatibilityEntry {
-    arrakis_version: string;    // Semver range
-    loa_finn_version: string;   // Semver range
-    contract_version: string;   // Exact version
-    status: 'supported' | 'deprecated' | 'unsupported';
-    notes?: string;
-  }
-  ```
-- Load compatibility data from `compatibility.json`
-- Export `getCompatibility(arrakisVersion, loaFinnVersion)` function
-- Export `validateContractCompatibility(contractVersion, peerVersion)` function
-- Add `compatibility.json` with initial entries for current versions
-
-**Acceptance Criteria**:
-- [ ] AC-2.6: `getCompatibility()` returns match for current version pair
-- [ ] AC-2.7: `validateContractCompatibility()` returns `{ compatible: true }` for matching versions
-- [ ] AC-2.8: `validateContractCompatibility()` returns `{ compatible: false, reason }` for mismatched versions
-- [ ] AC-2.9: Unit tests for all compatibility scenarios
-- [ ] AC-2.20: Negotiation wired into arrakis request path: `contract_version` included in JWT claims sent to loa-finn
-- [ ] AC-2.21: `AgentGateway` calls `validateContractCompatibility()` on loa-finn response version; incompatible → fail-fast with `CONTRACT_VERSION_MISMATCH` error code
-- [ ] AC-2.22: E2E test: arrakis sends `contract_version` claim → loa-finn stub echoes its version → arrakis validates compatibility
-- [ ] AC-2.23: E2E test: version mismatch scenario → arrakis returns explicit error (not silent fallthrough)
-
-#### Task 2.3: POOL_PROVIDER_HINT as Configurable Routing Policy
-
-**Modified**: `packages/adapters/agent/pool-mapping.ts`, `packages/adapters/agent/config.ts`
-
-- Replace hardcoded `POOL_PROVIDER_HINT` constant with configurable policy:
-  ```typescript
-  // Load from POOL_PROVIDER_HINTS env var (JSON) or use defaults
-  // Format: {"cheap":"openai","fast-code":"openai","reviewer":"openai","reasoning":"anthropic","architect":"anthropic"}
-  ```
-- Add `POOL_PROVIDER_HINTS` to `config.ts` environment loading
-- Validate loaded hints against known pool IDs at startup (warn on unknown pools, fail on invalid providers)
-- Preserve current defaults as fallback when env var not set
-- Document configuration in CLAUDE.md Chain Provider Architecture section
-
-**Acceptance Criteria**:
-- [ ] AC-2.10: `POOL_PROVIDER_HINTS` env var overrides default mapping
-- [ ] AC-2.11: Missing env var falls back to current hardcoded defaults
-- [ ] AC-2.12: Invalid JSON in env var → startup warning + defaults used
-- [ ] AC-2.13: Unknown pool ID in hints → startup warning (non-fatal)
-- [ ] AC-2.14: Invalid provider value → startup error (fatal — security boundary)
-- [ ] AC-2.15: Unit tests for all configuration scenarios
-
-#### Task 2.4: Federation Seed — `delegated_by` JWT Claim
-
-**Modified**: `tests/e2e/contracts/schema/loa-finn-contract.json`, `packages/adapters/agent/jwt-service.ts`
-
-- Add optional `delegated_by` field to JWT claims schema:
-  ```json
-  "delegated_by": {
-    "type": ["string", "null"],
-    "description": "Community ID that delegated pool access (federation, future use)"
-  }
-  ```
-- Add `delegated_by` to JWT signing (null for now — placeholder for cross-community delegation)
-- Document the field's purpose in contract README: "Reserved for future community federation"
-
-**Acceptance Criteria**:
-- [ ] AC-2.16: `delegated_by` field present in JWT schema (optional, nullable)
-- [ ] AC-2.17: JWT signing includes `delegated_by: null` by default
-- [ ] AC-2.18: E2E tests pass with new claim present
-- [ ] AC-2.19: No behavioral change — purely additive schema extension
-
----
-
-## Sprint 3: Gateway Lifecycle + Security Hardening (G-4, G-5, G-6)
-
-**Global ID**: 211
-**Goal**: Externalize the gateway state machine, fix the API key heap persistence, and share circuit breaker state across the fleet.
-
-**Why Third**: These are structural improvements that don't depend on Sprint 2's contract changes. Can be developed in parallel with Sprint 2.
-
-### Tasks
-
-#### Task 3.1: Extract `RequestLifecycle` Protocol Object
-
-**New File**: `packages/adapters/agent/request-lifecycle.ts`
-**Modified**: `packages/adapters/agent/agent-gateway.ts`
-
-- Extract the implicit RECEIVED→RESERVED→EXECUTING→FINALIZED state machine into `RequestLifecycle`:
-  ```typescript
-  type LifecycleState = 'RECEIVED' | 'VALIDATED' | 'RESERVED' | 'EXECUTING' | 'FINALIZED' | 'FAILED';
-
-  class RequestLifecycle {
-    private state: LifecycleState = 'RECEIVED';
-
-    // State transition methods with invariant enforcement
-    validate(request, context): ValidatedRequest;
-    reserve(budget, ensemble, byok): ReservedRequest;
-    execute(client, request): Promise<ExecutingRequest>;
-    finalize(usage, budget): FinalizedRequest;
-    fail(error, budget): FailedRequest;
-
-    // Introspection
-    getState(): LifecycleState;
-    getDuration(): number;
-    getTrace(): LifecycleEvent[];
-  }
-  ```
-- Refactor `AgentGateway.invoke()` and `stream()` to use `RequestLifecycle`
-- Each state transition emits a structured log event (for distributed tracing)
-- Invalid state transitions throw `LifecycleError` (e.g., can't FINALIZE from RECEIVED)
-- The lifecycle trace array provides the complete decision trail for debugging
-
-**Acceptance Criteria**:
-- [ ] AC-3.1: `RequestLifecycle` enforces valid state transitions only
-- [ ] AC-3.2: Invalid transitions (e.g., RECEIVED → FINALIZED) throw `LifecycleError`
-- [ ] AC-3.3: `invoke()` and `stream()` refactored to use `RequestLifecycle`
-- [ ] AC-3.4: Each state transition emits structured log with traceId
-- [ ] AC-3.5: `getTrace()` returns complete lifecycle event history
-- [ ] AC-3.6: All existing tests pass without modification (behavioral equivalence)
-- [ ] AC-3.7: Unit tests for all valid and invalid state transitions
-- [ ] AC-3.25: EMF metric emitted: `LifecycleFinalState` with dimension `{final_state}` (count, unit: None)
-
-#### Task 3.2: API Key Isolation Boundary for Auth Headers (V8 Heap Fix)
-
-**Modified**: `packages/adapters/agent/byok-proxy-handler.ts`
-
-- Minimize API key string exposure window in auth header construction:
-  - Current: `apiKey.toString('utf8')` → string persists in V8 heap after `apiKey.fill(0)`
-  - New: Isolate string materialization to the smallest possible scope:
-    1. Keep key encrypted in memory (Buffer) until the last possible moment
-    2. Materialize string only inside an isolated helper that constructs the HTTP request
-    3. Use `undici.request()` (low-level, avoids global fetch header caching) for the proxy call
-    4. Null all local references immediately after request dispatch
-    5. `apiKey.fill(0)` in `finally` block clears the Buffer copy
-  - Investigate: if `undici` dispatchers support Buffer header values natively, prefer that path (zero string copies)
-  - If full Buffer-through is infeasible with the chosen HTTP client, document the limitation and implement the isolation boundary approach
-- Add `@security` JSDoc annotation documenting the rationale and chosen approach
-- Add heap snapshot regression test: after request completion, V8 heap snapshot searched for key substring (must not appear outside of `undici` internals)
-
-**Acceptance Criteria**:
-- [ ] AC-3.8: No application-level `toString()` on key Buffer outside the isolated dispatch boundary
-- [ ] AC-3.9: Key materialized as string only at HTTP dispatch point (not in `AgentGateway` or `BYOKProxyHandler` class scope)
-- [ ] AC-3.10: `apiKey.fill(0)` in `finally` block clears the Buffer; all string references nulled
-- [ ] AC-3.11: Existing BYOK proxy tests pass
-- [ ] AC-3.12: Heap snapshot regression test: key substring not found in V8 heap after request finalization (tolerance: undici internal buffers exempt)
-- [ ] AC-3.24: HTTP client choice documented with security rationale (undici preferred over global fetch)
-
-#### Task 3.3: Fleet-Wide Redis Circuit Breaker
-
-**New File**: `packages/adapters/agent/redis-circuit-breaker.ts`
-**Modified**: `packages/adapters/agent/byok-manager.ts`
-
-- Implement `RedisCircuitBreaker` that shares state across ECS containers:
-  ```typescript
-  class RedisCircuitBreaker {
-    // State stored in Redis key: `circuit:{component}`
-    // Uses atomic Lua script for state transitions
-    constructor(redis, component, config);
-
-    async isAllowed(): Promise<boolean>;  // Check + transition half-open
-    async onSuccess(): Promise<void>;     // Transition to closed
-    async onFailure(): Promise<void>;     // Record failure, potentially open
-
-    async getState(): Promise<CircuitState>;
-  }
-  ```
-- Atomic state transitions via Redis Lua scripts (no TOCTOU between check and transition)
-- Fallback to process-local circuit breaker if Redis unavailable (graceful degradation)
-- Replace `CircuitBreaker` in `BYOKManager` with `RedisCircuitBreaker`
-- Add `circuit_breaker_state_change` structured log event
-
-**Acceptance Criteria**:
-- [ ] AC-3.13: Circuit breaker state visible across multiple container instances (Redis key)
-- [ ] AC-3.14: State transitions are atomic (Lua script, no race conditions)
-- [ ] AC-3.15: Redis unavailable → falls back to process-local breaker
-- [ ] AC-3.16: State change emits structured log event
-- [ ] AC-3.17: Unit tests with mock Redis for all state transitions
-- [ ] AC-3.18: Integration test: two `RedisCircuitBreaker` instances (distinct `instance_id`) sharing a single testcontainer Redis — assert shared state transitions (open/half-open/closed propagation)
-- [ ] AC-3.26: EMF metric emitted: `CircuitBreakerState` with dimensions `{component, state}` (gauge, unit: None)
-
-#### Task 3.4: `estimateInputTokens()` Calibration Harness
-
-**New File**: `packages/adapters/agent/token-estimator.ts`
-**Modified**: `packages/adapters/agent/agent-gateway.ts`
-
-- Extract `estimateInputTokens()` from `AgentGateway` into `TokenEstimator` class:
-  ```typescript
-  class TokenEstimator {
-    // Current: ~4 chars per token (rough estimate)
-    // New: configurable chars-per-token with model-specific overrides
-    estimate(messages, options?: { modelAlias?: string }): number;
-
-    // Calibration: compare estimates vs actuals
-    recordActual(estimated: number, actual: number, modelAlias: string): void;
-    getCalibrationStats(): { meanError: number, p95Error: number, sampleCount: number };
-  }
-  ```
-- Default 4 chars/token with per-model overrides (e.g., Claude models tend to ~3.5)
-- `recordActual()` stores estimate/actual pairs in-memory circular buffer (last 1000)
-- Emit `token_estimate_drift` metric when error > 50%
-- Log calibration stats every 100 requests
-
-**Acceptance Criteria**:
-- [ ] AC-3.19: `TokenEstimator` extracted with configurable chars-per-token
-- [ ] AC-3.20: Model-specific overrides via configuration
-- [ ] AC-3.21: Calibration stats computed from estimate/actual pairs
-- [ ] AC-3.22: EMF metric emitted: `TokenEstimateDrift` with dimensions `{model_alias}` when estimate error > 50% (unit: Percent)
-- [ ] AC-3.23: Unit tests for estimation and calibration
-
----
-
-## Sprint 4: Ensemble Budget Optimization + Observability (G-7)
-
-**Global ID**: 212
-**Goal**: Optimize ensemble fallback budget reservation and update observability for all new capabilities.
-
-**Why Last**: Depends on per-model accounting (Sprint 1) and lifecycle tracing (Sprint 3). Dashboard updates require all metrics to be flowing.
-
-### Tasks
-
-#### Task 4.1: Incremental Reservation Release for Fallback Strategy
-
-**Modified**: `packages/adapters/agent/ensemble-mapper.ts`, `packages/adapters/agent/agent-gateway.ts`
-
-- Change fallback strategy budget behavior:
-  - Current: Reserve N× upfront, hold until finalization
-  - New: Reserve 1× initially. On each failed attempt, reserve 1× more (incremental)
-  - Total reservation never exceeds N× (invariant preserved)
-  - On success at attempt K: release remaining (N-K) capacity
-- **BYOK/platform composition rule** (interacts with Sprint 1 Task 1.3):
-  - Reservation unit = cost estimate for **platform-only** models in the current attempt
-  - BYOK attempts do NOT increment the reservation counter (they cost 0 for platform budget)
-  - `attemptNumber` for reservation purposes counts only platform attempts, not total attempts
-  - Example: fallback [BYOK-A, platform-B, platform-C] → reserve 1× on attempt to B, reserve 1× more on attempt to C. BYOK-A attempt is free-pass (no reservation change)
-- Add `EnsembleMapper.computeIncrementalReservation()`:
-  ```typescript
-  computeIncrementalReservation(
-    strategy: EnsembleStrategy,
-    attemptNumber: number,  // 1-indexed, platform attempts only
-    platformModelCount: number,  // count of non-BYOK models in ensemble
-    baseCost: number,
-    accountingMode: 'PLATFORM_BUDGET' | 'BYOK_NO_BUDGET',
-  ): { reserveAdditional: number; releaseCapacity: number; }
-  ```
-- Update `AgentGateway` to call incremental reservation for fallback strategy only
-- `best_of_n` and `consensus` remain N× upfront (parallel execution requires it)
-
-**Acceptance Criteria**:
-- [ ] AC-4.1: Fallback strategy starts with 1× reservation (platform models only)
-- [ ] AC-4.2: Each failed platform attempt adds 1× additional reservation
-- [ ] AC-4.3: Successful attempt releases all remaining capacity
-- [ ] AC-4.4: Total reservation never exceeds platformModelCount× (invariant)
-- [ ] AC-4.5: `best_of_n` and `consensus` unchanged (still N× upfront)
-- [ ] AC-4.6: Unit tests for fallback with success at attempt 1, 2, N
-- [ ] AC-4.7: Unit test: fallback exhausts all N attempts → total reserved = platformModelCount×
-- [ ] AC-4.22: Unit test: mixed BYOK/platform fallback [BYOK, platform, platform] — BYOK attempt skips reservation, platform attempts reserve incrementally
-- [ ] AC-4.23: Unit test: all-BYOK fallback → zero platform reservation (edge case)
-- [ ] AC-4.24: Budget invariant `committed ≤ reserved` proven for all mixed fallback scenarios (at least 3 test vectors)
-
-#### Task 4.2: Capability Audit Log
-
-**New File**: `packages/adapters/agent/capability-audit.ts`
-**Modified**: `packages/adapters/agent/agent-gateway.ts`
-
-- Emit structured audit events for every capability exercise:
-  ```typescript
-  interface CapabilityAuditEvent {
-    event_type: 'pool_access' | 'byok_usage' | 'ensemble_invocation' | 'model_access';
-    timestamp: string;
-    trace_id: string;
-    community_id: string;
-    user_id: string;
-    pool_id: string;
-    access_level: string;
-    // Capability-specific fields
-    ensemble_strategy?: string;
-    ensemble_n?: number;
-    byok_provider?: string;
-    model_breakdown?: ModelInvocationResult[];
-    budget_reserved_micro?: number;
-    budget_committed_micro?: number;
-  }
-  ```
-- Emit via structured log (CloudWatch Log Metric Filters can aggregate)
-- Include lifecycle trace from `RequestLifecycle.getTrace()`
-- Respect data retention policy: no PII, no message content
-
-**Acceptance Criteria**:
-- [ ] AC-4.8: Every request emits at least one `capability_audit` event
-- [ ] AC-4.9: Ensemble requests emit `ensemble_invocation` with `model_breakdown`
-- [ ] AC-4.10: BYOK requests emit `byok_usage` with provider
-- [ ] AC-4.11: Events include lifecycle trace for debugging
-- [ ] AC-4.12: No PII or message content in audit events
-
-#### Task 4.3: Dashboard + Alarm Updates for Per-Model Metrics
-
-**Modified**: `infrastructure/terraform/agent-monitoring.tf`
-
-- Add new CloudWatch dashboard widgets:
-  - **Per-Model Cost Distribution**: Stacked bar chart showing cost by model ID
-  - **BYOK vs Platform Accounting**: Pie chart of `accounting_mode` distribution
-  - **Ensemble Savings**: Time series of `savings_micro` (reservation vs committed delta)
-  - **Token Estimate Accuracy**: Line chart of mean estimate error over time
-  - **Lifecycle State Distribution**: Bar chart of requests by final lifecycle state
-  - **Fleet Circuit Breaker**: Gauge showing shared CB state across containers
-- Add new alarms:
-  - **Token Estimate Drift**: Alert when mean estimate error > 100% for 15 min
-  - **Ensemble Budget Overrun**: Alert when any ensemble `savings_micro` < 0
-
-**Acceptance Criteria**:
-- [ ] AC-4.13: 6 new dashboard widgets added, each referencing an EMF metric emitted in Sprints 1/3: `PerModelCost`, `EnsembleSavings`, `TokenEstimateDrift`, `LifecycleFinalState`, `CircuitBreakerState`, and `accounting_mode` dimension on `PerModelCost`
-- [ ] AC-4.14: 2 new alarms configured with SNS: `TokenEstimateDrift` (mean > 100% for 15 min), `EnsembleSavings` (< 0 for any request)
-- [ ] AC-4.15: `terraform plan` validates cleanly
-- [ ] AC-4.16: Dashboard total ≥ 17 widgets (11 existing + 6 new)
-- [ ] AC-4.21: Smoke test: EMF log lines for each metric name validated against Terraform widget metric references (no orphan widgets)
-
-#### Task 4.4: Full E2E Regression + Documentation
-
-**Modified**: `tests/e2e/agent-gateway-e2e.test.ts`, `CLAUDE.md`
-
-- Run full E2E suite — verify all existing + new scenarios pass
-- Update CLAUDE.md Chain Provider Architecture section:
-  - Add per-model accounting documentation
-  - Add provider policy configuration documentation
-  - Add capability audit event format
-  - Update key files table with new files
-- Verify beads task closure for all sprint tasks
-
-**Acceptance Criteria**:
-- [ ] AC-4.17: All E2E tests pass (≥ 17 scenarios)
-- [ ] AC-4.18: CLAUDE.md updated with new architecture
-- [ ] AC-4.19: No lint/type errors across codebase
-- [ ] AC-4.20: All beads tasks closed
+- [ ] AC-1.13: Compatibility data lives in `packages/contracts/schema/compatibility.json`
+- [ ] AC-1.14: `compatibility.ts` loads data from JSON file at module init
+- [ ] AC-1.15: Load-time validation: missing required fields → throw at startup (fail-fast)
+- [ ] AC-1.16: JSON file included in `npm pack` output (via `files` array)
+- [ ] AC-1.17: `getCompatibility()` and `validateContractCompatibility()` work identically with loaded data
+- [ ] AC-1.18: All existing compatibility tests pass without modification
+- [ ] AC-1.19: Adding a new compatibility entry requires editing only `compatibility.json` (no TypeScript source code changes)
 
 ---
 
 ## Dependency Graph
 
 ```
-Sprint 1 (Per-Model Accounting)
-  ├─→ Sprint 2 (Contract Protocol + Policy) ────────┐
-  └─→ Sprint 3 (Lifecycle + Security) ──────────────┤
-                                                      ▼
-                                               Sprint 4 (Budget Optimization + Observability)
+Task 1.1 (Sorted Sets)  ──┐
+Task 1.2 (Audit Guard)  ──┼──→ Single commit: feat(sprint-1): BB7 protocol refinement
+Task 1.3 (Data-Driven)  ──┘
 ```
 
-Sprints 2 and 3 are **independent** and can be developed in either order.
-Sprint 4 **depends** on Sprints 1–3 (needs per-model metrics, lifecycle traces, and fleet CB before dashboard updates).
-
----
-
-## Rollback Criteria & Procedures
-
-### Sprint 1: Per-Model Accounting
-
-**Rollback trigger**: Usage report schema change breaks loa-finn consumption
-**Rollback steps**:
-1. Revert contract schema to `1.0.0` (remove `model_breakdown`)
-2. Revert `ensemble-accounting.ts` and gateway changes
-3. Run E2E suite to verify original 13 scenarios pass
-**Data safety**: Schema extension is additive — `model_breakdown` is optional. loa-finn should ignore unknown fields.
-
-### Sprint 2: Contract Package Move
-
-**Rollback trigger**: Import paths break across workspace
-**Rollback steps**:
-1. Restore `tests/e2e/contracts/` as import source
-2. Revert workspace configuration
-3. `pnpm install` to re-resolve
-**Data safety**: No runtime data affected — purely build-time change.
-
-### Sprint 3: Buffer Auth Headers
-
-**Rollback trigger**: Provider API rejects Buffer-based headers
-**Rollback steps**:
-1. Revert to string-based header construction (known working)
-2. Document that the V8 heap risk is accepted for now
-**Data safety**: No data loss — purely auth mechanism change.
-
-### Sprint 4: Incremental Reservation
-
-**Rollback trigger**: Budget accounting inconsistency in fallback strategy
-**Rollback steps**:
-1. Revert to N× upfront reservation for fallback
-2. Verify budget invariant (committed ≤ reserved) holds
-**Data safety**: Budget reservations auto-expire via TTL — no manual cleanup needed.
+All 3 tasks are independent — they modify different files with no cross-dependencies.
 
 ---
 
@@ -620,47 +172,23 @@ Sprint 4 **depends** on Sprints 1–3 (needs per-model metrics, lifecycle traces
 
 | Risk | Probability | Impact | Mitigation |
 |------|-------------|--------|------------|
-| Per-model accounting breaks existing E2E tests | Low | High | `model_breakdown` is optional in schema — backward compatible |
-| Buffer auth headers rejected by fetch API | Medium | Medium | Fallback to `node:http` module which natively supports Buffer headers |
-| Redis circuit breaker adds latency to BYOK path | Low | Medium | Lua script executes in <1ms; fallback to process-local if slow |
-| Contract package move breaks CI | Medium | Low | Update all imports in single commit; workspace resolution handles it |
-| Incremental reservation creates race condition | Medium | High | All reservation operations are atomic Redis INCRBY — no race window |
-
----
-
-## Sprint Metrics Targets
-
-| Sprint | Tasks | New Files | Modified Files | New Tests |
-|--------|-------|-----------|----------------|-----------|
-| Sprint 1 | 5 | 1 | 6 | 10+ |
-| Sprint 2 | 4 | 1 | 6 | 8+ |
-| Sprint 3 | 4 | 2 | 4 | 12+ |
-| Sprint 4 | 4 | 1 | 4 | 6+ |
-| **Total** | **17** | **5** | **20** | **36+** |
-
-### EMF Metric ↔ Dashboard Widget Map
-
-| Metric Name | Emitted In | Unit | Dimensions | Dashboard Widget |
-|-------------|-----------|------|------------|------------------|
-| `PerModelCost` | Sprint 1 (Task 1.3) | micro-USD | `model_id`, `provider`, `accounting_mode` | Per-Model Cost Distribution, BYOK vs Platform |
-| `EnsembleSavings` | Sprint 1 (Task 1.3) | micro-USD | `strategy` | Ensemble Savings |
-| `LifecycleFinalState` | Sprint 3 (Task 3.1) | Count | `final_state` | Lifecycle State Distribution |
-| `TokenEstimateDrift` | Sprint 3 (Task 3.4) | Percent | `model_alias` | Token Estimate Accuracy |
-| `CircuitBreakerState` | Sprint 3 (Task 3.3) | None (gauge) | `component`, `state` | Fleet Circuit Breaker |
+| Mixed-fleet sorted set rollout splits failure counts | Low | High | Phase A dual-write: new code writes both ZSET + CSV and migrates CSV→ZSET on read — fleet-wide count stays consistent |
+| Audit validation false positives block real events | Low | Medium | Guard logs warning + skips, never throws; unit tests verify both valid and invalid paths |
+| JSON import not resolved in compiled output | Low | Medium | TypeScript `resolveJsonModule` compiles JSON inline; no runtime file I/O needed |
+| JSON file not included in npm pack | Low | Low | Verified via `npm pack --dry-run` in acceptance criteria |
 
 ---
 
 ## FAANG Precedent Map
 
-| Sprint | Pattern | Precedent |
-|--------|---------|-----------|
-| Sprint 1 | Per-model cost attribution | AWS Cost Explorer: per-service, per-tag cost breakdown that enabled the entire FinOps discipline |
-| Sprint 2 | Protocol extraction from test infra | Protocol Buffers: Google's `.proto` files evolved from internal docs to the internet's serialization standard |
-| Sprint 3 | Fleet-wide circuit breaker | Netflix Hystrix → resilience4j: process-local CB was insufficient at scale, leading to shared state patterns |
-| Sprint 4 | Incremental resource reservation | AWS EC2 Spot: capacity released incrementally as winning bids are determined, not held until auction closes |
+| Task | Pattern | Precedent |
+|------|---------|-----------|
+| Task 1.1 | Sorted set for time-windowed counting | Uber rate limiter (2018): ZADD for sliding window counters at 100M+ RPM |
+| Task 1.2 | Runtime validation of audit events | AWS CloudTrail: validates event structure before emission; Google Cloud Audit Logs use protobuf schemas |
+| Task 1.3 | Data-driven configuration | gRPC service config loaded from JSON; Kubernetes API server loads storage media types from configuration |
 
 ---
 
 **Document Owner**: Hounfour Integration Team
 **Review Cadence**: Per sprint completion
-**Bridgebuilder Review**: Requested after Sprint 4 (Round 7)
+**Bridgebuilder Review**: Round 8 after implementation

--- a/packages/contracts/schema/compatibility.json
+++ b/packages/contracts/schema/compatibility.json
@@ -1,0 +1,16 @@
+[
+  {
+    "arrakis_version": ">=0.1.0",
+    "loa_finn_version": ">=0.1.0",
+    "contract_version": "1.0.0",
+    "status": "supported",
+    "notes": "Initial contract — base pool mapping, JWT claims, usage reports"
+  },
+  {
+    "arrakis_version": ">=0.1.0",
+    "loa_finn_version": ">=0.1.0",
+    "contract_version": "1.1.0",
+    "status": "supported",
+    "notes": "Per-model accounting — model_breakdown in usage reports (backward-compatible)"
+  }
+]


### PR DESCRIPTION
## Summary

Implements all 3 critical findings from Bridgebuilder Round 7 review of PR #55 (The Capability Mesh).

| Finding | File | Change |
|---------|------|--------|
| **R7-1** (Scalability) | `redis-circuit-breaker.ts` | CSV failure tracking → Redis sorted sets (O(log n)) with Phase A dual-write for mixed-fleet safety |
| **R7-3** (Reliability) | `capability-audit.ts` | Runtime required-field validation before audit event emission (warn + skip, never throw) |
| **R7-4** (Maintainability) | `compatibility.ts` + `compatibility.json` | Hardcoded TS array → JSON import with load-time validation |

### Sprint Breakdown

| Sprint | Status | Cycles | Files Changed |
|--------|--------|--------|---------------|
| sprint-1 | Complete | 1 | 7 |

### Key Design Decisions

- **Mixed-fleet dual-write**: During rolling deployment, new Lua scripts write failures to both sorted set AND legacy CSV hash field. Old containers read CSV, new containers read sorted set + migrate CSV on access. Fleet-wide failure count stays consistent.
- **Audit guard is non-blocking**: Missing required fields log a warning and skip emission — audit events never crash requests.
- **JSON import via `resolveJsonModule`**: No `readFileSync` — TypeScript resolves JSON at compile time, avoiding runtime path issues in ESM/bundler environments.

### GPT 5.2 Cross-Model Review

| Phase | Iterations | Verdict |
|-------|-----------|---------|
| Sprint Plan | 3 | APPROVED |
| Code | 2 | APPROVED |

### Test plan

- [ ] Verify `LUA_FAILURE` uses `ZREMRANGEBYSCORE` + `ZADD` + `ZCARD` (not CSV parsing)
- [ ] Verify `LUA_SUCCESS` clears both sorted set and legacy CSV field
- [ ] Verify audit event with empty `trace_id` logs warning and skips emission
- [ ] Verify valid audit events pass validation without false positives
- [ ] Verify `compatibility.json` loads correctly via TypeScript import
- [ ] Verify malformed compatibility JSON throws at startup (fail-fast)
- [ ] Run `tsc --noEmit` — 0 new errors introduced

Generated with [Claude Code](https://claude.com/claude-code)