### PR TITLE
chore(infra): track apdao-world → world-apdao gh repo rename

### DIFF
--- a/infrastructure/terraform/world-apdao.tf
+++ b/infrastructure/terraform/world-apdao.tf
@@ -6,7 +6,7 @@ module "world_apdao" {
   source = "./modules/world"
 
   name        = "apdao"
-  repo        = "0xHoneyJar/apdao-world"
+  repo        = "0xHoneyJar/world-apdao"
   environment = var.environment
 
   cluster_id               = aws_ecs_cluster.main.id


### PR DESCRIPTION
## Summary
- gh-side rename completed: `0xHoneyJar/apdao-world` → `0xHoneyJar/world-apdao` (GitHub redirects keep existing references working)
- This PR updates the `repo` field in `world-apdao.tf` so the canonical reference matches the new name
- Doctrine: vault/wiki/concepts/loa-org-naming-conventions.md (operator decision 2026-04-28 late — prefix-first to mirror `construct-{slug}` family; precedent: `0xHoneyJar/world-base` exists since 2026-03-31)

## Other renames in the same session (no .tf changes here)
- `sprawl-world` → `world-sprawl` (no terraform consumer in this repo)
- `mibera-world` → `world-mibera` (this repo's `world-mibera.tf` references `mibera-honeyroad` app repo, not the world repo — unchanged)

## Generator-of-truth
The freeside-worlds registry (`0xHoneyJar/freeside-worlds`) is the source of truth for these `.tf` files. Its `packages/registry/worlds/apdao.yaml` was updated in lockstep + tf-out matches semantically.

## Test plan
- [x] No resource state changes (terraform plan should be clean — only the `repo` string changes for ECR + IAM role description)
- [ ] After merge: GitHub Actions OIDC role binding still works for `0xHoneyJar/world-apdao` deploys (GitHub redirects + the `aws_iam_openid_connect_provider` references the OIDC issuer URL, not the repo name, so should be transparent — verify on next world-apdao push)

## Cross-reference
- Coordination plan: 0xHoneyJar/freeside-worlds → see bonfire-side `grimoires/bonfire/context/world-prefix-flip-plan.md`
- Doctrine: vault/wiki/concepts/{loa-org-naming-conventions, freeside-modules-as-installables, world-system-pattern}.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)