### PR TITLE
feat(cycle-009): world-constructs-network terraform (DRAFT)

### DIFF
--- a/infrastructure/terraform/world-constructs-network-secrets.tf
+++ b/infrastructure/terraform/world-constructs-network-secrets.tf
@@ -1,0 +1,80 @@
+# =============================================================================
+# constructs-network — AWS Secrets Manager structure
+# =============================================================================
+# Defines the 16 runtime secrets the constructs-network ECS task resolves at
+# task start. Values are NOT populated by terraform — they're loaded via
+# `scripts/load-constructs-network-secrets.sh` (to be authored, mirrors
+# load-honeyroad-secrets.sh). The script pulls from operator-side env (Vercel
+# export or 1Password), validates non-empty + no placeholder, and calls
+# aws secretsmanager put-secret-value.
+#
+# This avoids committing secret values to git while keeping the structural
+# definition in IaC. Mismatch between this set and world-constructs-network.tf's
+# `secrets = {...}` map → terraform plan error.
+#
+# Intentionally absent (by design):
+#   - NEXT_PUBLIC_*       public-by-design, --build-arg only in CI
+#   - SENTRY_AUTH_TOKEN   build-time-only, BuildKit --secret mount in CI
+#   - CONSTRUCTS_API_URL  non-secret; set as env_var in world-constructs-network.tf
+#   - NODE_ENV            non-secret; set as env_var
+#
+# Env-var source-of-truth mapping (operator reference, for migration):
+#   apps/constructs-network/.env.example  → AWS Secrets Manager key (this file)
+#   Vercel env dashboard (loa-constructs-explorer-5bfi / successor)  → ditto
+#
+# Related: loa-freeside#176, cycle-009 SEED, sprawl-world:apps/constructs-network
+# =============================================================================
+
+locals {
+  constructs_network_secrets = toset([
+    # AI APIs (agent-facing catalog + signal generation)
+    "anthropic_api_key",
+    "gemini_api_key",
+    "google_api_key",
+
+    # Convex (catalog DB backend; write key for cron + server actions)
+    "convex_url",
+    "convex_write_key",
+
+    # Cron auth (bearer token for /api/cron/reconcile)
+    "cron_secret",
+
+    # Signals pipeline (feedback → Convex → Discord)
+    "signals_api_key",
+    "signals_endpoint",
+    "discord_signals_webhook_url",
+
+    # Linear (ticket integration, webhook)
+    "linear_api_key",
+    "linear_webhook_secret",
+
+    # Telegram (notification bot for operators)
+    "telegram_bot_token",
+    "telegram_chat_id",
+
+    # Umami (self-hosted analytics, multi-site)
+    "umami_api_key",
+    "umami_purupuru_website_id",
+    "umami_site_ids",
+  ])
+}
+
+resource "aws_secretsmanager_secret" "constructs_network" {
+  for_each = local.constructs_network_secrets
+
+  name                    = "${local.name_prefix}/worlds/constructs-network/${each.value}"
+  description             = "constructs-network runtime secret: ${each.value}"
+  kms_key_id              = aws_kms_key.secrets.arn
+  recovery_window_in_days = 7
+
+  tags = merge(local.common_tags, {
+    World  = "constructs-network"
+    Secret = each.value
+  })
+}
+
+# NOTE on re-creation: recovery_window_in_days = 7 means a destroyed secret
+# remains recoverable (not purged) for 7 days. To re-create a secret with the
+# same name within that window, either wait 7 days OR manually delete with
+# `aws secretsmanager delete-secret --secret-id <arn> --force-delete-without-recovery`.
+# This pattern inherited from world-mibera-secrets.tf.

--- a/infrastructure/terraform/world-constructs-network.tf
+++ b/infrastructure/terraform/world-constructs-network.tf
@@ -1,0 +1,130 @@
+# =============================================================================
+# World: constructs-network — constructs.network registry UI (Next.js 15 + Convex)
+# =============================================================================
+# Cycle-009 L-migrate-constructs (loa-constructs, parallel to loa-freeside#176):
+# Migrates the constructs.network UI off Vercel onto Freeside ECS Fargate.
+# The app is a Next.js 15 monorepo member at
+# 0xHoneyJar/sprawl-world:apps/constructs-network (lifted from loa-constructs
+# in cycle-007 via PR #39). Vercel project `loa-constructs-explorer-5bfi`
+# retired post-cutover + 48h parallel window (see cycle-009 SEED).
+#
+# Bug closed: bd-1o9 (constructs.network empty-catalog — Vercel config drift
+# + stale build path). Migration supersedes spot-fix per cycle-008 L-bug-triage.
+#
+# Registry + network visibility is part of the product, not chrome
+# (operator 2026-04-24: "visibility and transparency with agents on a UI
+# surface is coexistence"). This migration restores the agent+human shared
+# UI that went dark post-cycle-007.
+#
+# Related: loa-freeside#176, #174, #153
+# SEED:    loa-constructs/grimoires/loa-constructs-seed-2026-04-21/cycle-009-SEED-freeside-host-migration.md
+# =============================================================================
+
+module "world_constructs_network" {
+  source = "./modules/world"
+
+  name        = "constructs-network"
+  repo        = "0xHoneyJar/sprawl-world"
+  environment = var.environment
+
+  # Shared infrastructure references
+  cluster_id               = aws_ecs_cluster.main.id
+  cluster_name             = aws_ecs_cluster.main.name
+  vpc_id                   = module.vpc.vpc_id
+  private_subnets          = module.vpc.private_subnets
+  alb_listener_arn         = aws_lb_listener.https.arn
+  alb_security_group_id    = aws_security_group.alb.id
+  efs_file_system_id       = aws_efs_file_system.worlds.id
+  efs_security_group_id    = aws_security_group.worlds_efs.id
+  github_oidc_provider_arn = aws_iam_openid_connect_provider.github.arn
+  kms_key_arn              = aws_kms_key.secrets.arn
+  name_prefix              = local.name_prefix
+  common_tags              = local.common_tags
+  aws_region               = var.aws_region
+  account_id               = data.aws_caller_identity.current.account_id
+
+  # Next.js 15 + Convex client + React Flow + Radix + Sentry. Starting point
+  # matching mibera baseline; tune via CloudWatch post-deploy. React Flow in
+  # particular can spike render memory on dense construct graphs.
+  cpu    = 512
+  memory = 1024
+
+  # Use dedicated /api/health endpoint — "/" renders the catalog landing with
+  # Convex queries, which can exceed 5s health-check timeout on cold cache.
+  # NOTE: /api/health does NOT yet exist in apps/constructs-network/app/api/
+  # and must be added as part of L-migrate-constructs dispatch (10-line route
+  # returning static 200 with no IO). See SEED AC-MC pre-apply checklist.
+  health_check_path = "/api/health"
+
+  # Non-secret runtime env.
+  # NEXT_PUBLIC_* vars are baked into the client bundle at build time via
+  # --build-arg in CI (see sprawl-world/.github/workflows/deploy-constructs-
+  # network.yml) — PUBLIC BY DESIGN and NOT stored in Secrets Manager.
+  env_vars = {
+    CONSTRUCTS_API_URL = "https://api.constructs.network/v1"
+    NODE_ENV           = "production"
+  }
+
+  # Runtime secrets — resolved by ECS from AWS Secrets Manager at task start.
+  # Structure defined in world-constructs-network-secrets.tf.
+  # Values populated via scripts/load-constructs-network-secrets.sh (to be
+  # authored in L-migrate-constructs dispatch; mirrors load-honeyroad-secrets.sh).
+  #
+  # Intentionally absent:
+  #   - NEXT_PUBLIC_*       public-by-design, --build-arg only (see above)
+  #   - SENTRY_AUTH_TOKEN   build-time-only, BuildKit --secret mount in CI
+  secrets = {
+    ANTHROPIC_API_KEY           = aws_secretsmanager_secret.constructs_network["anthropic_api_key"].arn
+    CONVEX_URL                  = aws_secretsmanager_secret.constructs_network["convex_url"].arn
+    CONVEX_WRITE_KEY            = aws_secretsmanager_secret.constructs_network["convex_write_key"].arn
+    CRON_SECRET                 = aws_secretsmanager_secret.constructs_network["cron_secret"].arn
+    DISCORD_SIGNALS_WEBHOOK_URL = aws_secretsmanager_secret.constructs_network["discord_signals_webhook_url"].arn
+    GEMINI_API_KEY              = aws_secretsmanager_secret.constructs_network["gemini_api_key"].arn
+    GOOGLE_API_KEY              = aws_secretsmanager_secret.constructs_network["google_api_key"].arn
+    LINEAR_API_KEY              = aws_secretsmanager_secret.constructs_network["linear_api_key"].arn
+    LINEAR_WEBHOOK_SECRET       = aws_secretsmanager_secret.constructs_network["linear_webhook_secret"].arn
+    SIGNALS_API_KEY             = aws_secretsmanager_secret.constructs_network["signals_api_key"].arn
+    SIGNALS_ENDPOINT            = aws_secretsmanager_secret.constructs_network["signals_endpoint"].arn
+    TELEGRAM_BOT_TOKEN          = aws_secretsmanager_secret.constructs_network["telegram_bot_token"].arn
+    TELEGRAM_CHAT_ID            = aws_secretsmanager_secret.constructs_network["telegram_chat_id"].arn
+    UMAMI_API_KEY               = aws_secretsmanager_secret.constructs_network["umami_api_key"].arn
+    UMAMI_PURUPURU_WEBSITE_ID   = aws_secretsmanager_secret.constructs_network["umami_purupuru_website_id"].arn
+    UMAMI_SITE_IDS              = aws_secretsmanager_secret.constructs_network["umami_site_ids"].arn
+  }
+
+  secret_arns = [for s in aws_secretsmanager_secret.constructs_network : s.arn]
+}
+
+# =============================================================================
+# Cron replacement: /api/cron/reconcile (was Vercel cron */15 * * * *)
+# =============================================================================
+# The retired Vercel cron hit constructs.network/api/cron/reconcile every 15
+# minutes with CRON_SECRET bearer auth. On ECS we re-home via EventBridge
+# scheduled rule → private target invoking the endpoint. The schedule
+# replacement is defined separately (not inline here) so it can be rotated
+# or disabled without re-planning the world module.
+#
+# Implementation: EventBridge rule + Lambda target (~30 LOC Python/Node) that
+# curls https://constructs-network.0xhoneyjar.xyz/api/cron/reconcile with
+# `Authorization: Bearer <CRON_SECRET>`. Secret resolved at Lambda invocation
+# via ECS task role extension, NOT embedded in EventBridge input (flatline-
+# style posture).
+#
+# DEFERRED: EventBridge + Lambda resource declaration. Draft issue + decision
+# tracked in loa-freeside#176 comment thread. If cron-reconcile turns out to
+# be non-load-bearing (catalog ingest pipeline is externalized), drop entirely.
+
+output "constructs_network_ecr_url" {
+  value       = module.world_constructs_network.ecr_repository_url
+  description = "ECR repository for constructs-network image pushes (CI uses this)"
+}
+
+output "constructs_network_ci_role_arn" {
+  value       = module.world_constructs_network.ci_deploy_role_arn
+  description = "IAM role ARN for sprawl-world constructs-network GitHub Actions OIDC (set as AWS_DEPLOY_ROLE_ARN_CONSTRUCTS_NETWORK repo secret)"
+}
+
+output "constructs_network_subdomain" {
+  value       = "constructs-network.${var.environment == "production" ? "0xhoneyjar.xyz" : "staging.0xhoneyjar.xyz"}"
+  description = "Provisional subdomain during staged cutover (before www.constructs.network alias swap)"
+}


### PR DESCRIPTION
Cycle-009 L-migrate-constructs draft. Adds terraform for constructs.network → Freeside ECS migration. **Not applied.**

Per [learner-expert-transparency-protocol](https://github.com/0xHoneyJar/loa-freeside/issues/176#issue-body) and #176: @zkSoju is still learning the freeside deploy surface. Assume every apply needs your audit. Where we say "we'll do X," read "we'll draft X and would welcome your audit or counter-proposal before touching your infrastructure."

## What this adds

Two files, mirrors `world-mibera.tf` pattern:

- `infrastructure/terraform/world-constructs-network.tf` · module block + outputs
- `infrastructure/terraform/world-constructs-network-secrets.tf` · 16-secret structure

## Target app

`0xHoneyJar/sprawl-world:apps/constructs-network` — Next.js 15 + Convex + React Flow + Radix + Sentry. Vercel project `loa-constructs-explorer-5bfi` retired post-cutover + 48h parallel window.

## Pattern consistency

| Field | Value | Rationale |
|---|---|---|
| `cpu`/`memory` | 512/1024 | Matches mibera baseline; tune via CloudWatch |
| `health_check_path` | `/api/health` | MUST be authored before apply (route doesn't exist yet in the app) |
| `env_vars` | `CONSTRUCTS_API_URL`, `NODE_ENV` | Non-secret runtime |
| `secrets` | 16 entries | AI keys, Convex, cron, signals, Linear, Telegram, Umami |
| `NEXT_PUBLIC_*` | build-arg only | Public by design, baked into client bundle |
| `SENTRY_AUTH_TOKEN` | BuildKit --secret | Never in image layer (per SKP-001 pattern) |

## Deferred (in-file comments flag)

- EventBridge cron replacement for `/api/cron/reconcile` (was Vercel `*/15 * * * *`) — rule + Lambda target TBD, or drop if non-load-bearing
- `scripts/load-constructs-network-secrets.sh` (mirrors honeyroad script)
- `apps/constructs-network/Dockerfile` authoring (sprawl-world side)
- `apps/constructs-network/app/api/health/route.ts` (sprawl-world side)
- DNS green/blue swap for `www.constructs.network` (48h parallel window)

## Status

| Check | Result |
|---|---|
| `terraform fmt` | ✓ clean |
| `terraform validate` | ✓ Success (module refs resolve) |
| `terraform plan` | — (operator IAM scoped to S3; KMS decrypt denied on tfstate. Paired run needed) |

## Three asks (owner's call framing)

### 1. Shape

Single-service (Shape B) following mibera template. If you want Shape C (hybrid: user-surface + api separate) or want to hold until #174 Purupuru multi-app resolves, let me know.

### 2. Cron replacement

\`/api/cron/reconcile\` runs every 15 min today (Vercel cron). Options:
- **EventBridge rule + Lambda target** — AWS-native, ~30 LOC sidecar
- **In-process app-level scheduler** — simpler, but extra memory + single-task constraint
- **Drop entirely** — if the reconcile is non-load-bearing (catalog ingest is externalized)

### 3. Timing

- Pair on \`apply\` this week, OR
- Sequential after mibera-honeyroad DNS cutover (your current branch) stabilizes

**Your call, no pressure.**

## Not blocking

constructs.network empty-catalog is user-visible today — registry + network visibility are product, not chrome (per operator 2026-04-24: *"visibility and transparency with agents on a UI surface is coexistence"* / #176). Not an emergency, but a real outage. Happy to take pairing this week if you can fit it; otherwise queued behind your active work.

## Corrections expected

Per protocol §4: amendments not silent edits.

## References

- #176 — cycle-009 disclosure issue
- #174 — Purupuru multi-app (parallel, kept separate)
- #153 — World Container Hosting spec
- sprawl-world PR #39 — cycle-007 adopt constructs-network (now on main via cycle-009 L-branch-reconcile PR #38)
- loa-constructs:grimoires/loa-constructs-seed-2026-04-21/cycle-009-SEED-freeside-host-migration.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)