### PR TITLE
infra: GitHub OIDC role for loa-finn CI deploys

### DIFF
--- a/infrastructure/terraform/ci-finn.tf
+++ b/infrastructure/terraform/ci-finn.tf
@@ -1,0 +1,114 @@
+# =============================================================================
+# GitHub Actions OIDC for loa-finn CI Deploys
+# =============================================================================
+# Creates an IAM role that loa-finn's GitHub Actions can assume via OIDC
+# to push Docker images to ECR and trigger ECS redeployments.
+#
+# Usage in loa-finn's .github/workflows/deploy-staging.yml:
+#   role-to-assume: <output.finn_ci_deploy_role_arn>
+#
+# References:
+#   - loa-finn issue #114 (staging infra migration)
+#   - Finn's deploy-staging.yml uses aws-actions/configure-aws-credentials
+#     with role-to-assume (OIDC, not static credentials)
+# =============================================================================
+
+# GitHub OIDC provider (account-level, likely already exists from prior setup)
+# Using data source to reference existing provider. If terraform plan fails
+# with "not found", create the provider resource instead (see comment below).
+data "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+# Uncomment if OIDC provider doesn't exist in this AWS account:
+# resource "aws_iam_openid_connect_provider" "github" {
+#   url             = "https://token.actions.githubusercontent.com"
+#   client_id_list  = ["sts.amazonaws.com"]
+#   thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+#   tags = merge(local.common_tags, { Name = "GitHub Actions OIDC" })
+# }
+
+# --- IAM Role for loa-finn CI ---
+
+resource "aws_iam_role" "finn_ci_deploy" {
+  name = "${local.name_prefix}-finn-ci-deploy"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = data.aws_iam_openid_connect_provider.github.arn
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+        }
+        StringLike = {
+          # Allow main branch pushes and environment-scoped tokens
+          "token.actions.githubusercontent.com:sub" = [
+            "repo:0xHoneyJar/loa-finn:ref:refs/heads/main",
+            "repo:0xHoneyJar/loa-finn:environment:staging"
+          ]
+        }
+      }
+    }]
+  })
+
+  tags = merge(local.common_tags, {
+    Service = "Finn"
+    Purpose = "CI/CD deploy from GitHub Actions"
+  })
+}
+
+# --- Least-Privilege Policy: ECR Push + ECS Deploy ---
+
+resource "aws_iam_role_policy" "finn_ci_deploy" {
+  name = "${local.name_prefix}-finn-ci-deploy-policy"
+  role = aws_iam_role.finn_ci_deploy.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ECRAuth"
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "ECRPush"
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
+          "ecr:PutImage"
+        ]
+        Resource = aws_ecr_repository.finn.arn
+      },
+      {
+        Sid    = "ECSDeployFinn"
+        Effect = "Allow"
+        Action = [
+          "ecs:UpdateService",
+          "ecs:DescribeServices"
+        ]
+        Resource = "arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:service/${aws_ecs_cluster.main.name}/${local.name_prefix}-finn"
+      }
+    ]
+  })
+}
+
+# --- Output for Finn repo secrets ---
+
+output "finn_ci_deploy_role_arn" {
+  description = "IAM role ARN for loa-finn GitHub Actions (set as AWS_DEPLOY_ROLE_ARN secret)"
+  value       = aws_iam_role.finn_ci_deploy.arn
+}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions OIDC IAM role so loa-finn's CI can push Docker images to ECR and trigger ECS redeployments without static credentials.

- Creates `arrakis-staging-finn-ci-deploy` IAM role with OIDC trust scoped to `repo:0xHoneyJar/loa-finn:ref:refs/heads/main` and `environment:staging`
- Least-privilege policy: ECR push to `arrakis-staging-loa-finn` + ECS update-service on `arrakis-staging-finn`
- Outputs `finn_ci_deploy_role_arn` for setting as `AWS_DEPLOY_ROLE_ARN` secret in Finn repo

## Context

Part of the staging infrastructure migration (loa-finn issue [#114](https://github.com/0xHoneyJar/loa-finn/issues/114)). Finn's stale Terraform and deploy scripts have been removed ([`c30f745`](https://github.com/0xHoneyJar/loa-finn/commit/c30f745)), and its CI now targets Freeside-managed service names. But Finn CI has **never had working AWS credentials** — deploys were manual. This PR creates the missing OIDC role so Finn CI can self-serve.

Dixie cleanup is also complete (see [issue comment](https://github.com/0xHoneyJar/loa-finn/issues/114#issuecomment-3982036449)).

## After merge

1. `terraform plan` + `terraform apply` to create the IAM role
2. Copy the `finn_ci_deploy_role_arn` output value
3. Set it as `AWS_DEPLOY_ROLE_ARN` secret in loa-finn repo settings
4. Run Finn's deploy-staging workflow to verify

## Note on OIDC provider

The terraform uses `data "aws_iam_openid_connect_provider" "github"` to reference an existing provider. If `terraform plan` fails with "not found", the commented-out `resource` block can be uncommented to create it.

## Test plan

- [ ] `terraform plan` shows only new resources (role + policy + output), no destructive changes
- [ ] `terraform apply` creates the role
- [ ] Set ARN as Finn repo secret, trigger Finn CI, verify ECR push + ECS deploy succeeds
- [ ] Verify OIDC trust rejects unauthorized repos (only `0xHoneyJar/loa-finn` on `main` or `staging` env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)