### PR TITLE
feat(cycle-010 DRAFT): world-freeside-dashboard terraform + @freeside/cli scaffold

### DIFF
--- a/infrastructure/terraform/world-constructs-network-secrets.tf
+++ b/infrastructure/terraform/world-constructs-network-secrets.tf
@@ -1,0 +1,80 @@
+# =============================================================================
+# constructs-network — AWS Secrets Manager structure
+# =============================================================================
+# Defines the 16 runtime secrets the constructs-network ECS task resolves at
+# task start. Values are NOT populated by terraform — they're loaded via
+# `scripts/load-constructs-network-secrets.sh` (to be authored, mirrors
+# load-honeyroad-secrets.sh). The script pulls from operator-side env (Vercel
+# export or 1Password), validates non-empty + no placeholder, and calls
+# aws secretsmanager put-secret-value.
+#
+# This avoids committing secret values to git while keeping the structural
+# definition in IaC. Mismatch between this set and world-constructs-network.tf's
+# `secrets = {...}` map → terraform plan error.
+#
+# Intentionally absent (by design):
+#   - NEXT_PUBLIC_*       public-by-design, --build-arg only in CI
+#   - SENTRY_AUTH_TOKEN   build-time-only, BuildKit --secret mount in CI
+#   - CONSTRUCTS_API_URL  non-secret; set as env_var in world-constructs-network.tf
+#   - NODE_ENV            non-secret; set as env_var
+#
+# Env-var source-of-truth mapping (operator reference, for migration):
+#   apps/constructs-network/.env.example  → AWS Secrets Manager key (this file)
+#   Vercel env dashboard (loa-constructs-explorer-5bfi / successor)  → ditto
+#
+# Related: loa-freeside#176, cycle-009 SEED, sprawl-world:apps/constructs-network
+# =============================================================================
+
+locals {
+  constructs_network_secrets = toset([
+    # AI APIs (agent-facing catalog + signal generation)
+    "anthropic_api_key",
+    "gemini_api_key",
+    "google_api_key",
+
+    # Convex (catalog DB backend; write key for cron + server actions)
+    "convex_url",
+    "convex_write_key",
+
+    # Cron auth (bearer token for /api/cron/reconcile)
+    "cron_secret",
+
+    # Signals pipeline (feedback → Convex → Discord)
+    "signals_api_key",
+    "signals_endpoint",
+    "discord_signals_webhook_url",
+
+    # Linear (ticket integration, webhook)
+    "linear_api_key",
+    "linear_webhook_secret",
+
+    # Telegram (notification bot for operators)
+    "telegram_bot_token",
+    "telegram_chat_id",
+
+    # Umami (self-hosted analytics, multi-site)
+    "umami_api_key",
+    "umami_purupuru_website_id",
+    "umami_site_ids",
+  ])
+}
+
+resource "aws_secretsmanager_secret" "constructs_network" {
+  for_each = local.constructs_network_secrets
+
+  name                    = "${local.name_prefix}/worlds/constructs-network/${each.value}"
+  description             = "constructs-network runtime secret: ${each.value}"
+  kms_key_id              = aws_kms_key.secrets.arn
+  recovery_window_in_days = 7
+
+  tags = merge(local.common_tags, {
+    World  = "constructs-network"
+    Secret = each.value
+  })
+}
+
+# NOTE on re-creation: recovery_window_in_days = 7 means a destroyed secret
+# remains recoverable (not purged) for 7 days. To re-create a secret with the
+# same name within that window, either wait 7 days OR manually delete with
+# `aws secretsmanager delete-secret --secret-id <arn> --force-delete-without-recovery`.
+# This pattern inherited from world-mibera-secrets.tf.

--- a/infrastructure/terraform/world-constructs-network.tf
+++ b/infrastructure/terraform/world-constructs-network.tf
@@ -1,0 +1,130 @@
+# =============================================================================
+# World: constructs-network — constructs.network registry UI (Next.js 15 + Convex)
+# =============================================================================
+# Cycle-009 L-migrate-constructs (loa-constructs, parallel to loa-freeside#176):
+# Migrates the constructs.network UI off Vercel onto Freeside ECS Fargate.
+# The app is a Next.js 15 monorepo member at
+# 0xHoneyJar/sprawl-world:apps/constructs-network (lifted from loa-constructs
+# in cycle-007 via PR #39). Vercel project `loa-constructs-explorer-5bfi`
+# retired post-cutover + 48h parallel window (see cycle-009 SEED).
+#
+# Bug closed: bd-1o9 (constructs.network empty-catalog — Vercel config drift
+# + stale build path). Migration supersedes spot-fix per cycle-008 L-bug-triage.
+#
+# Registry + network visibility is part of the product, not chrome
+# (operator 2026-04-24: "visibility and transparency with agents on a UI
+# surface is coexistence"). This migration restores the agent+human shared
+# UI that went dark post-cycle-007.
+#
+# Related: loa-freeside#176, #174, #153
+# SEED:    loa-constructs/grimoires/loa-constructs-seed-2026-04-21/cycle-009-SEED-freeside-host-migration.md
+# =============================================================================
+
+module "world_constructs_network" {
+  source = "./modules/world"
+
+  name        = "constructs-network"
+  repo        = "0xHoneyJar/sprawl-world"
+  environment = var.environment
+
+  # Shared infrastructure references
+  cluster_id               = aws_ecs_cluster.main.id
+  cluster_name             = aws_ecs_cluster.main.name
+  vpc_id                   = module.vpc.vpc_id
+  private_subnets          = module.vpc.private_subnets
+  alb_listener_arn         = aws_lb_listener.https.arn
+  alb_security_group_id    = aws_security_group.alb.id
+  efs_file_system_id       = aws_efs_file_system.worlds.id
+  efs_security_group_id    = aws_security_group.worlds_efs.id
+  github_oidc_provider_arn = aws_iam_openid_connect_provider.github.arn
+  kms_key_arn              = aws_kms_key.secrets.arn
+  name_prefix              = local.name_prefix
+  common_tags              = local.common_tags
+  aws_region               = var.aws_region
+  account_id               = data.aws_caller_identity.current.account_id
+
+  # Next.js 15 + Convex client + React Flow + Radix + Sentry. Starting point
+  # matching mibera baseline; tune via CloudWatch post-deploy. React Flow in
+  # particular can spike render memory on dense construct graphs.
+  cpu    = 512
+  memory = 1024
+
+  # Use dedicated /api/health endpoint — "/" renders the catalog landing with
+  # Convex queries, which can exceed 5s health-check timeout on cold cache.
+  # NOTE: /api/health does NOT yet exist in apps/constructs-network/app/api/
+  # and must be added as part of L-migrate-constructs dispatch (10-line route
+  # returning static 200 with no IO). See SEED AC-MC pre-apply checklist.
+  health_check_path = "/api/health"
+
+  # Non-secret runtime env.
+  # NEXT_PUBLIC_* vars are baked into the client bundle at build time via
+  # --build-arg in CI (see sprawl-world/.github/workflows/deploy-constructs-
+  # network.yml) — PUBLIC BY DESIGN and NOT stored in Secrets Manager.
+  env_vars = {
+    CONSTRUCTS_API_URL = "https://api.constructs.network/v1"
+    NODE_ENV           = "production"
+  }
+
+  # Runtime secrets — resolved by ECS from AWS Secrets Manager at task start.
+  # Structure defined in world-constructs-network-secrets.tf.
+  # Values populated via scripts/load-constructs-network-secrets.sh (to be
+  # authored in L-migrate-constructs dispatch; mirrors load-honeyroad-secrets.sh).
+  #
+  # Intentionally absent:
+  #   - NEXT_PUBLIC_*       public-by-design, --build-arg only (see above)
+  #   - SENTRY_AUTH_TOKEN   build-time-only, BuildKit --secret mount in CI
+  secrets = {
+    ANTHROPIC_API_KEY           = aws_secretsmanager_secret.constructs_network["anthropic_api_key"].arn
+    CONVEX_URL                  = aws_secretsmanager_secret.constructs_network["convex_url"].arn
+    CONVEX_WRITE_KEY            = aws_secretsmanager_secret.constructs_network["convex_write_key"].arn
+    CRON_SECRET                 = aws_secretsmanager_secret.constructs_network["cron_secret"].arn
+    DISCORD_SIGNALS_WEBHOOK_URL = aws_secretsmanager_secret.constructs_network["discord_signals_webhook_url"].arn
+    GEMINI_API_KEY              = aws_secretsmanager_secret.constructs_network["gemini_api_key"].arn
+    GOOGLE_API_KEY              = aws_secretsmanager_secret.constructs_network["google_api_key"].arn
+    LINEAR_API_KEY              = aws_secretsmanager_secret.constructs_network["linear_api_key"].arn
+    LINEAR_WEBHOOK_SECRET       = aws_secretsmanager_secret.constructs_network["linear_webhook_secret"].arn
+    SIGNALS_API_KEY             = aws_secretsmanager_secret.constructs_network["signals_api_key"].arn
+    SIGNALS_ENDPOINT            = aws_secretsmanager_secret.constructs_network["signals_endpoint"].arn
+    TELEGRAM_BOT_TOKEN          = aws_secretsmanager_secret.constructs_network["telegram_bot_token"].arn
+    TELEGRAM_CHAT_ID            = aws_secretsmanager_secret.constructs_network["telegram_chat_id"].arn
+    UMAMI_API_KEY               = aws_secretsmanager_secret.constructs_network["umami_api_key"].arn
+    UMAMI_PURUPURU_WEBSITE_ID   = aws_secretsmanager_secret.constructs_network["umami_purupuru_website_id"].arn
+    UMAMI_SITE_IDS              = aws_secretsmanager_secret.constructs_network["umami_site_ids"].arn
+  }
+
+  secret_arns = [for s in aws_secretsmanager_secret.constructs_network : s.arn]
+}
+
+# =============================================================================
+# Cron replacement: /api/cron/reconcile (was Vercel cron */15 * * * *)
+# =============================================================================
+# The retired Vercel cron hit constructs.network/api/cron/reconcile every 15
+# minutes with CRON_SECRET bearer auth. On ECS we re-home via EventBridge
+# scheduled rule → private target invoking the endpoint. The schedule
+# replacement is defined separately (not inline here) so it can be rotated
+# or disabled without re-planning the world module.
+#
+# Implementation: EventBridge rule + Lambda target (~30 LOC Python/Node) that
+# curls https://constructs-network.0xhoneyjar.xyz/api/cron/reconcile with
+# `Authorization: Bearer <CRON_SECRET>`. Secret resolved at Lambda invocation
+# via ECS task role extension, NOT embedded in EventBridge input (flatline-
+# style posture).
+#
+# DEFERRED: EventBridge + Lambda resource declaration. Draft issue + decision
+# tracked in loa-freeside#176 comment thread. If cron-reconcile turns out to
+# be non-load-bearing (catalog ingest pipeline is externalized), drop entirely.
+
+output "constructs_network_ecr_url" {
+  value       = module.world_constructs_network.ecr_repository_url
+  description = "ECR repository for constructs-network image pushes (CI uses this)"
+}
+
+output "constructs_network_ci_role_arn" {
+  value       = module.world_constructs_network.ci_deploy_role_arn
+  description = "IAM role ARN for sprawl-world constructs-network GitHub Actions OIDC (set as AWS_DEPLOY_ROLE_ARN_CONSTRUCTS_NETWORK repo secret)"
+}
+
+output "constructs_network_subdomain" {
+  value       = "constructs-network.${var.environment == "production" ? "0xhoneyjar.xyz" : "staging.0xhoneyjar.xyz"}"
+  description = "Provisional subdomain during staged cutover (before www.constructs.network alias swap)"
+}

--- a/infrastructure/terraform/world-freeside-dashboard-secrets.tf
+++ b/infrastructure/terraform/world-freeside-dashboard-secrets.tf
@@ -1,0 +1,59 @@
+# =============================================================================
+# freeside-dashboard — AWS Secrets Manager structure
+# =============================================================================
+# Cycle-010 L-migrate-prep (DRAFT · not applied · not in PR yet).
+# Defines the 4 runtime secrets the freeside-dashboard ECS task resolves at
+# task start. Values are NOT populated by terraform — they're loaded via
+# `sprawl-world/scripts/load-freeside-dashboard-secrets.sh` (to be authored).
+#
+# This avoids committing secret values to git while keeping the structural
+# definition in IaC. Mismatch between this set and world-freeside-dashboard.tf's
+# `secrets = {...}` map → terraform plan error.
+#
+# Intentionally absent (by design):
+#   - ADMIN_ADDRESSES    public wallet allowlist; set as env_var, not secret
+#   - SIWE_*             non-secret config; env_var
+#   - AWS_ACCESS_KEY_ID  avoid static keys; prefer task role + IAM policy
+#                        attachment (deferred, see world-freeside-dashboard.tf
+#                        "task-role extension" comment)
+#
+# Env-var source-of-truth mapping (operator reference, for migration):
+#   sprawl-world/apps/dashboard/.env.example  → AWS Secrets Manager key (this file)
+#
+# Related: loa-freeside#176, cycle-009 SEED, cycle-010 SEED §AC-MP.6
+# =============================================================================
+
+locals {
+  freeside_dashboard_secrets = toset([
+    # Turso (SvelteKit session + dashboard state)
+    "turso_database_url",
+    "turso_auth_token",
+
+    # GitHub (deploy correlation + log-fetch)
+    "github_token",
+
+    # Sentry DSN — treated as secret pending L-migrate-dashboard decision
+    # (see world-freeside-dashboard.tf `secrets` comment). If reclassified as
+    # non-secret env_var, remove from this set + move to module env_vars.
+    "sentry_dsn",
+  ])
+}
+
+resource "aws_secretsmanager_secret" "freeside_dashboard" {
+  for_each = local.freeside_dashboard_secrets
+
+  name                    = "${local.name_prefix}/worlds/freeside-dashboard/${each.value}"
+  description             = "freeside-dashboard runtime secret: ${each.value}"
+  kms_key_id              = aws_kms_key.secrets.arn
+  recovery_window_in_days = 7
+
+  tags = merge(local.common_tags, {
+    World  = "freeside-dashboard"
+    Secret = each.value
+  })
+}
+
+# NOTE on re-creation: recovery_window_in_days = 7 — destroyed secrets are
+# recoverable for 7 days. To re-create within that window, either wait or
+# `aws secretsmanager delete-secret --secret-id <arn> --force-delete-without-recovery`.
+# Inherited from world-mibera-secrets.tf + world-constructs-network-secrets.tf.

--- a/infrastructure/terraform/world-freeside-dashboard.tf
+++ b/infrastructure/terraform/world-freeside-dashboard.tf
@@ -1,0 +1,126 @@
+# =============================================================================
+# World: freeside-dashboard — SvelteKit operator dashboard (adapter-node)
+# =============================================================================
+# Cycle-010 L-migrate-prep (DRAFT · not applied · not in PR yet).
+# Mirror of world-constructs-network.tf, tuned for SvelteKit adapter-node
+# runtime. Host target: sprawl-world/apps/dashboard/ on ECS Fargate.
+#
+# The dashboard IS the operator surface for Freeside worlds (per PRD
+# grimoires/loa/cycles/cycle-374098eb43/). Migrating it onto Freeside ECS is
+# the ultimate dogfood — if the dashboard can't deploy itself onto the
+# platform it describes, the platform has a credibility gap. Cycle-009
+# L-migrate-dashboard / cycle-010 L-migrate-prep predicate closes that gap.
+#
+# Bootstrap sequence: Vercel deploy of apps/dashboard stays warm at ALL TIMES
+# through cutover + 48h post-cutover. DNS flip-back in <5min if freeside-
+# dashboard-on-freeside fails. Explicit rollback SLA (cycle-009 AC-MD.5).
+#
+# Related: loa-freeside#176, cycle-009 SEED §L-migrate-dashboard, cycle-010 SEED
+# =============================================================================
+
+module "world_freeside_dashboard" {
+  source = "./modules/world"
+
+  name        = "freeside-dashboard"
+  repo        = "0xHoneyJar/sprawl-world"
+  environment = var.environment
+
+  # Shared infrastructure references
+  cluster_id               = aws_ecs_cluster.main.id
+  cluster_name             = aws_ecs_cluster.main.name
+  vpc_id                   = module.vpc.vpc_id
+  private_subnets          = module.vpc.private_subnets
+  alb_listener_arn         = aws_lb_listener.https.arn
+  alb_security_group_id    = aws_security_group.alb.id
+  efs_file_system_id       = aws_efs_file_system.worlds.id
+  efs_security_group_id    = aws_security_group.worlds_efs.id
+  github_oidc_provider_arn = aws_iam_openid_connect_provider.github.arn
+  kms_key_arn              = aws_kms_key.secrets.arn
+  name_prefix              = local.name_prefix
+  common_tags              = local.common_tags
+  aws_region               = var.aws_region
+  account_id               = data.aws_caller_identity.current.account_id
+
+  # SvelteKit adapter-node. Lighter footprint than Next.js (no Sentry webpack
+  # plugin overhead). Start at the module default 256/512, bump if observed.
+  cpu    = 256
+  memory = 512
+
+  # Use /api/health endpoint — "/" renders world-list with Turso queries;
+  # cold-cache path can exceed 5s health-check timeout. /api/health is a
+  # framework-standard static 200 (to be added if not present).
+  health_check_path = "/api/health"
+
+  # Non-secret runtime env.
+  #   ADMIN_ADDRESSES  public wallet allowlist; security is signature
+  #                    verification, not key secrecy.
+  #   SIWE_*           domain/origin config for SIWE; non-secret.
+  #   KILL_SESSIONS    break-glass; intentionally empty; set via
+  #                    `aws ssm put-parameter` + force-deploy when needed.
+  env_vars = {
+    NODE_ENV       = "production"
+    PORT           = "3000"
+    SIWE_DOMAIN    = "dashboard.sprawl.world"
+    SIWE_ORIGIN    = "https://dashboard.sprawl.world"
+    SIWE_CHAIN_ID  = "8453"
+    KILL_SESSIONS  = ""
+    # FREESIDE_ECS_CLUSTER + FREESIDE_COST_ACCOUNT_ID are populated post-apply
+    # once the cluster ARN + account ID are known — set via `aws ssm` or
+    # module-outputs-wired-in on a follow-up apply.
+  }
+
+  # Runtime secrets — resolved by ECS from AWS Secrets Manager at task start.
+  # Structure defined in world-freeside-dashboard-secrets.tf.
+  # Values populated via sprawl-world/scripts/load-freeside-dashboard-secrets.sh
+  # (to be authored in L-migrate-dashboard dispatch; mirrors
+  # load-constructs-network-secrets.sh).
+  #
+  # Intentionally absent:
+  #   - ADMIN_ADDRESSES    public allowlist, env_var only (see above)
+  #   - SIWE_*             config, env_var only
+  #   - SENTRY_DSN         per operator convention, DSN is non-secret env_var
+  #                        IF treating as semi-public; else move to secrets.
+  #                        Filed as open decision in L-migrate-dashboard.
+  secrets = {
+    TURSO_DATABASE_URL    = aws_secretsmanager_secret.freeside_dashboard["turso_database_url"].arn
+    TURSO_AUTH_TOKEN      = aws_secretsmanager_secret.freeside_dashboard["turso_auth_token"].arn
+    GITHUB_TOKEN          = aws_secretsmanager_secret.freeside_dashboard["github_token"].arn
+    SENTRY_DSN            = aws_secretsmanager_secret.freeside_dashboard["sentry_dsn"].arn
+  }
+
+  secret_arns = [for s in aws_secretsmanager_secret.freeside_dashboard : s.arn]
+}
+
+# =============================================================================
+# ECS task-role extension: dashboard reads ECS state for observability
+# =============================================================================
+# The dashboard is an operator surface that reads ECS cluster state (services,
+# tasks, events), ECR image tags, and CloudWatch logs for all Freeside worlds.
+# That requires specific IAM permissions on the dashboard's own ECS task role,
+# beyond the default world-module policy (which just grants secrets access).
+#
+# DEFERRED: task-role additional-policy-attachment resource. Draft scope:
+#   - ecs:DescribeClusters, DescribeServices, DescribeTasks, ListTasks
+#   - ecr:DescribeImages, BatchGetImage (read-only)
+#   - logs:DescribeLogStreams, GetLogEvents, FilterLogEvents
+#   - tagging:GetResources (for cost-tag correlation)
+#   Scoped to `arn:aws:ecs:*:*:cluster/arrakis-*` and children only.
+#
+# Tracked as open decision in L-migrate-dashboard (cycle-011+ continuation).
+# Acceptable interim: dashboard runs in read-only-degraded mode if these perms
+# are missing — env FREESIDE_ECS_CLUSTER empty → dashboard shows "ECS probe unavailable".
+
+output "freeside_dashboard_ecr_url" {
+  value       = module.world_freeside_dashboard.ecr_repository_url
+  description = "ECR repository for freeside-dashboard image pushes (sprawl-world CI uses this)"
+}
+
+output "freeside_dashboard_ci_role_arn" {
+  value       = module.world_freeside_dashboard.ci_deploy_role_arn
+  description = "IAM role ARN for sprawl-world freeside-dashboard GitHub Actions OIDC (set as AWS_DEPLOY_ROLE_ARN_FREESIDE_DASHBOARD repo secret)"
+}
+
+output "freeside_dashboard_subdomain" {
+  value       = "freeside-dashboard.${var.environment == "production" ? "0xhoneyjar.xyz" : "staging.0xhoneyjar.xyz"}"
+  description = "Provisional subdomain during staged cutover (before dashboard.sprawl.world alias swap)"
+}

--- a/packages/freeside-cli/README.md
+++ b/packages/freeside-cli/README.md
@@ -1,0 +1,64 @@
+# @freeside/cli (freeside)
+
+> World-hosting CLI for the Freeside ECS substrate. Placeholder scaffold — working bash reference lives at [sprawl-world/scripts/freeside](https://github.com/0xHoneyJar/sprawl-world/blob/main/scripts/freeside).
+
+**Status**: DRAFT · not yet implemented in this directory · reference bash exists · cycle-010 scaffold staking out the eventual home.
+
+## Why this directory exists
+
+Cycle-010 (2026-04-24) shipped a working bash CLI at `sprawl-world/scripts/freeside` that collapses cycle-009's hand-authored world-provisioning into `freeside world create <name>`. The bash is the concrete primitive; this TypeScript/commander home is the proposed forward migration so the CLI lives as a publishable package alongside [`@arrakis/cli`](../cli/) (gaib) and becomes composable with a future `freeside-mcp` server per the [mcp-wraps-cli pattern](~/hivemind/wiki/concepts/mcp-wraps-cli-pattern.md).
+
+## Naming lineage (read before renaming anything)
+
+- **`gaib`** (shipped, `@arrakis/cli` v0.1.0) — declarative Discord IaC by Jani. `gaib login/sandbox/server`. Cycle-007 complete.
+- **`freeside`** (cycle-010, bash reference) — world-hosting CLI by operator. `freeside world create`. Discord-IaC scope NOT touched.
+
+The name `gaib` was coined under Arrakis (Freeside's old name) and drifted onto Jani's Discord tool after the product rename. The operator's preferred end-state (pending Jani review and confirmation) is a **unified `freeside` binary** that subsumes gaib's subverbs:
+
+```
+$ freeside login                     # inherits from gaib
+$ freeside sandbox new               # inherits from gaib
+$ freeside server apply              # inherits from gaib (Discord IaC)
+$ freeside world create mibera       # added cycle-010
+$ freeside discord apply             # possible alias of `server`
+```
+
+This reduces external-facing CLI namespace to one binary (Vercel/vercel parity) while preserving every scope currently shipped. The rename is **Jani's call**.
+
+## What this scaffold is, and isn't
+
+**Is**:
+- A placeholder directory so the `@freeside/cli` namespace is staked out in loa-freeside.
+- A signpost: future TypeScript/commander implementation migrates from `sprawl-world/scripts/freeside`.
+- A concrete destination Jani can fill in, review, or delete if the preferred path is different.
+
+**Is NOT**:
+- A working binary. The bash at `sprawl-world/scripts/freeside` is the only working CLI today.
+- A premature commitment to the rename. If Jani prefers siblings, rename this package to something else or discard.
+- A test suite, release automation, or publishing config. Those land cycle-011+ after the rename decision.
+
+## Migration path (cycle-011+ proposal)
+
+1. Port the bash template-emission functions to TypeScript, one verb at a time (`world create` first).
+2. Add vitest suites for (a) dry-run determinism (byte-identical across runs) and (b) template-substitution correctness (CLI output matches cycle-009 hand-authored artifacts up to name tokens).
+3. If Jani accepts the unified-binary rename: fold `@arrakis/cli` subverbs into this package as commander subcommands; `gaib` binary stays as a thin backwards-compat shim that rewrites args to `freeside <same-args>`.
+4. Publish `@freeside/cli` to the internal npm registry.
+5. Ship `@freeside/mcp` as the CLI-wrapping adapter per [mcp-wraps-cli-pattern](~/hivemind/wiki/concepts/mcp-wraps-cli-pattern.md).
+
+## Until then, use the bash
+
+```bash
+# From a sprawl-world checkout
+./scripts/freeside world create mibera2 --dry-run
+./scripts/freeside world create mibera2 --pr
+```
+
+See `scripts/freeside help` for full flags.
+
+## Related
+
+- cycle-010 SEED — `loa-constructs/grimoires/loa-constructs-seed-2026-04-21/cycle-010-SEED-freeside-cli-ui-substrate.md`
+- `~/hivemind/wiki/freeside-vision.md` §"Add One File, Get a World" (naming lineage footnote)
+- `~/hivemind/wiki/concepts/mcp-wraps-cli-pattern.md` §Current state
+- `~/hivemind/wiki/concepts/naming-drift-hygiene.md`
+- loa-freeside#176, #177 (cycle-009 disclosure + terraform DRAFT)

--- a/packages/freeside-cli/package.json
+++ b/packages/freeside-cli/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@freeside/cli",
+  "version": "0.0.0-placeholder-cycle-010",
+  "description": "Freeside world-hosting CLI — placeholder scaffold; working bash at sprawl-world/scripts/freeside. See README.md for migration path.",
+  "type": "module",
+  "bin": {
+    "freeside": "./dist/bin/freeside.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "private": true,
+  "scripts": {
+    "build": "echo 'not-implemented — see README.md; working CLI lives at sprawl-world/scripts/freeside' && exit 1",
+    "typecheck": "echo 'not-implemented' && exit 0"
+  },
+  "keywords": [
+    "freeside",
+    "world-hosting",
+    "ecs",
+    "iac",
+    "placeholder"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/0xHoneyJar/loa-freeside.git",
+    "directory": "packages/freeside-cli"
+  },
+  "license": "AGPL-3.0"
+}


### PR DESCRIPTION
## Disclosure

@zksoju is still learning Terraform + co-evolving the Freeside world-hosting surface with you. Assume every file here needs your audit. Where we say "we did X," read "we did X and would welcome you reverting it."

This PR is a **reference for you to review, amend, or discard** — not a merge ask. It exists alongside #177 (constructs.network) as cycle-009's remaining L-migrate-dashboard predicate + cycle-010's `@freeside/cli` namespace stake. No `terraform apply` planned until you've reviewed both.

## What shipped (DRAFT)

### `infrastructure/terraform/world-freeside-dashboard.tf` + `-secrets.tf`
- Mirrors `world-constructs-network.tf` (#177) and `world-mibera.tf` structure
- SvelteKit adapter-node target: cpu=256, memory=512, `/api/health` probe, env_vars for SIWE config, 4 secrets (Turso x2, GitHub, Sentry-DSN)
- Deferred: ECS task-role extension so the dashboard can read ECS cluster state (it's the Freeside operator surface). Scoped note in-file; cycle-011+ open decision.
- Bootstrap sequence: Vercel deploy of the dashboard stays warm through cutover + 48h per cycle-009 AC-MD.5 rollback SLA

### `packages/freeside-cli/` (README + package.json only)
- **Placeholder scaffold**, not a working binary. Stakes out the `@freeside/cli` destination directory.
- The working CLI is bash at [`sprawl-world/scripts/freeside`](https://github.com/0xHoneyJar/sprawl-world/tree/feat/spiral-cycle-010-freeside-cli-ui-substrate/scripts) (cycle-010, also in this cycle). `freeside world create <name>` with `--dry-run`/`--commit`/`--pr` modes. `--apply` intentionally absent (IAM seam stays with you).
- README.md documents the gaib→freeside naming lineage (see "Naming ask" below).

## Why two PRs instead of stacking on #177

Separate scope: #177 = real constructs.network migration (applied, running, then DNS cut). This PR = dashboard-migration predicate + CLI namespace stake (draft, no apply). Keeping them separate so you can merge/close independently.

## Your call

### 1. Naming ask (the big one)

The `gaib` binary was coined under Arrakis (Freeside's old name) and drifted onto your Discord-IaC tool after the product rename. The operator's preferred end-state is **one unified `freeside` binary** (Vercel/vercel parity — the product IS the CLI):

```
$ freeside login                     # inherited from gaib
$ freeside sandbox new               # inherited from gaib
$ freeside server apply              # inherited from gaib (Discord IaC)
$ freeside world create mibera       # added cycle-010
$ freeside discord apply             # possible alias of `server`
```

Rationale: one binary name to discover, zero external-facing namespace collision, `gaib` remains as a thin backwards-compat shim if needed. This is **your call** — the rename touches your shipped package (`@arrakis/cli` → `@freeside/cli`) and your docs (`docs/gaib/` → `docs/freeside/`). If you prefer siblings (`gaib` + `freeside` as distinct CLIs), we'll rename the placeholder `packages/freeside-cli/` to whatever you prefer, or delete it.

See `packages/freeside-cli/README.md` §"Naming lineage" for the full framing.

### 2. world-freeside-dashboard.tf review

- **cpu/memory defaults** — if 256/512 undersizes a SvelteKit adapter-node dashboard at operator-working-session scale, we'd rather your numbers than ours
- **Turso vs Freeside-owned DB** — the dashboard currently uses Turso for session state. Alternative: move to a Freeside-owned Postgres/RDS to eliminate the last external vendor (cf. #159 consolidation). Your call on timing.
- **ECS task-role extension** — deferred note in the TF. If you have a standard pattern for "world needs to read ECS cluster state," we'd compose on yours; otherwise we'll draft a policy attachment in cycle-011.
- **Sentry DSN classification** — currently treated as a runtime secret. If you treat DSNs as non-secret env_vars (public-by-design like NEXT_PUBLIC_*), move to env_vars map.

### 3. packages/freeside-cli/ destiny

- If you accept the unified-binary rename: `packages/freeside-cli/` becomes the new home for all of `gaib`'s subcommands. Cycle-011+ migrates the bash reference + folds in `@arrakis/cli`.
- If you prefer siblings: rename to `packages/world-cli/` or similar, or discard this scaffold.
- If you prefer a different forward path entirely: delete the scaffold and tell us where the CLI should live.

## Related

- cycle-010 SEED — `loa-constructs/grimoires/loa-constructs-seed-2026-04-21/cycle-010-SEED-freeside-cli-ui-substrate.md`
- cycle-009 SEED — same directory, `cycle-009-SEED-freeside-host-migration.md`
- Bash CLI reference — sprawl-world `scripts/freeside` (cycle-010 branch, companion PR forthcoming if operator opens one)
- loa-freeside#176 #177 — cycle-009 disclosure + constructs.network terraform DRAFT
- Doctrine: [[bonfire-at-composition-seam]] (paired on apply), [[learner-expert-transparency-protocol]] (this PR body), [[naming-is-diagnostic]] (§1.5 rename), [[naming-drift-hygiene]] (Arrakis-remnant footnote)

## Not in this PR

- `terraform apply` — stays with Jani, paired
- ECS task-role extension for dashboard — cycle-011+ open decision
- `@freeside/cli` TypeScript implementation — placeholder only; working CLI is bash at sprawl-world
- Discord-IaC integration into Freeside visual layer — operator-flagged cycle-011+ forward-work
- Purupuru migration — blocked on #174 Shape A/B/C resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)