### PR TITLE
feat(infra): AWS API Gateway auth proxy for Dynamic Labs SSO

### DIFF
--- a/grimoires/loa/a2a/gpt-review/code-findings-3.json
+++ b/grimoires/loa/a2a/gpt-review/code-findings-3.json
@@ -1,13 +1,38 @@
 {
-  "verdict": "APPROVED",
-  "summary": "Previous feedback was addressed by asserting the exact expected genesis hash value, and no new blocking issues were introduced.",
-  "previous_issues_status": [
+  "verdict": "CHANGES_REQUIRED",
+  "summary": "CORS configuration is insecure/invalid for credentialed requests, proxy integration URI will break root route, and API mapping references the wrong stage field.",
+  "issues": [
     {
-      "original_issue": "Tests only validated format of SCORING_PATH_GENESIS_HASH and not the exact expected value",
-      "status": "fixed",
-      "notes": "Added an exact match assertion for the SHA-256 of the empty string."
+      "severity": "critical",
+      "file": "infrastructure/terraform/auth-proxy.tf",
+      "line": 25,
+      "description": "CORS allow_origins includes wildcard patterns and untrusted domains while allow_credentials=true. HTTP API CORS does not support wildcard subdomains, and credentialed CORS with broad origins creates a cookie-leak risk.",
+      "current_code": "```hcl\n  cors_configuration {\n    allow_origins     = [\n      \"https://*.0xhoneyjar.xyz\",\n      \"https://0xhoneyjar.xyz\",\n      \"https://*.vercel.app\",\n    ]\n    allow_methods     = [\"GET\", \"POST\", \"PUT\", \"DELETE\", \"OPTIONS\", \"PATCH\"]\n    allow_headers     = [\"*\"]\n    expose_headers    = [\"*\"]\n    allow_credentials = true\n    max_age           = 86400\n  }\n```",
+      "fixed_code": "```hcl\nlocals {\n  # Explicit allowlist required for credentialed CORS (no wildcards).\n  auth_proxy_allowed_origins = [\n    \"https://0xhoneyjar.xyz\",\n    \"https://app.0xhoneyjar.xyz\",\n    \"https://dashboard.0xhoneyjar.xyz\",\n    \"https://community.0xhoneyjar.xyz\",\n  ]\n}\n\n  cors_configuration {\n    allow_origins     = local.auth_proxy_allowed_origins\n    allow_methods     = [\"GET\", \"POST\", \"PUT\", \"DELETE\", \"OPTIONS\", \"PATCH\"]\n    allow_headers     = [\"Authorization\", \"Content-Type\", \"X-Requested-With\", \"Accept\", \"Origin\"]\n    expose_headers    = [\"Content-Length\", \"Content-Type\"]\n    allow_credentials = true\n    max_age           = 86400\n  }\n```",
+      "explanation": "HTTP API CORS does not accept wildcard subdomains and browsers disallow credentialed CORS with wildcard origins. An explicit allowlist prevents credential leakage to arbitrary origins and ensures CORS config applies reliably."
+    },
+    {
+      "severity": "major",
+      "file": "infrastructure/terraform/auth-proxy.tf",
+      "line": 60,
+      "description": "integration_uri uses a {proxy} path parameter that does not exist on the root route (ANY /), causing failures or forwarding to a literal {proxy} path. HTTP API proxy integrations automatically append the request path.",
+      "current_code": "```hcl\nresource \"aws_apigatewayv2_integration\" \"dynamic_proxy\" {\n  api_id             = aws_apigatewayv2_api.auth_proxy.id\n  integration_type   = \"HTTP_PROXY\"\n  integration_method = \"ANY\"\n  integration_uri    = \"https://app.dynamic.xyz/{proxy}\"\n\n  # Forward all headers including cookies for SSO\n  request_parameters = {\n    \"overwrite:header.host\" = \"app.dynamic.xyz\"\n  }\n}\n```",
+      "fixed_code": "```hcl\nresource \"aws_apigatewayv2_integration\" \"dynamic_proxy\" {\n  api_id             = aws_apigatewayv2_api.auth_proxy.id\n  integration_type   = \"HTTP_PROXY\"\n  integration_method = \"ANY\"\n  # HTTP API appends the incoming path/query automatically.\n  integration_uri    = \"https://app.dynamic.xyz\"\n\n  # Forward all headers including cookies for SSO\n  request_parameters = {\n    \"overwrite:header.host\" = \"app.dynamic.xyz\"\n  }\n}\n```",
+      "explanation": "Using {proxy} in the integration URI breaks the root route because there is no path parameter to substitute. For HTTP API proxy integrations, the request path and query string are automatically forwarded when the base URI is provided."
+    },
+    {
+      "severity": "major",
+      "file": "infrastructure/terraform/auth-proxy.tf",
+      "line": 140,
+      "description": "API mapping stage uses the stage ID instead of the stage name. The API mapping expects the stage name and can fail or map incorrectly.",
+      "current_code": "```hcl\nresource \"aws_apigatewayv2_api_mapping\" \"auth\" {\n  api_id      = aws_apigatewayv2_api.auth_proxy.id\n  domain_name = aws_apigatewayv2_domain_name.auth.id\n  stage       = aws_apigatewayv2_stage.default.id\n}\n```",
+      "fixed_code": "```hcl\nresource \"aws_apigatewayv2_api_mapping\" \"auth\" {\n  api_id      = aws_apigatewayv2_api.auth_proxy.id\n  domain_name = aws_apigatewayv2_domain_name.auth.id\n  stage       = aws_apigatewayv2_stage.default.name\n}\n```",
+      "explanation": "The API mapping requires the stage name (e.g., \"$default\"), not the stage ID. Using the name ensures correct custom domain mapping."
     }
   ],
-  "new_blocking_concerns": [],
-  "iteration": 2
+  "fabrication_check": {
+    "passed": true,
+    "concerns": []
+  },
+  "iteration": 1
 }

--- a/grimoires/loa/a2a/gpt-review/code-findings-4.json
+++ b/grimoires/loa/a2a/gpt-review/code-findings-4.json
@@ -1,29 +1,23 @@
 {
-  "verdict": "CHANGES_REQUIRED",
-  "summary": "Two blocking issues found: unreliable vector path resolution in monorepos/workspaces and missing assertions for invalid JWT vectors allowing false positives.",
-  "issues": [
+  "verdict": "APPROVED",
+  "summary": "All previously identified issues have been addressed correctly with no new blocking problems introduced.",
+  "previous_issues_status": [
     {
-      "severity": "major",
-      "file": "tests/protocol-conformance.test.ts",
-      "line": 39,
-      "description": "resolveVectorsDir hardcodes a node_modules path that fails in workspaces/hoisted installs, causing tests to break when the package is not physically located at that path.",
-      "current_code": "```typescript\nfunction resolveVectorsDir(): string {\n  // Walk up from this test file to find node_modules (vitest doesn't support import.meta.resolve)\n  const __dirname = dirname(fileURLToPath(import.meta.url));\n  const root = resolve(__dirname, '..', '..');\n  return resolve(root, 'node_modules', '@0xhoneyjar', 'loa-hounfour', 'vectors');\n}\n```",
-      "fixed_code": "```typescript\nfunction resolveVectorsDir(): string {\n  // Resolve package root reliably in monorepos/hoisted installs\n  const require = createRequire(import.meta.url);\n  const pkgJsonPath = require.resolve('@0xhoneyjar/loa-hounfour/package.json');\n  return resolve(dirname(pkgJsonPath), 'vectors');\n}\n```",
-      "explanation": "Using Node's module resolution ensures the vectors directory is found regardless of hoisting or workspace layout, preventing path resolution failures."
+      "original_issue": "CORS allow_origins included wildcards/untrusted domains while allow_credentials=true",
+      "status": "fixed",
+      "notes": "Now uses an explicit allowlist with specific origins and tightened headers, which is valid for credentialed CORS."
     },
     {
-      "severity": "major",
-      "file": "tests/protocol-conformance.test.ts",
-      "line": 160,
-      "description": "Invalid JWT vectors are never asserted; the test allows schema-valid claims to pass even when vectors are marked invalid, masking regressions.",
-      "current_code": "```typescript\n    it(`[${vector.id}] ${vector.description}`, () => {\n      const result = validate(JwtClaimsSchema, vector.claims);\n      if (vector.expected === 'valid') {\n        // Some vectors test JWT-level concerns (expiry, audience) that schema\n        // validation alone doesn't cover. Schema only validates shape/types.\n        // For \"valid\" vectors, the claims shape should at minimum parse.\n        if (!result.valid) {\n          // If schema rejects a \"valid\" vector, it's likely a JWT-level test\n          // (e.g., expired token) where claims are structurally valid but\n          // logically expired. This is expected — schema validates structure only.\n          // Check if the only failures are non-structural (key rotation, expiry)\n          const structuralErrors = (result.errors || []).filter(\n            (e) => !e.includes('exp') && !e.includes('iat') && !e.includes('kid'),\n          );\n          if (structuralErrors.length > 0) {\n            expect(result.valid, `Expected valid but got errors: ${result.errors?.join(', ')}`).toBe(true);\n          }\n        }\n      }\n      // For \"invalid\" vectors, we just verify the schema catches them or they have\n      // JWT-level errors that our runtime would catch\n    });\n```",
-      "fixed_code": "```typescript\n    it(`[${vector.id}] ${vector.description}`, () => {\n      const result = validate(JwtClaimsSchema, vector.claims);\n      if (vector.expected === 'valid') {\n        // Some vectors test JWT-level concerns (expiry, audience) that schema\n        // validation alone doesn't cover. Schema only validates shape/types.\n        // For \"valid\" vectors, the claims shape should at minimum parse.\n        if (!result.valid) {\n          // If schema rejects a \"valid\" vector, it's likely a JWT-level test\n          // (e.g., expired token) where claims are structurally valid but\n          // logically expired. This is expected — schema validates structure only.\n          // Check if the only failures are non-structural (key rotation, expiry)\n          const structuralErrors = (result.errors || []).filter(\n            (e) => !e.includes('exp') && !e.includes('iat') && !e.includes('kid'),\n          );\n          if (structuralErrors.length > 0) {\n            expect(result.valid, `Expected valid but got errors: ${result.errors?.join(', ')}`).toBe(true);\n          }\n        }\n      } else {\n        // For \"invalid\" vectors, schema should reject them unless they are\n        // explicitly JWT-level invalidations (e.g., exp/iat/nbf/aud/iss/signature).\n        if (result.valid) {\n          const err = (vector.error ?? '').toLowerCase();\n          const jwtOnly = /exp|iat|nbf|aud|iss|kid|signature|alg|token|issuer|audience/.test(err);\n          if (!jwtOnly) {\n            expect(\n              result.valid,\n              `Expected invalid but schema accepted claims; error=${vector.error ?? 'none'}`,\n            ).toBe(false);\n          }\n        } else {\n          expect(result.valid).toBe(false);\n        }\n      }\n    });\n```",
-      "explanation": "This enforces invalid vectors, while still allowing JWT-level invalidations that schema validation does not cover."
+      "original_issue": "integration_uri used {proxy} placeholder causing root route failures",
+      "status": "fixed",
+      "notes": "integration_uri is now the base host, relying on HTTP API path forwarding."
+    },
+    {
+      "original_issue": "API mapping stage referenced stage ID instead of stage name",
+      "status": "fixed",
+      "notes": "Stage now uses aws_apigatewayv2_stage.default.name."
     }
   ],
-  "fabrication_check": {
-    "passed": true,
-    "concerns": []
-  },
-  "iteration": 1
+  "new_blocking_concerns": [],
+  "iteration": 2
 }

--- a/grimoires/loa/a2a/gpt-review/code-findings-5.json
+++ b/grimoires/loa/a2a/gpt-review/code-findings-5.json
@@ -1,13 +1,23 @@
 {
   "verdict": "APPROVED",
-  "summary": "The routing override now validates shapes at runtime and safely falls back, resolving the prior crash risk.",
+  "summary": "All previously identified issues remain fixed and no new blocking problems were introduced.",
   "previous_issues_status": [
     {
-      "original_issue": "resolvePoolId() assumed routingOverride.policy.personalities array shape and could throw on malformed policy",
+      "original_issue": "CORS allow_origins included wildcards/untrusted domains while allow_credentials=true",
       "status": "fixed",
-      "notes": "Runtime validation now guards personalities array and task_routing object before access, preventing .find crashes and preserving fallback behavior."
+      "notes": "Explicit allowlist with credentialed CORS is still in place."
+    },
+    {
+      "original_issue": "integration_uri used {proxy} placeholder causing root route failures",
+      "status": "fixed",
+      "notes": "integration_uri remains the base host with proper path forwarding."
+    },
+    {
+      "original_issue": "API mapping stage referenced stage ID instead of stage name",
+      "status": "fixed",
+      "notes": "Stage mapping uses aws_apigatewayv2_stage.default.name."
     }
   ],
   "new_blocking_concerns": [],
-  "iteration": 2
+  "iteration": 3
 }

--- a/infrastructure/terraform/auth-proxy.tf
+++ b/infrastructure/terraform/auth-proxy.tf
@@ -1,0 +1,207 @@
+# =============================================================================
+# Dynamic Auth Proxy — AWS API Gateway HTTP API
+# =============================================================================
+#
+# Replaces Dynamic Labs' custom domain proxy (alias.app.dynamicauth.com) with
+# an AWS-managed transparent proxy that correctly sets CORS headers on ALL
+# responses — including 404s and other error codes.
+#
+# Root cause: Dynamic's proxy only sets CORS headers on 2xx responses. When
+# the SDK hits /csrf (404), the browser sees a CORS violation instead of a
+# clean 404, breaking SDK initialization.
+#
+# Architecture:
+#   auth.0xhoneyjar.xyz → API Gateway HTTP API → app.dynamic.xyz
+#
+# References:
+#   - https://github.com/0xHoneyJar/mcv-interface/issues/7
+#   - infrastructure/terraform/dns/honeyjar-xyz-auth.tf (DNS records)
+#
+# Rollback: Change DNS record back to alias.app.dynamicauth.com
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# API Gateway HTTP API
+# -----------------------------------------------------------------------------
+
+resource "aws_apigatewayv2_api" "auth_proxy" {
+  name          = "${local.name_prefix}-auth-proxy"
+  protocol_type = "HTTP"
+  description   = "Transparent proxy to Dynamic Labs API with CORS on all responses"
+
+  cors_configuration {
+    # Explicit allowlist required — credentialed CORS forbids wildcard origins.
+    # Add new subdomains here as apps are deployed.
+    allow_origins = [
+      "https://0xhoneyjar.xyz",
+      "https://moneycomb.0xhoneyjar.xyz",
+      "https://honey.0xhoneyjar.xyz",
+      "https://hub.0xhoneyjar.xyz",
+      "https://midi.0xhoneyjar.xyz",
+      "https://mibera.0xhoneyjar.xyz",
+      "https://cubquests.0xhoneyjar.xyz",
+      "https://henlo.0xhoneyjar.xyz",
+      "https://auction.0xhoneyjar.xyz",
+      "https://app.0xhoneyjar.xyz",
+      "https://staging.0xhoneyjar.xyz",
+    ]
+    allow_methods     = ["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"]
+    allow_headers     = ["Authorization", "Content-Type", "X-Requested-With", "Accept", "Origin"]
+    expose_headers    = ["Content-Length", "Content-Type"]
+    allow_credentials = true
+    max_age           = 86400
+  }
+
+  tags = merge(local.common_tags, {
+    Service = "AuthProxy"
+    Purpose = "Dynamic Labs CORS proxy"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# HTTP Proxy Integration → Dynamic Labs
+# -----------------------------------------------------------------------------
+
+resource "aws_apigatewayv2_integration" "dynamic_proxy" {
+  api_id             = aws_apigatewayv2_api.auth_proxy.id
+  integration_type   = "HTTP_PROXY"
+  integration_method = "ANY"
+  # HTTP API appends incoming path/query automatically — no {proxy} placeholder needed.
+  integration_uri    = "https://app.dynamic.xyz"
+
+  # Forward all headers including cookies for SSO
+  request_parameters = {
+    "overwrite:header.host" = "app.dynamic.xyz"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Catch-all Route
+# -----------------------------------------------------------------------------
+
+resource "aws_apigatewayv2_route" "proxy_route" {
+  api_id    = aws_apigatewayv2_api.auth_proxy.id
+  route_key = "ANY /{proxy+}"
+  target    = "integrations/${aws_apigatewayv2_integration.dynamic_proxy.id}"
+}
+
+# Root path route (for /api/v0 direct hits)
+resource "aws_apigatewayv2_route" "root_route" {
+  api_id    = aws_apigatewayv2_api.auth_proxy.id
+  route_key = "ANY /"
+  target    = "integrations/${aws_apigatewayv2_integration.dynamic_proxy.id}"
+}
+
+# -----------------------------------------------------------------------------
+# Stage (auto-deploy)
+# -----------------------------------------------------------------------------
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.auth_proxy.id
+  name        = "$default"
+  auto_deploy = true
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.auth_proxy.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      ip             = "$context.identity.sourceIp"
+      requestTime    = "$context.requestTime"
+      httpMethod     = "$context.httpMethod"
+      routeKey       = "$context.routeKey"
+      status         = "$context.status"
+      protocol       = "$context.protocol"
+      responseLength = "$context.responseLength"
+      integrationStatus = "$context.integrationStatus"
+      path           = "$context.path"
+    })
+  }
+
+  tags = merge(local.common_tags, {
+    Service = "AuthProxy"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# CloudWatch Logs
+# -----------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "auth_proxy" {
+  name              = "/aws/apigateway/${local.name_prefix}-auth-proxy"
+  retention_in_days = 14
+
+  tags = merge(local.common_tags, {
+    Service = "AuthProxy"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# ACM Certificate for auth.0xhoneyjar.xyz
+# -----------------------------------------------------------------------------
+
+resource "aws_acm_certificate" "auth_proxy" {
+  domain_name       = "auth.0xhoneyjar.xyz"
+  validation_method = "DNS"
+
+  tags = merge(local.common_tags, {
+    Service = "AuthProxy"
+    Purpose = "TLS for auth proxy custom domain"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Custom Domain
+# -----------------------------------------------------------------------------
+
+resource "aws_apigatewayv2_domain_name" "auth" {
+  domain_name = "auth.0xhoneyjar.xyz"
+
+  domain_name_configuration {
+    certificate_arn = aws_acm_certificate.auth_proxy.arn
+    endpoint_type   = "REGIONAL"
+    security_policy = "TLS_1_2"
+  }
+
+  tags = merge(local.common_tags, {
+    Service = "AuthProxy"
+  })
+
+  depends_on = [aws_acm_certificate_validation.auth_proxy]
+}
+
+# Certificate validation (DNS record created in the DNS root)
+resource "aws_acm_certificate_validation" "auth_proxy" {
+  certificate_arn = aws_acm_certificate.auth_proxy.arn
+
+  # Validation happens via DNS record — see dns/honeyjar-xyz-auth.tf
+  # The validation record must exist before this resource completes.
+  # For initial apply, you may need to apply the DNS root first.
+}
+
+# -----------------------------------------------------------------------------
+# API Mapping
+# -----------------------------------------------------------------------------
+
+resource "aws_apigatewayv2_api_mapping" "auth" {
+  api_id      = aws_apigatewayv2_api.auth_proxy.id
+  domain_name = aws_apigatewayv2_domain_name.auth.id
+  stage       = aws_apigatewayv2_stage.default.name
+}
+
+# -----------------------------------------------------------------------------
+# Outputs
+# -----------------------------------------------------------------------------
+
+output "auth_proxy_api_endpoint" {
+  description = "API Gateway endpoint URL (for testing before DNS cutover)"
+  value       = aws_apigatewayv2_api.auth_proxy.api_endpoint
+}
+
+output "auth_proxy_domain_target" {
+  description = "Target domain name for DNS CNAME/alias record"
+  value       = aws_apigatewayv2_domain_name.auth.domain_name_configuration[0].target_domain_name
+}

--- a/infrastructure/terraform/dns/honeyjar-xyz-auth.tf
+++ b/infrastructure/terraform/dns/honeyjar-xyz-auth.tf
@@ -1,27 +1,56 @@
 # =============================================================================
-# DNS Root — Dynamic Auth Proxy Records
-# INC-001: auth.0xhoneyjar.xyz unreachable after Gandi → Route 53 migration
-# https://github.com/0xHoneyJar/mibera-dimensions/issues/162
+# DNS Root — Auth Proxy Records
 # =============================================================================
 #
-# Dynamic's custom auth proxy enables cross-subdomain SSO via HttpOnly cookies
-# on .0xhoneyjar.xyz. All apps (midi, mibera, cubquests, henlo, hub) depend on
-# this subdomain for wallet connection and session management.
+# Routes auth.0xhoneyjar.xyz to our AWS API Gateway auth proxy, which
+# transparently forwards to Dynamic Labs (app.dynamic.xyz) with correct
+# CORS headers on ALL responses — fixing the CSRF/SSO initialization issue.
 #
-# This is NOT a Vercel project — it won't appear in `vercel domains inspect`.
-# The wildcard *.0xhoneyjar.xyz → Vercel CNAME must NOT catch this subdomain.
+# Previous: CNAME → alias.app.dynamicauth.com (Dynamic's broken CORS proxy)
+# Current:  CNAME → API Gateway custom domain (our proxy, correct CORS)
+#
+# References:
+#   - https://github.com/0xHoneyJar/mcv-interface/issues/7
+#   - infrastructure/terraform/auth-proxy.tf (proxy definition)
+#
+# Rollback: Change records back to ["alias.app.dynamicauth.com"] and remove
+#           the ACM validation record.
+# =============================================================================
 
-# Dynamic custom auth proxy — cross-subdomain SSO
+# Auth proxy — points to our API Gateway custom domain
+# The target_domain_name is output by the auth-proxy.tf compute root.
+# For the initial DNS root apply BEFORE the compute root creates the API Gateway,
+# use a placeholder or apply compute root first.
+#
+# IMPORTANT: This is a cross-root reference. The API Gateway custom domain
+# target must be copied from `terraform output auth_proxy_domain_target`
+# in the compute root. We use a variable to avoid cross-state coupling.
 resource "aws_route53_record" "auth_dynamic" {
   zone_id = aws_route53_zone.honeyjar.zone_id
   name    = "auth.${var.domain}"
   type    = "CNAME"
   ttl     = 300
-  records = ["alias.app.dynamicauth.com"]
+  # When auth_proxy_domain_target is set, route to our API Gateway proxy.
+  # Otherwise, fall back to Dynamic's default proxy (pre-migration state).
+  records = [var.auth_proxy_domain_target != "" ? var.auth_proxy_domain_target : "alias.app.dynamicauth.com"]
 }
 
-# Dynamic TLS cert verification for auth subdomain
+# ACM certificate DNS validation for auth.0xhoneyjar.xyz
+# The validation record name/value come from the ACM certificate in the
+# compute root. After initial setup, these are stable and don't change.
+# Only created when auth proxy is active (ACM cert needs DNS validation)
+resource "aws_route53_record" "auth_acm_validation" {
+  count   = var.auth_proxy_acm_validation_name != "" ? 1 : 0
+  zone_id = aws_route53_zone.honeyjar.zone_id
+  name    = var.auth_proxy_acm_validation_name
+  type    = "CNAME"
+  ttl     = 300
+  records = [var.auth_proxy_acm_validation_value]
+}
+
+# Legacy Dynamic ACME challenge — keep until fully cutover, then remove
 resource "aws_route53_record" "auth_dynamic_acme" {
+  count   = var.auth_proxy_domain_target != "" ? 0 : 1
   zone_id = aws_route53_zone.honeyjar.zone_id
   name    = "_acme-challenge.auth.${var.domain}"
   type    = "TXT"

--- a/infrastructure/terraform/dns/variables.tf
+++ b/infrastructure/terraform/dns/variables.tf
@@ -73,3 +73,28 @@ variable "dmarc_email" {
   type    = string
   default = "dmarc@0xhoneyjar.xyz"
 }
+
+# =============================================================================
+# Auth Proxy (cross-root reference from compute root)
+# =============================================================================
+# These values come from `terraform output` in the compute root after
+# auth-proxy.tf is applied. Pass via -var or terraform.tfvars.
+# Default "" preserves the legacy Dynamic ACME challenge record.
+
+variable "auth_proxy_domain_target" {
+  description = "API Gateway custom domain target for auth.0xhoneyjar.xyz (from compute root output)"
+  type        = string
+  default     = ""
+}
+
+variable "auth_proxy_acm_validation_name" {
+  description = "ACM certificate DNS validation record name (from compute root output)"
+  type        = string
+  default     = ""
+}
+
+variable "auth_proxy_acm_validation_value" {
+  description = "ACM certificate DNS validation record value (from compute root output)"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

- Add API Gateway HTTP API as transparent proxy from `auth.0xhoneyjar.xyz` to `app.dynamic.xyz`
- CORS headers on ALL responses (200, 404, 500) — fixes the broken CSRF initialization
- Explicit origin allowlist (no wildcards) with credential forwarding for SSO cookies
- ACM TLS certificate with DNS validation
- CloudWatch access logging
- DNS records conditionally route to API Gateway or fall back to legacy Dynamic proxy
- Cross-root variable pattern for compute→DNS reference

## Root Cause

Dynamic Labs' custom domain proxy only sets CORS headers on 2xx responses. The `/csrf` endpoint returns 404 (removed in SDK v4.61.x). Browser sees CORS violation → SDK init fails → all login broken.

## Deployment Steps

1. `terraform apply` in compute root — creates API Gateway, ACM cert, custom domain
2. Copy outputs: `terraform output auth_proxy_domain_target` and ACM validation values
3. `terraform apply` in DNS root with `-var auth_proxy_domain_target=<value>` etc.
4. Wait for ACM validation + DNS propagation (~5 min)
5. Test: `curl -I https://auth.0xhoneyjar.xyz/api/v0/sdk/{envId}/csrf` — should have CORS headers even on 404
6. Re-enable `apiBaseUrl` in frontend repos + cookie domain in Dynamic dashboard

## Rollback

Set `auth_proxy_domain_target=""` in DNS root tfvars → `terraform apply` → routes back to `alias.app.dynamicauth.com`.

## GPT Review

APPROVED after 3 iterations:
- Iter 1: Fixed wildcard CORS origins, integration URI path, stage ID/name
- Iter 2: All fixes verified
- Iter 3: Full changeset approved

## Test plan

- [ ] `terraform plan` shows expected creates (API Gateway, ACM, custom domain, logs)
- [ ] `terraform apply` succeeds in compute root
- [ ] ACM certificate validates via DNS
- [ ] `curl` to API Gateway endpoint returns Dynamic response with CORS headers
- [ ] DNS cutover: auth.0xhoneyjar.xyz resolves to API Gateway
- [ ] SDK initialization succeeds with `apiBaseUrl` re-enabled
- [ ] Cross-app SSO works (cookie set on `.0xhoneyjar.xyz`)

Fixes https://github.com/0xHoneyJar/mcv-interface/issues/7

🤖 Generated with [Claude Code](https://claude.com/claude-code)