### PR TITLE
chore(deps): consolidate dependency bumps

### DIFF
--- a/apps/gateway/Cargo.toml
+++ b/apps/gateway/Cargo.toml
@@ -30,8 +30,8 @@ dotenvy = "0.15"
 # Observability (Sprint S-4)
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-metrics = "0.21"
-metrics-exporter-prometheus = "0.12"
+metrics = "0.24"
+metrics-exporter-prometheus = "0.18"
 
 # HTTP server for health endpoints (Sprint S-4)
 axum = "0.8"
@@ -44,7 +44,7 @@ thiserror = "2"
 uuid = { version = "1", features = ["v4"] }
 
 # Concurrent data structures (Sprint S-4)
-dashmap = "5"
+dashmap = "6"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -45,10 +45,10 @@
   },
   "devDependencies": {
     "@types/amqplib": "^0.10.5",
-    "@types/node": "^22.19.8",
+    "@types/node": "^22.19.10",
     "@types/opossum": "^8.1.7",
     "@vitest/coverage-v8": "^4.0.18",
-    "msw": "^2.12.8",
+    "msw": "^2.12.9",
     "tsx": "^4.19.2",
     "typescript": "^5.6.3",
     "vitest": "^4.0.17"


### PR DESCRIPTION
## Summary

Consolidates 4 Dependabot PRs into a single update. Twilight ecosystem upgrades are deferred due to breaking API changes.

### Included

| Package | From | To | Scope |
|---------|------|----|-------|
| dashmap | 5 | 6 | gateway (Rust) |
| metrics | 0.21 | 0.24 | gateway (Rust) |
| metrics-exporter-prometheus | 0.12 | 0.18 | gateway (Rust) |
| @types/node | ^22.19.8 | ^22.19.10 | worker (Node) |
| msw | ^2.12.8 | ^2.12.9 | worker (Node) |

### Excluded (deferred)

| Package | From | To | Reason |
|---------|------|----|--------|
| twilight-http | 0.15 | 0.17 | Breaking: Config API, ShardId u64→u32, error handling |
| twilight-model | 0.15 | 0.17 | Breaking: GuildCreate field→method, event variant changes |

The twilight ecosystem 0.15→0.17 upgrade requires code changes across `pool.rs`, `serialize.rs`, and `state.rs`. Tracked separately.

### Audit

- **dashmap 6**: Only uses `.get()`, `.get_mut()`, `.insert()`, `.iter()`, `.len()` — no `.entry()` API (which changed). Safe.
- **metrics 0.24**: Uses `counter!`, `histogram!`, `gauge!`, `describe_*` macros. Basic macro API stable. Safe.
- **metrics-exporter-prometheus 0.18**: Uses `PrometheusBuilder::new().install_recorder()` and `.render()`. Core API stable. Safe.
- **@types/node, msw**: Dev dependencies, patch bumps. Safe.

### Note

The gateway has pre-existing compilation issues from `twilight-gateway` already being at 0.17 while `twilight-model`/`twilight-http` remain at 0.15 (version skew). This PR does not worsen the situation.

Supersedes: #41, #42, #44, #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)