### PR TITLE
feat(infra): migrate mibera world to mibera-honeyroad (B2 Sprint 1)

### DIFF
--- a/infrastructure/terraform/world-mibera-secrets.tf
+++ b/infrastructure/terraform/world-mibera-secrets.tf
@@ -1,0 +1,82 @@
+# =============================================================================
+# Honey Road (mibera-honeyroad) — AWS Secrets Manager structure
+# =============================================================================
+# Defines the 23 runtime secrets the Honey Road ECS task resolves at start.
+# Values are NOT populated by terraform — they're loaded via
+# `scripts/load-honeyroad-secrets.sh` which pulls from Vercel env and validates
+# (non-empty + no placeholder) before calling aws secretsmanager put-secret-value.
+# This avoids committing secret values to git while keeping the structural
+# definition in IaC (prd.md §6.4, flatline SKP-004).
+#
+# The key set here MUST be a superset of the keys referenced in
+# world-mibera.tf's `secrets = {...}` map. Mismatch → terraform plan error.
+#
+# Intentionally absent (by design):
+#   - NEXT_PUBLIC_*       public-by-design, --build-arg only in CI
+#   - SENTRY_AUTH_TOKEN   build-time-only, BuildKit --secret mount in CI
+#
+# Related: 0xHoneyJar/loa-freeside#153
+# =============================================================================
+
+locals {
+  honeyroad_secrets = toset([
+    # Database
+    "database_url",
+    "supabase_service_role",
+
+    # Auth (Dynamic Labs + iron-session)
+    "dynamic_auth_token",
+    "dynamic_server_api_key",
+    "session_secret",
+
+    # AI APIs (vendor personality, honey-gpt)
+    "openai_api_key",
+    "anthropic_api_key",
+
+    # Wallet signer (admin scripts + runtime)
+    "dev_wallet_pk",
+
+    # Background jobs (Trigger.dev)
+    "trigger_secret",
+
+    # OAuth (forum account linking)
+    "twitter_client_id",
+    "twitter_client_secret",
+    "discord_client_id",
+    "discord_client_secret",
+
+    # Media (Cloudinary CDN)
+    "cloudinary_key",
+    "cloudinary_secret",
+
+    # Analytics / data
+    "dune_api_key",
+
+    # API gates (internal auth)
+    "quests_api_secret",
+    "vm_api_secret",
+
+    # AWS S3 (VM avatar/GIF/quiz image storage)
+    "aws_access_key_vm",
+    "aws_secret_key_vm",
+    "aws_bucket_name_vm",
+    "aws_region_vm",
+
+    # CSP (frame-ancestors for hub embedding)
+    "allowed_parent_url",
+  ])
+}
+
+resource "aws_secretsmanager_secret" "honeyroad" {
+  for_each = local.honeyroad_secrets
+
+  name        = "arrakis/${var.environment}/worlds/honeyroad/${each.key}"
+  description = "Honey Road (mibera-honeyroad) runtime secret — loaded via scripts/load-honeyroad-secrets.sh"
+  kms_key_id  = aws_kms_key.secrets.arn
+
+  tags = merge(local.common_tags, {
+    World   = "mibera"
+    App     = "honeyroad"
+    Purpose = each.key
+  })
+}

--- a/infrastructure/terraform/world-mibera.tf
+++ b/infrastructure/terraform/world-mibera.tf
@@ -1,14 +1,21 @@
 # =============================================================================
-# World: mibera — Identity mirror + marketplace (Berachain)
+# World: mibera — Honey Road marketplace (Next.js 15.3.8, Berachain)
 # =============================================================================
-# Issue: https://github.com/0xHoneyJar/loa-freeside/issues/153
+# B2 migration 2026-04-16: repo swapped from mibera-world (SvelteKit sovereign-
+# stack prototype) to mibera-honeyroad (production Vercel-hosted Next.js app).
+# See grimoires/loa/prd.md §10 for the in-place-swap vs destroy-recreate
+# tradeoff rationale. The `name = "mibera"` is preserved to keep the ECR repo,
+# ALB listener rule, and Route53 slot stable across the swap.
+#
+# Related: 0xHoneyJar/loa-freeside#153
+# Seed:    (bonfire) grimoires/bonfire/context/honeyroad-to-freeside-seed/
 # =============================================================================
 
 module "world_mibera" {
   source = "./modules/world"
 
   name        = "mibera"
-  repo        = "0xHoneyJar/mibera-world"
+  repo        = "0xHoneyJar/mibera-honeyroad"
   environment = var.environment
 
   # Shared infrastructure references
@@ -27,19 +34,68 @@ module "world_mibera" {
   aws_region               = var.aws_region
   account_id               = data.aws_caller_identity.current.account_id
 
-  cpu    = 256
-  memory = 512
+  # Next.js 15 + Sentry + sharp is heavier than the SvelteKit baseline (256/512).
+  # Starting point; tune via CloudWatch observation (prd.md §6.3).
+  cpu    = 512
+  memory = 1024
 
+  # Honey Road responds 200 at / (Next.js default). Module health check uses
+  # `node -e "require('http').get(...)"` which is portable on node:22-alpine.
+  health_check_path = "/"
+
+  # Non-secret runtime env. NEXT_PUBLIC_* vars are baked into the client bundle
+  # at build time via --build-arg in CI (see mibera-honeyroad/.github/workflows/
+  # deploy-freeside.yml) — they are PUBLIC BY DESIGN and MUST NOT be stored as
+  # "secrets". The security boundary for NEXT_PUBLIC_SUPABASE_ANON_KEY is
+  # Supabase Row Level Security, not secrecy of the key (flatline SKP-001).
   env_vars = {
-    PUBLIC_CHAIN_ID = "80094"
-    PUBLIC_RPC_URL  = "https://rpc.berachain.com"
+    NEXT_PUBLIC_DYNAMIC_COOKIE_DOMAIN = "auth.0xhoneyjar.xyz"
   }
+
+  # Runtime secrets — resolved by ECS from AWS Secrets Manager at task start.
+  # Values populated via scripts/load-honeyroad-secrets.sh (see world-mibera-
+  # secrets.tf for the structural definition of each secret).
+  #
+  # Intentionally absent:
+  #   - NEXT_PUBLIC_*       — public-by-design, --build-arg only (see above)
+  #   - SENTRY_AUTH_TOKEN   — build-time-only, BuildKit --secret mount in CI
+  #                           (never lands in an image layer; never reaches a
+  #                           running container — prd.md:299, flatline SKP-001)
+  secrets = {
+    DATABASE_URL                = aws_secretsmanager_secret.honeyroad["database_url"].arn
+    SUPABASE_SERVICE_ROLE_KEY   = aws_secretsmanager_secret.honeyroad["supabase_service_role"].arn
+    DYNAMIC_AUTH_TOKEN          = aws_secretsmanager_secret.honeyroad["dynamic_auth_token"].arn
+    DYNAMIC_SERVER_API_KEY      = aws_secretsmanager_secret.honeyroad["dynamic_server_api_key"].arn
+    OPENAI_API_KEY              = aws_secretsmanager_secret.honeyroad["openai_api_key"].arn
+    ANTHROPIC_API_KEY           = aws_secretsmanager_secret.honeyroad["anthropic_api_key"].arn
+    SESSION_SECRET              = aws_secretsmanager_secret.honeyroad["session_secret"].arn
+    DEV_WALLET_PRIVATE_KEY      = aws_secretsmanager_secret.honeyroad["dev_wallet_pk"].arn
+    TRIGGER_SECRET_KEY          = aws_secretsmanager_secret.honeyroad["trigger_secret"].arn
+    TWITTER_CLIENT_ID           = aws_secretsmanager_secret.honeyroad["twitter_client_id"].arn
+    TWITTER_CLIENT_SECRET       = aws_secretsmanager_secret.honeyroad["twitter_client_secret"].arn
+    DISCORD_CLIENT_ID           = aws_secretsmanager_secret.honeyroad["discord_client_id"].arn
+    DISCORD_CLIENT_SECRET       = aws_secretsmanager_secret.honeyroad["discord_client_secret"].arn
+    CLOUDINARY_API_KEY          = aws_secretsmanager_secret.honeyroad["cloudinary_key"].arn
+    CLOUDINARY_API_SECRET       = aws_secretsmanager_secret.honeyroad["cloudinary_secret"].arn
+    DUNE_API_KEY                = aws_secretsmanager_secret.honeyroad["dune_api_key"].arn
+    QUESTS_API_SECRET           = aws_secretsmanager_secret.honeyroad["quests_api_secret"].arn
+    VM_API_SECRET               = aws_secretsmanager_secret.honeyroad["vm_api_secret"].arn
+    AWS_ACCESS_KEY_ID_VM        = aws_secretsmanager_secret.honeyroad["aws_access_key_vm"].arn
+    AWS_SECRET_ACCESS_KEY_VM    = aws_secretsmanager_secret.honeyroad["aws_secret_key_vm"].arn
+    AWS_BUCKET_NAME_VM          = aws_secretsmanager_secret.honeyroad["aws_bucket_name_vm"].arn
+    AWS_REGION_VM               = aws_secretsmanager_secret.honeyroad["aws_region_vm"].arn
+    ALLOWED_PARENT_URL          = aws_secretsmanager_secret.honeyroad["allowed_parent_url"].arn
+  }
+
+  secret_arns = [for s in aws_secretsmanager_secret.honeyroad : s.arn]
 }
 
 output "mibera_ecr_url" {
-  value = module.world_mibera.ecr_repository_url
+  value       = module.world_mibera.ecr_repository_url
+  description = "ECR repository for Honey Road image pushes (CI uses this)"
 }
 
 output "mibera_ci_role_arn" {
-  value = module.world_mibera.ci_deploy_role_arn
+  value       = module.world_mibera.ci_deploy_role_arn
+  description = "IAM role ARN for mibera-honeyroad GitHub Actions OIDC (set as AWS_DEPLOY_ROLE_ARN repo secret)"
 }

--- a/scripts/load-honeyroad-secrets.sh
+++ b/scripts/load-honeyroad-secrets.sh
@@ -92,10 +92,13 @@ for entry in "${MAP[@]}"; do
     continue
   fi
 
-  if aws secretsmanager put-secret-value \
+  # Pipe secret via stdin instead of --secret-string "$raw" — the CLI arg form
+  # is visible in /proc/*/cmdline, ps aux, and shell history (bridgebuilder
+  # CRIT-001). file:///dev/stdin reads from stdin without touching disk.
+  if printf '%s' "$raw" | aws secretsmanager put-secret-value \
       --profile "$AWS_PROFILE" --region "$AWS_REGION" \
       --secret-id "${SECRET_PREFIX}/${aws_key}" \
-      --secret-string "$raw" >/dev/null 2>&1; then
+      --secret-string file:///dev/stdin >/dev/null 2>&1; then
     echo "OK:               $vercel_var -> $aws_key"
     pass=$((pass+1))
   else

--- a/scripts/load-honeyroad-secrets.sh
+++ b/scripts/load-honeyroad-secrets.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Honey Road (mibera-honeyroad) — AWS Secrets Manager loader
+# =============================================================================
+# Pulls secrets from Vercel env (pre-fetched via `vercel env pull`) and posts
+# them to AWS Secrets Manager under the arrakis/<env>/worlds/honeyroad/ prefix.
+#
+# Validations (flatline SKP-004):
+#   - non-empty values (empty secret crashes ECS at task start)
+#   - no placeholder values (your_*, REDACTED, xxx, <...>)
+#
+# Usage:
+#   vercel env pull /tmp/honeyroad.env --yes --environment=production
+#   bash scripts/load-honeyroad-secrets.sh
+#
+# Related: grimoires/loa/prd.md §6.4, 06-execution-plan.md:189-274
+# =============================================================================
+set -euo pipefail
+
+AWS_PROFILE="${AWS_PROFILE:-admin}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+ENVIRONMENT="${ENVIRONMENT:-production}"
+ENV_FILE="${ENV_FILE:-/tmp/honeyroad.env}"
+SECRET_PREFIX="arrakis/${ENVIRONMENT}/worlds/honeyroad"
+
+# vercel-var → aws-secret-key mapping.
+# ONLY true runtime secrets. NEXT_PUBLIC_* and SENTRY_AUTH_TOKEN are handled
+# separately in CI (--build-arg and BuildKit --secret mount respectively).
+declare -a MAP=(
+  "DATABASE_URL:database_url"
+  "SUPABASE_SERVICE_ROLE_KEY:supabase_service_role"
+  "DYNAMIC_AUTH_TOKEN:dynamic_auth_token"
+  "DYNAMIC_SERVER_API_KEY:dynamic_server_api_key"
+  "OPENAI_API_KEY:openai_api_key"
+  "ANTHROPIC_API_KEY:anthropic_api_key"
+  "SESSION_SECRET:session_secret"
+  "DEV_WALLET_PRIVATE_KEY:dev_wallet_pk"
+  "TRIGGER_SECRET_KEY:trigger_secret"
+  "TWITTER_CLIENT_ID:twitter_client_id"
+  "TWITTER_CLIENT_SECRET:twitter_client_secret"
+  "DISCORD_CLIENT_ID:discord_client_id"
+  "DISCORD_CLIENT_SECRET:discord_client_secret"
+  "CLOUDINARY_API_KEY:cloudinary_key"
+  "CLOUDINARY_API_SECRET:cloudinary_secret"
+  "DUNE_API_KEY:dune_api_key"
+  "QUESTS_API_SECRET:quests_api_secret"
+  "VM_API_SECRET:vm_api_secret"
+  "AWS_ACCESS_KEY_ID_VM:aws_access_key_vm"
+  "AWS_SECRET_ACCESS_KEY_VM:aws_secret_key_vm"
+  "AWS_BUCKET_NAME_VM:aws_bucket_name_vm"
+  "AWS_REGION_VM:aws_region_vm"
+  "ALLOWED_PARENT_URL:allowed_parent_url"
+)
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "ERROR: $ENV_FILE not found" >&2
+  echo "Run: vercel env pull $ENV_FILE --yes --environment=production" >&2
+  exit 1
+fi
+
+# Preflight: confirm AWS identity before writing anything
+EXPECTED_ACCOUNT="${EXPECTED_ACCOUNT:-891376933289}"
+ACTUAL_ACCOUNT=$(aws sts get-caller-identity --profile "$AWS_PROFILE" --query Account --output text)
+if [[ "$ACTUAL_ACCOUNT" != "$EXPECTED_ACCOUNT" ]]; then
+  echo "ERROR: Wrong AWS account. Expected $EXPECTED_ACCOUNT, got $ACTUAL_ACCOUNT" >&2
+  exit 1
+fi
+
+echo "Loading Honey Road secrets to $SECRET_PREFIX/* (account $ACTUAL_ACCOUNT)"
+echo ""
+
+pass=0
+fail=0
+failures=()
+
+for entry in "${MAP[@]}"; do
+  vercel_var="${entry%%:*}"
+  aws_key="${entry##*:}"
+  raw=$(grep "^${vercel_var}=" "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2- | sed -E 's/^"(.*)"$/\1/' || echo "")
+
+  if [[ -z "$raw" ]]; then
+    echo "FAIL empty:       $vercel_var"
+    failures+=("$vercel_var (empty)")
+    ((fail++))
+    continue
+  fi
+
+  if [[ "$raw" =~ ^(your_|REDACTED|xxx|\<) ]]; then
+    echo "FAIL placeholder: $vercel_var -> ${raw:0:20}..."
+    failures+=("$vercel_var (placeholder)")
+    ((fail++))
+    continue
+  fi
+
+  if aws secretsmanager put-secret-value \
+      --profile "$AWS_PROFILE" --region "$AWS_REGION" \
+      --secret-id "${SECRET_PREFIX}/${aws_key}" \
+      --secret-string "$raw" >/dev/null 2>&1; then
+    echo "OK:               $vercel_var -> $aws_key"
+    ((pass++))
+  else
+    echo "FAIL put:         $vercel_var -> $aws_key"
+    failures+=("$vercel_var (put-secret-value failed)")
+    ((fail++))
+  fi
+done
+
+# Cleanup: never leave secrets on disk
+rm -f "$ENV_FILE"
+
+echo ""
+echo "Summary: $pass passed, $fail failed"
+
+if [[ $fail -gt 0 ]]; then
+  echo ""
+  echo "Failures:"
+  for f in "${failures[@]}"; do
+    echo "  - $f"
+  done
+  exit 1
+fi
+
+exit 0

--- a/scripts/load-honeyroad-secrets.sh
+++ b/scripts/load-honeyroad-secrets.sh
@@ -81,14 +81,14 @@ for entry in "${MAP[@]}"; do
   if [[ -z "$raw" ]]; then
     echo "FAIL empty:       $vercel_var"
     failures+=("$vercel_var (empty)")
-    ((fail++))
+    fail=$((fail+1))
     continue
   fi
 
   if [[ "$raw" =~ ^(your_|REDACTED|xxx|\<) ]]; then
     echo "FAIL placeholder: $vercel_var -> ${raw:0:20}..."
     failures+=("$vercel_var (placeholder)")
-    ((fail++))
+    fail=$((fail+1))
     continue
   fi
 
@@ -97,11 +97,11 @@ for entry in "${MAP[@]}"; do
       --secret-id "${SECRET_PREFIX}/${aws_key}" \
       --secret-string "$raw" >/dev/null 2>&1; then
     echo "OK:               $vercel_var -> $aws_key"
-    ((pass++))
+    pass=$((pass+1))
   else
     echo "FAIL put:         $vercel_var -> $aws_key"
     failures+=("$vercel_var (put-secret-value failed)")
-    ((fail++))
+    fail=$((fail+1))
   fi
 done
 


### PR DESCRIPTION
## Summary

**B2 Sprint 1** of Honey Road → Freeside ECS migration. Replaces the SvelteKit sovereign-stack prototype (`mibera-world`) in `module "world_mibera"` with the production Next.js app (`mibera-honeyroad`), keeping `name = "mibera"` stable across the in-place repo swap.

Companion PR in `mibera-honeyroad`: [feat/freeside-ecs-migration](https://github.com/0xHoneyJar/mibera-honeyroad/pull/new/feat/freeside-ecs-migration) — adds Dockerfile + GHA workflow + BuildKit secret-mount pattern.

PRD + SDD + Sprint Plan live in `bonfire/grimoires/loa/{prd,sdd,sprint}.md`. Seed bundle at `bonfire/grimoires/bonfire/context/honeyroad-to-freeside-seed/` (flatline-reviewed 3-model).

## Changes

### `infrastructure/terraform/world-mibera.tf` (edit)

- `repo`: `0xHoneyJar/mibera-world` → `0xHoneyJar/mibera-honeyroad`
- `name`: unchanged (`mibera`) — preserves ECR repo + ALB listener rule + Route53 slot across swap
- Sizing: `cpu=256/memory=512` → `cpu=512/memory=1024` (Next.js 15 + Sentry + sharp heavier than SvelteKit baseline)
- `desired_count=1`: unchanged (module validates `<= 1` per SQLite heritage; Honey Road on external Supabase so safe, but module-level change is @janitooor track — flatline SKP-002 defense)
- `health_check_path="/"`: unchanged (Next.js responds 200 at `/`)
- `env_vars`: only non-secret `NEXT_PUBLIC_DYNAMIC_COOKIE_DOMAIN=auth.0xhoneyjar.xyz` (rest are build-time bakeable)
- `secrets = {...}`: 23 ARN refs to `aws_secretsmanager_secret.honeyroad[*]` (see next file)
- **Intentionally absent** from secrets map: `NEXT_PUBLIC_*` (public by design, bundle-baked) and `SENTRY_AUTH_TOKEN` (build-time only, BuildKit mount) — flatline SKP-001 integration

### `infrastructure/terraform/world-mibera-secrets.tf` (new)

`for_each` over 23 secret keys → `aws_secretsmanager_secret.honeyroad` resources at `arrakis/${var.environment}/worlds/honeyroad/{key}`, KMS-encrypted with `aws_kms_key.secrets`.

Categories: database (2), auth (3), AI (2), wallet (1), jobs (1), OAuth (4), media (2), analytics (1), API gates (2), S3 (4), CSP (1) = **23**.

**Structural-only**: values NOT committed. Populated via the loader script below.

### `scripts/load-honeyroad-secrets.sh` (new)

Validated loader (**flatline SKP-004 integration**):

- Pulls Vercel env from `/tmp/honeyroad.env` (pre-fetched via `vercel env pull`)
- **Preflight** AWS account guard (expects `891376933289`)
- **Validates** each value: non-empty + no placeholder (`your_*|REDACTED|xxx|<`)
- `aws secretsmanager put-secret-value` per entry
- **Cleans up** `/tmp/honeyroad.env` on exit
- Exits 1 with failure summary if ANY entries fail

## Operator flow (HITL Gate 1, Step 1.6)

```bash
# Terraform apply (review plan first)
cd infrastructure/terraform
AWS_PROFILE=admin terraform init -backend-config=environments/production/backend.tfvars -reconfigure
AWS_PROFILE=admin terraform plan -var-file=environments/production/terraform.tfvars -out=/tmp/b2-sprint1.tfplan

# HITL review — plan MUST show:
#   - ~23 aws_secretsmanager_secret.honeyroad[*] CREATED
#   - module.world_mibera.aws_ecs_task_definition.world UPDATED (new image ref + cpu/memory)
#   - module.world_mibera.aws_ecs_service.world UPDATED (new task def rev)
#   - module.world_mibera.aws_ecr_repository.world UNCHANGED (validates in-place swap)
#   - NO deletes beyond expected

AWS_PROFILE=admin terraform apply /tmp/b2-sprint1.tfplan

# Then populate secrets values (never committed)
vercel env pull /tmp/honeyroad.env --yes --environment=production
bash scripts/load-honeyroad-secrets.sh
# Expected: "Summary: 23 passed, 0 failed"

# Capture outputs for Sprint 2
terraform output mibera_ecr_url
terraform output mibera_ci_role_arn   # → set as AWS_DEPLOY_ROLE_ARN in mibera-honeyroad repo
```

## Test plan

- [ ] `terraform plan` shows expected CREATE/UPDATE pattern (see HITL review criteria above)
- [ ] `terraform apply` succeeds
- [ ] `aws secretsmanager list-secrets --query 'SecretList[?starts_with(Name, \`arrakis/production/worlds/honeyroad/\`)]' | jq length` returns **23**
- [ ] Loader script reports `23 passed, 0 failed`
- [ ] Terraform outputs `mibera_ecr_url` + `mibera_ci_role_arn` captured

## Anti-scope (08-anti-scope.md)

- NO DNS changes in this PR (Sprint 3 Step 3.1, separate targeted apply)
- NO untargeted apply in `dns/` (5-adds-3-ALB-flips drift — @janitooor track)
- NO `desired_count > 1` (module validates `<= 1`; multi-task is separate track)
- NO module internal changes (Q7 `alb_idle_timeout` if not exposed → @janitooor)

## Rollback

Pre-traffic change: no user-visible impact. Revert file changes + `terraform apply` restores pre-Sprint-1 state. Sprint 3 DNS cutover has separate <10-min rollback via targeted Route53 destroy (see SDD §1.10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)