### PR TITLE
chore(infra): drop supabase_service_role from mibera secrets (post-Drizzle)

### DIFF
--- a/infrastructure/terraform/world-mibera-secrets.tf
+++ b/infrastructure/terraform/world-mibera-secrets.tf
@@ -20,9 +20,8 @@
 
 locals {
   honeyroad_secrets = toset([
-    # Database
+    # Database (Drizzle + Railway Postgres, post-Supabase migration)
     "database_url",
-    "supabase_service_role",
 
     # Auth (Dynamic Labs + iron-session)
     "dynamic_auth_token",

--- a/infrastructure/terraform/world-mibera.tf
+++ b/infrastructure/terraform/world-mibera.tf
@@ -63,7 +63,6 @@ module "world_mibera" {
   #                           running container — prd.md:299, flatline SKP-001)
   secrets = {
     DATABASE_URL                = aws_secretsmanager_secret.honeyroad["database_url"].arn
-    SUPABASE_SERVICE_ROLE_KEY   = aws_secretsmanager_secret.honeyroad["supabase_service_role"].arn
     DYNAMIC_AUTH_TOKEN          = aws_secretsmanager_secret.honeyroad["dynamic_auth_token"].arn
     DYNAMIC_SERVER_API_KEY      = aws_secretsmanager_secret.honeyroad["dynamic_server_api_key"].arn
     OPENAI_API_KEY              = aws_secretsmanager_secret.honeyroad["openai_api_key"].arn


### PR DESCRIPTION
## Summary

Cleanup following the Honey Road Drizzle migration. Main removed \`@supabase/supabase-js\` (commit \`7fda5a3\`); this drops the stale \`supabase_service_role\` entry from the world_mibera secrets map and the honeyroad_secrets for_each toset.

## Already applied

Targeted terraform apply ran:
- \`-target=module.world_mibera -target=aws_secretsmanager_secret.honeyroad\`
- Result: **1 add / 2 change / 2 destroy**
  - Added: new ECS task def revision
  - Changed: ecs_service (new task def ref), execution_secrets IAM policy (no longer KMS-decrypts the stale secret)
  - Destroyed: old task def revision, \`arrakis/production/worlds/honeyroad/supabase_service_role\` (30-day planned deletion window per Secrets Manager default)

This PR brings the terraform source in sync with applied state.

## Context

Part of B2 migration. See loa-freeside#165 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)