### PR TITLE
fix(ci): remove Template Protection guard — unblock CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,94 +8,10 @@ on:
 
 jobs:
   # =============================================================================
-  # TEMPLATE PROTECTION - Blocks forbidden files from being committed
+  # VALIDATE - Check framework files, JSON, versions, links
   # =============================================================================
-  template-guard:
-    name: Template Protection
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Block forbidden template files
-        id: check-forbidden
-        run: |
-          echo "Checking for forbidden template files..."
-
-          # Define forbidden patterns for the loa template repository
-          # These files should NEVER be committed to the main loa template
-          FORBIDDEN_FILES=(
-            "grimoires/loa/prd.md"
-            "grimoires/loa/sdd.md"
-            "grimoires/loa/sprint.md"
-            "grimoires/loa/NOTES.md"
-            "grimoires/loa/ledger.json"
-            "grimoires/loa/ledger.json.bak"
-          )
-
-          FORBIDDEN_DIRS=(
-            "grimoires/loa/a2a/sprint-"
-            "grimoires/loa/a2a/index.md"
-            "grimoires/loa/a2a/deployment-feedback.md"
-            "grimoires/loa/a2a/trajectory/"
-            "grimoires/loa/deployment/"
-            "grimoires/loa/reality/"
-            "grimoires/loa/analytics/"
-            "grimoires/loa/research/"
-            "grimoires/pub/"
-            ".claude/constructs/"
-          )
-
-          VIOLATIONS=()
-
-          # Check for forbidden files
-          for pattern in "${FORBIDDEN_FILES[@]}"; do
-            if [ -f "$pattern" ]; then
-              VIOLATIONS+=("$pattern")
-            fi
-          done
-
-          # Check for forbidden directories/patterns
-          for pattern in "${FORBIDDEN_DIRS[@]}"; do
-            # Find any files matching the pattern (excluding README.md)
-            while IFS= read -r file; do
-              if [[ "$file" != *"/README.md" ]]; then
-                VIOLATIONS+=("$file")
-              fi
-            done < <(find . -path "./$pattern*" -type f 2>/dev/null | head -50)
-          done
-
-          if [ ${#VIOLATIONS[@]} -gt 0 ]; then
-            echo ""
-            echo "============================================================"
-            echo "ERROR: Forbidden files detected in template repository!"
-            echo "============================================================"
-            echo ""
-            echo "The following files must NOT be committed to the loa template:"
-            echo ""
-            for file in "${VIOLATIONS[@]}"; do
-              echo "  - $file"
-            done
-            echo ""
-            echo "These files are project-specific or contain licensed content and should be gitignored."
-            echo "Note: .claude/constructs/ contains user-licensed skills that should never be committed."
-            echo "If this is intentional, add [skip-template-guard] to commit message."
-            echo "============================================================"
-            exit 1
-          fi
-
-          echo "Template protection check passed - no forbidden files found"
-
-      - name: Check for skip override
-        if: failure() && contains(github.event.head_commit.message, '[skip-template-guard]')
-        run: |
-          echo "WARNING: Template guard bypassed via [skip-template-guard] in commit message"
-          echo "This should only be used for exceptional circumstances!"
-
   validate:
     name: Validate Framework Files
-    needs: template-guard
     runs-on: ubuntu-latest
 
     steps:
@@ -231,7 +147,6 @@ jobs:
 
   markdown-lint:
     name: Lint Markdown
-    needs: template-guard
     runs-on: ubuntu-latest
 
     steps:
@@ -265,7 +180,6 @@ jobs:
 
   yaml-lint:
     name: Lint YAML
-    needs: template-guard
     runs-on: ubuntu-latest
 
     steps:
@@ -284,7 +198,6 @@ jobs:
   # =============================================================================
   unit-tests:
     name: Unit Tests
-    needs: template-guard
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -318,7 +231,6 @@ jobs:
   # =============================================================================
   integration-tests:
     name: Integration Tests
-    needs: template-guard
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
## Summary

- Remove `template-guard` job from `ci.yml` — it was designed for the loa template repo and has been blocking all CI on project repos since inception
- Remove `needs: template-guard` from all downstream jobs (validate, lint, unit tests, integration tests)
- All CI jobs now run independently without a gating dependency

## Context

The Template Protection guard blocks grimoire files (`prd.md`, `sdd.md`, `reality/`, `a2a/`, `deployment/`) that legitimately exist in loa-freeside. Since all downstream CI jobs had `needs: template-guard`, they were always SKIPPED when the guard failed. **CI has never passed on loa-freeside.**

This is Phase 0 (Unblock CI) from the [Command Deck staging deployment sequence](https://github.com/0xHoneyJar/loa-finn/issues/66#issuecomment-3970362541).

## What Changes

| Before | After |
|--------|-------|
| template-guard always FAILS (grimoire files exist) | No template-guard (project repo, not template) |
| validate, lint, tests always SKIPPED | All jobs run independently |
| CI has **never passed** on loa-freeside | CI should pass (first time) |

## Test plan

- [ ] CI workflow runs on this PR (validate, lint, unit tests, integration tests all execute)
- [ ] Verify no regressions in Secret Scanning, Security Audit workflows (independent)
- [ ] After merge, confirm main branch CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)