### PR TITLE
feat(dns): re-add mibera to world_subdomains (draft — blocked on dns/ state reconciliation)

### DIFF
--- a/infrastructure/terraform/dns/honeyjar-xyz-worlds.tf
+++ b/infrastructure/terraform/dns/honeyjar-xyz-worlds.tf
@@ -12,11 +12,14 @@
 
 locals {
   # All worlds hosted on the compute ALB.
-  # 2026-04-16: "mibera" temporarily removed to restore Honey Road (Vercel) at
-  # mibera.0xhoneyjar.xyz while we migrate Honey Road onto Freeside. Re-add once
-  # Honey Road is an ECS-hosted world.
+  # 2026-04-18: "mibera" re-added after Honey Road (mibera-honeyroad Next.js 15)
+  # migrated to ECS Fargate behind the compute ALB. Production target group
+  # arrakis-production-w-mibera healthy; /api/health + / + /guide return 200.
+  # See 0xHoneyJar/loa-freeside#153 (migration thread) + amendment comment
+  # 4271567701 for Terraform-literacy context.
   world_subdomains = var.enable_production_api ? toset([
     "apdao",
+    "mibera",
     "rektdrop",
     "score-api",
   ]) : toset([])


### PR DESCRIPTION
## Summary

- Re-adds `mibera` to `world_subdomains` in `infrastructure/terraform/dns/honeyjar-xyz-worlds.tf` — reverses the B1 DNS revert (commit `84718e63`) now that Honey Road is live on Freeside ECS.
- **DOES NOT apply cleanly today.** Draft PR; see "Why draft" below.
- The live cutover has already happened via `aws route53 change-resource-record-sets` (change `/change/C05894852S2C26TU2K20N`, INSYNC 2026-04-18 00:57 UTC). This PR just gets the config written down so it lands when the `dns/` root state is reconcilable.

## Why draft (the problem a @janitooor audit needs to unblock)

The `dns/` root has real, structural state drift that makes `terraform apply` unsafe from this branch today. Summary of what I found tonight while trying to run the "targeted apply" this sprint plan called for:

| Artifact | What tonight showed |
|---|---|
| S3 state object | `s3://arrakis-tfstate-891376933289/dns/production.tfstate` **does not exist**. Only `dns/staging.tfstate`. |
| Historical convention | `dns/staging.tfstate` actually manages the PRODUCTION `0xhoneyjar.xyz` zone. Initialized with `-backend-config=environments/staging/backend.tfvars`. Easy for a learner to miss; I missed it initially and had to correct loa-freeside#153. |
| State vs AWS drift | `rektdrop` in state: alias → staging ALB. In AWS: alias → production ALB. Drifted. `score-api` in state: staging ALB. In AWS: staging ALB (weird, but matches). `apdao`: consistent, production ALB. |
| Config vs state drift | `staging/terraform.tfvars` sets `environment = "staging"`, which resolves the ALB data source to staging ALB. So a plan of `aws_route53_record.world["mibera"]` from this branch proposes to create the record pointing at the **staging** ALB, not the production ALB. Applying that would break the cutover we just did. |
| Zone tag drift | Plan also shows `aws_route53_zone.honeyjar` tags would change (Environment=production → staging; Purpose added). Pre-existing drift. |

**Net: running `terraform apply` from this branch with either backend would do the wrong thing.**

- Staging backend + staging tfvars → proposes to point mibera at staging ALB ❌
- Production backend + production tfvars → proposes to create `aws_route53_zone.honeyjar` from scratch (state is empty there) ❌

So the branch is correct as *eventual config*, but can't be safely applied until the `dns/` root is reconciled.

## What would unblock this PR

A reconciliation pass in `dns/` — importing all existing production Route53 records into the staging-backend state so state matches AWS, then either deciding if `environment = staging` → staging-ALB is actually the intent for shared records (and flipping them in AWS), or restructuring so the ALB data source can pick production ALB under the staging tfvars. I'm out of my depth on which is right.

## Test plan (aspirational — unblocked by the above)

- [ ] State + AWS reconciled via `terraform import`
- [ ] `terraform plan -target='aws_route53_record.world["mibera"]'` shows **no changes** (existing record matches config)
- [ ] Untargeted `terraform plan` shows **no spurious drift** (baseline re-established)
- [ ] Merge this PR; ripe for future mergers without the drift-warning header

## What I already did (CLI, with operator auth)

- Created the A-alias record for `mibera.0xhoneyjar.xyz` pointing at `arrakis-production-alb-427042206.us-east-1.elb.amazonaws.com` via the CLI because I could not safely do it via terraform from this branch.
- Did **not** run `terraform import` on the new record — I called this @janitooor-owned reconciliation work in loa-freeside#153 earlier tonight, and the framework's safety hooks correctly held me to that.
- Filed mibera-honeyroad#88 for a separate runtime issue surfaced during cutover validation (`ALLOWED_PARENT_URL` secret unresolved at runtime → CSP `frame-ancestors 'self' undefined http://localhost:3000`).

## Related

- 0xHoneyJar/loa-freeside#153 — migration thread, including the latest correction comment
- 0xHoneyJar/loa-freeside#172 — `aws_security_group_rule.mibera_broad_tcp_outbound` also waits on module-level egress variable
- 0xHoneyJar/loa-freeside#159 — older `dns/` drift source (5 adds + 3 ALB flips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)