### PR TITLE
feat(t11+t20): assets.0xhoneyjar.xyz sovereign CDN + smoke/parity hardening

### DIFF
--- a/decisions/006-image-optimizer-stays-on-d163.md
+++ b/decisions/006-image-optimizer-stays-on-d163.md
@@ -1,0 +1,83 @@
+# ADR-006: Image Optimizer Stays on `d163aeqznbc6js` for `mature-freeside-operator-and-cutover` Cycle
+
+**Date**: 2026-04-29
+**Status**: Accepted
+**Cycle**: `mature-freeside-operator-and-cutover` (Sprint 1, Phase 0 cutover)
+**Authors**: opus-4-7-1m (via /vault dig + AWS API verification) + zksoju (operator approval)
+
+## Context
+
+The cycle planning assumed Phase 0 would migrate the org's "image plane" off CloudFront `d163aeqznbc6js.cloudfront.net` to a new sovereign endpoint `assets.0xhoneyjar.xyz`. This framing came from the external-services audit (`micodex-studio/grimoires/loa/proposals/external-services-audit-2026-04-29.md`) which identified d163 as "the entire org's image plane."
+
+Pre-flight discovery 2026-04-29 (using `aws --profile admin` queries against account `891376933289`) revealed the d163 distribution is actually an **image-optimizer chain**, not a static-asset CDN:
+
+- 2 origins:
+  - `tf-next-image-optimizer` (API Gateway `mosnc349cc`) — handles default behavior
+  - `thj-assets.s3.us-west-2.amazonaws.com` — handles `*.webp` cache behavior (direct bypass)
+- 2 Lambdas behind the API Gateway:
+  - `tf-next-image` (terraform-managed, `terraform-aws-next-js-image-optimization` module)
+  - `Image-resizer` (custom-built, NOT terraform-managed; built ~mid-2024 by an early-org team member)
+- Backing S3 bucket: `thj-assets` (us-west-2, private, OAC-protected)
+
+This architecture has been **stable for ~2 years**. The operator confirmed it's load-bearing and pre-dates the freeside-* family entirely.
+
+Full architecture map: SDD §0.4 + `~/vault/wiki/concepts/image-plane-architecture.md`.
+
+## Decision
+
+**The image optimizer chain (`Image-resizer` + `tf-next-image` Lambdas + their API Gateway routing) is OUT OF SCOPE for the `mature-freeside-operator-and-cutover` cycle.**
+
+Phase 0 ships a NEW CloudFront distribution under `assets.0xhoneyjar.xyz` that:
+- Points at the SAME `thj-assets` S3 bucket (no new bucket)
+- Has the SAME `*.webp` cache behavior (mirrors legacy fast path)
+- Default behavior is plain S3 direct (NO image optimizer chain replication)
+
+Apps that consume direct webp paths get the new URL contract immediately. Apps that consume optimizer paths (`/images/{proxy+}` or `/_next/image*`) keep using `d163aeqznbc6js.cloudfront.net` — zero migration risk to the optimizer chain.
+
+## Rationale
+
+1. **Stability**: The optimizer chain has worked for 2 years under production load. Migrating it during a defensive cutover compounds risk unnecessarily.
+2. **Scope discipline**: Phase 0's primary value is publishing a stable URL contract for external builders (Adeitasuna/MibeStats per SDD §0.2). That value lands without touching the optimizer.
+3. **Format coverage limitation**: The optimizer is image-only (webp output via `TF_NEXTIMAGE_FORMATS=["image/webp"]`). mp4/video/audio bypass it entirely (operator-known; reflected in the `*.webp` cache behavior design). Re-hosting the optimizer requires re-architecting around this limitation; that's its own cycle.
+4. **Mixed governance**: `tf-next-image` is terraform-managed; `Image-resizer` is custom + undocumented. Migrating both requires reconciling two different management models. Sprint-1 lacks the budget for that work.
+5. **No urgency**: The audit's "SPOF" framing was partially correct but the actual SPOF risk is the AWS account + the S3 bucket (both shared by legacy and new distributions). Adding a new distribution provides config-isolation but doesn't reduce account-level risk; that requires multi-account work which is its own future cycle.
+
+## Consequences
+
+### Positive
+
+- **Sprint-1 scope shrinks ~30%**: T12 (bulk sync) and T13 (dual-write cron) drop entirely. T11 (terraform apply) narrows to distribution + alias + ACM (no new bucket).
+- **Optimizer chain risk: zero**. No code or config changes to the production optimizer.
+- **Builder UX**: Adeitasuna and future external builders get the stable URL contract via `assets.0xhoneyjar.xyz/{world}/{category}/{...}` for direct-access patterns.
+- **Knowledge captured**: The vault page `~/vault/wiki/concepts/image-plane-architecture.md` documents the optimizer chain for future cycles + new engineers.
+
+### Negative
+
+- **Apps using optimizer paths don't get the URL contract** in Sprint-1. They continue depending on `d163aeqznbc6js.cloudfront.net`. The "consolidated stable endpoint" promise is partial.
+- **Custom `Image-resizer` Lambda remains undocumented**. Its source code is in S3 Lambda zip; no visible git repo. If it breaks, recovery requires reverse-engineering or rebuild. Risk persists past Sprint-1.
+- **Future re-host work compounds**: when a future cycle decides to migrate the optimizer, it inherits the same complexity (mixed governance, format limitations, undocumented custom Lambda) we deferred today.
+
+### Neutral / forward-pointing
+
+Future cycles may decide to:
+
+| Path | What | Tradeoff |
+|---|---|---|
+| **Sunset** | Apps migrate to direct webp serving; Lambdas decommissioned | Cleanest; requires per-app refactor; loses on-the-fly resize |
+| **Re-host** | Replicate both Lambdas under `assets.0xhoneyjar.xyz` infrastructure; bring `Image-resizer` source under git management | Most fidelity; recovers undocumented infra as part of the work; heavy |
+| **Replace** | Swap to CloudFront Functions (edge), Lambda@Edge, or Vercel Image Optimization | Modern; zero Lambda mgmt; format coverage may differ |
+
+Each is a meaningful cycle of its own. None are Sprint-1 scope.
+
+## Cross-references
+
+- SDD: `~/bonfire/grimoires/loa/sdd.md` §0.1 (Amendment 2026-04-29) + §0.4 (Image Plane Architecture)
+- PRD: `~/bonfire/grimoires/loa/prd.md` §4.2.B.1 (post-Amendment 2026-04-29)
+- Sprint plan: `~/bonfire/grimoires/loa/sprint.md` T11 (revised), T12 (DESCOPED), T13 (DESCOPED), T11.5 (this ADR)
+- Vault doctrine: `~/vault/wiki/concepts/image-plane-architecture.md`, `~/vault/wiki/concepts/url-contract-as-bridge.md`, `~/vault/wiki/concepts/contracts-as-bridges.md`
+- External-services audit: `~/Documents/GitHub/micodex-studio/grimoires/loa/proposals/external-services-audit-2026-04-29.md`
+- Beads: `bd-z5z` (T12 DEFERRED), `bd-a56` (T13 DEFERRED), `bd-in6` (T11 narrowed)
+
+## Approval
+
+- **2026-04-29**: opus-4-7-1m + zksoju (operator) — accepted post-pre-flight discovery, AskUserQuestion routing on /run halt confirmed amendment + ADR + vault filing approach.

--- a/decisions/cloudfront-dns-2026-04-29.md
+++ b/decisions/cloudfront-dns-2026-04-29.md
@@ -1,0 +1,117 @@
+# DNS records created during T11 (mature-freeside-operator-and-cutover Sprint 1)
+
+**Date**: 2026-04-29
+**Cycle**: `mature-freeside-operator-and-cutover` (Sprint 1, T11 + T11.5)
+**Authors**: opus-4-7-1m + zksoju (operator approval via `/loa` "🚀 t11 apply now")
+**Hosted zone**: `0xhoneyjar.xyz` (`Z01393483Y40WF3N1H76`)
+
+This file logs the manual Route53 changes made during T11. Per project memory
+`freeside-dns-state-untracked`, production DNS is intentionally NOT
+terraform-managed; this log is the audit trail.
+
+## Records added
+
+### 1. CAA at `assets.0xhoneyjar.xyz` (CREATED)
+
+```
+Name: assets.0xhoneyjar.xyz
+Type: CAA
+TTL:  300
+Values:
+  0 issue "amazon.com"
+  0 issuewild "amazon.com"
+  0 iodef "mailto:security@0xhoneyjar.xyz"
+```
+
+**Why**: The `*.0xhoneyjar.xyz` wildcard CNAME points to `cname.vercel-dns.com`,
+and per RFC 8659 ACM follows CNAME chains for CAA lookups. Vercel's CAA records
+do NOT include amazon, so ACM validation initially failed with `CAA_ERROR`.
+Adding an explicit CAA record at `assets.0xhoneyjar.xyz` (a) authorizes amazon
+for that name and (b) breaks the wildcard match (since the name now has explicit
+records, per RFC 4592), severing the Vercel-CNAME chain entirely.
+
+**Change ID**: `/change/C0892690A5G34U7LNG1`
+
+### 2. A + AAAA aliases at `assets.0xhoneyjar.xyz` (CREATED)
+
+```
+Name:         assets.0xhoneyjar.xyz
+Type:         A (alias) + AAAA (alias)
+Alias target: dpi55hct91flc.cloudfront.net
+Alias zone:   Z2FDTNDATAQYW2 (CloudFront's global hosted zone)
+EvaluateTargetHealth: false
+```
+
+**Why**: Routes `assets.0xhoneyjar.xyz` to the new CloudFront distribution
+`EX3XFQSXORXM5` provisioned by `module.freeside_storage`. The
+`EvaluateTargetHealth: false` is correct for CloudFront aliases (CloudFront
+does not expose an alias-evaluable health check).
+
+**Change ID**: `/change/C05321931L2KOMJTT44SQ`
+
+## Records temporarily added then deleted
+
+### Validation CNAME(s) for failed ACM cert(s)
+
+During T11 we attempted to provision a fresh ACM cert for
+`assets.0xhoneyjar.xyz`. Both attempts failed with `CAA_ERROR` despite the
+fix above (likely AWS-internal DNS cache stickiness for the prior failure).
+The validation CNAMEs were created and then cleaned up:
+
+```
+Name:  _fb387d3b14cc933792c1316895c6e88a.assets.0xhoneyjar.xyz
+Type:  CNAME
+Value: _f5918a887c1852e2023c0da5122e5b91.jkddzztszm.acm-validations.aws.
+
+Lifecycle: created 20:29 UTC, deleted 20:32 UTC, recreated 20:33 UTC, finally deleted 20:44 UTC
+```
+
+The decision shifted to **reuse the existing `*.0xhoneyjar.xyz` wildcard ACM
+cert** (`arn:aws:acm:us-east-1:891376933289:certificate/c96a10f5-…`) — already
+ISSUED and in use by the production + staging ALBs. The wildcard cert covers
+`assets.0xhoneyjar.xyz` as a depth-2 subdomain match. The module gained an
+`existing_acm_certificate_arn` variable to support this reuse pattern.
+
+## Records NOT touched
+
+- `*.0xhoneyjar.xyz` wildcard CNAME → `cname.vercel-dns.com` — unchanged. The
+  explicit CAA + alias at `assets.0xhoneyjar.xyz` overrides the wildcard for
+  that one name; everything else still uses Vercel.
+- Apex `0xhoneyjar.xyz` CAA records — unchanged (already authorize amazon +
+  letsencrypt).
+- `auth.0xhoneyjar.xyz`, `api.0xhoneyjar.xyz`, `mibera.0xhoneyjar.xyz`,
+  `apdao.0xhoneyjar.xyz`, `rektdrop.0xhoneyjar.xyz`, `score-api.0xhoneyjar.xyz` —
+  unchanged.
+- Legacy CloudFront distribution `d163aeqznbc6js.cloudfront.net` — unchanged
+  per ADR-006.
+
+## Verification
+
+```bash
+# DNS resolution
+dig +short assets.0xhoneyjar.xyz @8.8.8.8
+# → 4× CloudFront IPs (99.84.215.*)
+
+# HTTP probe — known-real key from thj-assets
+curl -I https://assets.0xhoneyjar.xyz/Mibera/generated/0.webp
+# → HTTP/2 200; content-type: image/webp; content-length: 684060
+
+# Parity with legacy
+curl -I https://d163aeqznbc6js.cloudfront.net/Mibera/generated/0.webp
+# → HTTP/2 200; content-type: image/webp; content-length: 684060 (identical bytes)
+```
+
+Both distributions back from the same `thj-assets` bucket; identical content.
+
+## Future cycles
+
+A future cycle SHOULD:
+1. Import the manual records (CAA + A/AAAA at `assets.0xhoneyjar.xyz`) into
+   terraform state so they're tracked.
+2. Uncomment the `aws_route53_record` blocks in
+   `infrastructure/terraform/freeside-storage/route53.tf` and validate they
+   match the imported state.
+3. Reconcile the wider DNS state-drift situation (5 adds + 3 ALB flips per
+   `freeside-dns-state-untracked` memory).
+
+This is its own cycle — not Sprint 1 scope.

--- a/docs/asset-url-contract.md
+++ b/docs/asset-url-contract.md
@@ -55,7 +55,7 @@ The most-consumed world. v1 routes:
 | Canonical route | Backing TODAY (post-sprint-1) | Backing AFTER named cycle | Phase |
 |---|---|---|---|
 | `/Mibera/generated/{tokenId}.webp` | S3 `thj-assets` (direct via `assets.0xhoneyjar.xyz`) | (unchanged) | — |
-| `/Mibera/final/{tokenId}.png` | Irys `gateway.irys.xyz/7rpvw…/{hash}.png` | S3 `thj-assets` (canonical route) | **mibera-2** |
+| `/Mibera/final/{tokenId}.png` | S3 `thj-assets` at legacy `reveal_phase8/images/{hash}.png` (Irys still serves the same hash but bytes may differ) | S3 `thj-assets` at canonical tokenId-keyed route | **mibera-2** _(optional polish)_ |
 | `/Mibera/reveal/phase{N}/{hash}.png` | CloudFront `d163aeqznbc6js/images/...` (legacy URL preserved during sprint-1) | Same key shape, eventually re-keyed canonical | **mibera-rekey** |
 | `/Mibera/parcels/{id}.png` | `thj-assets.s3…/parcels/parcelsImages/{id}.png` (S3-direct, not via this CDN today) | S3 `thj-assets` at canonical route | **mibera-3** |
 | `/Mibera/miladies/{id}.png` | `thj-assets.s3…/fractures/miladies/images/{id}.png` (S3-direct) | S3 `thj-assets` at canonical route | **mibera-3** |
@@ -65,6 +65,22 @@ The most-consumed world. v1 routes:
 
 Allowed Mibera categories (v1): `final`, `reveal`, `parcels`, `miladies`,
 `traits`, `og`, `generated`, `expressions`, `layers`, `archetypes`.
+
+> 🪞 **Mibera primary renders — important correction (2026-04-29)**: the original framing
+> of this cycle assumed the 10k Mibera-primary PNGs only lived on Irys (and would need a
+> future Mibera-2 cycle to re-host). That was wrong. The same hash-keyed PNGs already
+> live on `thj-assets` at `reveal_phase{1..8}/images/{hash}.png` (8 phases of reveal
+> renderings; phase 8 is the canonical/latest per Gumi 2026-04-29). Codex consumers
+> wanting to flip from `gateway.irys.xyz/...` to the new CDN can do so today via:
+>
+> ```
+> gateway.irys.xyz/7rpvw…/{hash}.png
+>   → assets.0xhoneyjar.xyz/reveal_phase8/images/{hash}.png
+> ```
+>
+> The `mibera-2` cycle is now **optional polish** that rekeys the legacy depth-2
+> hash-keyed shape to canonical depth-3 tokenId-keyed shape. The codex flip is not
+> blocked on it. See [`construct-mibera-codex` issue #54](https://github.com/0xHoneyJar/construct-mibera-codex/issues/54).
 
 ---
 

--- a/docs/asset-url-contract.md
+++ b/docs/asset-url-contract.md
@@ -1,0 +1,229 @@
+# Asset URL Contract — `assets.0xhoneyjar.xyz`
+
+> **Audience**: external community builders (Adeitasuna's MibeStats, future
+> consumers) and internal cycles (Mibera-2/3/4/rekey, future world migrations).
+
+This doc declares the canonical URL contract for the sovereign asset surface
+at `https://assets.0xhoneyjar.xyz/`. It is paired with a machine-readable
+JSON Schema and a TypeScript interface — fetch either to programmatically
+consume the contract.
+
+| Artifact | Path | Purpose |
+|---|---|---|
+| **TS interface** | `freeside-storage/packages/protocol/src/url-contract.ts` | Canonical typed contract |
+| **JSON Schema** | `freeside-storage/packages/protocol/url-contract.schema.json` | ajv-runtime validation |
+| **This doc** | `loa-freeside/docs/asset-url-contract.md` | Human surface |
+
+The schema is the durable artifact. Future versioning works by incrementing
+the schema (semver) and republishing this doc to match. Builders should
+prefer the schema for programmatic consumption and treat this doc as the
+narrative companion.
+
+---
+
+## 1. Canonical template
+
+```
+https://assets.0xhoneyjar.xyz/{world}/{category}/{...}
+```
+
+| Token | Meaning |
+|---|---|
+| `{world}` | Top-level world slug. v1 enum: `Mibera`, `Purupuru`, `sprawl`. Matches the top-level S3 prefix on `thj-assets`. |
+| `{category}` | World-specific sub-prefix. See per-world tables below for allowed values. |
+| `{...}` | Tail path within the category — typically `{tokenId}.png`, `{hash}.png`, or category-specific naming. |
+
+JSON Schema `$id`: `https://github.com/0xHoneyJar/freeside-storage/blob/main/packages/protocol/url-contract.schema.json`
+
+Validate with ajv:
+
+```typescript
+import Ajv from 'ajv';
+import schema from '@freeside-storage/protocol/url-contract.schema.json' with { type: 'json' };
+
+const ajv = new Ajv({ strict: true });
+const validate = ajv.compile(schema);
+if (!validate(currentContract)) console.error(validate.errors);
+```
+
+---
+
+## 2. Mibera (worked example)
+
+The most-consumed world. v1 routes:
+
+| Canonical route | Backing TODAY (post-sprint-1) | Backing AFTER named cycle | Phase |
+|---|---|---|---|
+| `/Mibera/generated/{tokenId}.webp` | S3 `thj-assets` (direct via `assets.0xhoneyjar.xyz`) | (unchanged) | — |
+| `/Mibera/final/{tokenId}.png` | Irys `gateway.irys.xyz/7rpvw…/{hash}.png` | S3 `thj-assets` (canonical route) | **mibera-2** |
+| `/Mibera/reveal/phase{N}/{hash}.png` | CloudFront `d163aeqznbc6js/images/...` (legacy URL preserved during sprint-1) | Same key shape, eventually re-keyed canonical | **mibera-rekey** |
+| `/Mibera/parcels/{id}.png` | `thj-assets.s3…/parcels/parcelsImages/{id}.png` (S3-direct, not via this CDN today) | S3 `thj-assets` at canonical route | **mibera-3** |
+| `/Mibera/miladies/{id}.png` | `thj-assets.s3…/fractures/miladies/images/{id}.png` (S3-direct) | S3 `thj-assets` at canonical route | **mibera-3** |
+| `/Mibera/reveal/phase1.1/{hash}.png` | IPFS `bafy…ipfs.dweb.link/{hash}.png` | S3 `thj-assets` at canonical route | **mibera-4** |
+| `/Mibera/og/{id}.png` | Mixed (Irys + Cloudinary) | (TBD; future cycle) | future |
+| `/Mibera/traits/{...}` | CloudFront `d163aeqznbc6js` (dimensions trait map) | (unchanged path; backing may rotate) | — |
+
+Allowed Mibera categories (v1): `final`, `reveal`, `parcels`, `miladies`,
+`traits`, `og`, `generated`, `expressions`, `layers`, `archetypes`.
+
+---
+
+## 3. Purupuru
+
+Path shapes preserved from current CloudFront mirror. Sprint-1 rotates origin
+to `assets.0xhoneyjar.xyz`; key paths unchanged.
+
+| Canonical route | Backing TODAY |
+|---|---|
+| `/Purupuru/cards/{cardId}.webp` | S3 `thj-assets` (via new alias) |
+| `/Purupuru/layers/{layerId}.webp` | S3 `thj-assets` (via new alias) |
+| `/Purupuru/archetypes/{id}` | S3 `thj-assets` (via new alias) |
+| `/Purupuru/sound/{...}` | S3 `thj-assets` (sound assets — when published) |
+
+Allowed Purupuru categories (v1): `cards`, `layers`, `archetypes`, `sound`.
+
+---
+
+## 4. Sprawl (rektdrop, cubquests)
+
+Path shapes preserved; sub-app discriminator is the second segment.
+
+| Canonical route | Backing TODAY |
+|---|---|
+| `/sprawl/rektdrop/{...}` | S3 `thj-assets` (via new alias) |
+| `/sprawl/cubquests/{...}` | S3 `thj-assets` (via new alias) |
+
+Allowed sprawl categories (v1): `rektdrop`, `cubquests`.
+
+---
+
+## 5. Future-cycle phase roster
+
+The contract declares migration phase IDs that future cycles consume. Each
+phase ID matches the `MigrationPhaseId` enum in the TS interface; consumers
+can codegen against the enum.
+
+| Phase ID | Cycle | Scope | Status |
+|---|---|---|---|
+| `sprint-1` | `mature-freeside-operator-and-cutover` | Establish parallel CloudFront against `thj-assets`; preserve `*.webp` fast path; preserve legacy URL shapes; publish this contract | **shipping now** |
+| `mibera-2` | `mibera-2` (TBD) | Re-host Mibera finals from Irys to S3 `thj-assets` at `/Mibera/final/{tokenId}.png` | future |
+| `mibera-3` | `mibera-3` (TBD) | Re-host parcels + miladies from S3-direct to S3 `thj-assets` at canonical routes | future |
+| `mibera-4` | `mibera-4` (TBD) | Re-host IPFS-pinned reveal phase 1.1 from dweb gateway to S3 `thj-assets` | future |
+| `mibera-rekey` | `mibera-rekey` (TBD; after mibera-2/3/4) | Single rekey pass: `/images/reveal_phase{N}/...` → `/Mibera/reveal/phase{N}/...`; redirects for grace window; deprecate legacy on published timeline | future |
+
+Future cycles consume this contract by reading the JSON Schema's
+`migrationPhases` array. They MAY add new phase IDs by extending the enum
+(additive minor — does NOT require a major version bump).
+
+---
+
+## 6. Forward-compat for IPFS permanence
+
+`assets.0xhoneyjar.xyz` is the public endpoint. The backing layer can swap
+transparently across cycles:
+
+```
+S3 (today, sprint-1)
+  → S3 + IPFS gateway origin (CloudFront origin failover)
+  → self-hosted IPFS gateway with S3 fallback
+  → IPFS pinning service primary, S3 archive
+```
+
+The URL contract is invariant across these transitions. CloudFront supports
+multiple origins with failover (Pinata's CloudFront + IPFS origin pattern is
+canonical). Future cycles may adopt this without changing
+`assets.0xhoneyjar.xyz/...` consumer URLs.
+
+---
+
+## 7. Versioning + governance
+
+- **Policy**: semver.
+- **v1**: locked at `1.0.0` (this cycle).
+- **Additive minors**: extending category enums, adding canonical routes,
+  adding migration phase IDs. Backwards-compatible.
+- **Breaking changes**: changing `host`, `template`, removing routes, removing
+  worlds. Requires:
+  1. Major version bump (e.g. `1.0.0` → `2.0.0`).
+  2. **90-day deprecation window** during which v1 and v2 coexist.
+  3. Public announcement to community builders (this doc + Discord + relevant
+     world repos).
+- **Schema is canonical**: when this doc and the JSON Schema disagree, the
+  schema wins. File a PR against the schema first; this doc updates to match.
+
+---
+
+## 8. How to consume the schema
+
+### Via TypeScript
+
+```typescript
+import {
+  URL_CONTRACT_V1,
+  isCanonicalPath,
+  type URLContract,
+  type WorldSlug,
+  type MigrationPhaseId,
+} from '@freeside-storage/protocol';
+
+const ok = isCanonicalPath(URL_CONTRACT_V1, '/Mibera/generated/0.webp');
+// → true
+
+// Discover routes for a world
+const mibera = URL_CONTRACT_V1.worlds.find((w) => w.slug === 'Mibera');
+console.log(mibera.routes.length); // → 6+
+```
+
+### Via JSON Schema (codegen, runtime validation)
+
+```bash
+# Codegen client types
+npx quicktype \
+  --src https://raw.githubusercontent.com/0xHoneyJar/freeside-storage/main/packages/protocol/url-contract.schema.json \
+  --src-lang schema \
+  --lang typescript \
+  --out url-contract.gen.ts
+
+# Or runtime ajv validation
+npm install ajv
+```
+
+```typescript
+import Ajv from 'ajv';
+import schema from './url-contract.schema.json' with { type: 'json' };
+
+const ajv = new Ajv({ strict: true });
+const validate = ajv.compile(schema);
+
+if (!validate(currentContract)) {
+  console.error('contract mismatch:', validate.errors);
+}
+```
+
+### Via the JSON Schema `$id` (any language with ajv-equivalent)
+
+```
+https://github.com/0xHoneyJar/freeside-storage/blob/main/packages/protocol/url-contract.schema.json
+```
+
+Pin the schema by version (semver tag) for reproducibility:
+
+```
+https://github.com/0xHoneyJar/freeside-storage/blob/v1.0.0/packages/protocol/url-contract.schema.json
+```
+
+---
+
+## 9. Sources of truth
+
+- **Schema** (canonical): `freeside-storage/packages/protocol/url-contract.schema.json`
+- **TS interface**: `freeside-storage/packages/protocol/src/url-contract.ts`
+- **Default v1 instance**: `URL_CONTRACT_V1` (exported from the TS module)
+- **SDD provenance**: `bonfire/grimoires/loa/sdd.md` §0.2 (per-world contract amendment) + §0.3 (contracts-as-bridges instance-N reframe)
+- **PRD provenance**: `bonfire/grimoires/loa/prd.md` (post-§4.2.B amendments)
+- **Doctrine page**: `~/vault/wiki/concepts/url-contract-as-bridge.md` (instance-4 of contracts-as-bridges)
+- **Cycle**: `mature-freeside-operator-and-cutover` (Sprint 1)
+
+For schema PRs, route through `freeside-storage`'s repo. For doc updates,
+this file is the home; cross-link from the schema's `$comment` fields when
+adding new sections.

--- a/infrastructure/terraform/freeside-storage.tf
+++ b/infrastructure/terraform/freeside-storage.tf
@@ -1,0 +1,117 @@
+# =============================================================================
+# freeside-storage — production root consumer
+# =============================================================================
+#
+# Per Sprint 1 of mature-freeside-operator-and-cutover cycle (T11). The module
+# itself lives at ./freeside-storage/ and was authored in T4. This file is the
+# production callsite that materializes the resources.
+#
+# Reality (per SDD §0.1 Amendment 3): no new bucket. The new CloudFront
+# distribution at assets.0xhoneyjar.xyz reads from the existing thj-assets
+# bucket in us-west-2. Image optimizer chain stays at d163aeqznbc6js
+# (unchanged) per ADR-006.
+#
+# Apply procedure (3 targeted phases — ACM validation is manual per
+# project memory `freeside-dns-state-untracked`):
+#
+#   # Phase 1: cert + OAC
+#   terraform apply \
+#     -target=module.freeside_storage.aws_acm_certificate.alias \
+#     -target=module.freeside_storage.aws_cloudfront_origin_access_control.s3_oac
+#
+#   # Phase 2: pull validation records, create CNAMEs by hand in Route53
+#   terraform output -json freeside_storage_acm_validation_records
+#   #   ...operator creates each CNAME in Route53 console...
+#   #   ...wait for ACM cert status to move PENDING_VALIDATION → ISSUED (5-30m)...
+#
+#   # Phase 3: full apply (creates the distribution)
+#   terraform apply -target=module.freeside_storage
+#
+#   # Phase 4: pull alias target + create A/AAAA in Route53 console
+#   terraform output -json freeside_storage_cloudfront_distribution_domain
+#
+#   # Phase 5: update thj-assets bucket policy in AWS console (additive OAC grant)
+#   terraform output -json freeside_storage_oac_grant
+# =============================================================================
+
+# us_west_2 provider alias — backing bucket thj-assets lives here
+provider "aws" {
+  alias  = "us_west_2"
+  region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Service   = "freeside-storage"
+      ManagedBy = "terraform"
+      Cycle     = "mature-freeside-operator-and-cutover"
+    }
+  }
+}
+
+module "freeside_storage" {
+  source = "./freeside-storage"
+
+  providers = {
+    aws           = aws.us_west_2 # default → bucket region (us-west-2)
+    aws.us_east_1 = aws           # us_east_1 alias → production root default (already us-east-1)
+  }
+
+  alias_fqdn            = "assets.0xhoneyjar.xyz"
+  backing_bucket_name   = "thj-assets"
+  backing_bucket_region = "us-west-2"
+  hosted_zone_name      = "0xhoneyjar.xyz"
+
+  # Reuse the existing wildcard cert *.0xhoneyjar.xyz (already ISSUED, used by ALBs).
+  # Avoids the CAA-cache issue we hit during T11 — the wildcard cert was issued
+  # before the *.0xhoneyjar.xyz → vercel-dns.com wildcard CNAME was added, so
+  # ACM has no stale CAA failure for it.
+  existing_acm_certificate_arn = "arn:aws:acm:us-east-1:891376933289:certificate/c96a10f5-ec24-4fed-9779-0a858eeff522"
+
+  common_tags = {
+    Service   = "freeside-storage"
+    ManagedBy = "terraform"
+    Cycle     = "mature-freeside-operator-and-cutover"
+  }
+}
+
+# Surface the module outputs at the root so `terraform output` works at the
+# canonical apply location.
+
+output "freeside_storage_cloudfront_distribution_id" {
+  description = "ID of the new CloudFront distribution"
+  value       = module.freeside_storage.cloudfront_distribution_id
+}
+
+output "freeside_storage_cloudfront_distribution_arn" {
+  description = "ARN — required for the bucket-policy OAC grant"
+  value       = module.freeside_storage.cloudfront_distribution_arn
+}
+
+output "freeside_storage_cloudfront_distribution_domain" {
+  description = "Auto-generated CF domain — target for the Route53 alias record"
+  value       = module.freeside_storage.cloudfront_distribution_domain
+}
+
+output "freeside_storage_cloudfront_hosted_zone_id" {
+  description = "CloudFront's hosted zone ID — required for the Route53 alias record"
+  value       = module.freeside_storage.cloudfront_hosted_zone_id
+}
+
+output "freeside_storage_acm_certificate_arn" {
+  description = "ACM cert ARN (us-east-1)"
+  value       = module.freeside_storage.acm_certificate_arn
+}
+
+output "freeside_storage_acm_validation_records" {
+  description = "DNS validation records to create MANUALLY in Route53"
+  value       = module.freeside_storage.acm_validation_records
+}
+
+output "freeside_storage_oac_grant" {
+  description = "Inputs for the manual bucket-policy update (OAC grant)"
+  value = {
+    distribution_arn = module.freeside_storage.cloudfront_distribution_arn
+    oac_id           = module.freeside_storage.oac_id
+    bucket_arn       = module.freeside_storage.backing_bucket_arn
+  }
+}

--- a/infrastructure/terraform/freeside-storage.tf
+++ b/infrastructure/terraform/freeside-storage.tf
@@ -48,12 +48,31 @@ provider "aws" {
   }
 }
 
+# Wildcard cert in us-east-1 — looked up dynamically so a future cert
+# rotation doesn't silently break this stack. Filtered by domain +
+# ISSUED state; most_recent picks the live one if multiple match.
+# (Bridgebuilder F002 — replaces hardcoded c96a10f5-… ARN.)
+data "aws_acm_certificate" "wildcard_0xhoneyjar" {
+  provider    = aws # production root default; already us-east-1 per var.aws_region
+  domain      = "*.0xhoneyjar.xyz"
+  statuses    = ["ISSUED"]
+  most_recent = true
+}
+
 module "freeside_storage" {
   source = "./freeside-storage"
 
+  # Provider mapping rationale:
+  #   - module's default `aws`     → us-west-2  (where thj-assets lives;
+  #                                  drives the `data.aws_s3_bucket.backing` lookup)
+  #   - module's `aws.us_east_1`   → us-east-1  (CloudFront + ACM requirement)
+  # The production root's default provider IS us-east-1 (per
+  # variables.tf `aws_region` default), so passing `aws` (the root default)
+  # to the module's `aws.us_east_1` alias is correct. Made explicit here
+  # to address bridgebuilder F001's concern about implicit assumptions.
   providers = {
-    aws           = aws.us_west_2 # default → bucket region (us-west-2)
-    aws.us_east_1 = aws           # us_east_1 alias → production root default (already us-east-1)
+    aws           = aws.us_west_2
+    aws.us_east_1 = aws
   }
 
   alias_fqdn            = "assets.0xhoneyjar.xyz"
@@ -65,7 +84,8 @@ module "freeside_storage" {
   # Avoids the CAA-cache issue we hit during T11 — the wildcard cert was issued
   # before the *.0xhoneyjar.xyz → vercel-dns.com wildcard CNAME was added, so
   # ACM has no stale CAA failure for it.
-  existing_acm_certificate_arn = "arn:aws:acm:us-east-1:891376933289:certificate/c96a10f5-ec24-4fed-9779-0a858eeff522"
+  # Resolved via data source; survives cert rotation without code change.
+  existing_acm_certificate_arn = data.aws_acm_certificate.wildcard_0xhoneyjar.arn
 
   common_tags = {
     Service   = "freeside-storage"

--- a/infrastructure/terraform/freeside-storage.tf
+++ b/infrastructure/terraform/freeside-storage.tf
@@ -87,6 +87,22 @@ module "freeside_storage" {
   # Resolved via data source; survives cert rotation without code change.
   existing_acm_certificate_arn = data.aws_acm_certificate.wildcard_0xhoneyjar.arn
 
+  # ---------------------------------------------------------------------------
+  # Cutover B (Amendment A2) — manifest-pattern metadata resolver
+  # ---------------------------------------------------------------------------
+  # Adds metadata.0xhoneyjar.xyz as a second alias on this distribution +
+  # provisions the CloudFront Function + KeyValueStore that resolve
+  # /{collection}/{tokenId} → /{collection}/metadata/v/{ver}/{tokenId}.json.
+  #
+  # Bootstrap pointer: Mibera v1 metadata published 2026-04-30 at
+  # s3://thj-assets/mibera/metadata/v/2026-04-30/{tokenId}.json (10000 files).
+  # ---------------------------------------------------------------------------
+  metadata_resolver_enabled = true
+  additional_aliases        = ["metadata.0xhoneyjar.xyz"]
+  metadata_resolver_initial_pointers = {
+    "mibera:current_version" = "2026-04-30"
+  }
+
   common_tags = {
     Service   = "freeside-storage"
     ManagedBy = "terraform"
@@ -134,4 +150,28 @@ output "freeside_storage_oac_grant" {
     oac_id           = module.freeside_storage.oac_id
     bucket_arn       = module.freeside_storage.backing_bucket_arn
   }
+}
+
+# -----------------------------------------------------------------------------
+# Cutover B — manifest resolver (only populated when enabled in module)
+# -----------------------------------------------------------------------------
+
+output "freeside_storage_metadata_kvs_arn" {
+  description = "CloudFront KeyValueStore ARN — pass to `aws cloudfront-keyvaluestore put-key` to update collection version pointers"
+  value       = module.freeside_storage.metadata_resolver_kvs_arn
+}
+
+output "freeside_storage_metadata_kvs_id" {
+  description = "CloudFront KeyValueStore ID (UUID) — companion to ARN"
+  value       = module.freeside_storage.metadata_resolver_kvs_id
+}
+
+output "freeside_storage_metadata_function_arn" {
+  description = "CloudFront Function ARN — the manifest resolver attached to this distribution"
+  value       = module.freeside_storage.metadata_resolver_function_arn
+}
+
+output "freeside_storage_metadata_aliases" {
+  description = "Additional FQDNs (e.g. metadata.0xhoneyjar.xyz). Each needs a Route53 record manually created per project memory `freeside-dns-state-untracked`."
+  value       = module.freeside_storage.metadata_resolver_aliases
 }

--- a/infrastructure/terraform/freeside-storage/.terraform.lock.hcl
+++ b/infrastructure/terraform/freeside-storage/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infrastructure/terraform/freeside-storage/README.md
+++ b/infrastructure/terraform/freeside-storage/README.md
@@ -1,0 +1,114 @@
+# freeside-storage — Terraform Module
+
+Sovereign asset surface (`assets.0xhoneyjar.xyz`) — a parallel CloudFront
+distribution against the existing `thj-assets` bucket.
+
+## What this module ships
+
+- 1 ACM certificate in `us-east-1` for the alias FQDN
+- 1 CloudFront Origin Access Control (OAC) for S3 access
+- 1 CloudFront distribution with two cache behaviors:
+  - `*.webp` → S3 direct (mirrors legacy `d163aeqznbc6js` fast path)
+  - default → S3 direct (NO image optimizer; explicit by design — see ADR-006)
+- 1 data source reference to the existing `thj-assets` bucket
+
+## What this module does NOT ship
+
+- A new S3 bucket (descoped per [Amendment 3](../../../decisions/006-image-optimizer-stays-on-d163.md))
+- IAM roles (cross-account assumed-role pattern not needed; see `iam.tf`)
+- Route53 alias record (manual per [`freeside-dns-state-untracked`](../../../README.md); see `route53.tf`)
+- The image optimizer chain (stays at `d163aeqznbc6js.cloudfront.net`; see ADR-006)
+
+## Usage
+
+```hcl
+provider "aws" {
+  region = "us-west-2"  # where thj-assets lives
+}
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"  # ACM cert + CloudFront require this
+}
+
+module "freeside_storage" {
+  source = "./freeside-storage"
+
+  providers = {
+    aws           = aws
+    aws.us_east_1 = aws.us_east_1
+  }
+
+  alias_fqdn            = "assets.0xhoneyjar.xyz"
+  backing_bucket_name   = "thj-assets"
+  backing_bucket_region = "us-west-2"
+  hosted_zone_name      = "0xhoneyjar.xyz"
+
+  common_tags = {
+    Service   = "freeside-storage"
+    ManagedBy = "terraform"
+    Cycle     = "mature-freeside-operator-and-cutover"
+  }
+}
+```
+
+## Apply procedure
+
+The apply is a 3-step dance because ACM cert validation is manual (per the
+project DNS doctrine):
+
+```bash
+# Step 1: create the cert + OAC. Distribution attach will fail until cert is ISSUED.
+terraform apply -target=aws_acm_certificate.alias \
+                -target=aws_cloudfront_origin_access_control.s3_oac
+
+# Step 2: pull validation records, create them manually in Route53 console
+terraform output -json acm_validation_records
+
+# ...wait for cert status to move from PENDING_VALIDATION to ISSUED (5-30min)...
+
+# Step 3: full apply — creates the distribution
+terraform apply
+
+# Step 4: pull the alias target + create A/AAAA alias records in Route53 console
+terraform output cloudfront_distribution_domain
+
+# Step 5: update thj-assets bucket policy (additive) to grant OAC
+terraform output oac_id
+terraform output cloudfront_distribution_arn
+# operator updates bucket policy in AWS console — see runbook
+```
+
+## Outputs
+
+| Output | Purpose |
+|--------|---------|
+| `cloudfront_distribution_id` | Reference for invalidations + monitoring |
+| `cloudfront_distribution_arn` | Required for the bucket policy OAC grant |
+| `cloudfront_distribution_domain` | Target for the Route53 alias record |
+| `cloudfront_hosted_zone_id` | Required for the Route53 alias record |
+| `alias_fqdn` | Custom domain (echoed for downstream automation) |
+| `acm_certificate_arn` | Reference for cert lifecycle |
+| `acm_validation_records` | List of `{name, type, value}` to create in Route53 |
+| `backing_bucket_name` | Existing bucket the distribution reads from |
+| `backing_bucket_arn` | For bucket-policy authoring |
+| `oac_id` | Required for the bucket policy OAC grant |
+
+## Acceptance (T11 sprint task)
+
+After apply + manual DNS + bucket-policy grant:
+
+```bash
+curl -I https://assets.0xhoneyjar.xyz/Mibera/generated/0.webp
+# expect: HTTP/2 200; content-type: image/webp
+```
+
+The legacy distribution `d163aeqznbc6js` is UNTOUCHED. Both distributions read
+from the same `thj-assets` bucket; the new one bypasses the optimizer chain
+for the `*.webp` direct + default-direct cache behaviors.
+
+## References
+
+- [SDD §0.1 Amendment 3 (Image Plane Reality)](../../../../bonfire/grimoires/loa/sdd.md)
+- [ADR-006 — Image Optimizer Stays on d163](../../../decisions/006-image-optimizer-stays-on-d163.md)
+- Project memory: `freeside-dns-state-untracked`, `freeside-secret-management-direction`

--- a/infrastructure/terraform/freeside-storage/README.md
+++ b/infrastructure/terraform/freeside-storage/README.md
@@ -77,7 +77,30 @@ terraform output cloudfront_distribution_domain
 terraform output oac_id
 terraform output cloudfront_distribution_arn
 # operator updates bucket policy in AWS console — see runbook
+
+# Step 6 (NEW — load-bearing gate per 2026-04-30 hotfix): smoke + parity
+bash ../../scripts/cdn-cors-smoke.sh   # CORS headers present on all behaviors
+bash ../../scripts/cdn-parity.sh       # bytes-identical with legacy d163
 ```
+
+## ⚠ Pre-flip checklist (do NOT skip)
+
+Per the 2026-04-30 production hotfix (CORS missing on the new distribution
+because the response headers policy wasn't attached), do not promote any
+consumer cutover until BOTH of these pass:
+
+```bash
+# Terraform-side: cors_response_headers_policy_id MUST be set on every
+# cache behavior (already enforced by main.tf locals; verify with):
+grep -n "response_headers_policy_id" infrastructure/terraform/freeside-storage/main.tf
+
+# Live-distribution-side: CORS smoke + bytes parity
+bash scripts/cdn-cors-smoke.sh    # exit 0 if all behaviors return ACAO
+bash scripts/cdn-parity.sh        # exit 0 if etag + content-length match legacy
+```
+
+Both scripts run in <10 seconds, no AWS auth required (public CDN probes).
+Wire as a CI gate on any PR that flips a consumer to `assets.0xhoneyjar.xyz`.
 
 ## Outputs
 

--- a/infrastructure/terraform/freeside-storage/examples/basic/.terraform.lock.hcl
+++ b/infrastructure/terraform/freeside-storage/examples/basic/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infrastructure/terraform/freeside-storage/examples/basic/main.tf
+++ b/infrastructure/terraform/freeside-storage/examples/basic/main.tf
@@ -1,0 +1,62 @@
+# =============================================================================
+# freeside-storage — Basic example
+# =============================================================================
+#
+# Smallest viable consumer of the module. Used for `terraform validate`
+# (proves consumability per T4 acceptance) AND as a copy-paste starting
+# point for the production root module that consumes freeside-storage.
+#
+# Run:
+#   terraform init -backend=false
+#   terraform validate
+# =============================================================================
+
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2" # where thj-assets lives
+}
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1" # ACM cert + CloudFront require this
+}
+
+module "freeside_storage" {
+  source = "../.."
+
+  providers = {
+    aws           = aws
+    aws.us_east_1 = aws.us_east_1
+  }
+
+  alias_fqdn            = "assets.0xhoneyjar.xyz"
+  backing_bucket_name   = "thj-assets"
+  backing_bucket_region = "us-west-2"
+  hosted_zone_name      = "0xhoneyjar.xyz"
+}
+
+output "distribution_id" {
+  value = module.freeside_storage.cloudfront_distribution_id
+}
+
+output "distribution_domain" {
+  value = module.freeside_storage.cloudfront_distribution_domain
+}
+
+output "alias_fqdn" {
+  value = module.freeside_storage.alias_fqdn
+}
+
+output "acm_validation_records" {
+  value = module.freeside_storage.acm_validation_records
+}

--- a/infrastructure/terraform/freeside-storage/iam.tf
+++ b/infrastructure/terraform/freeside-storage/iam.tf
@@ -1,0 +1,24 @@
+# =============================================================================
+# freeside-storage — IAM Roles (DEFERRED per Amendment 3)
+# =============================================================================
+#
+# Per SDD §0.1 Amendment 3 (2026-04-29), the cross-account assumed-role pattern
+# (readonly + writer roles for bulk sync between legacy + new buckets) is no
+# longer needed. Reality: single account, single backing bucket — no cross-
+# account role assumption required. OAC on the new distribution handles bucket
+# access without role-assumption.
+#
+# This file is a placeholder kept to match the SDD §7.1 module skeleton spec.
+#
+# Future cycles MAY add IAM roles when:
+#   - Cross-account deploys are introduced (e.g., pre-prod / prod isolation)
+#   - The operator-facing parity script wants a least-privilege role distinct
+#     from the admin profile
+#   - Trigger.dev jobs need scoped write access (cf. T25 STRETCH)
+#
+# References:
+#   - SDD §0.1 Amendment 3
+#   - decisions/006-image-optimizer-stays-on-d163.md
+# =============================================================================
+
+# (intentionally empty)

--- a/infrastructure/terraform/freeside-storage/main.tf
+++ b/infrastructure/terraform/freeside-storage/main.tf
@@ -125,7 +125,7 @@ resource "aws_cloudfront_distribution" "main" {
   price_class         = var.price_class
   http_version        = "http2and3"
 
-  aliases = [var.alias_fqdn]
+  aliases = concat([var.alias_fqdn], var.additional_aliases)
 
   origin {
     origin_id                = local.origin_id_s3
@@ -188,6 +188,19 @@ resource "aws_cloudfront_distribution" "main" {
     # consumers). Same policy applies; canvas-painting consumers need it.
     response_headers_policy_id = local.cors_response_headers_policy_id
 
+    # Cutover B (Amendment A2) — manifest resolver. Conditional via
+    # var.metadata_resolver_enabled. The function rewrites
+    #   /{collection}/{tokenId}  →  /{collection}/metadata/v/{ver}/{tokenId}.json
+    # for requests that match. Non-matching paths pass through unmodified,
+    # so existing assets.* traffic is untouched.
+    dynamic "function_association" {
+      for_each = var.metadata_resolver_enabled ? [1] : []
+      content {
+        event_type   = "viewer-request"
+        function_arn = aws_cloudfront_function.metadata_resolver[0].arn
+      }
+    }
+
     forwarded_values {
       query_string = false
       headers      = []
@@ -240,3 +253,54 @@ resource "aws_cloudfront_distribution" "main" {
 # Future cycle SHOULD codify the bucket policy in this module via
 # `aws_s3_bucket_policy` with a data source for the existing policy and a
 # merge step. Risky (overwrites) without careful testing — deferred.
+
+# =============================================================================
+# Cutover B (Amendment A2) — Manifest-Pattern Metadata Resolver
+# =============================================================================
+# Provisions:
+#   - 1 CloudFront KeyValueStore                  (collection→version pointers)
+#   - 1 CloudFront Function (cloudfront-js-2.0)   (rewrites stable URLs)
+#   - N initial KV entries from `metadata_resolver_initial_pointers`
+#   - Function attached to the distribution's default cache behavior above
+#
+# The function code lives at ./metadata-resolver.js. It runs on
+# viewer-request, reads the KV pointer for the requested collection, and
+# rewrites /{collection}/{tokenId} → /{collection}/metadata/v/{ver}/{id}.json.
+#
+# Routing semantics: the same distribution serves both assets.0xhoneyjar.xyz
+# and metadata.0xhoneyjar.xyz. The function's path regex is the implicit
+# selector — assets.* requests rarely match /^/[a-z][a-z0-9-]*\/\d+$/, while
+# metadata.* requests by-design hit that shape. Non-matching requests pass
+# through unchanged.
+# =============================================================================
+
+resource "aws_cloudfront_key_value_store" "metadata_pointers" {
+  count    = var.metadata_resolver_enabled ? 1 : 0
+  provider = aws.us_east_1
+
+  name    = "${var.name_prefix}-metadata-pointers"
+  comment = "Collection→version pointer store consumed by the metadata-resolver CloudFront Function (Cutover B)"
+}
+
+resource "aws_cloudfrontkeyvaluestore_key" "initial_pointers" {
+  for_each = var.metadata_resolver_enabled ? var.metadata_resolver_initial_pointers : {}
+  provider = aws.us_east_1
+
+  key_value_store_arn = aws_cloudfront_key_value_store.metadata_pointers[0].arn
+  key                 = each.key
+  value               = each.value
+}
+
+resource "aws_cloudfront_function" "metadata_resolver" {
+  count    = var.metadata_resolver_enabled ? 1 : 0
+  provider = aws.us_east_1
+
+  name    = "${var.name_prefix}-metadata-resolver"
+  runtime = "cloudfront-js-2.0"
+  comment = "Resolve /{collection}/{tokenId} to versioned metadata path via KeyValueStore (Cutover B, Amendment A2)"
+  publish = true
+
+  key_value_store_associations = [aws_cloudfront_key_value_store.metadata_pointers[0].arn]
+
+  code = file("${path.module}/metadata-resolver.js")
+}

--- a/infrastructure/terraform/freeside-storage/main.tf
+++ b/infrastructure/terraform/freeside-storage/main.tf
@@ -74,6 +74,11 @@ resource "aws_acm_certificate" "alias" {
   domain_name       = var.alias_fqdn
   validation_method = "DNS"
 
+  # Note: `create_before_destroy` is moot in the production callsite (which
+  # always supplies `existing_acm_certificate_arn`, setting count=0 here).
+  # It applies only to the standalone-cert path (no existing cert), which
+  # is currently unused in production. Kept for module reusability.
+  # (Bridgebuilder F017)
   lifecycle {
     create_before_destroy = true
   }
@@ -130,6 +135,14 @@ resource "aws_cloudfront_distribution" "main" {
   }
 
   # ---- Cache behavior #1: *.webp → S3 direct (fast path mirror) ----
+  # NOTE (Bridgebuilder F012): The `forwarded_values` block below is the
+  # legacy CloudFront cache-key API. AWS recommends migrating to managed
+  # cache policies (e.g. `cache_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6"`
+  # for Managed-CachingOptimized). Migration deferred to a future cycle —
+  # the change is mutually exclusive with `forwarded_values` + `min_ttl`/
+  # `default_ttl`/`max_ttl` blocks, so it's a coordinated swap, not a
+  # one-line tweak. Current behavior matches Managed-CachingOptimized
+  # semantics (no query in cache key, no cookies forwarded).
   ordered_cache_behavior {
     path_pattern           = "*.webp"
     target_origin_id       = local.origin_id_s3

--- a/infrastructure/terraform/freeside-storage/main.tf
+++ b/infrastructure/terraform/freeside-storage/main.tf
@@ -34,6 +34,11 @@ locals {
   origin_id_s3   = "${var.name_prefix}-s3-${var.backing_bucket_name}"
   s3_origin_host = "${var.backing_bucket_name}.s3.${var.backing_bucket_region}.amazonaws.com"
 
+  # Either reuse an existing cert (e.g. *.0xhoneyjar.xyz wildcard) or use the
+  # one this module provisions. The conditional resource below honors both
+  # paths.
+  acm_certificate_arn = var.existing_acm_certificate_arn != null ? var.existing_acm_certificate_arn : try(aws_acm_certificate.alias[0].arn, "")
+
   tags = merge(var.common_tags, {
     Module = var.name_prefix
   })
@@ -54,6 +59,7 @@ data "aws_s3_bucket" "backing" {
 # -----------------------------------------------------------------------------
 
 resource "aws_acm_certificate" "alias" {
+  count    = var.existing_acm_certificate_arn != null ? 0 : 1
   provider = aws.us_east_1
 
   domain_name       = var.alias_fqdn
@@ -158,7 +164,7 @@ resource "aws_cloudfront_distribution" "main" {
   }
 
   viewer_certificate {
-    acm_certificate_arn      = aws_acm_certificate.alias.arn
+    acm_certificate_arn      = local.acm_certificate_arn
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.2_2021"
   }

--- a/infrastructure/terraform/freeside-storage/main.tf
+++ b/infrastructure/terraform/freeside-storage/main.tf
@@ -39,6 +39,15 @@ locals {
   # paths.
   acm_certificate_arn = var.existing_acm_certificate_arn != null ? var.existing_acm_certificate_arn : try(aws_acm_certificate.alias[0].arn, "")
 
+  # AWS-managed `Managed-CORS-With-Preflight` response headers policy.
+  # Adds `Access-Control-Allow-Origin: *` (and friends) to all responses
+  # so browser canvas consumers (img crossOrigin="anonymous" + drawImage)
+  # don't taint the canvas. Same policy that the legacy d163 distribution
+  # attaches to its *.webp cache behavior. Global ID, valid in every AWS
+  # account; documented at:
+  # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-response-headers-policies.html#managed-response-headers-policies-cors
+  cors_response_headers_policy_id = "5cc3b908-e619-4b99-88e5-2cf7f45965bd"
+
   tags = merge(var.common_tags, {
     Module = var.name_prefix
   })
@@ -133,6 +142,13 @@ resource "aws_cloudfront_distribution" "main" {
     default_ttl = var.default_ttl
     max_ttl     = var.max_ttl
 
+    # CORS — required because consumer apps (mibera-honeyroad/dimensions
+    # `useTraitCanvas` hook) load images with `crossOrigin="anonymous"` to
+    # paint onto a `<canvas>` via `drawImage`. Without `Access-Control-Allow-
+    # Origin` headers the canvas is tainted and drawImage throws. Mirrors
+    # the legacy d163 distribution's *.webp behavior config.
+    response_headers_policy_id = local.cors_response_headers_policy_id
+
     forwarded_values {
       query_string = false
       headers      = []
@@ -153,6 +169,11 @@ resource "aws_cloudfront_distribution" "main" {
     min_ttl     = var.min_ttl
     default_ttl = var.default_ttl
     max_ttl     = var.max_ttl
+
+    # CORS — see comment on the *.webp cache behavior. Default behavior
+    # serves PNGs (e.g. `/reveal_phase8/images/{hash}.png` for codex
+    # consumers). Same policy applies; canvas-painting consumers need it.
+    response_headers_policy_id = local.cors_response_headers_policy_id
 
     forwarded_values {
       query_string = false

--- a/infrastructure/terraform/freeside-storage/main.tf
+++ b/infrastructure/terraform/freeside-storage/main.tf
@@ -1,0 +1,202 @@
+# =============================================================================
+# freeside-storage — Main (locals + computed values)
+# =============================================================================
+#
+# Per SDD §0.1 Amendment 3 (2026-04-29) the original framing of "new bucket +
+# bulk sync + dual-write" is descoped. The reality:
+#
+#   - thj-assets (us-west-2) is the existing sovereign asset store
+#   - The legacy distribution `d163aeqznbc6js` is an image-OPTIMIZER chain
+#     with a *.webp direct-S3 fast path
+#   - Phase 0 publishes a STABLE URL CONTRACT surface for external builders
+#     by adding a parallel distribution against the SAME backing bucket
+#   - Apps using direct *.webp paths get the URL contract immediately
+#   - Apps using optimizer paths (`/images/{proxy+}`, `/_next/image*`) keep
+#     using d163aeqznbc6js (optimizer migration deferred per ADR-006)
+#
+# This module ships:
+#   - 1 data source for the existing thj-assets bucket
+#   - 1 ACM certificate in us-east-1 for assets.0xhoneyjar.xyz
+#   - 1 CloudFront Origin Access Control (OAC) for the new distribution
+#   - 1 CloudFront distribution with alias + 2 cache behaviors
+#   - 1 S3 bucket policy statement attached as an OAC grant (additive, in
+#     bucket-policy.tf — bucket policy is an OUT-OF-MODULE concern; see README)
+#
+# What this module does NOT ship:
+#   - A new bucket (descoped per Amendment 3)
+#   - IAM roles (cross-account assumed-role pattern is no longer needed; see
+#     iam.tf for placeholder)
+#   - Route53 record (manual per project-memory `freeside-dns-state-untracked`;
+#     see route53.tf)
+# =============================================================================
+
+locals {
+  origin_id_s3   = "${var.name_prefix}-s3-${var.backing_bucket_name}"
+  s3_origin_host = "${var.backing_bucket_name}.s3.${var.backing_bucket_region}.amazonaws.com"
+
+  tags = merge(var.common_tags, {
+    Module = var.name_prefix
+  })
+}
+
+# -----------------------------------------------------------------------------
+# Existing bucket — read-only data source
+# -----------------------------------------------------------------------------
+# We do NOT manage thj-assets in this module. It pre-dates this cycle and is
+# managed elsewhere. We only reference it as a CloudFront origin.
+
+data "aws_s3_bucket" "backing" {
+  bucket = var.backing_bucket_name
+}
+
+# -----------------------------------------------------------------------------
+# ACM certificate for the alias FQDN (us-east-1 — CloudFront requirement)
+# -----------------------------------------------------------------------------
+
+resource "aws_acm_certificate" "alias" {
+  provider = aws.us_east_1
+
+  domain_name       = var.alias_fqdn
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = merge(local.tags, {
+    Name = "${var.name_prefix}-${var.alias_fqdn}"
+  })
+}
+
+# DNS validation records are CREATED MANUALLY in Route53 per project-memory
+# `freeside-dns-state-untracked` (production DNS untracked by terraform).
+# The operator runs:
+#   terraform output acm_validation_records
+# then creates each CNAME in the Route53 console. After creation, the cert
+# moves from PENDING_VALIDATION to ISSUED.
+#
+# A future cycle SHOULD import the validation records into terraform and
+# replace this manual step with `aws_acm_certificate_validation`.
+
+# -----------------------------------------------------------------------------
+# CloudFront Origin Access Control (modern; replaces OAI)
+# -----------------------------------------------------------------------------
+
+resource "aws_cloudfront_origin_access_control" "s3_oac" {
+  name                              = "${var.name_prefix}-s3-oac"
+  description                       = "OAC for ${var.alias_fqdn} → ${var.backing_bucket_name}"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# -----------------------------------------------------------------------------
+# CloudFront distribution
+# -----------------------------------------------------------------------------
+# Two cache behaviors:
+#   1. *.webp → S3 origin (direct; mirrors legacy d163aeqznbc6js fast path)
+#   2. default → S3 origin (direct; NO optimizer chain — see ADR-006)
+
+resource "aws_cloudfront_distribution" "main" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "freeside-storage — sovereign asset surface (${var.alias_fqdn})"
+  default_root_object = ""
+  price_class         = var.price_class
+  http_version        = "http2and3"
+
+  aliases = [var.alias_fqdn]
+
+  origin {
+    origin_id                = local.origin_id_s3
+    domain_name              = local.s3_origin_host
+    origin_access_control_id = aws_cloudfront_origin_access_control.s3_oac.id
+    # OAC requires no S3OriginConfig block (modern). OAC handles auth via SigV4.
+  }
+
+  # ---- Cache behavior #1: *.webp → S3 direct (fast path mirror) ----
+  ordered_cache_behavior {
+    path_pattern           = "*.webp"
+    target_origin_id       = local.origin_id_s3
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    min_ttl     = var.min_ttl
+    default_ttl = var.default_ttl
+    max_ttl     = var.max_ttl
+
+    forwarded_values {
+      query_string = false
+      headers      = []
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  # ---- Default cache behavior: S3 direct (no optimizer; explicit by design) ----
+  default_cache_behavior {
+    target_origin_id       = local.origin_id_s3
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    min_ttl     = var.min_ttl
+    default_ttl = var.default_ttl
+    max_ttl     = var.max_ttl
+
+    forwarded_values {
+      query_string = false
+      headers      = []
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate.alias.arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tags = merge(local.tags, {
+    Name = "${var.name_prefix}-${var.alias_fqdn}"
+  })
+
+  # ACM cert must be ISSUED before the distribution can attach it.
+  # Since we DNS-validate manually (see comment above), the operator must
+  # confirm cert status before applying this resource. Use `-target` for
+  # phased apply if needed:
+  #   terraform apply -target=aws_acm_certificate.alias
+  #   # ...manually create CNAME, wait for ISSUED...
+  #   terraform apply
+}
+
+# -----------------------------------------------------------------------------
+# Bucket policy grant for OAC
+# -----------------------------------------------------------------------------
+# The new distribution's OAC must be ALLOWED in the bucket policy. The bucket
+# is shared (legacy distribution + new distribution both read from it), so the
+# policy is ADDITIVE — we do NOT overwrite the existing bucket policy.
+#
+# This is intentionally OUT OF SCOPE for this module skeleton. The bucket
+# policy update is a manual step documented in T11's runbook:
+#
+#   1. terraform apply (creates OAC + distribution)
+#   2. terraform output cloudfront_distribution_arn
+#   3. operator updates bucket policy in AWS console (additive Statement)
+#   4. terraform output is the source of truth for the ARN to grant
+#
+# Future cycle SHOULD codify the bucket policy in this module via
+# `aws_s3_bucket_policy` with a data source for the existing policy and a
+# merge step. Risky (overwrites) without careful testing — deferred.

--- a/infrastructure/terraform/freeside-storage/metadata-resolver.js
+++ b/infrastructure/terraform/freeside-storage/metadata-resolver.js
@@ -91,8 +91,9 @@ function notFound() {
   };
 }
 
-// Bridgebuilder F1: explicit export for cloudfront-js-2.0 ES Module runtime.
-// While AWS examples sometimes omit it (the runtime auto-discovers a top-level
-// `handler` function), the explicit export removes ambiguity and is harmless
-// if redundant.
-export { handler };
+// Note: cloudfront-js-2.0 auto-discovers a top-level `handler` function by
+// name. An explicit `export { handler };` was tried (Bridgebuilder F1) but
+// causes the runtime to error with "The CloudFront function associated with
+// the CloudFront distribution is invalid or could not run." Confirmed via
+// 2026-05-01 production smoke (503 on metadata.* requests). Convention: no
+// export statement; the runtime discovers `handler` automatically.

--- a/infrastructure/terraform/freeside-storage/metadata-resolver.js
+++ b/infrastructure/terraform/freeside-storage/metadata-resolver.js
@@ -1,0 +1,98 @@
+// =============================================================================
+// metadata-resolver — CloudFront Function (viewer-request)
+// =============================================================================
+//
+// Resolves stable metadata URLs to versioned S3 paths via KeyValueStore.
+//
+// Design (Cutover B per migrate-mibera-sovereignty-2026-04-30):
+//
+//   GET https://metadata.0xhoneyjar.xyz/{collection}/{tokenId}
+//        │
+//        ▼  (this function reads KV at the edge)
+//        kvs.get(`${collection}:current_version`)  →  e.g.  "2026-04-30"
+//        │
+//        ▼  (rewrite request URI)
+//   GET https://metadata.0xhoneyjar.xyz/{collection}/metadata/v/{version}/{tokenId}.json
+//        │
+//        ▼  (CloudFront caches on rewritten path; S3 origin serves bytes)
+//   s3://thj-assets/{collection}/metadata/v/{version}/{tokenId}.json
+//
+// Pass-through: any request that doesn't match the {collection}/{tokenId} shape
+// (e.g. /manifest.json, static/versioned paths) is left untouched. Same function
+// runs for both metadata.0xhoneyjar.xyz and assets.0xhoneyjar.xyz aliases —
+// the path regex acts as the host-implicit gate (assets paths never match it).
+//
+// Constraints (CloudFront Functions):
+//   - Hard 10ms execution time
+//   - 2 KB max compiled code size
+//   - No subrequests (only KV reads + URI rewrite + header set)
+//   - cloudfront-js-2.0 runtime required for KV access
+//
+// =============================================================================
+
+import cf from 'cloudfront';
+
+// KV handle is bound at function-association time (Function-Association.KeyValueStoreAssociations).
+const kvs = cf.kvs();
+
+// Bridgebuilder F2: version-string allowlist. KV value MUST match this shape
+// before being interpolated into a URI. Guards against:
+//   - empty / undefined values (defensive even if kvs.get's contract is to throw)
+//   - malformed pointers containing `/`, `..`, whitespace, control chars
+//   - any value that could escape the path or produce an invalid S3 key
+const VERSION_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+async function handler(event) {
+  const request = event.request;
+
+  // Match /{collection}/{tokenId} — lowercase collection slug, numeric token id.
+  // Any path that doesn't match (versioned paths, static files) passes through.
+  const match = request.uri.match(/^\/([a-z][a-z0-9-]*)\/(\d+)$/);
+  if (!match) {
+    return request;
+  }
+
+  const collection = match[1];
+  const tokenId = match[2];
+
+  // Resolve current version pointer for this collection.
+  let version;
+  try {
+    version = await kvs.get(`${collection}:current_version`);
+  } catch (e) {
+    // Pointer missing for this collection — return 404 rather than serve a
+    // stale or unrelated path.
+    return notFound();
+  }
+
+  // Bridgebuilder F2: explicit validation. Even if kvs.get resolves successfully,
+  // the value must match VERSION_PATTERN before being used in the URI rewrite.
+  // A malformed pointer would produce a broken or unsafe path; defensive 404
+  // is the safe failure mode.
+  if (!version || !VERSION_PATTERN.test(version)) {
+    return notFound();
+  }
+
+  // Rewrite to immutable versioned bytes path on S3 origin.
+  // Note: CloudFront Functions on viewer-request rewrite the URI BEFORE the
+  // cache lookup, so the cache key uses the rewritten path. This means the
+  // same versioned bytes URL caches identically whether reached through the
+  // manifest pointer or directly via the versioned URL — intentional.
+  request.uri = `/${collection}/metadata/v/${version}/${tokenId}.json`;
+  return request;
+}
+
+function notFound() {
+  // Bridgebuilder F7: status-only response (no body) — the most reliable
+  // shape for cloudfront-js-2.0 viewer-request generated responses.
+  return {
+    statusCode: 404,
+    statusDescription: 'Not Found',
+  };
+}
+
+// Bridgebuilder F1: explicit export for cloudfront-js-2.0 ES Module runtime.
+// While AWS examples sometimes omit it (the runtime auto-discovers a top-level
+// `handler` function), the explicit export removes ambiguity and is harmless
+// if redundant.
+export { handler };

--- a/infrastructure/terraform/freeside-storage/metadata-resolver.test-fixtures.json
+++ b/infrastructure/terraform/freeside-storage/metadata-resolver.test-fixtures.json
@@ -1,0 +1,95 @@
+{
+  "_comment": "CloudFront Function test event fixtures for metadata-resolver.js. Use with `aws cloudfront test-function` after publish. Bridgebuilder F10.",
+  "_invocation_template": "aws cloudfront test-function --name freeside-storage-metadata-resolver --if-match <ETag> --event-object fileb://metadata-resolver.test-fixtures.json --stage DEVELOPMENT",
+  "_cases": [
+    {
+      "name": "matching path with valid pointer",
+      "expected_outcome": "URI rewritten to /mibera/metadata/v/2026-04-30/5000.json",
+      "expected_kv_lookup": "mibera:current_version",
+      "request": {
+        "method": "GET",
+        "uri": "/mibera/5000",
+        "querystring": {},
+        "headers": { "host": { "value": "metadata.0xhoneyjar.xyz" } },
+        "cookies": {}
+      }
+    },
+    {
+      "name": "matching path with missing pointer (unknown collection)",
+      "expected_outcome": "404 Not Found (kvs.get throws)",
+      "request": {
+        "method": "GET",
+        "uri": "/unknowncollection/5000",
+        "querystring": {},
+        "headers": { "host": { "value": "metadata.0xhoneyjar.xyz" } },
+        "cookies": {}
+      }
+    },
+    {
+      "name": "non-matching path — versioned URL passthrough",
+      "expected_outcome": "Pass through unchanged (no rewrite)",
+      "request": {
+        "method": "GET",
+        "uri": "/mibera/metadata/v/2026-04-30/5000.json",
+        "querystring": {},
+        "headers": { "host": { "value": "metadata.0xhoneyjar.xyz" } },
+        "cookies": {}
+      }
+    },
+    {
+      "name": "non-matching path — assets path passthrough",
+      "expected_outcome": "Pass through unchanged",
+      "request": {
+        "method": "GET",
+        "uri": "/Mibera/generated/5000.webp",
+        "querystring": {},
+        "headers": { "host": { "value": "assets.0xhoneyjar.xyz" } },
+        "cookies": {}
+      }
+    },
+    {
+      "name": "non-matching path — uppercase collection (regex strict on lowercase)",
+      "expected_outcome": "Pass through unchanged",
+      "request": {
+        "method": "GET",
+        "uri": "/Mibera/5000",
+        "querystring": {},
+        "headers": { "host": { "value": "metadata.0xhoneyjar.xyz" } },
+        "cookies": {}
+      }
+    },
+    {
+      "name": "non-matching path — trailing slash",
+      "expected_outcome": "Pass through unchanged",
+      "request": {
+        "method": "GET",
+        "uri": "/mibera/5000/",
+        "querystring": {},
+        "headers": { "host": { "value": "metadata.0xhoneyjar.xyz" } },
+        "cookies": {}
+      }
+    },
+    {
+      "name": "non-matching path — non-numeric tokenId",
+      "expected_outcome": "Pass through unchanged",
+      "request": {
+        "method": "GET",
+        "uri": "/mibera/abc",
+        "querystring": {},
+        "headers": { "host": { "value": "metadata.0xhoneyjar.xyz" } },
+        "cookies": {}
+      }
+    },
+    {
+      "name": "edge — manifest.json (root file passthrough)",
+      "expected_outcome": "Pass through unchanged",
+      "request": {
+        "method": "GET",
+        "uri": "/manifest.json",
+        "querystring": {},
+        "headers": { "host": { "value": "metadata.0xhoneyjar.xyz" } },
+        "cookies": {}
+      }
+    }
+  ]
+}

--- a/infrastructure/terraform/freeside-storage/outputs.tf
+++ b/infrastructure/terraform/freeside-storage/outputs.tf
@@ -28,14 +28,14 @@ output "alias_fqdn" {
 }
 
 output "acm_certificate_arn" {
-  description = "ARN of the ACM cert in us-east-1"
-  value       = aws_acm_certificate.alias.arn
+  description = "ARN of the ACM cert in us-east-1 (the one this module is using — either provisioned or reused)"
+  value       = local.acm_certificate_arn
 }
 
 output "acm_validation_records" {
-  description = "DNS validation records to create MANUALLY in Route53. Each entry: { name, type, value }. Operator creates these in the console; cert moves to ISSUED."
-  value = [
-    for o in aws_acm_certificate.alias.domain_validation_options : {
+  description = "DNS validation records to create MANUALLY in Route53. Empty when reusing an existing cert. Each entry: { name, type, value }. Operator creates these in the console; cert moves to ISSUED."
+  value = var.existing_acm_certificate_arn != null ? [] : [
+    for o in aws_acm_certificate.alias[0].domain_validation_options : {
       name  = o.resource_record_name
       type  = o.resource_record_type
       value = o.resource_record_value

--- a/infrastructure/terraform/freeside-storage/outputs.tf
+++ b/infrastructure/terraform/freeside-storage/outputs.tf
@@ -57,3 +57,27 @@ output "oac_id" {
   description = "Origin Access Control ID. Required when authoring the bucket policy OAC grant."
   value       = aws_cloudfront_origin_access_control.s3_oac.id
 }
+
+# -----------------------------------------------------------------------------
+# Cutover B — manifest resolver outputs (only populated when enabled)
+# -----------------------------------------------------------------------------
+
+output "metadata_resolver_kvs_arn" {
+  description = "ARN of the CloudFront KeyValueStore for collection version pointers. Use this with `aws cloudfront-keyvaluestore put-key` to update pointers post-bootstrap. Empty when metadata_resolver_enabled = false."
+  value       = var.metadata_resolver_enabled ? aws_cloudfront_key_value_store.metadata_pointers[0].arn : ""
+}
+
+output "metadata_resolver_kvs_id" {
+  description = "ID of the CloudFront KeyValueStore (UUID-ish). Companion to the ARN."
+  value       = var.metadata_resolver_enabled ? aws_cloudfront_key_value_store.metadata_pointers[0].id : ""
+}
+
+output "metadata_resolver_function_arn" {
+  description = "ARN of the CloudFront Function that resolves manifest pointers to versioned bytes."
+  value       = var.metadata_resolver_enabled ? aws_cloudfront_function.metadata_resolver[0].arn : ""
+}
+
+output "metadata_resolver_aliases" {
+  description = "FQDNs that the manifest resolver serves (in addition to the canonical alias_fqdn). For Route53 record provisioning."
+  value       = var.additional_aliases
+}

--- a/infrastructure/terraform/freeside-storage/outputs.tf
+++ b/infrastructure/terraform/freeside-storage/outputs.tf
@@ -1,0 +1,59 @@
+# =============================================================================
+# freeside-storage — Outputs
+# =============================================================================
+
+output "cloudfront_distribution_id" {
+  description = "ID of the new CloudFront distribution"
+  value       = aws_cloudfront_distribution.main.id
+}
+
+output "cloudfront_distribution_arn" {
+  description = "ARN of the new CloudFront distribution. Use for bucket-policy OAC grant."
+  value       = aws_cloudfront_distribution.main.arn
+}
+
+output "cloudfront_distribution_domain" {
+  description = "Auto-generated CloudFront domain (e.g. d1234abcd.cloudfront.net). Target for the Route53 alias record."
+  value       = aws_cloudfront_distribution.main.domain_name
+}
+
+output "cloudfront_hosted_zone_id" {
+  description = "CloudFront's hosted zone ID. Required for the Route53 alias record."
+  value       = aws_cloudfront_distribution.main.hosted_zone_id
+}
+
+output "alias_fqdn" {
+  description = "Custom domain alias for the new distribution"
+  value       = var.alias_fqdn
+}
+
+output "acm_certificate_arn" {
+  description = "ARN of the ACM cert in us-east-1"
+  value       = aws_acm_certificate.alias.arn
+}
+
+output "acm_validation_records" {
+  description = "DNS validation records to create MANUALLY in Route53. Each entry: { name, type, value }. Operator creates these in the console; cert moves to ISSUED."
+  value = [
+    for o in aws_acm_certificate.alias.domain_validation_options : {
+      name  = o.resource_record_name
+      type  = o.resource_record_type
+      value = o.resource_record_value
+    }
+  ]
+}
+
+output "backing_bucket_name" {
+  description = "Existing S3 bucket the distribution reads from"
+  value       = data.aws_s3_bucket.backing.bucket
+}
+
+output "backing_bucket_arn" {
+  description = "ARN of the backing bucket (for reference; bucket policy update is manual)"
+  value       = data.aws_s3_bucket.backing.arn
+}
+
+output "oac_id" {
+  description = "Origin Access Control ID. Required when authoring the bucket policy OAC grant."
+  value       = aws_cloudfront_origin_access_control.s3_oac.id
+}

--- a/infrastructure/terraform/freeside-storage/route53.tf
+++ b/infrastructure/terraform/freeside-storage/route53.tf
@@ -1,0 +1,56 @@
+# =============================================================================
+# freeside-storage — Route53 alias (MANUAL per L5 + freeside-dns-state-untracked)
+# =============================================================================
+#
+# Per project memory `freeside-dns-state-untracked`: production DNS records are
+# NOT managed via terraform. Mixing terraform-managed and manual DNS in the
+# same `apply` is a documented footgun (the proposed-to-create-duplicate-zone
+# antipattern).
+#
+# Approach:
+#   1. terraform apply (creates ACM cert + OAC + distribution)
+#   2. Operator MANUALLY creates the alias A/AAAA record in the AWS console:
+#        Hosted zone:  0xhoneyjar.xyz (Z01393483Y40WF3N1H76)
+#        Record name:  assets
+#        Record type:  A (alias) + AAAA (alias)
+#        Alias target: <terraform output cloudfront_distribution_domain>
+#        Hosted zone:  Z2FDTNDATAQYW2 (CloudFront's global zone, fixed)
+#   3. Manual record creation is logged to:
+#        loa-freeside/decisions/cloudfront-dns-2026-04-29.md
+#
+# Future cycle SHOULD:
+#   - Import the manual records into terraform state
+#   - Uncomment the resource block below
+#   - Make a one-shot apply that takes ownership cleanly
+#
+# Reference: SDD §7.5
+# =============================================================================
+
+# resource "aws_route53_record" "alias_a" {
+#   zone_id = data.aws_route53_zone.parent.zone_id
+#   name    = var.alias_fqdn
+#   type    = "A"
+#
+#   alias {
+#     name                   = aws_cloudfront_distribution.main.domain_name
+#     zone_id                = aws_cloudfront_distribution.main.hosted_zone_id
+#     evaluate_target_health = false
+#   }
+# }
+#
+# resource "aws_route53_record" "alias_aaaa" {
+#   zone_id = data.aws_route53_zone.parent.zone_id
+#   name    = var.alias_fqdn
+#   type    = "AAAA"
+#
+#   alias {
+#     name                   = aws_cloudfront_distribution.main.domain_name
+#     zone_id                = aws_cloudfront_distribution.main.hosted_zone_id
+#     evaluate_target_health = false
+#   }
+# }
+#
+# data "aws_route53_zone" "parent" {
+#   name         = var.hosted_zone_name
+#   private_zone = false
+# }

--- a/infrastructure/terraform/freeside-storage/variables.tf
+++ b/infrastructure/terraform/freeside-storage/variables.tf
@@ -32,6 +32,12 @@ variable "alias_fqdn" {
   default     = "assets.0xhoneyjar.xyz"
 }
 
+variable "existing_acm_certificate_arn" {
+  description = "Optional ARN of an existing ACM certificate (us-east-1) that covers `alias_fqdn`. If supplied, the module reuses this cert instead of provisioning a new one. Useful when a wildcard cert already exists for the parent zone (e.g. `*.0xhoneyjar.xyz`) — and avoids CAA-cache issues on freshly-issued certs."
+  type        = string
+  default     = null
+}
+
 variable "hosted_zone_name" {
   description = "Route53 hosted zone where the alias record lives. Used in route53.tf — currently commented out per project memory `freeside-dns-state-untracked`; manual record creation is documented in decisions/cloudfront-dns-2026-04-29.md."
   type        = string

--- a/infrastructure/terraform/freeside-storage/variables.tf
+++ b/infrastructure/terraform/freeside-storage/variables.tf
@@ -1,0 +1,79 @@
+# =============================================================================
+# freeside-storage — Input Variables
+# =============================================================================
+#
+# Per SDD §0.1 Amendment 3 (2026-04-29): NO new bucket. The module provisions a
+# parallel CloudFront distribution + alias + ACM cert against the existing
+# `thj-assets` bucket. The optimizer chain stays at d163aeqznbc6js.cloudfront.net
+# (see decisions/006-image-optimizer-stays-on-d163.md).
+# =============================================================================
+
+variable "name_prefix" {
+  description = "Prefix for resource names (e.g. 'freeside-storage')"
+  type        = string
+  default     = "freeside-storage"
+}
+
+variable "backing_bucket_name" {
+  description = "Existing S3 bucket the new distribution reads from. Per SDD §0.4 image plane reality, this is `thj-assets`."
+  type        = string
+  default     = "thj-assets"
+}
+
+variable "backing_bucket_region" {
+  description = "Region of the backing S3 bucket. Used to construct the regional endpoint for the CloudFront origin."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "alias_fqdn" {
+  description = "Custom domain for the new distribution (per SDD §0 L5)"
+  type        = string
+  default     = "assets.0xhoneyjar.xyz"
+}
+
+variable "hosted_zone_name" {
+  description = "Route53 hosted zone where the alias record lives. Used in route53.tf — currently commented out per project memory `freeside-dns-state-untracked`; manual record creation is documented in decisions/cloudfront-dns-2026-04-29.md."
+  type        = string
+  default     = "0xhoneyjar.xyz"
+}
+
+variable "tenant_prefixes" {
+  description = "S3 key prefixes that map to tenants. Documented for reference; not enforced at the CloudFront layer (path-based tenancy is a doc/contract concern, not a CDN concern)."
+  type        = list(string)
+  default     = ["Mibera", "Purupuru", "sprawl"]
+}
+
+variable "price_class" {
+  description = "CloudFront price class. PriceClass_100 = US/CA/EU (lowest cost; sufficient for sovereign asset surface)."
+  type        = string
+  default     = "PriceClass_100"
+}
+
+variable "min_ttl" {
+  description = "Minimum TTL for cache behaviors (seconds)"
+  type        = number
+  default     = 0
+}
+
+variable "default_ttl" {
+  description = "Default TTL for cache behaviors (seconds)"
+  type        = number
+  default     = 86400 # 24h
+}
+
+variable "max_ttl" {
+  description = "Maximum TTL for cache behaviors (seconds)"
+  type        = number
+  default     = 31536000 # 1y
+}
+
+variable "common_tags" {
+  description = "Tags applied to all resources"
+  type        = map(string)
+  default = {
+    Service   = "freeside-storage"
+    ManagedBy = "terraform"
+    Cycle     = "mature-freeside-operator-and-cutover"
+  }
+}

--- a/infrastructure/terraform/freeside-storage/variables.tf
+++ b/infrastructure/terraform/freeside-storage/variables.tf
@@ -85,3 +85,62 @@ variable "common_tags" {
     Cycle     = "mature-freeside-operator-and-cutover"
   }
 }
+
+# -----------------------------------------------------------------------------
+# Cutover B (2026-04-30, Amendment A2) — manifest-pattern metadata resolver
+# -----------------------------------------------------------------------------
+# When `metadata_resolver_enabled = true`, the module:
+#   - adds `additional_aliases` to the distribution (e.g. metadata.0xhoneyjar.xyz)
+#   - provisions a CloudFront KeyValueStore for collection→version pointers
+#   - provisions a CloudFront Function (viewer-request) that rewrites
+#     /{collection}/{tokenId} → /{collection}/metadata/v/{version}/{tokenId}.json
+#   - attaches the function to the default cache behavior
+#
+# When false (default), the distribution is unchanged from Cutover A.
+#
+# Reversibility (corrected per Bridgebuilder F4):
+#   - Setting enabled=false plans to DESTROY the KV store and pointer keys
+#     (count/for_each are gated on this flag).
+#   - KV pointer values are NOT preserved across a disable→enable round-trip.
+#   - For non-destructive disable in production: set `additional_aliases = []`
+#     and remove the function_association externally. That detaches
+#     metadata.{org} traffic without destroying KV state.
+#   - True KV-state preservation across toggle requires decoupling the KV
+#     store resource from this flag (always provision KV, gate only the
+#     function_association + aliases). Deferred to follow-on cycle.
+# -----------------------------------------------------------------------------
+
+variable "metadata_resolver_enabled" {
+  description = "When true, provision the manifest-pattern metadata resolver (CF Function + KeyValueStore + alias extension). See migrate-mibera-sovereignty-2026-04-30.plan.yaml Amendment A2."
+  type        = bool
+  default     = false
+}
+
+variable "additional_aliases" {
+  description = <<-EOT
+    Additional FQDNs to attach as CloudFront aliases (e.g.
+    ['metadata.0xhoneyjar.xyz']). Empty list = single alias mode (Cutover A).
+
+    Prerequisites per alias (Bridgebuilder F5 — operator must verify before apply):
+      1. Cert coverage — `existing_acm_certificate_arn` must cover the FQDN.
+         A `*.0xhoneyjar.xyz` wildcard cert covers depth-2 (e.g. `metadata.*`)
+         but NOT depth-3 (`a.b.0xhoneyjar.xyz` would need a separate cert).
+      2. Route53 record — manual A/AAAA ALIAS pointing at the distribution
+         domain (per project memory `freeside-dns-state-untracked`; Route53
+         is currently outside terraform). Pull target via:
+            terraform output cloudfront_distribution_domain
+         Then create the alias record in the Route53 console.
+      3. CloudFront rejects aliases not covered by the cert AT APPLY TIME, so
+         a missed cert match fails fast. Route53 omission = NXDOMAIN at the
+         FQDN, distribution itself is unaffected (alias is registered, just
+         unreachable).
+  EOT
+  type        = list(string)
+  default     = []
+}
+
+variable "metadata_resolver_initial_pointers" {
+  description = "Initial entries to seed the KeyValueStore at creation time. Map of `{collection}:current_version` → version string. Example: { \"mibera:current_version\" = \"2026-04-30\" }. After bootstrap, ops updates pointers via `aws cloudfront-keyvaluestore put-key`."
+  type        = map(string)
+  default     = {}
+}

--- a/infrastructure/terraform/freeside-storage/variables.tf
+++ b/infrastructure/terraform/freeside-storage/variables.tf
@@ -39,16 +39,18 @@ variable "existing_acm_certificate_arn" {
 }
 
 variable "hosted_zone_name" {
-  description = "Route53 hosted zone where the alias record lives. Used in route53.tf — currently commented out per project memory `freeside-dns-state-untracked`; manual record creation is documented in decisions/cloudfront-dns-2026-04-29.md."
+  description = "Route53 hosted zone where the alias record lives. RESERVED for the future DNS-import cycle that takes ownership of `route53.tf` (currently commented out per project memory `freeside-dns-state-untracked`). Not consumed by any active code today; kept so the future cycle can wire it without re-introducing the variable. (Bridgebuilder F019)"
   type        = string
   default     = "0xhoneyjar.xyz"
 }
 
-variable "tenant_prefixes" {
-  description = "S3 key prefixes that map to tenants. Documented for reference; not enforced at the CloudFront layer (path-based tenancy is a doc/contract concern, not a CDN concern)."
-  type        = list(string)
-  default     = ["Mibera", "Purupuru", "sprawl"]
-}
+# `tenant_prefixes` removed per Bridgebuilder F018 — the prior version of this
+# variable was documented as "reference only, not enforced at the CloudFront
+# layer", which created confusion. Tenant-prefix taxonomy lives in the URL
+# contract schema (`freeside-storage/packages/protocol/url-contract.schema.json`)
+# and the public doc at `loa-freeside/docs/asset-url-contract.md`. If a future
+# cycle wires CloudFront-layer tenant enforcement (path patterns, distinct
+# behaviors), the variable comes back with a real consumer.
 
 variable "price_class" {
   description = "CloudFront price class. PriceClass_100 = US/CA/EU (lowest cost; sufficient for sovereign asset surface)."

--- a/infrastructure/terraform/freeside-storage/versions.tf
+++ b/infrastructure/terraform/freeside-storage/versions.tf
@@ -1,0 +1,39 @@
+# =============================================================================
+# freeside-storage — Provider Version Constraints
+# =============================================================================
+#
+# CloudFront + ACM require the us-east-1 region. The caller MUST supply two
+# AWS provider configurations:
+#
+#   provider "aws" {
+#     region = "us-west-2"  # or wherever the backing thj-assets bucket lives
+#   }
+#
+#   provider "aws" {
+#     alias  = "us_east_1"
+#     region = "us-east-1"  # ACM cert + CloudFront require this
+#   }
+#
+# Then pass both into this module:
+#
+#   module "freeside_storage" {
+#     source = "./freeside-storage"
+#     providers = {
+#       aws           = aws
+#       aws.us_east_1 = aws.us_east_1
+#     }
+#     # ...vars
+#   }
+# =============================================================================
+
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "~> 5.0"
+      configuration_aliases = [aws.us_east_1]
+    }
+  }
+}

--- a/packages/gaib-cli/README.md
+++ b/packages/gaib-cli/README.md
@@ -1,0 +1,85 @@
+# @loa-freeside/gaib-cli
+
+Sovereign secrets CLI — `gaib secrets pull/push/help` against AWS Secrets
+Manager, resolving slugs against the `freeside-worlds` registry.
+
+Per SDD §0 L3, this is a peer to `packages/cli` (the world-deploy surface)
+— different audience, different IAM scope.
+
+## Install
+
+```bash
+cd packages/gaib-cli
+pnpm install
+pnpm build
+# `gaib` is now on PATH (via the workspace bin link)
+```
+
+## Usage
+
+```bash
+# Pull mibera prod as a dotenv stream
+gaib secrets pull --world mibera --env prod --format dotenv > .env.cutover
+
+# Use the secrets, then revoke the working file
+unset $(grep -oE '^[A-Z_]+' .env.cutover) && rm .env.cutover
+
+# Push rotated secrets after a flip (prod requires --confirm)
+gaib secrets push --world mibera --env prod --from-file .env.rotated --confirm
+
+# Help
+gaib help
+gaib secrets pull --help
+```
+
+## Authentication
+
+Uses your existing AWS profile via `AWS_PROFILE` env or `~/.aws/credentials`.
+No new IAM roles — the CLI assumes the operator already has read/write
+permissions on `arrakis-{staging|production}-<slug>` Secrets Manager entries.
+
+For sprint-1 of `mature-freeside-operator-and-cutover` cycle, use:
+
+```bash
+export AWS_PROFILE=admin    # IAM user zksoju-cli
+gaib secrets pull --world mibera --env prod --format dotenv > /dev/null
+# (verify it returns 0; do not actually pipe values to disk in this test)
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Unauthorized (AWS auth failure) |
+| 2 | Missing world (slug not in registry) |
+| 3 | Schema violation (registry mismatch, malformed JSON, etc.) |
+| 4 | Retryable network error (AWS throttle / 5xx) |
+| 5 | Bad invocation (missing required flag, prod-without-confirm) |
+
+## Security
+
+- Never logs secret VALUES; logs counts + key names only.
+- Pull writes to stdout; operator is responsible for stdout routing.
+- Push validates against `freeside-worlds/packages/registry/worlds/<slug>.yaml`'s
+  `secrets:` array. Keys absent from the registry are rejected.
+- Prod pushes require `--confirm` to defend against muscle-memory mistakes.
+
+## Convention: AWS secret shape
+
+Each world has ONE Secrets Manager secret per env, named:
+
+- `arrakis-staging-<slug>`
+- `arrakis-production-<slug>`
+
+The secret's value is a JSON object — `{ "ENV_VAR": "value", ... }` — and
+the keys must match the `env_var` field of every entry in the world YAML's
+`secrets:` array. This mirrors the existing `scripts/load-honeyroad-secrets.sh`
+pattern.
+
+## References
+
+- SDD §0 L3 (peer placement)
+- SDD §9 (full design — package layout, commands, exit codes, auth, security)
+- KRANZ persona: secrets orchestration is INLINE in `coordinating-cutover` per L8
+- Project memory: `freeside-secret-management-direction`

--- a/packages/gaib-cli/package.json
+++ b/packages/gaib-cli/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@loa-freeside/gaib-cli",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Sovereign secrets CLI — `gaib secrets pull/push/help` against AWS Secrets Manager, resolving slug → ARN via freeside-worlds registry. Peer to packages/cli (world-deploy surface); per SDD L3 — different audience, different IAM scope.",
+  "type": "module",
+  "main": "./dist/cli.js",
+  "bin": {
+    "gaib": "./dist/cli.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist",
+    "dev": "tsx src/cli.ts"
+  },
+  "dependencies": {
+    "@aws-sdk/client-secrets-manager": "^3.700.0",
+    "@aws-sdk/credential-providers": "^3.700.0",
+    "clipanion": "^4.0.0-rc.4",
+    "typanion": "^3.14.0",
+    "yaml": "^2.6.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.0",
+    "vitest": "^1.0.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "license": "UNLICENSED"
+}

--- a/packages/gaib-cli/pnpm-lock.yaml
+++ b/packages/gaib-cli/pnpm-lock.yaml
@@ -1,0 +1,3191 @@
+lockfileVersion: '6.0'
+
+dependencies:
+  '@aws-sdk/client-secrets-manager':
+    specifier: ^3.700.0
+    version: 3.709.0
+  '@aws-sdk/credential-providers':
+    specifier: ^3.700.0
+    version: 3.709.0(@aws-sdk/client-sso-oidc@3.1039.0)
+  clipanion:
+    specifier: ^4.0.0-rc.4
+    version: 4.0.0-rc.4(typanion@3.14.0)
+  typanion:
+    specifier: ^3.14.0
+    version: 3.14.0
+  yaml:
+    specifier: ^2.6.0
+    version: 2.6.0
+
+devDependencies:
+  '@types/node':
+    specifier: ^20.0.0
+    version: 20.0.0
+  tsx:
+    specifier: ^4.7.0
+    version: 4.7.0
+  typescript:
+    specifier: ^5.3.0
+    version: 5.3.2
+  vitest:
+    specifier: ^1.0.0
+    version: 1.0.0(@types/node@20.0.0)
+
+packages:
+
+  /@aws-crypto/sha256-browser@5.2.0:
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.709.0
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-crypto/sha256-js@5.2.0:
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.709.0
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-crypto/supports-web-crypto@5.2.0:
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-crypto/util@5.2.0:
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+    dependencies:
+      '@aws-sdk/types': 3.709.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/client-cognito-identity@3.709.0:
+    resolution: {integrity: sha512-I5a8ilF+jKAz6fmOOuHy2UEcod9ikRGBjACcC6ayxs4z4VqTnWynD6ALKvtUR3lk1Ur6nzAG1tTm/qAYKKmyBg==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/client-sso-oidc': 3.709.0(@aws-sdk/client-sts@3.709.0)
+      '@aws-sdk/client-sts': 3.709.0
+      '@aws-sdk/core': 3.709.0
+      '@aws-sdk/credential-provider-node': 3.709.0(@aws-sdk/client-sso-oidc@3.709.0)(@aws-sdk/client-sts@3.709.0)
+      '@aws-sdk/middleware-host-header': 3.709.0
+      '@aws-sdk/middleware-logger': 3.709.0
+      '@aws-sdk/middleware-recursion-detection': 3.709.0
+      '@aws-sdk/middleware-user-agent': 3.709.0
+      '@aws-sdk/region-config-resolver': 3.709.0
+      '@aws-sdk/types': 3.709.0
+      '@aws-sdk/util-endpoints': 3.709.0
+      '@aws-sdk/util-user-agent-browser': 3.709.0
+      '@aws-sdk/util-user-agent-node': 3.709.0
+      '@smithy/config-resolver': 3.0.13
+      '@smithy/core': 2.5.7
+      '@smithy/fetch-http-handler': 4.1.3
+      '@smithy/hash-node': 3.0.11
+      '@smithy/invalid-dependency': 3.0.11
+      '@smithy/middleware-content-length': 3.0.13
+      '@smithy/middleware-endpoint': 3.2.8
+      '@smithy/middleware-retry': 3.0.34
+      '@smithy/middleware-serde': 3.0.11
+      '@smithy/middleware-stack': 3.0.11
+      '@smithy/node-config-provider': 3.1.12
+      '@smithy/node-http-handler': 3.3.3
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/smithy-client': 3.7.0
+      '@smithy/types': 3.7.2
+      '@smithy/url-parser': 3.0.11
+      '@smithy/util-base64': 3.0.0
+      '@smithy/util-body-length-browser': 3.0.0
+      '@smithy/util-body-length-node': 3.0.0
+      '@smithy/util-defaults-mode-browser': 3.0.34
+      '@smithy/util-defaults-mode-node': 3.0.34
+      '@smithy/util-endpoints': 2.1.7
+      '@smithy/util-middleware': 3.0.11
+      '@smithy/util-retry': 3.0.11
+      '@smithy/util-utf8': 3.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/client-secrets-manager@3.709.0:
+    resolution: {integrity: sha512-AiNuMTCqc2gt6n5sjtcnEGvDgW+PJPcDSWi9BB/0dUStqRsrJ6LqqQXWs0sXixHWX1PSkCZeYCt/4dw5VOwwag==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/client-sso-oidc': 3.709.0(@aws-sdk/client-sts@3.709.0)
+      '@aws-sdk/client-sts': 3.709.0
+      '@aws-sdk/core': 3.709.0
+      '@aws-sdk/credential-provider-node': 3.709.0(@aws-sdk/client-sso-oidc@3.709.0)(@aws-sdk/client-sts@3.709.0)
+      '@aws-sdk/middleware-host-header': 3.709.0
+      '@aws-sdk/middleware-logger': 3.709.0
+      '@aws-sdk/middleware-recursion-detection': 3.709.0
+      '@aws-sdk/middleware-user-agent': 3.709.0
+      '@aws-sdk/region-config-resolver': 3.709.0
+      '@aws-sdk/types': 3.709.0
+      '@aws-sdk/util-endpoints': 3.709.0
+      '@aws-sdk/util-user-agent-browser': 3.709.0
+      '@aws-sdk/util-user-agent-node': 3.709.0
+      '@smithy/config-resolver': 3.0.13
+      '@smithy/core': 2.5.7
+      '@smithy/fetch-http-handler': 4.1.3
+      '@smithy/hash-node': 3.0.11
+      '@smithy/invalid-dependency': 3.0.11
+      '@smithy/middleware-content-length': 3.0.13
+      '@smithy/middleware-endpoint': 3.2.8
+      '@smithy/middleware-retry': 3.0.34
+      '@smithy/middleware-serde': 3.0.11
+      '@smithy/middleware-stack': 3.0.11
+      '@smithy/node-config-provider': 3.1.12
+      '@smithy/node-http-handler': 3.3.3
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/smithy-client': 3.7.0
+      '@smithy/types': 3.7.2
+      '@smithy/url-parser': 3.0.11
+      '@smithy/util-base64': 3.0.0
+      '@smithy/util-body-length-browser': 3.0.0
+      '@smithy/util-body-length-node': 3.0.0
+      '@smithy/util-defaults-mode-browser': 3.0.34
+      '@smithy/util-defaults-mode-node': 3.0.34
+      '@smithy/util-endpoints': 2.1.7
+      '@smithy/util-middleware': 3.0.11
+      '@smithy/util-retry': 3.0.11
+      '@smithy/util-utf8': 3.0.0
+      '@types/uuid': 9.0.8
+      tslib: 2.8.1
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/client-sso-oidc@3.1039.0:
+    resolution: {integrity: sha512-18b99/IENp7R2gpN0+0L0baUYyM4CBI9HdvSPDXfegPFT0pI3i/miLwr1+X664s4DhtLvoj6vWgPdxjRdFyBPQ==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/credential-provider-node': 3.972.38
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.37
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.23
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.6
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/client-sso-oidc@3.709.0(@aws-sdk/client-sts@3.709.0):
+    resolution: {integrity: sha512-1w6egz17QQy661lNCRmZZlqIANEbD6g2VFAQIJbVwSiu7brg+GUns+mT1eLLLHAMQc1sL0Ds8/ybSK2SrgGgIA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-sts': ^3.709.0
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/client-sts': 3.709.0
+      '@aws-sdk/core': 3.709.0
+      '@aws-sdk/credential-provider-node': 3.709.0(@aws-sdk/client-sso-oidc@3.709.0)(@aws-sdk/client-sts@3.709.0)
+      '@aws-sdk/middleware-host-header': 3.709.0
+      '@aws-sdk/middleware-logger': 3.709.0
+      '@aws-sdk/middleware-recursion-detection': 3.709.0
+      '@aws-sdk/middleware-user-agent': 3.709.0
+      '@aws-sdk/region-config-resolver': 3.709.0
+      '@aws-sdk/types': 3.709.0
+      '@aws-sdk/util-endpoints': 3.709.0
+      '@aws-sdk/util-user-agent-browser': 3.709.0
+      '@aws-sdk/util-user-agent-node': 3.709.0
+      '@smithy/config-resolver': 3.0.13
+      '@smithy/core': 2.5.7
+      '@smithy/fetch-http-handler': 4.1.3
+      '@smithy/hash-node': 3.0.11
+      '@smithy/invalid-dependency': 3.0.11
+      '@smithy/middleware-content-length': 3.0.13
+      '@smithy/middleware-endpoint': 3.2.8
+      '@smithy/middleware-retry': 3.0.34
+      '@smithy/middleware-serde': 3.0.11
+      '@smithy/middleware-stack': 3.0.11
+      '@smithy/node-config-provider': 3.1.12
+      '@smithy/node-http-handler': 3.3.3
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/smithy-client': 3.7.0
+      '@smithy/types': 3.7.2
+      '@smithy/url-parser': 3.0.11
+      '@smithy/util-base64': 3.0.0
+      '@smithy/util-body-length-browser': 3.0.0
+      '@smithy/util-body-length-node': 3.0.0
+      '@smithy/util-defaults-mode-browser': 3.0.34
+      '@smithy/util-defaults-mode-node': 3.0.34
+      '@smithy/util-endpoints': 2.1.7
+      '@smithy/util-middleware': 3.0.11
+      '@smithy/util-retry': 3.0.11
+      '@smithy/util-utf8': 3.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/client-sso@3.709.0:
+    resolution: {integrity: sha512-Qxeo8cN0jNy6Wnbqq4wucffAGJM6sJjofoTgNtPA6cC7sPYx7aYC6OAAAo6NaMRY+WywOKdS9Wgjx2QYRxKx7w==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.709.0
+      '@aws-sdk/middleware-host-header': 3.709.0
+      '@aws-sdk/middleware-logger': 3.709.0
+      '@aws-sdk/middleware-recursion-detection': 3.709.0
+      '@aws-sdk/middleware-user-agent': 3.709.0
+      '@aws-sdk/region-config-resolver': 3.709.0
+      '@aws-sdk/types': 3.709.0
+      '@aws-sdk/util-endpoints': 3.709.0
+      '@aws-sdk/util-user-agent-browser': 3.709.0
+      '@aws-sdk/util-user-agent-node': 3.709.0
+      '@smithy/config-resolver': 3.0.13
+      '@smithy/core': 2.5.7
+      '@smithy/fetch-http-handler': 4.1.3
+      '@smithy/hash-node': 3.0.11
+      '@smithy/invalid-dependency': 3.0.11
+      '@smithy/middleware-content-length': 3.0.13
+      '@smithy/middleware-endpoint': 3.2.8
+      '@smithy/middleware-retry': 3.0.34
+      '@smithy/middleware-serde': 3.0.11
+      '@smithy/middleware-stack': 3.0.11
+      '@smithy/node-config-provider': 3.1.12
+      '@smithy/node-http-handler': 3.3.3
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/smithy-client': 3.7.0
+      '@smithy/types': 3.7.2
+      '@smithy/url-parser': 3.0.11
+      '@smithy/util-base64': 3.0.0
+      '@smithy/util-body-length-browser': 3.0.0
+      '@smithy/util-body-length-node': 3.0.0
+      '@smithy/util-defaults-mode-browser': 3.0.34
+      '@smithy/util-defaults-mode-node': 3.0.34
+      '@smithy/util-endpoints': 2.1.7
+      '@smithy/util-middleware': 3.0.11
+      '@smithy/util-retry': 3.0.11
+      '@smithy/util-utf8': 3.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/client-sts@3.709.0:
+    resolution: {integrity: sha512-cBAvlPg6yslXNL385UUGFPw+XY+lA9BzioNdIFkMo3fEUlTShogTtiWz4LsyLHoN6LhKojssP9DSmmWKWjCZIw==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/client-sso-oidc': 3.709.0(@aws-sdk/client-sts@3.709.0)
+      '@aws-sdk/core': 3.709.0
+      '@aws-sdk/credential-provider-node': 3.709.0(@aws-sdk/client-sso-oidc@3.709.0)(@aws-sdk/client-sts@3.709.0)
+      '@aws-sdk/middleware-host-header': 3.709.0
+      '@aws-sdk/middleware-logger': 3.709.0
+      '@aws-sdk/middleware-recursion-detection': 3.709.0
+      '@aws-sdk/middleware-user-agent': 3.709.0
+      '@aws-sdk/region-config-resolver': 3.709.0
+      '@aws-sdk/types': 3.709.0
+      '@aws-sdk/util-endpoints': 3.709.0
+      '@aws-sdk/util-user-agent-browser': 3.709.0
+      '@aws-sdk/util-user-agent-node': 3.709.0
+      '@smithy/config-resolver': 3.0.13
+      '@smithy/core': 2.5.7
+      '@smithy/fetch-http-handler': 4.1.3
+      '@smithy/hash-node': 3.0.11
+      '@smithy/invalid-dependency': 3.0.11
+      '@smithy/middleware-content-length': 3.0.13
+      '@smithy/middleware-endpoint': 3.2.8
+      '@smithy/middleware-retry': 3.0.34
+      '@smithy/middleware-serde': 3.0.11
+      '@smithy/middleware-stack': 3.0.11
+      '@smithy/node-config-provider': 3.1.12
+      '@smithy/node-http-handler': 3.3.3
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/smithy-client': 3.7.0
+      '@smithy/types': 3.7.2
+      '@smithy/url-parser': 3.0.11
+      '@smithy/util-base64': 3.0.0
+      '@smithy/util-body-length-browser': 3.0.0
+      '@smithy/util-body-length-node': 3.0.0
+      '@smithy/util-defaults-mode-browser': 3.0.34
+      '@smithy/util-defaults-mode-node': 3.0.34
+      '@smithy/util-endpoints': 2.1.7
+      '@smithy/util-middleware': 3.0.11
+      '@smithy/util-retry': 3.0.11
+      '@smithy/util-utf8': 3.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/core@3.709.0:
+    resolution: {integrity: sha512-7kuSpzdOTAE026j85wq/fN9UDZ70n0OHw81vFqMWwlEFtm5IQ/MRCLKcC4HkXxTdfy1PqFlmoXxWqeBa15tujw==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.709.0
+      '@smithy/core': 2.5.7
+      '@smithy/node-config-provider': 3.1.12
+      '@smithy/property-provider': 3.1.11
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/signature-v4': 4.2.4
+      '@smithy/smithy-client': 3.7.0
+      '@smithy/types': 3.7.2
+      '@smithy/util-middleware': 3.0.11
+      fast-xml-parser: 4.4.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/core@3.974.7:
+    resolution: {integrity: sha512-YhRC90ofz5oolTJZlA8voU/oUrCB2azi8Usx51k8hhB5LpWbYQMMXKUqSqkoL0Cru+RQJgWTHpAfEDDIwfUhJw==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.22
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.6
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-cognito-identity@3.709.0:
+    resolution: {integrity: sha512-WLzDcYo7pob8fPeeOhgVqYuV21uUKWb1RobITQzZhv0ZSToIl1KjuyRQsznC23Sot9CFl+0V2QLFFNwRiIuH7w==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-sdk/client-cognito-identity': 3.709.0
+      '@aws-sdk/types': 3.709.0
+      '@smithy/property-provider': 3.1.11
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-provider-env@3.709.0:
+    resolution: {integrity: sha512-ZMAp9LSikvHDFVa84dKpQmow6wsg956Um20cKuioPpX2GGreJFur7oduD+tRJT6FtIOHn+64YH+0MwiXLhsaIQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.709.0
+      '@aws-sdk/types': 3.709.0
+      '@smithy/property-provider': 3.1.11
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-env@3.972.33:
+    resolution: {integrity: sha512-bJV7eViSJV6GSuuN+VIdNVPdwPsNSf75BiC2v5alPrjR/OCcqgKwSZInKbDFz9mNeizldsyf67jt6YSIiv53Cw==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-http@3.709.0:
+    resolution: {integrity: sha512-lIS7XLwCOyJnLD70f+VIRr8DNV1HPQe9oN6aguYrhoczqz7vDiVZLe3lh714cJqq9rdxzFypK5DqKHmcscMEPQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.709.0
+      '@aws-sdk/types': 3.709.0
+      '@smithy/fetch-http-handler': 4.1.3
+      '@smithy/node-http-handler': 3.3.3
+      '@smithy/property-provider': 3.1.11
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/smithy-client': 3.7.0
+      '@smithy/types': 3.7.2
+      '@smithy/util-stream': 3.3.4
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-http@3.972.35:
+    resolution: {integrity: sha512-x/BQGEIdq0oI+4WxLjKmnQvT7CnF9r8ezdGt7wXwxb7ckHXQz0Zmgxt8v3Ne0JaT3R5YefmuybHX6E8EnsDXyA==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-ini@3.709.0(@aws-sdk/client-sso-oidc@3.1039.0)(@aws-sdk/client-sts@3.709.0):
+    resolution: {integrity: sha512-qCF8IIGcPoUp+Ib3ANhbF5gElxFd+kIrtv2/1tKdvhudMANstQbMiWV0LTH47ZZR6c3as4iSrm09NZnpEoD/pA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-sts': ^3.709.0
+    dependencies:
+      '@aws-sdk/client-sts': 3.709.0
+      '@aws-sdk/core': 3.709.0
+      '@aws-sdk/credential-provider-env': 3.709.0
+      '@aws-sdk/credential-provider-http': 3.709.0
+      '@aws-sdk/credential-provider-process': 3.709.0
+      '@aws-sdk/credential-provider-sso': 3.709.0(@aws-sdk/client-sso-oidc@3.1039.0)
+      '@aws-sdk/credential-provider-web-identity': 3.709.0(@aws-sdk/client-sts@3.709.0)
+      '@aws-sdk/types': 3.709.0
+      '@smithy/credential-provider-imds': 3.2.8
+      '@smithy/property-provider': 3.1.11
+      '@smithy/shared-ini-file-loader': 3.1.12
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-provider-ini@3.709.0(@aws-sdk/client-sso-oidc@3.709.0)(@aws-sdk/client-sts@3.709.0):
+    resolution: {integrity: sha512-qCF8IIGcPoUp+Ib3ANhbF5gElxFd+kIrtv2/1tKdvhudMANstQbMiWV0LTH47ZZR6c3as4iSrm09NZnpEoD/pA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-sts': ^3.709.0
+    dependencies:
+      '@aws-sdk/client-sts': 3.709.0
+      '@aws-sdk/core': 3.709.0
+      '@aws-sdk/credential-provider-env': 3.709.0
+      '@aws-sdk/credential-provider-http': 3.709.0
+      '@aws-sdk/credential-provider-process': 3.709.0
+      '@aws-sdk/credential-provider-sso': 3.709.0(@aws-sdk/client-sso-oidc@3.709.0)
+      '@aws-sdk/credential-provider-web-identity': 3.709.0(@aws-sdk/client-sts@3.709.0)
+      '@aws-sdk/types': 3.709.0
+      '@smithy/credential-provider-imds': 3.2.8
+      '@smithy/property-provider': 3.1.11
+      '@smithy/shared-ini-file-loader': 3.1.12
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-provider-ini@3.972.37:
+    resolution: {integrity: sha512-eUTpmWfd/BKsq9medhCRcu+GRAhFP2Zrn7/2jKDHHOOjCkhrMoTp/t4cEthqFoG7gE0VGp5wUxrXTdvBCmSmJg==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/credential-provider-env': 3.972.33
+      '@aws-sdk/credential-provider-http': 3.972.35
+      '@aws-sdk/credential-provider-login': 3.972.37
+      '@aws-sdk/credential-provider-process': 3.972.33
+      '@aws-sdk/credential-provider-sso': 3.972.37
+      '@aws-sdk/credential-provider-web-identity': 3.972.37
+      '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-provider-login@3.972.37:
+    resolution: {integrity: sha512-Ty68y8ISSC+g5Q3D0K8uAaoINwvfaOslnNpsF/LgVUxyosYXHawcK2yV4HLXDVugiTTYLQfJfcw0ce5meAGkKw==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-provider-node@3.709.0(@aws-sdk/client-sso-oidc@3.1039.0)(@aws-sdk/client-sts@3.709.0):
+    resolution: {integrity: sha512-4HRX9KYWPSjO5O/Vg03YAsebKpvTjTvpK1n7zHYBmlLMBLxUrVsL1nNKKC5p2/7OW3RL8XR1ki3QkoV7kGRxUQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.709.0
+      '@aws-sdk/credential-provider-http': 3.709.0
+      '@aws-sdk/credential-provider-ini': 3.709.0(@aws-sdk/client-sso-oidc@3.1039.0)(@aws-sdk/client-sts@3.709.0)
+      '@aws-sdk/credential-provider-process': 3.709.0
+      '@aws-sdk/credential-provider-sso': 3.709.0(@aws-sdk/client-sso-oidc@3.1039.0)
+      '@aws-sdk/credential-provider-web-identity': 3.709.0(@aws-sdk/client-sts@3.709.0)
+      '@aws-sdk/types': 3.709.0
+      '@smithy/credential-provider-imds': 3.2.8
+      '@smithy/property-provider': 3.1.11
+      '@smithy/shared-ini-file-loader': 3.1.12
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
+      - '@aws-sdk/client-sts'
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-provider-node@3.709.0(@aws-sdk/client-sso-oidc@3.709.0)(@aws-sdk/client-sts@3.709.0):
+    resolution: {integrity: sha512-4HRX9KYWPSjO5O/Vg03YAsebKpvTjTvpK1n7zHYBmlLMBLxUrVsL1nNKKC5p2/7OW3RL8XR1ki3QkoV7kGRxUQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.709.0
+      '@aws-sdk/credential-provider-http': 3.709.0
+      '@aws-sdk/credential-provider-ini': 3.709.0(@aws-sdk/client-sso-oidc@3.709.0)(@aws-sdk/client-sts@3.709.0)
+      '@aws-sdk/credential-provider-process': 3.709.0
+      '@aws-sdk/credential-provider-sso': 3.709.0(@aws-sdk/client-sso-oidc@3.709.0)
+      '@aws-sdk/credential-provider-web-identity': 3.709.0(@aws-sdk/client-sts@3.709.0)
+      '@aws-sdk/types': 3.709.0
+      '@smithy/credential-provider-imds': 3.2.8
+      '@smithy/property-provider': 3.1.11
+      '@smithy/shared-ini-file-loader': 3.1.12
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
+      - '@aws-sdk/client-sts'
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-provider-node@3.972.38:
+    resolution: {integrity: sha512-BQ9XYnBDVxR2HuV5huXYQYF/PZMTsY+EnwfGnCU2cA8Zw63XpkOtPY8WqiMIZMQCrKPQQEiFURS/o9CIolRLqg==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.33
+      '@aws-sdk/credential-provider-http': 3.972.35
+      '@aws-sdk/credential-provider-ini': 3.972.37
+      '@aws-sdk/credential-provider-process': 3.972.33
+      '@aws-sdk/credential-provider-sso': 3.972.37
+      '@aws-sdk/credential-provider-web-identity': 3.972.37
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-provider-process@3.709.0:
+    resolution: {integrity: sha512-IAC+jPlGQII6jhIylHOwh3RgSobqlgL59nw2qYTURr8hMCI0Z1p5y2ee646HTVt4WeCYyzUAXfxr6YI/Vitv+Q==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.709.0
+      '@aws-sdk/types': 3.709.0
+      '@smithy/property-provider': 3.1.11
+      '@smithy/shared-ini-file-loader': 3.1.12
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-process@3.972.33:
+    resolution: {integrity: sha512-yfjGksI9WQbdMObb0VeLXqzTLI+a0qXLJT9gCDiv0+X/xjPpI3mTz6a5FibrhpuEKIe0gSgvs3MaoFZy5cx4WA==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-sso@3.709.0(@aws-sdk/client-sso-oidc@3.1039.0):
+    resolution: {integrity: sha512-rYdTDOxazS2GdGScelsRK5CAkktRLCCdRjlwXaxrcW57j749hEqxcF5uTv9RD6WBwInfedcSywErNZB+hylQlg==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-sdk/client-sso': 3.709.0
+      '@aws-sdk/core': 3.709.0
+      '@aws-sdk/token-providers': 3.709.0(@aws-sdk/client-sso-oidc@3.1039.0)
+      '@aws-sdk/types': 3.709.0
+      '@smithy/property-provider': 3.1.11
+      '@smithy/shared-ini-file-loader': 3.1.12
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-provider-sso@3.709.0(@aws-sdk/client-sso-oidc@3.709.0):
+    resolution: {integrity: sha512-rYdTDOxazS2GdGScelsRK5CAkktRLCCdRjlwXaxrcW57j749hEqxcF5uTv9RD6WBwInfedcSywErNZB+hylQlg==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-sdk/client-sso': 3.709.0
+      '@aws-sdk/core': 3.709.0
+      '@aws-sdk/token-providers': 3.709.0(@aws-sdk/client-sso-oidc@3.709.0)
+      '@aws-sdk/types': 3.709.0
+      '@smithy/property-provider': 3.1.11
+      '@smithy/shared-ini-file-loader': 3.1.12
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-provider-sso@3.972.37:
+    resolution: {integrity: sha512-fpwE+20ntpp3i9Xb9vUuQfXLDKYHH+5I2V+ZG96SX1nBzrruhy10RXDgmN7t1etOz3c55stlA3TeQASUA451NQ==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/token-providers': 3.1039.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-provider-web-identity@3.709.0(@aws-sdk/client-sts@3.709.0):
+    resolution: {integrity: sha512-2lbDfE0IQ6gma/7BB2JpkjW5G0wGe4AS0x80oybYAYYviJmUtIR3Cn2pXun6bnAWElt4wYKl4su7oC36rs5rNA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-sts': ^3.709.0
+    dependencies:
+      '@aws-sdk/client-sts': 3.709.0
+      '@aws-sdk/core': 3.709.0
+      '@aws-sdk/types': 3.709.0
+      '@smithy/property-provider': 3.1.11
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-web-identity@3.972.37:
+    resolution: {integrity: sha512-aryawqyebf+3WhAFNHfF62rekFpYtVcVN7dQ89qnAWsa4n5hJst8qBG6gXC24WHtW7Nnhkf9ScYnjwo0Brn3bw==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-providers@3.709.0(@aws-sdk/client-sso-oidc@3.1039.0):
+    resolution: {integrity: sha512-v1OfAWhYhAz7XPtjWlQ3jDLZHCpuNrLP2bRWTEjRty8yZLN92ANehincULUGvUNszFO8rfpq2g4dmtk8XmqTzA==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-sdk/client-cognito-identity': 3.709.0
+      '@aws-sdk/client-sso': 3.709.0
+      '@aws-sdk/client-sts': 3.709.0
+      '@aws-sdk/core': 3.709.0
+      '@aws-sdk/credential-provider-cognito-identity': 3.709.0
+      '@aws-sdk/credential-provider-env': 3.709.0
+      '@aws-sdk/credential-provider-http': 3.709.0
+      '@aws-sdk/credential-provider-ini': 3.709.0(@aws-sdk/client-sso-oidc@3.1039.0)(@aws-sdk/client-sts@3.709.0)
+      '@aws-sdk/credential-provider-node': 3.709.0(@aws-sdk/client-sso-oidc@3.1039.0)(@aws-sdk/client-sts@3.709.0)
+      '@aws-sdk/credential-provider-process': 3.709.0
+      '@aws-sdk/credential-provider-sso': 3.709.0(@aws-sdk/client-sso-oidc@3.1039.0)
+      '@aws-sdk/credential-provider-web-identity': 3.709.0(@aws-sdk/client-sts@3.709.0)
+      '@aws-sdk/types': 3.709.0
+      '@smithy/credential-provider-imds': 3.2.8
+      '@smithy/property-provider': 3.1.11
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/middleware-host-header@3.709.0:
+    resolution: {integrity: sha512-8gQYCYAaIw4lOCd5WYdf15Y/61MgRsAnrb2eiTl+icMlUOOzl8aOl5iDwm/Idp0oHZTflwxM4XSvGXO83PRWcw==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.709.0
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/middleware-host-header@3.972.10:
+    resolution: {integrity: sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/middleware-logger@3.709.0:
+    resolution: {integrity: sha512-jDoGSccXv9zebnpUoisjWd5u5ZPIalrmm6TjvPzZ8UqzQt3Beiz0tnQwmxQD6KRc7ADweWP5Ntiqzbw9xpVajg==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.709.0
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/middleware-logger@3.972.10:
+    resolution: {integrity: sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/middleware-recursion-detection@3.709.0:
+    resolution: {integrity: sha512-PObL/wLr4lkfbQ0yXUWaoCWu/jcwfwZzCjsUiXW/H6hW9b/00enZxmx7OhtJYaR6xmh/Lcx5wbhIoDCbzdv0tw==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.709.0
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/middleware-recursion-detection@3.972.11:
+    resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/middleware-sdk-s3@3.972.36:
+    resolution: {integrity: sha512-YhPix+0x/MdQrb1Ug1GDKeS5fqylIy+naz800asX8II4jqfTk2KY2KhmmYCwZcky8YWtRQQwWCGdoqeAnip8Uw==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/middleware-user-agent@3.709.0:
+    resolution: {integrity: sha512-ooc9ZJvgkjPhi9q05XwSfNTXkEBEIfL4hleo5rQBKwHG3aTHvwOM7LLzhdX56QZVa6sorPBp6fwULuRDSqiQHw==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.709.0
+      '@aws-sdk/types': 3.709.0
+      '@aws-sdk/util-endpoints': 3.709.0
+      '@smithy/core': 2.5.7
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/middleware-user-agent@3.972.37:
+    resolution: {integrity: sha512-N1oNpdiLoVAWYD3WFBnUi3LlfoDA06ZHo4ozyjbsJNLvILzvt//0CnR8N+CZ0NWeYgVB/5V59ivixHCWCx2ALw==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-retry': 4.3.6
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/nested-clients@3.997.5:
+    resolution: {integrity: sha512-jGFr6DxtcMTmzOkG/a0jCZYv4BBDmeNYVeO+/memSoDkYCJu4Y58xviYmzwJfYyIVSts+X/BVjJm1uGBnwHEMg==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.37
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.24
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.23
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.6
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/region-config-resolver@3.709.0:
+    resolution: {integrity: sha512-/NoCAMEVKAg3kBKOrNtgOfL+ECt6nrl+L7q2SyYmrcY4tVCmwuECVqewQaHc03fTnJijfKLccw0Fj+6wOCnB6w==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.709.0
+      '@smithy/node-config-provider': 3.1.12
+      '@smithy/types': 3.7.2
+      '@smithy/util-config-provider': 3.0.0
+      '@smithy/util-middleware': 3.0.11
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/region-config-resolver@3.972.13:
+    resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/signature-v4-multi-region@3.996.24:
+    resolution: {integrity: sha512-amP7tLikppN940wbBFISYqiuzVmpzMS9U3mcgtmVLjX4fdWI/SNCvrXv6ZxfVzTT4cT0rPKOLhFah2xLwzREWw==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.36
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/token-providers@3.1039.0:
+    resolution: {integrity: sha512-NMSFL2HwkAOoCeLCQiqoOq5pT3vVbSjww2QZTuYgYknVwhhv125PSDzZIcL5EYnlxuPWjEOdauZK+FspkZDVdw==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/token-providers@3.709.0(@aws-sdk/client-sso-oidc@3.1039.0):
+    resolution: {integrity: sha512-q5Ar6k71nci43IbULFgC8a89d/3EHpmd7HvBzqVGRcHnoPwh8eZDBfbBXKH83NGwcS1qPSRYiDbVfeWPm4/1jA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-sso-oidc': ^3.709.0
+    dependencies:
+      '@aws-sdk/client-sso-oidc': 3.1039.0
+      '@aws-sdk/types': 3.709.0
+      '@smithy/property-provider': 3.1.11
+      '@smithy/shared-ini-file-loader': 3.1.12
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/token-providers@3.709.0(@aws-sdk/client-sso-oidc@3.709.0):
+    resolution: {integrity: sha512-q5Ar6k71nci43IbULFgC8a89d/3EHpmd7HvBzqVGRcHnoPwh8eZDBfbBXKH83NGwcS1qPSRYiDbVfeWPm4/1jA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-sso-oidc': ^3.709.0
+    dependencies:
+      '@aws-sdk/client-sso-oidc': 3.709.0(@aws-sdk/client-sts@3.709.0)
+      '@aws-sdk/types': 3.709.0
+      '@smithy/property-provider': 3.1.11
+      '@smithy/shared-ini-file-loader': 3.1.12
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/types@3.709.0:
+    resolution: {integrity: sha512-ArtLTMxgjf13Kfu3gWH3Ez9Q5TkDdcRZUofpKH3pMGB/C6KAbeSCtIIDKfoRTUABzyGlPyCrZdnFjKyH+ypIpg==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/types@3.973.8:
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/util-arn-parser@3.972.3:
+    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/util-endpoints@3.709.0:
+    resolution: {integrity: sha512-Mbc7AtL5WGCTKC16IGeUTz+sjpC3ptBda2t0CcK0kMVw3THDdcSq6ZlNKO747cNqdbwUvW34oHteUiHv4/z88Q==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.709.0
+      '@smithy/types': 3.7.2
+      '@smithy/util-endpoints': 2.1.7
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/util-endpoints@3.996.8:
+    resolution: {integrity: sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-endpoints': 3.4.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/util-locate-window@3.965.5:
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/util-user-agent-browser@3.709.0:
+    resolution: {integrity: sha512-/rL2GasJzdTWUURCQKFldw2wqBtY4k4kCiA2tVZSKg3y4Ey7zO34SW8ebaeCE2/xoWOyLR2/etdKyphoo4Zrtg==}
+    dependencies:
+      '@aws-sdk/types': 3.709.0
+      '@smithy/types': 3.7.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/util-user-agent-browser@3.972.10:
+    resolution: {integrity: sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==}
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/util-user-agent-node@3.709.0:
+    resolution: {integrity: sha512-trBfzSCVWy7ILgqhEXgiuM7hfRCw4F4a8IK90tjk9YL0jgoJ6eJuOp7+DfCtHJaygoBxD3cdMFkOu+lluFmGBA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.709.0
+      '@aws-sdk/types': 3.709.0
+      '@smithy/node-config-provider': 3.1.12
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/util-user-agent-node@3.973.23:
+    resolution: {integrity: sha512-gGwq8L2Euw0aNG6Ey4EktiAo3fSCVoDy1CaBIthd+oeaKHPXUrNaApMewQ6La5Hv0lcznOtECZaNvYyc5LXXfA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.37
+      '@aws-sdk/types': 3.973.8
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/xml-builder@3.972.22:
+    resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.1
+      fast-xml-parser: 5.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws/lambda-invoke-store@0.2.4:
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
+    dev: false
+
+  /@esbuild/aix-ppc64@0.19.12:
+    resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/aix-ppc64@0.21.5:
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.19.12:
+    resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.21.5:
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm@0.19.12:
+    resolution: {integrity: sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm@0.21.5:
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.19.12:
+    resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.21.5:
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64@0.19.12:
+    resolution: {integrity: sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64@0.21.5:
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.19.12:
+    resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.21.5:
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.19.12:
+    resolution: {integrity: sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.21.5:
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.19.12:
+    resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.21.5:
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64@0.19.12:
+    resolution: {integrity: sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64@0.21.5:
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.19.12:
+    resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.21.5:
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.19.12:
+    resolution: {integrity: sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.21.5:
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.19.12:
+    resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.21.5:
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el@0.19.12:
+    resolution: {integrity: sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el@0.21.5:
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.19.12:
+    resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.21.5:
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64@0.19.12:
+    resolution: {integrity: sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64@0.21.5:
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.19.12:
+    resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.21.5:
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64@0.19.12:
+    resolution: {integrity: sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64@0.21.5:
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.19.12:
+    resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.21.5:
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.19.12:
+    resolution: {integrity: sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.21.5:
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.19.12:
+    resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.21.5:
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.19.12:
+    resolution: {integrity: sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.21.5:
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-ia32@0.19.12:
+    resolution: {integrity: sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-ia32@0.21.5:
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.19.12:
+    resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.21.5:
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@jest/schemas@29.6.3:
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.27.10
+    dev: true
+
+  /@jridgewell/sourcemap-codec@1.5.5:
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+    dev: true
+
+  /@nodable/entities@2.1.0:
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+    dev: false
+
+  /@rollup/rollup-android-arm-eabi@4.60.2:
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-android-arm64@4.60.2:
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-arm64@4.60.2:
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-x64@4.60.2:
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-freebsd-arm64@4.60.2:
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-freebsd-x64@4.60.2:
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-gnueabihf@4.60.2:
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-musleabihf@4.60.2:
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-gnu@4.60.2:
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-musl@4.60.2:
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-loong64-gnu@4.60.2:
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-loong64-musl@4.60.2:
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-ppc64-gnu@4.60.2:
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-ppc64-musl@4.60.2:
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-gnu@4.60.2:
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-musl@4.60.2:
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-s390x-gnu@4.60.2:
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-gnu@4.60.2:
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-musl@4.60.2:
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-openbsd-x64@4.60.2:
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-openharmony-arm64@4.60.2:
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-arm64-msvc@4.60.2:
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-ia32-msvc@4.60.2:
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-gnu@4.60.2:
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-msvc@4.60.2:
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@sinclair/typebox@0.27.10:
+    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
+    dev: true
+
+  /@smithy/abort-controller@3.1.9:
+    resolution: {integrity: sha512-yiW0WI30zj8ZKoSYNx90no7ugVn3khlyH/z5W8qtKBtVE6awRALbhSG+2SAHA1r6bO/6M9utxYKVZ3PCJ1rWxw==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/config-resolver@3.0.13:
+    resolution: {integrity: sha512-Gr/qwzyPaTL1tZcq8WQyHhTZREER5R1Wytmz4WnVGL4onA3dNk6Btll55c8Vr58pLdvWZmtG8oZxJTw3t3q7Jg==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/node-config-provider': 3.1.12
+      '@smithy/types': 3.7.2
+      '@smithy/util-config-provider': 3.0.0
+      '@smithy/util-middleware': 3.0.11
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/config-resolver@4.4.17:
+    resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/core@2.5.7:
+    resolution: {integrity: sha512-8olpW6mKCa0v+ibCjoCzgZHQx1SQmZuW/WkrdZo73wiTprTH6qhmskT60QLFdT9DRa5mXxjz89kQPZ7ZSsoqqg==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/middleware-serde': 3.0.11
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/types': 3.7.2
+      '@smithy/util-body-length-browser': 3.0.0
+      '@smithy/util-middleware': 3.0.11
+      '@smithy/util-stream': 3.3.4
+      '@smithy/util-utf8': 3.0.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/core@3.23.17:
+    resolution: {integrity: sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/credential-provider-imds@3.2.8:
+    resolution: {integrity: sha512-ZCY2yD0BY+K9iMXkkbnjo+08T2h8/34oHd0Jmh6BZUSZwaaGlGCyBT/3wnS7u7Xl33/EEfN4B6nQr3Gx5bYxgw==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/node-config-provider': 3.1.12
+      '@smithy/property-provider': 3.1.11
+      '@smithy/types': 3.7.2
+      '@smithy/url-parser': 3.0.11
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/credential-provider-imds@4.2.14:
+    resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/fetch-http-handler@4.1.3:
+    resolution: {integrity: sha512-6SxNltSncI8s689nvnzZQc/dPXcpHQ34KUj6gR/HBroytKOd/isMG3gJF/zBE1TBmTT18TXyzhg3O3SOOqGEhA==}
+    dependencies:
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/querystring-builder': 3.0.11
+      '@smithy/types': 3.7.2
+      '@smithy/util-base64': 3.0.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/fetch-http-handler@5.3.17:
+    resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/hash-node@3.0.11:
+    resolution: {integrity: sha512-emP23rwYyZhQBvklqTtwetkQlqbNYirDiEEwXl2v0GYWMnCzxst7ZaRAnWuy28njp5kAH54lvkdG37MblZzaHA==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/types': 3.7.2
+      '@smithy/util-buffer-from': 3.0.0
+      '@smithy/util-utf8': 3.0.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/hash-node@4.2.14:
+    resolution: {integrity: sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/invalid-dependency@3.0.11:
+    resolution: {integrity: sha512-NuQmVPEJjUX6c+UELyVz8kUx8Q539EDeNwbRyu4IIF8MeV7hUtq1FB3SHVyki2u++5XLMFqngeMKk7ccspnNyQ==}
+    dependencies:
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/invalid-dependency@4.2.14:
+    resolution: {integrity: sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/is-array-buffer@2.2.0:
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/is-array-buffer@3.0.0:
+    resolution: {integrity: sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/is-array-buffer@4.2.2:
+    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/middleware-content-length@3.0.13:
+    resolution: {integrity: sha512-zfMhzojhFpIX3P5ug7jxTjfUcIPcGjcQYzB9t+rv0g1TX7B0QdwONW+ATouaLoD7h7LOw/ZlXfkq4xJ/g2TrIw==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/middleware-content-length@4.2.14:
+    resolution: {integrity: sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/middleware-endpoint@3.2.8:
+    resolution: {integrity: sha512-OEJZKVUEhMOqMs3ktrTWp7UvvluMJEvD5XgQwRePSbDg1VvBaL8pX8mwPltFn6wk1GySbcVwwyldL8S+iqnrEQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/core': 2.5.7
+      '@smithy/middleware-serde': 3.0.11
+      '@smithy/node-config-provider': 3.1.12
+      '@smithy/shared-ini-file-loader': 3.1.12
+      '@smithy/types': 3.7.2
+      '@smithy/url-parser': 3.0.11
+      '@smithy/util-middleware': 3.0.11
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/middleware-endpoint@4.4.32:
+    resolution: {integrity: sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/middleware-retry@3.0.34:
+    resolution: {integrity: sha512-yVRr/AAtPZlUvwEkrq7S3x7Z8/xCd97m2hLDaqdz6ucP2RKHsBjEqaUA2ebNv2SsZoPEi+ZD0dZbOB1u37tGCA==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/node-config-provider': 3.1.12
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/service-error-classification': 3.0.11
+      '@smithy/smithy-client': 3.7.0
+      '@smithy/types': 3.7.2
+      '@smithy/util-middleware': 3.0.11
+      '@smithy/util-retry': 3.0.11
+      tslib: 2.8.1
+      uuid: 9.0.1
+    dev: false
+
+  /@smithy/middleware-retry@4.5.7:
+    resolution: {integrity: sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.6
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/middleware-serde@3.0.11:
+    resolution: {integrity: sha512-KzPAeySp/fOoQA82TpnwItvX8BBURecpx6ZMu75EZDkAcnPtO6vf7q4aH5QHs/F1s3/snQaSFbbUMcFFZ086Mw==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/middleware-serde@4.2.20:
+    resolution: {integrity: sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/middleware-stack@3.0.11:
+    resolution: {integrity: sha512-1HGo9a6/ikgOMrTrWL/WiN9N8GSVYpuRQO5kjstAq4CvV59bjqnh7TbdXGQ4vxLD3xlSjfBjq5t1SOELePsLnA==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/middleware-stack@4.2.14:
+    resolution: {integrity: sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/node-config-provider@3.1.12:
+    resolution: {integrity: sha512-O9LVEu5J/u/FuNlZs+L7Ikn3lz7VB9hb0GtPT9MQeiBmtK8RSY3ULmsZgXhe6VAlgTw0YO+paQx4p8xdbs43vQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/property-provider': 3.1.11
+      '@smithy/shared-ini-file-loader': 3.1.12
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/node-config-provider@4.3.14:
+    resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/node-http-handler@3.3.3:
+    resolution: {integrity: sha512-BrpZOaZ4RCbcJ2igiSNG16S+kgAc65l/2hmxWdmhyoGWHTLlzQzr06PXavJp9OBlPEG/sHlqdxjWmjzV66+BSQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/abort-controller': 3.1.9
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/querystring-builder': 3.0.11
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/node-http-handler@4.6.1:
+    resolution: {integrity: sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/property-provider@3.1.11:
+    resolution: {integrity: sha512-I/+TMc4XTQ3QAjXfOcUWbSS073oOEAxgx4aZy8jHaf8JQnRkq2SZWw8+PfDtBvLUjcGMdxl+YwtzWe6i5uhL/A==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/property-provider@4.2.14:
+    resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/protocol-http@4.1.8:
+    resolution: {integrity: sha512-hmgIAVyxw1LySOwkgMIUN0kjN8TG9Nc85LJeEmEE/cNEe2rkHDUWhnJf2gxcSRFLWsyqWsrZGw40ROjUogg+Iw==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/protocol-http@5.3.14:
+    resolution: {integrity: sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/querystring-builder@3.0.11:
+    resolution: {integrity: sha512-u+5HV/9uJaeLj5XTb6+IEF/dokWWkEqJ0XiaRRogyREmKGUgZnNecLucADLdauWFKUNbQfulHFEZEdjwEBjXRg==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/types': 3.7.2
+      '@smithy/util-uri-escape': 3.0.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/querystring-builder@4.2.14:
+    resolution: {integrity: sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-uri-escape': 4.2.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/querystring-parser@3.0.11:
+    resolution: {integrity: sha512-Je3kFvCsFMnso1ilPwA7GtlbPaTixa3WwC+K21kmMZHsBEOZYQaqxcMqeFFoU7/slFjKDIpiiPydvdJm8Q/MCw==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/querystring-parser@4.2.14:
+    resolution: {integrity: sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/service-error-classification@3.0.11:
+    resolution: {integrity: sha512-QnYDPkyewrJzCyaeI2Rmp7pDwbUETe+hU8ADkXmgNusO1bgHBH7ovXJiYmba8t0fNfJx75fE8dlM6SEmZxheog==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/types': 3.7.2
+    dev: false
+
+  /@smithy/service-error-classification@4.3.1:
+    resolution: {integrity: sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.14.1
+    dev: false
+
+  /@smithy/shared-ini-file-loader@3.1.12:
+    resolution: {integrity: sha512-1xKSGI+U9KKdbG2qDvIR9dGrw3CNx+baqJfyr0igKEpjbHL5stsqAesYBzHChYHlelWtb87VnLWlhvfCz13H8Q==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/shared-ini-file-loader@4.4.9:
+    resolution: {integrity: sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/signature-v4@4.2.4:
+    resolution: {integrity: sha512-5JWeMQYg81TgU4cG+OexAWdvDTs5JDdbEZx+Qr1iPbvo91QFGzjy0IkXAKaXUHqmKUJgSHK0ZxnCkgZpzkeNTA==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/is-array-buffer': 3.0.0
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/types': 3.7.2
+      '@smithy/util-hex-encoding': 3.0.0
+      '@smithy/util-middleware': 3.0.11
+      '@smithy/util-uri-escape': 3.0.0
+      '@smithy/util-utf8': 3.0.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/signature-v4@5.3.14:
+    resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-uri-escape': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/smithy-client@3.7.0:
+    resolution: {integrity: sha512-9wYrjAZFlqWhgVo3C4y/9kpc68jgiSsKUnsFPzr/MSiRL93+QRDafGTfhhKAb2wsr69Ru87WTiqSfQusSmWipA==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/core': 2.5.7
+      '@smithy/middleware-endpoint': 3.2.8
+      '@smithy/middleware-stack': 3.0.11
+      '@smithy/protocol-http': 4.1.8
+      '@smithy/types': 3.7.2
+      '@smithy/util-stream': 3.3.4
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/smithy-client@4.12.13:
+    resolution: {integrity: sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/types@3.7.2:
+    resolution: {integrity: sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/types@4.14.1:
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/url-parser@3.0.11:
+    resolution: {integrity: sha512-TmlqXkSk8ZPhfc+SQutjmFr5FjC0av3GZP4B/10caK1SbRwe/v+Wzu/R6xEKxoNqL+8nY18s1byiy6HqPG37Aw==}
+    dependencies:
+      '@smithy/querystring-parser': 3.0.11
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/url-parser@4.2.14:
+    resolution: {integrity: sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/querystring-parser': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-base64@3.0.0:
+    resolution: {integrity: sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/util-buffer-from': 3.0.0
+      '@smithy/util-utf8': 3.0.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-base64@4.3.2:
+    resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-body-length-browser@3.0.0:
+    resolution: {integrity: sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-body-length-browser@4.2.2:
+    resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-body-length-node@3.0.0:
+    resolution: {integrity: sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-body-length-node@4.2.3:
+    resolution: {integrity: sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-buffer-from@2.2.0:
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-buffer-from@3.0.0:
+    resolution: {integrity: sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/is-array-buffer': 3.0.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-buffer-from@4.2.2:
+    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-config-provider@3.0.0:
+    resolution: {integrity: sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-config-provider@4.2.2:
+    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-defaults-mode-browser@3.0.34:
+    resolution: {integrity: sha512-FumjjF631lR521cX+svMLBj3SwSDh9VdtyynTYDAiBDEf8YPP5xORNXKQ9j0105o5+ARAGnOOP/RqSl40uXddA==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@smithy/property-provider': 3.1.11
+      '@smithy/smithy-client': 3.7.0
+      '@smithy/types': 3.7.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-defaults-mode-browser@4.3.49:
+    resolution: {integrity: sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-defaults-mode-node@3.0.34:
+    resolution: {integrity: sha512-vN6aHfzW9dVVzkI0wcZoUXvfjkl4CSbM9nE//08lmUMyf00S75uuCpTrqF9uD4bD9eldIXlt53colrlwKAT8Gw==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@smithy/config-resolver': 3.0.13
+      '@smithy/credential-provider-imds': 3.2.8
+      '@smithy/node-config-provider': 3.1.12
+      '@smithy/property-provider': 3.1.11
+      '@smithy/smithy-client': 3.7.0
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-defaults-mode-node@4.2.54:
+    resolution: {integrity: sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-endpoints@2.1.7:
+    resolution: {integrity: sha512-tSfcqKcN/Oo2STEYCABVuKgJ76nyyr6skGl9t15hs+YaiU06sgMkN7QYjo0BbVw+KT26zok3IzbdSOksQ4YzVw==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/node-config-provider': 3.1.12
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-endpoints@3.4.2:
+    resolution: {integrity: sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-hex-encoding@3.0.0:
+    resolution: {integrity: sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-hex-encoding@4.2.2:
+    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-middleware@3.0.11:
+    resolution: {integrity: sha512-dWpyc1e1R6VoXrwLoLDd57U1z6CwNSdkM69Ie4+6uYh2GC7Vg51Qtan7ITzczuVpqezdDTKJGJB95fFvvjU/ow==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-middleware@4.2.14:
+    resolution: {integrity: sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-retry@3.0.11:
+    resolution: {integrity: sha512-hJUC6W7A3DQgaee3Hp9ZFcOxVDZzmBIRBPlUAk8/fSOEl7pE/aX7Dci0JycNOnm9Mfr0KV2XjIlUOcGWXQUdVQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/service-error-classification': 3.0.11
+      '@smithy/types': 3.7.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-retry@4.3.6:
+    resolution: {integrity: sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-stream@3.3.4:
+    resolution: {integrity: sha512-SGhGBG/KupieJvJSZp/rfHHka8BFgj56eek9px4pp7lZbOF+fRiVr4U7A3y3zJD8uGhxq32C5D96HxsTC9BckQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/fetch-http-handler': 4.1.3
+      '@smithy/node-http-handler': 3.3.3
+      '@smithy/types': 3.7.2
+      '@smithy/util-base64': 3.0.0
+      '@smithy/util-buffer-from': 3.0.0
+      '@smithy/util-hex-encoding': 3.0.0
+      '@smithy/util-utf8': 3.0.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-stream@4.5.25:
+    resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-uri-escape@3.0.0:
+    resolution: {integrity: sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-uri-escape@4.2.2:
+    resolution: {integrity: sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-utf8@2.3.0:
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-utf8@3.0.0:
+    resolution: {integrity: sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@smithy/util-buffer-from': 3.0.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-utf8@4.2.2:
+    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/uuid@1.1.2:
+    resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@types/estree@1.0.8:
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+    dev: true
+
+  /@types/node@20.0.0:
+    resolution: {integrity: sha512-cD2uPTDnQQCVpmRefonO98/PPijuOnnEy5oytWJFPY1N9aJCz2wJ5kSGWO+zJoed2cY2JxQh6yBuUq4vIn61hw==}
+    dev: true
+
+  /@types/uuid@9.0.8:
+    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
+    dev: false
+
+  /@vitest/expect@1.0.0:
+    resolution: {integrity: sha512-EbqHCSzQhAY8Su/uLsMCDXkC26LyqQO54kAqJy/DubBqwpRre1iMzvDMPWx+YPfNIN3w7/ydKaJWjH6qRoz0fA==}
+    dependencies:
+      '@vitest/spy': 1.0.0
+      '@vitest/utils': 1.0.0
+      chai: 4.5.0
+    dev: true
+
+  /@vitest/runner@1.0.0:
+    resolution: {integrity: sha512-1CaYs4knCexozpGxNiT89foiIxidOdU220QpU6CKMN0qU05e3K5XNH8f4pW9KyXH37o1Zin1cLHkoLr/k7NyrQ==}
+    dependencies:
+      '@vitest/utils': 1.0.0
+      p-limit: 5.0.0
+      pathe: 1.1.2
+    dev: true
+
+  /@vitest/snapshot@1.0.0:
+    resolution: {integrity: sha512-kAcQJGsaHMBLrY0QC6kMe7S+JgiMielX2qHqgWFxlUir5IVekJGokJcYTzoOp+MRN1Gue3Q6H5fZD4aC0XHloA==}
+    dependencies:
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      pretty-format: 29.7.0
+    dev: true
+
+  /@vitest/spy@1.0.0:
+    resolution: {integrity: sha512-k2gZwSi7nkwcYMj1RNgb45jNUDV/opAGlsVvcmYrRXu2QljMSlyAa0Yut+n3S39XoEKp0I4ggVLABj0xVInynw==}
+    dependencies:
+      tinyspy: 2.2.1
+    dev: true
+
+  /@vitest/utils@1.0.0:
+    resolution: {integrity: sha512-r9JhgaP2bUYSnKE9w0aNblCIK8SKpDhXfJgE4TzjDNq3G40Abo5WXJBEKYAteq5p+OWedSFUg6GirNOlH7pN7Q==}
+    dependencies:
+      diff-sequences: 29.6.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
+    dev: true
+
+  /acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+    dependencies:
+      acorn: 8.16.0
+    dev: true
+
+  /acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
+  /ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+    dev: true
+
+  /bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+    dev: false
+
+  /cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /chai@4.5.0:
+    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
+    engines: {node: '>=4'}
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
+    dev: true
+
+  /check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+    dependencies:
+      get-func-name: 2.0.2
+    dev: true
+
+  /clipanion@4.0.0-rc.4(typanion@3.14.0):
+    resolution: {integrity: sha512-CXkMQxU6s9GklO/1f714dkKBMu1lopS1WFF0B8o4AxPykR1hpozxSiUZ5ZUeBjfPgCWqbcNOtZVFhB8Lkfp1+Q==}
+    peerDependencies:
+      typanion: '*'
+    dependencies:
+      typanion: 3.14.0
+    dev: false
+
+  /confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+    dev: true
+
+  /cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+    dev: true
+
+  /debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+    dev: true
+
+  /deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+    dependencies:
+      type-detect: 4.1.0
+    dev: true
+
+  /diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+
+  /esbuild@0.19.12:
+    resolution: {integrity: sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.19.12
+      '@esbuild/android-arm': 0.19.12
+      '@esbuild/android-arm64': 0.19.12
+      '@esbuild/android-x64': 0.19.12
+      '@esbuild/darwin-arm64': 0.19.12
+      '@esbuild/darwin-x64': 0.19.12
+      '@esbuild/freebsd-arm64': 0.19.12
+      '@esbuild/freebsd-x64': 0.19.12
+      '@esbuild/linux-arm': 0.19.12
+      '@esbuild/linux-arm64': 0.19.12
+      '@esbuild/linux-ia32': 0.19.12
+      '@esbuild/linux-loong64': 0.19.12
+      '@esbuild/linux-mips64el': 0.19.12
+      '@esbuild/linux-ppc64': 0.19.12
+      '@esbuild/linux-riscv64': 0.19.12
+      '@esbuild/linux-s390x': 0.19.12
+      '@esbuild/linux-x64': 0.19.12
+      '@esbuild/netbsd-x64': 0.19.12
+      '@esbuild/openbsd-x64': 0.19.12
+      '@esbuild/sunos-x64': 0.19.12
+      '@esbuild/win32-arm64': 0.19.12
+      '@esbuild/win32-ia32': 0.19.12
+      '@esbuild/win32-x64': 0.19.12
+    dev: true
+
+  /esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+    dev: true
+
+  /execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+    dev: true
+
+  /fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
+    dependencies:
+      path-expression-matcher: 1.5.0
+    dev: false
+
+  /fast-xml-parser@4.4.1:
+    resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
+    hasBin: true
+    dependencies:
+      strnum: 1.1.2
+    dev: false
+
+  /fast-xml-parser@5.7.2:
+    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
+    hasBin: true
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
+    dev: false
+
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+    dev: true
+
+  /get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
+    dev: true
+
+  /get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+    dev: true
+
+  /human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
+    dev: true
+
+  /is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
+
+  /isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    dev: true
+
+  /local-pkg@0.5.1:
+    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
+    engines: {node: '>=14'}
+    dependencies:
+      mlly: 1.8.2
+      pkg-types: 1.3.1
+    dev: true
+
+  /loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+    dependencies:
+      get-func-name: 2.0.2
+    dev: true
+
+  /magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+    dev: true
+
+  /merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+    dev: true
+
+  /mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+    dev: true
+
+  /ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    dev: true
+
+  /nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: true
+
+  /npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      path-key: 4.0.0
+    dev: true
+
+  /onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      mimic-fn: 4.0.0
+    dev: true
+
+  /p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      yocto-queue: 1.2.2
+    dev: true
+
+  /path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+    dev: false
+
+  /path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+    dev: true
+
+  /pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+    dev: true
+
+  /pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+    dev: true
+
+  /picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+    dev: true
+
+  /pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+    dev: true
+
+  /postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+    dev: true
+
+  /pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+    dev: true
+
+  /react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+    dev: true
+
+  /resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    dev: true
+
+  /rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+    dev: true
+
+  /shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+    dependencies:
+      shebang-regex: 3.0.0
+    dev: true
+
+  /shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    dev: true
+
+  /signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+    dev: true
+
+  /source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    dev: true
+
+  /std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+    dev: true
+
+  /strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /strip-literal@1.3.0:
+    resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
+    dependencies:
+      acorn: 8.16.0
+    dev: true
+
+  /strnum@1.1.2:
+    resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
+    dev: false
+
+  /strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
+    dev: false
+
+  /tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+    dev: true
+
+  /tinypool@0.8.4:
+    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+    dev: false
+
+  /tsx@4.7.0:
+    resolution: {integrity: sha512-I+t79RYPlEYlHn9a+KzwrvEwhJg35h/1zHsLC2JXvhC2mdynMv6Zxzvhv5EMV6VF5qJlLlkSnMVvdZV3PSIGcg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      esbuild: 0.19.12
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /typanion@3.14.0:
+    resolution: {integrity: sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==}
+    dev: false
+
+  /type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /typescript@5.3.2:
+    resolution: {integrity: sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
+
+  /ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+    dev: true
+
+  /uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+    dev: false
+
+  /vite-node@1.0.0(@types/node@20.0.0):
+    resolution: {integrity: sha512-9pGEPYsHy+7Ok7d6FkvniCmMI58IJ4KfFSK0Xq2FHWPQoBRpJKubaNBvMcXm0+uAwS6K2Rh9qJOKijdgqrjN+Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.21(@types/node@20.0.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vite@5.4.21(@types/node@20.0.0):
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 20.0.0
+      esbuild: 0.21.5
+      postcss: 8.5.12
+      rollup: 4.60.2
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /vitest@1.0.0(@types/node@20.0.0):
+    resolution: {integrity: sha512-jpablj5+ifiFHV3QGOxPews3uxBuu6rQUzTaQYtEd6ocBpdQBil6AvmmGRQ3Rn0WPgyzb+Ni+JekfMyng+qYng==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 20.0.0
+      '@vitest/expect': 1.0.0
+      '@vitest/runner': 1.0.0
+      '@vitest/snapshot': 1.0.0
+      '@vitest/spy': 1.0.0
+      '@vitest/utils': 1.0.0
+      acorn-walk: 8.3.5
+      cac: 6.7.14
+      chai: 4.5.0
+      debug: 4.4.3
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.10.0
+      strip-literal: 1.3.0
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.21(@types/node@20.0.0)
+      vite-node: 1.0.0(@types/node@20.0.0)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+    dependencies:
+      isexe: 2.0.0
+    dev: true
+
+  /why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+    dev: true
+
+  /yaml@2.6.0:
+    resolution: {integrity: sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==}
+    engines: {node: '>= 14'}
+    hasBin: true
+    dev: false
+
+  /yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
+    dev: true

--- a/packages/gaib-cli/src/cli.ts
+++ b/packages/gaib-cli/src/cli.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+/**
+ * gaib — sovereign secrets CLI for loa-freeside.
+ *
+ * Entry point. clipanion routes paths like ["secrets", "pull"] to the
+ * matching command class.
+ */
+import { Cli } from 'clipanion';
+
+import { GaibHelpCommand } from './commands/help.js';
+import { SecretsPullCommand } from './commands/pull.js';
+import { SecretsPushCommand } from './commands/push.js';
+
+const cli = new Cli({
+  binaryLabel: 'gaib',
+  binaryName: 'gaib',
+  binaryVersion: '0.1.0',
+});
+
+cli.register(GaibHelpCommand);
+cli.register(SecretsPullCommand);
+cli.register(SecretsPushCommand);
+
+cli.runExit(process.argv.slice(2));

--- a/packages/gaib-cli/src/commands/help.ts
+++ b/packages/gaib-cli/src/commands/help.ts
@@ -1,0 +1,38 @@
+/**
+ * Default + help command. clipanion auto-generates per-command help via
+ * `Command.Usage`; this command provides the top-level overview.
+ */
+import { Command } from 'clipanion';
+
+export class GaibHelpCommand extends Command {
+  static paths = [Command.Default, ['help']];
+
+  async execute(): Promise<number> {
+    this.context.stdout.write(`gaib — sovereign secrets CLI
+
+Usage:
+  gaib secrets pull  --world <slug> --env <staging|prod> [--format dotenv|json|raw]
+  gaib secrets push  --world <slug> --env <staging|prod> --from-file <path> [--confirm]
+  gaib secrets help  [<command>]
+
+Slugs come from freeside-worlds/packages/registry/worlds/<slug>.yaml.
+Secrets are stored in AWS Secrets Manager under arrakis-{staging|production}-<slug>.
+
+Authentication uses your existing AWS profile (AWS_PROFILE env or
+~/.aws/credentials). No new IAM roles.
+
+Exit codes:
+  0  Success
+  1  Unauthorized (AWS auth failure)
+  2  Missing world (slug not in registry)
+  3  Schema violation (key not declared, malformed JSON, etc.)
+  4  Retryable network error (AWS throttle / 5xx)
+  5  Bad invocation (missing required flag)
+
+For per-command help:
+  gaib secrets pull --help
+  gaib secrets push --help
+`);
+    return 0;
+  }
+}

--- a/packages/gaib-cli/src/commands/pull.ts
+++ b/packages/gaib-cli/src/commands/pull.ts
@@ -1,0 +1,120 @@
+/**
+ * `gaib secrets pull --world <slug> --env <staging|prod> [--format <dotenv|json|raw>]`
+ *
+ * Per SDD §9.2 + §9.5. Never logs values; only counts + key names.
+ */
+import { Command, Option } from 'clipanion';
+import * as t from 'typanion';
+
+import { AwsSecretsClient, GaibSecretsError } from '../lib/aws.js';
+import { formatSecrets } from '../lib/format.js';
+import { deriveSecretId, resolveWorld } from '../lib/world-resolver.js';
+import { ExitCodes, type Environment, type OutputFormat } from '../types.js';
+
+export class SecretsPullCommand extends Command {
+  static paths = [['secrets', 'pull']];
+
+  static usage = Command.Usage({
+    category: 'Secrets',
+    description: 'Pull world secrets from AWS Secrets Manager',
+    details: `
+      Resolves <slug> against the freeside-worlds registry, fetches the
+      world's per-environment secret from AWS Secrets Manager, and writes
+      it to stdout in the requested format.
+
+      Never logs secret values. Operator is responsible for stdout routing.
+    `,
+    examples: [
+      ['Pull mibera prod as dotenv', '$0 secrets pull --world mibera --env prod --format dotenv'],
+      ['Pull staging as json', '$0 secrets pull --world midi --env staging --format json'],
+    ],
+  });
+
+  world = Option.String('--world', {
+    required: true,
+    description: 'World slug (e.g. mibera, midi)',
+    validator: t.isString(),
+  });
+
+  env = Option.String('--env', {
+    required: true,
+    description: 'Target environment (staging | prod)',
+    validator: t.isEnum(['staging', 'prod'] as const),
+  });
+
+  format = Option.String('--format', 'dotenv', {
+    description: 'Output format (dotenv | json | raw)',
+    validator: t.isEnum(['dotenv', 'json', 'raw'] as const),
+  });
+
+  region = Option.String('--region', {
+    description: 'AWS region override (default: us-east-1 or AWS_REGION)',
+  });
+
+  registryRoot = Option.String('--registry-root', {
+    description: 'Path to freeside-worlds registry/worlds dir (override)',
+  });
+
+  async execute(): Promise<number> {
+    // 1. Resolve the world from the registry.
+    const resolved = await resolveWorld({
+      slug: this.world,
+      registryRoot: this.registryRoot,
+    });
+
+    if (resolved.variant === 'missing') {
+      this.context.stderr.write(
+        `gaib: world '${this.world}' not found at ${resolved.searchedPath}\n`,
+      );
+      return ExitCodes.MISSING_WORLD;
+    }
+    if (resolved.variant === 'error') {
+      this.context.stderr.write(`gaib: ${resolved.reason}\n`);
+      return ExitCodes.SCHEMA_VIOLATION;
+    }
+
+    const declaredSecrets = resolved.world.secrets ?? [];
+
+    // 2. Fetch the AWS secret.
+    const aws = new AwsSecretsClient(this.region ? { region: this.region } : {});
+    const secretId = deriveSecretId(this.world, this.env as Environment);
+
+    let envVars: Record<string, string>;
+    try {
+      envVars = await aws.getJsonSecret(secretId);
+    } catch (err) {
+      if (err instanceof GaibSecretsError) {
+        this.context.stderr.write(`gaib: ${err.message}\n`);
+        return err.exitCode;
+      }
+      this.context.stderr.write(
+        `gaib: unexpected error: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return ExitCodes.SCHEMA_VIOLATION;
+    }
+
+    // 3. Cross-check: every key the registry declares should exist in AWS.
+    //    Surface missing keys to stderr (NOT values), but do not block — pull
+    //    is a read; surfacing is the operator's signal to push or rotate.
+    const missing: string[] = [];
+    for (const sec of declaredSecrets) {
+      if (!(sec.env_var in envVars)) missing.push(sec.env_var);
+    }
+    if (missing.length > 0) {
+      this.context.stderr.write(
+        `gaib: warning — ${missing.length} registry-declared key(s) absent in AWS: ${missing.join(', ')}\n`,
+      );
+    }
+
+    // 4. Render to stdout.
+    const out = formatSecrets({ envVars }, this.format as OutputFormat);
+    this.context.stdout.write(out);
+
+    // 5. Audit trail — count only, no values.
+    this.context.stderr.write(
+      `gaib: pulled ${Object.keys(envVars).length} key(s) from ${secretId}\n`,
+    );
+
+    return ExitCodes.SUCCESS;
+  }
+}

--- a/packages/gaib-cli/src/commands/push.ts
+++ b/packages/gaib-cli/src/commands/push.ts
@@ -1,0 +1,156 @@
+/**
+ * `gaib secrets push --world <slug> --env <staging|prod> --from-file <path> [--confirm]`
+ *
+ * Per SDD §9.2: validates against the world's registry secrets list before
+ * write. Refuses if file contains keys not declared in the registry.
+ *
+ * Per SDD §9.5: requires explicit `--confirm` for prod.
+ */
+import { readFile } from 'node:fs/promises';
+
+import { Command, Option } from 'clipanion';
+import * as t from 'typanion';
+
+import { AwsSecretsClient, GaibSecretsError } from '../lib/aws.js';
+import { parseDotenv } from '../lib/format.js';
+import { deriveSecretId, resolveWorld } from '../lib/world-resolver.js';
+import { ExitCodes, type Environment } from '../types.js';
+
+export class SecretsPushCommand extends Command {
+  static paths = [['secrets', 'push']];
+
+  static usage = Command.Usage({
+    category: 'Secrets',
+    description: 'Push world secrets to AWS Secrets Manager from a dotenv file',
+    details: `
+      Reads a dotenv file, validates each key against the world's registry
+      secrets[] list, and writes to AWS Secrets Manager. Refuses keys not
+      declared in the registry.
+
+      Prod pushes require an explicit --confirm flag.
+    `,
+    examples: [
+      [
+        'Push staging from .env.cutover (no --confirm needed)',
+        '$0 secrets push --world mibera --env staging --from-file .env.cutover',
+      ],
+      [
+        'Push prod with --confirm',
+        '$0 secrets push --world mibera --env prod --from-file .env.rotated --confirm',
+      ],
+    ],
+  });
+
+  world = Option.String('--world', {
+    required: true,
+    description: 'World slug',
+    validator: t.isString(),
+  });
+
+  env = Option.String('--env', {
+    required: true,
+    description: 'Target environment (staging | prod)',
+    validator: t.isEnum(['staging', 'prod'] as const),
+  });
+
+  fromFile = Option.String('--from-file', {
+    required: true,
+    description: 'Path to dotenv file',
+    validator: t.isString(),
+  });
+
+  confirm = Option.Boolean('--confirm', false, {
+    description: 'Required for prod env',
+  });
+
+  region = Option.String('--region', {
+    description: 'AWS region override',
+  });
+
+  registryRoot = Option.String('--registry-root', {
+    description: 'Path to freeside-worlds registry/worlds dir (override)',
+  });
+
+  async execute(): Promise<number> {
+    // 1. Prod gate.
+    if (this.env === 'prod' && !this.confirm) {
+      this.context.stderr.write(
+        `gaib: --confirm is required for --env prod\n`,
+      );
+      return ExitCodes.BAD_INVOCATION;
+    }
+
+    // 2. Resolve the world.
+    const resolved = await resolveWorld({
+      slug: this.world,
+      registryRoot: this.registryRoot,
+    });
+
+    if (resolved.variant === 'missing') {
+      this.context.stderr.write(
+        `gaib: world '${this.world}' not found at ${resolved.searchedPath}\n`,
+      );
+      return ExitCodes.MISSING_WORLD;
+    }
+    if (resolved.variant === 'error') {
+      this.context.stderr.write(`gaib: ${resolved.reason}\n`);
+      return ExitCodes.SCHEMA_VIOLATION;
+    }
+
+    const declared = new Set(
+      (resolved.world.secrets ?? []).map((s) => s.env_var),
+    );
+    if (declared.size === 0) {
+      this.context.stderr.write(
+        `gaib: world '${this.world}' has no registry-declared secrets — nothing to push against\n`,
+      );
+      return ExitCodes.SCHEMA_VIOLATION;
+    }
+
+    // 3. Read + parse the dotenv file.
+    let raw: string;
+    try {
+      raw = await readFile(this.fromFile, 'utf8');
+    } catch (err) {
+      this.context.stderr.write(
+        `gaib: failed to read ${this.fromFile}: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return ExitCodes.BAD_INVOCATION;
+    }
+    const parsed = parseDotenv(raw);
+
+    // 4. Validate against the registry.
+    const undeclaredKeys = Object.keys(parsed).filter((k) => !declared.has(k));
+    if (undeclaredKeys.length > 0) {
+      this.context.stderr.write(
+        `gaib: file contains ${undeclaredKeys.length} key(s) NOT declared in registry: ${undeclaredKeys.join(', ')}\n`,
+      );
+      this.context.stderr.write(
+        `gaib: refusing push — declare in freeside-worlds/packages/registry/worlds/${this.world}.yaml first\n`,
+      );
+      return ExitCodes.SCHEMA_VIOLATION;
+    }
+
+    // 5. Push.
+    const aws = new AwsSecretsClient(this.region ? { region: this.region } : {});
+    const secretId = deriveSecretId(this.world, this.env as Environment);
+
+    try {
+      await aws.putJsonSecret(secretId, parsed);
+    } catch (err) {
+      if (err instanceof GaibSecretsError) {
+        this.context.stderr.write(`gaib: ${err.message}\n`);
+        return err.exitCode;
+      }
+      this.context.stderr.write(
+        `gaib: unexpected error: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return ExitCodes.SCHEMA_VIOLATION;
+    }
+
+    this.context.stderr.write(
+      `gaib: pushed ${Object.keys(parsed).length} key(s) to ${secretId}\n`,
+    );
+    return ExitCodes.SUCCESS;
+  }
+}

--- a/packages/gaib-cli/src/lib/aws.ts
+++ b/packages/gaib-cli/src/lib/aws.ts
@@ -1,0 +1,171 @@
+/**
+ * Thin wrapper around AWS Secrets Manager for gaib-cli.
+ *
+ * Per SDD §9.4: uses existing AWS profile (`AWS_PROFILE` env or
+ * `~/.aws/credentials`). NO new IAM roles.
+ *
+ * Per SDD §9.5: never logs secret VALUES. Caller is responsible for not
+ * routing values to logs; this module logs only counts + key names.
+ */
+import {
+  GetSecretValueCommand,
+  PutSecretValueCommand,
+  ResourceNotFoundException,
+  SecretsManagerClient,
+} from '@aws-sdk/client-secrets-manager';
+
+import { ExitCodes, type ExitCode } from '../types.js';
+
+export interface AwsClientOptions {
+  region?: string;
+}
+
+export class GaibSecretsError extends Error {
+  constructor(
+    message: string,
+    readonly exitCode: ExitCode,
+  ) {
+    super(message);
+    this.name = 'GaibSecretsError';
+  }
+}
+
+export class AwsSecretsClient {
+  private readonly client: SecretsManagerClient;
+
+  constructor(opts: AwsClientOptions = {}) {
+    this.client = new SecretsManagerClient({
+      region: opts.region ?? process.env.AWS_REGION ?? 'us-east-1',
+    });
+  }
+
+  /**
+   * Fetch the JSON map stored at `SecretId`. Returns the parsed object.
+   *
+   * The convention in loa-freeside: each world has ONE secret (e.g.
+   * `arrakis-production-mibera`) whose value is a JSON object mapping
+   * env-var names to values.
+   */
+  async getJsonSecret(secretId: string): Promise<Record<string, string>> {
+    let result;
+    try {
+      result = await this.client.send(
+        new GetSecretValueCommand({ SecretId: secretId }),
+      );
+    } catch (err) {
+      if (err instanceof ResourceNotFoundException) {
+        throw new GaibSecretsError(
+          `Secrets Manager: secret '${secretId}' not found`,
+          ExitCodes.MISSING_WORLD,
+        );
+      }
+      throw classifyAwsError(err);
+    }
+
+    const raw = result.SecretString;
+    if (!raw) {
+      throw new GaibSecretsError(
+        `Secrets Manager: secret '${secretId}' has no SecretString (binary?)`,
+        ExitCodes.SCHEMA_VIOLATION,
+      );
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      throw new GaibSecretsError(
+        `Secrets Manager: secret '${secretId}' is not valid JSON: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        ExitCodes.SCHEMA_VIOLATION,
+      );
+    }
+
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new GaibSecretsError(
+        `Secrets Manager: secret '${secretId}' is not a JSON object`,
+        ExitCodes.SCHEMA_VIOLATION,
+      );
+    }
+
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof v !== 'string') {
+        throw new GaibSecretsError(
+          `Secrets Manager: secret '${secretId}' key '${k}' is not a string`,
+          ExitCodes.SCHEMA_VIOLATION,
+        );
+      }
+      out[k] = v;
+    }
+    return out;
+  }
+
+  /**
+   * Overwrite the JSON map stored at `SecretId`. Caller has already validated
+   * the contents against the world's registry. AWS Secrets Manager creates a
+   * new version automatically — old versions remain accessible via VersionId
+   * until rotation policy expires them.
+   */
+  async putJsonSecret(secretId: string, value: Record<string, string>): Promise<void> {
+    try {
+      await this.client.send(
+        new PutSecretValueCommand({
+          SecretId: secretId,
+          SecretString: JSON.stringify(value),
+        }),
+      );
+    } catch (err) {
+      if (err instanceof ResourceNotFoundException) {
+        throw new GaibSecretsError(
+          `Secrets Manager: secret '${secretId}' not found (push expects existing secret; create via console or terraform)`,
+          ExitCodes.MISSING_WORLD,
+        );
+      }
+      throw classifyAwsError(err);
+    }
+  }
+}
+
+/**
+ * Map AWS SDK errors onto gaib-cli's exit-code taxonomy.
+ */
+function classifyAwsError(err: unknown): GaibSecretsError {
+  const name = (err as { name?: string }).name ?? '';
+  const status =
+    (err as { $metadata?: { httpStatusCode?: number } }).$metadata?.httpStatusCode ?? 0;
+
+  // Auth errors
+  if (
+    name === 'CredentialsProviderError' ||
+    name === 'AccessDeniedException' ||
+    name === 'UnrecognizedClientException' ||
+    name === 'InvalidSignatureException' ||
+    status === 401 ||
+    status === 403
+  ) {
+    return new GaibSecretsError(
+      `AWS auth failure: ${name || 'unknown'} (check AWS_PROFILE / ~/.aws/credentials)`,
+      ExitCodes.UNAUTHORIZED,
+    );
+  }
+
+  // Retryable transient
+  if (
+    name === 'ThrottlingException' ||
+    name === 'ProvisionedThroughputExceededException' ||
+    (status >= 500 && status < 600)
+  ) {
+    return new GaibSecretsError(
+      `AWS retryable error: ${name || 'unknown'} (HTTP ${status})`,
+      ExitCodes.RETRYABLE_NETWORK,
+    );
+  }
+
+  // Anything else — bubble as schema-shape mismatch by default
+  return new GaibSecretsError(
+    `AWS unexpected error: ${name || (err instanceof Error ? err.message : String(err))}`,
+    ExitCodes.SCHEMA_VIOLATION,
+  );
+}

--- a/packages/gaib-cli/src/lib/format.ts
+++ b/packages/gaib-cli/src/lib/format.ts
@@ -1,0 +1,110 @@
+/**
+ * Output formatters for gaib-cli — dotenv | json | raw.
+ *
+ * Per SDD §9.5: secret VALUES go to stdout (operator pipes to env or file).
+ * This module formats; it never logs to stderr by accident.
+ */
+import type { OutputFormat } from '../types.js';
+
+export interface FormatInput {
+  envVars: Record<string, string>;
+}
+
+/**
+ * Render `envVars` per the requested format and return the serialized string.
+ * The caller writes to stdout.
+ */
+export function formatSecrets(input: FormatInput, format: OutputFormat): string {
+  switch (format) {
+    case 'dotenv':
+      return renderDotenv(input.envVars);
+    case 'json':
+      return JSON.stringify(input.envVars, null, 2);
+    case 'raw':
+      return renderRaw(input.envVars);
+    default: {
+      const _exhaustive: never = format;
+      throw new Error(`unsupported format: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+/**
+ * Dotenv format. Each line: `KEY=value`. Values are quoted only when they
+ * contain spaces, quotes, or backslashes. Multi-line values use double-quotes
+ * with `\n` escapes.
+ */
+function renderDotenv(envVars: Record<string, string>): string {
+  const lines: string[] = [];
+  for (const [key, value] of Object.entries(envVars)) {
+    lines.push(`${key}=${escapeDotenvValue(value)}`);
+  }
+  return lines.join('\n') + '\n';
+}
+
+function escapeDotenvValue(value: string): string {
+  if (value === '') return '';
+  if (value.includes('\n') || value.includes('"') || value.includes('\\')) {
+    const escaped = value
+      .replaceAll('\\', '\\\\')
+      .replaceAll('"', '\\"')
+      .replaceAll('\n', '\\n')
+      .replaceAll('\r', '\\r');
+    return `"${escaped}"`;
+  }
+  if (/[\s'#]/.test(value)) {
+    return `"${value}"`;
+  }
+  return value;
+}
+
+/**
+ * Raw: one line per value, no keys. Useful for piping a single key:
+ *
+ *   gaib secrets pull --world mibera --env prod --format raw \
+ *     | grep -A1 DATABASE_URL | tail -1
+ */
+function renderRaw(envVars: Record<string, string>): string {
+  return Object.values(envVars).join('\n') + '\n';
+}
+
+/**
+ * Parse a dotenv file into an object. Used by `gaib secrets push --from-file`.
+ * Intentionally minimal: handles `KEY=value`, `KEY="value with spaces"`,
+ * comment lines (`# ...`), and blank lines. Multi-line values are NOT
+ * supported in the parser — the operator is expected to provide single-line
+ * values per dotenv convention.
+ */
+export function parseDotenv(input: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const rawLine of input.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+
+    const key = line.slice(0, eq).trim();
+    if (!key || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+
+    let value = line.slice(eq + 1);
+    // Strip optional surrounding quotes.
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    }
+    // Unescape minimal sequences for double-quoted values.
+    if (line.slice(eq + 1).startsWith('"')) {
+      value = value
+        .replaceAll('\\n', '\n')
+        .replaceAll('\\r', '\r')
+        .replaceAll('\\"', '"')
+        .replaceAll('\\\\', '\\');
+    }
+    out[key] = value;
+  }
+  return out;
+}

--- a/packages/gaib-cli/src/lib/world-resolver.ts
+++ b/packages/gaib-cli/src/lib/world-resolver.ts
@@ -4,7 +4,8 @@
  * Per SDD §9 + L2: the registry under `freeside-worlds/packages/registry/`
  * is canonical. gaib-cli READS it; never writes back.
  */
-import { readFile, stat } from 'node:fs/promises';
+import { stat as fsStat, readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 
 import { parse as parseYaml } from 'yaml';
@@ -12,18 +13,38 @@ import { parse as parseYaml } from 'yaml';
 import type { RegistryWorld, ResolveWorldResult } from '../types.js';
 
 /**
- * Default registry root. Override via env var `FREESIDE_REGISTRY_ROOT` or
- * `--registry-root` CLI flag.
+ * Resolution order for the registry root (Bridgebuilder F009 — fixes
+ * windows / CI / non-author setups where the prior HOME-based hardcoded
+ * path was unreachable):
+ *
+ *   1. opts.registryRoot               (explicit CLI flag)
+ *   2. $FREESIDE_REGISTRY_ROOT          (env var, recommended for CI)
+ *   3. ./packages/registry/worlds       (running inside freeside-worlds repo)
+ *   4. ../freeside-worlds/...           (running inside a sibling repo)
+ *   5. ~/Documents/GitHub/freeside-worlds/...   (legacy author default)
+ *
+ * Paths are checked existence-wise; the first one that exists wins.
+ * If none exist the call returns `variant: missing` with the searched path.
  */
-const DEFAULT_REGISTRY_ROOT = resolve(
-  process.env.HOME ?? '',
-  'Documents',
-  'GitHub',
-  'freeside-worlds',
-  'packages',
-  'registry',
-  'worlds',
-);
+const DEFAULT_REGISTRY_CANDIDATES: string[] = [
+  resolve(process.cwd(), 'packages', 'registry', 'worlds'),
+  resolve(process.cwd(), '..', 'freeside-worlds', 'packages', 'registry', 'worlds'),
+  resolve(homedir(), 'Documents', 'GitHub', 'freeside-worlds', 'packages', 'registry', 'worlds'),
+];
+
+async function resolveDefaultRegistryRoot(): Promise<string> {
+  for (const candidate of DEFAULT_REGISTRY_CANDIDATES) {
+    try {
+      const s = await fsStat(candidate);
+      if (s.isDirectory()) return candidate;
+    } catch {
+      // try next candidate
+    }
+  }
+  // Fall through to the legacy default for the error message to surface a
+  // sensible "tried this path" hint.
+  return DEFAULT_REGISTRY_CANDIDATES[DEFAULT_REGISTRY_CANDIDATES.length - 1] ?? process.cwd();
+}
 
 export interface ResolveWorldOptions {
   slug: string;
@@ -33,11 +54,14 @@ export interface ResolveWorldOptions {
 export async function resolveWorld(
   opts: ResolveWorldOptions,
 ): Promise<ResolveWorldResult> {
-  const root = opts.registryRoot ?? process.env.FREESIDE_REGISTRY_ROOT ?? DEFAULT_REGISTRY_ROOT;
+  const root =
+    opts.registryRoot ??
+    process.env.FREESIDE_REGISTRY_ROOT ??
+    (await resolveDefaultRegistryRoot());
   const path = join(root, `${opts.slug}.yaml`);
 
   try {
-    await stat(path);
+    await fsStat(path);
   } catch {
     return { variant: 'missing', slug: opts.slug, searchedPath: path };
   }

--- a/packages/gaib-cli/src/lib/world-resolver.ts
+++ b/packages/gaib-cli/src/lib/world-resolver.ts
@@ -1,0 +1,115 @@
+/**
+ * Resolve a world slug to its registry YAML and parsed shape.
+ *
+ * Per SDD §9 + L2: the registry under `freeside-worlds/packages/registry/`
+ * is canonical. gaib-cli READS it; never writes back.
+ */
+import { readFile, stat } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+import { parse as parseYaml } from 'yaml';
+
+import type { RegistryWorld, ResolveWorldResult } from '../types.js';
+
+/**
+ * Default registry root. Override via env var `FREESIDE_REGISTRY_ROOT` or
+ * `--registry-root` CLI flag.
+ */
+const DEFAULT_REGISTRY_ROOT = resolve(
+  process.env.HOME ?? '',
+  'Documents',
+  'GitHub',
+  'freeside-worlds',
+  'packages',
+  'registry',
+  'worlds',
+);
+
+export interface ResolveWorldOptions {
+  slug: string;
+  registryRoot?: string;
+}
+
+export async function resolveWorld(
+  opts: ResolveWorldOptions,
+): Promise<ResolveWorldResult> {
+  const root = opts.registryRoot ?? process.env.FREESIDE_REGISTRY_ROOT ?? DEFAULT_REGISTRY_ROOT;
+  const path = join(root, `${opts.slug}.yaml`);
+
+  try {
+    await stat(path);
+  } catch {
+    return { variant: 'missing', slug: opts.slug, searchedPath: path };
+  }
+
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch (err) {
+    return {
+      variant: 'error',
+      reason: `failed to read ${path}: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch (err) {
+    return {
+      variant: 'error',
+      reason: `failed to parse ${path}: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  if (!isRegistryWorld(parsed)) {
+    return {
+      variant: 'error',
+      reason: `${path} does not match expected registry shape (slug, repo, optional secrets[])`,
+    };
+  }
+
+  return { variant: 'found', world: parsed, sourcePath: path };
+}
+
+/**
+ * Light type-guard against the registry shape. We don't ajv-validate here —
+ * that's the registry's own validate.ts pipeline. We only check the fields
+ * gaib-cli consumes are present + correctly typed.
+ */
+function isRegistryWorld(value: unknown): value is RegistryWorld {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.slug !== 'string') return false;
+  if (typeof v.repo !== 'string') return false;
+  if (typeof v.name !== 'string') return false;
+
+  if (v.secrets !== undefined) {
+    if (!Array.isArray(v.secrets)) return false;
+    for (const s of v.secrets) {
+      if (typeof s !== 'object' || s === null) return false;
+      const sec = s as Record<string, unknown>;
+      if (typeof sec.key !== 'string') return false;
+      if (typeof sec.env_var !== 'string') return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Derive the AWS Secrets Manager secret ID for a given world + env. Mirrors
+ * the existing loa-freeside convention (per `scripts/load-honeyroad-secrets.sh`
+ * and friends): the secret ID is the world slug suffixed by env when staging.
+ *
+ * - prod:    `arrakis-production-{slug}`
+ * - staging: `arrakis-staging-{slug}`
+ *
+ * Values for individual env-vars live as JSON keys WITHIN the per-world
+ * secret (one Secrets Manager secret per world, holding a JSON map of all
+ * env-vars). This mirrors the `load-honeyroad-secrets.sh` pattern.
+ */
+export function deriveSecretId(slug: string, env: 'staging' | 'prod'): string {
+  const prefix = env === 'prod' ? 'arrakis-production' : 'arrakis-staging';
+  return `${prefix}-${slug}`;
+}

--- a/packages/gaib-cli/src/types.ts
+++ b/packages/gaib-cli/src/types.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared types for gaib-cli.
+ */
+
+export type OutputFormat = 'dotenv' | 'json' | 'raw';
+export type Environment = 'staging' | 'prod';
+
+/**
+ * Exit codes per SDD §9.3.
+ */
+export const ExitCodes = {
+  SUCCESS: 0,
+  UNAUTHORIZED: 1,
+  MISSING_WORLD: 2,
+  SCHEMA_VIOLATION: 3,
+  RETRYABLE_NETWORK: 4,
+  BAD_INVOCATION: 5,
+} as const;
+
+export type ExitCode = (typeof ExitCodes)[keyof typeof ExitCodes];
+
+/**
+ * A secret entry as it appears in `freeside-worlds/registry/worlds/{slug}.yaml`
+ * `secrets:` array. Trimmed to the fields gaib-cli consumes.
+ */
+export interface RegistrySecret {
+  /** Identifier within the world's registry (e.g. "database_url") */
+  key: string;
+  /** Env var name applications read (e.g. "DATABASE_URL") */
+  env_var: string;
+  /** Lifecycle hint — runtime vs. build-time. Default: runtime. */
+  lifecycle?: 'runtime' | 'build';
+  /** Optional human description from the registry */
+  description?: string;
+}
+
+/**
+ * The full registry shape we care about. Other fields exist (hosting,
+ * env_vars, identity, etc.) — gaib-cli ignores them.
+ */
+export interface RegistryWorld {
+  slug: string;
+  name: string;
+  repo: string;
+  secrets?: RegistrySecret[];
+}
+
+/**
+ * In-memory representation of a pulled secret.
+ *
+ * IMPORTANT: never log `value` directly per SDD §9.5. Logging surfaces use
+ * `RegistrySecret` (key + env_var only) or counts.
+ */
+export interface PulledSecret {
+  registryKey: string;     // matches RegistrySecret.key
+  envVar: string;          // matches RegistrySecret.env_var
+  value: string;           // load-bearing — never print except on stdout
+  arn: string;             // AWS Secrets Manager ARN
+}
+
+/**
+ * Result of resolving a slug to its registry world. Discriminated so callers
+ * can distinguish missing-from-registry from filesystem errors.
+ */
+export type ResolveWorldResult =
+  | { variant: 'found'; world: RegistryWorld; sourcePath: string }
+  | { variant: 'missing'; slug: string; searchedPath: string }
+  | { variant: 'error'; reason: string };

--- a/packages/gaib-cli/tsconfig.json
+++ b/packages/gaib-cli/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "tests"]
+}

--- a/scripts/cdn-cors-smoke.sh
+++ b/scripts/cdn-cors-smoke.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# =============================================================================
+# cdn-cors-smoke.sh — CORS smoke test for the assets.0xhoneyjar.xyz CDN
+# =============================================================================
+#
+# Exit codes:
+#   0 — all probes returned HTTP 200 with `access-control-allow-origin`
+#   1 — at least one probe missing CORS or non-200
+#   2 — bad invocation
+#
+# Catches the class of bug surfaced 2026-04-30: T4 terraform skeleton
+# created a new CloudFront distribution without attaching the
+# `Managed-CORS-With-Preflight` response headers policy. Browser canvas
+# consumers (img crossOrigin="anonymous" + drawImage) silently failed
+# because Access-Control-Allow-Origin was missing on every response.
+#
+# Run before promoting any cutover to production:
+#   bash scripts/cdn-cors-smoke.sh
+#   bash scripts/cdn-cors-smoke.sh --host assets.0xhoneyjar.xyz --origin https://mibera.0xhoneyjar.xyz
+#
+# Or wire as a CI gate (smoke-cutover.yml workflow per SDD §10.2).
+# =============================================================================
+set -euo pipefail
+
+HOST="${HOST:-assets.0xhoneyjar.xyz}"
+ORIGIN="${ORIGIN:-https://mibera.0xhoneyjar.xyz}"
+
+# Parse flags (override env via CLI)
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host)    HOST="$2"; shift 2 ;;
+    --origin)  ORIGIN="$2"; shift 2 ;;
+    --help|-h) sed -n '2,20p' "$0"; exit 0 ;;
+    *)         echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Representative paths covering all the cache behaviors we ship:
+#   *.webp behavior        — Mibera/generated, Mibera/layers_webp, Mibera/quiz_archetypes
+#   default behavior       — reveal_phase{N}/images/*.png (codex-mcp surface)
+#   default + path-shape   — Purupuru, sprawl
+PATHS=(
+  "Mibera/generated/0.webp"
+  "Mibera/generated/1.webp"
+  "Mibera/layers_webp/background_thumb/74_basque.webp"
+  "Mibera/quiz_archetypes/1.webp"
+  "reveal_phase8/images/8a7e39404ebf86073fab1d068d7037930298d121.png"
+)
+
+pass=0
+fail=0
+failures=()
+
+echo "🌐 cdn-cors-smoke · host=$HOST · origin=$ORIGIN"
+echo ""
+
+for path in "${PATHS[@]}"; do
+  url="https://$HOST/$path"
+  headers=$(curl -sI --max-time 8 -H "Origin: $ORIGIN" "$url" 2>/dev/null | tr -d '\r')
+
+  status=$(echo "$headers" | head -n1 | awk '{print $2}')
+  acao=$(echo "$headers" | grep -i '^access-control-allow-origin:' | head -n1 | awk -F': ' '{print $2}')
+  cache=$(echo "$headers" | grep -i '^x-cache:' | head -n1 | awk -F': ' '{print $2}')
+
+  if [[ "$status" == "200" && -n "$acao" ]]; then
+    printf "  ✅ %s · %s · %s\n" "$status" "${acao:-<missing>}" "/$path"
+    pass=$((pass + 1))
+  else
+    printf "  ❌ %s · ACAO=%s · cache=%s · /%s\n" "${status:-<no-response>}" "${acao:-<missing>}" "${cache:-<n/a>}" "$path"
+    failures+=("/$path  status=${status:-none}  acao=${acao:-missing}")
+    fail=$((fail + 1))
+  fi
+done
+
+echo ""
+echo "summary: $pass passed · $fail failed"
+
+if [[ $fail -gt 0 ]]; then
+  echo ""
+  echo "failures:"
+  for f in "${failures[@]}"; do
+    echo "  - $f"
+  done
+  echo ""
+  echo "🩹 if ACAO is <missing>: the CloudFront distribution lacks a Response Headers Policy."
+  echo "   Attach the AWS-managed Managed-CORS-With-Preflight policy via terraform"
+  echo "   (see infrastructure/terraform/freeside-storage/main.tf locals.cors_response_headers_policy_id)"
+  echo "   or via aws-cli for emergency:"
+  echo "   aws cloudfront update-distribution --id <DIST_ID> ..."
+  exit 1
+fi
+
+exit 0

--- a/scripts/cdn-cors-smoke.sh
+++ b/scripts/cdn-cors-smoke.sh
@@ -54,20 +54,45 @@ failures=()
 echo "🌐 cdn-cors-smoke · host=$HOST · origin=$ORIGIN"
 echo ""
 
+# Helper — assert ACAO is "*" or the requested origin (not just non-empty;
+# Bridgebuilder F011: a misconfig like `null` or `false` would otherwise pass).
+acao_acceptable() {
+  local v="$1"
+  local origin="$2"
+  [[ "$v" == "*" || "$v" == "$origin" ]]
+}
+
 for path in "${PATHS[@]}"; do
   url="https://$HOST/$path"
-  headers=$(curl -sI --max-time 8 -H "Origin: $ORIGIN" "$url" 2>/dev/null | tr -d '\r')
 
+  # GET probe — what the browser sends for canvas img loads (simple CORS request).
+  headers=$(curl -sI --max-time 8 -H "Origin: $ORIGIN" "$url" 2>/dev/null | tr -d '\r')
   status=$(echo "$headers" | head -n1 | awk '{print $2}')
   acao=$(echo "$headers" | grep -i '^access-control-allow-origin:' | head -n1 | awk -F': ' '{print $2}')
   cache=$(echo "$headers" | grep -i '^x-cache:' | head -n1 | awk -F': ' '{print $2}')
 
-  if [[ "$status" == "200" && -n "$acao" ]]; then
-    printf "  ✅ %s · %s · %s\n" "$status" "${acao:-<missing>}" "/$path"
+  # OPTIONS preflight probe — would catch regressions for non-simple
+  # cross-origin requests (custom headers, POST with content-type etc.).
+  # Canvas consumers don't trigger preflight today, but this guards against
+  # future regressions. (Bridgebuilder F011)
+  pre_headers=$(curl -sI -X OPTIONS --max-time 8 \
+    -H "Origin: $ORIGIN" \
+    -H "Access-Control-Request-Method: GET" \
+    "$url" 2>/dev/null | tr -d '\r')
+  pre_acao=$(echo "$pre_headers" | grep -i '^access-control-allow-origin:' | head -n1 | awk -F': ' '{print $2}')
+  pre_methods=$(echo "$pre_headers" | grep -i '^access-control-allow-methods:' | head -n1 | awk -F': ' '{print $2}')
+
+  if [[ "$status" == "200" ]] \
+     && acao_acceptable "$acao" "$ORIGIN" \
+     && acao_acceptable "$pre_acao" "$ORIGIN"; then
+    printf "  ✅ %s · GET ACAO=%s · OPTIONS ACAO=%s methods=%s · /%s\n" \
+      "$status" "${acao}" "${pre_acao}" "${pre_methods:-<missing>}" "$path"
     pass=$((pass + 1))
   else
-    printf "  ❌ %s · ACAO=%s · cache=%s · /%s\n" "${status:-<no-response>}" "${acao:-<missing>}" "${cache:-<n/a>}" "$path"
-    failures+=("/$path  status=${status:-none}  acao=${acao:-missing}")
+    printf "  ❌ %s · GET ACAO=%s · OPTIONS ACAO=%s · cache=%s · /%s\n" \
+      "${status:-<no-response>}" "${acao:-<missing>}" "${pre_acao:-<missing>}" \
+      "${cache:-<n/a>}" "$path"
+    failures+=("/$path  status=${status:-none}  get-acao=${acao:-missing}  options-acao=${pre_acao:-missing}")
     fail=$((fail + 1))
   fi
 done

--- a/scripts/cdn-parity.sh
+++ b/scripts/cdn-parity.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# =============================================================================
+# cdn-parity.sh — bytes-identical probe between two CDN distributions
+# =============================================================================
+#
+# Compares ETag + Content-Length on representative keys served by two CDNs.
+# Used during cutovers to verify the new distribution serves identical bytes
+# as the legacy one (catches origin-config drift, encoding mismatches,
+# bucket-policy gaps before users notice).
+#
+# Layer 2 of the SDD §10 three-layer validation gate.
+#
+# Run as part of pre-flip verification:
+#   bash scripts/cdn-parity.sh
+#   bash scripts/cdn-parity.sh --new assets.0xhoneyjar.xyz --legacy d163aeqznbc6js.cloudfront.net
+#
+# Exit codes:
+#   0 — all probes have identical etag + content-length
+#   1 — at least one probe drifted (different bytes)
+#   2 — bad invocation / both failed
+# =============================================================================
+set -euo pipefail
+
+NEW="${NEW:-assets.0xhoneyjar.xyz}"
+LEGACY="${LEGACY:-d163aeqznbc6js.cloudfront.net}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --new)     NEW="$2"; shift 2 ;;
+    --legacy)  LEGACY="$2"; shift 2 ;;
+    --help|-h) sed -n '2,20p' "$0"; exit 0 ;;
+    *)         echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Sample paths — webp-direct fast path on both distributions.
+# Optimizer paths (/images/{proxy+}, /_next/image*) are NOT compared
+# because they intentionally diverge per ADR-006.
+PATHS=(
+  "Mibera/generated/0.webp"
+  "Mibera/generated/1.webp"
+  "Mibera/generated/100.webp"
+  "Mibera/layers_webp/background_thumb/74_basque.webp"
+  "Mibera/quiz_archetypes/1.webp"
+)
+
+identical=0
+drifted=0
+errors=0
+findings=()
+
+echo "📐 cdn-parity · new=$NEW · legacy=$LEGACY"
+echo ""
+
+for path in "${PATHS[@]}"; do
+  new_h=$(curl -sI --max-time 8 "https://$NEW/$path"    2>/dev/null | tr -d '\r')
+  leg_h=$(curl -sI --max-time 8 "https://$LEGACY/$path" 2>/dev/null | tr -d '\r')
+
+  new_etag=$(echo "$new_h" | grep -i '^etag:' | head -n1 | awk -F': ' '{print $2}')
+  new_len=$(echo "$new_h"  | grep -i '^content-length:' | head -n1 | awk -F': ' '{print $2}')
+  leg_etag=$(echo "$leg_h" | grep -i '^etag:' | head -n1 | awk -F': ' '{print $2}')
+  leg_len=$(echo "$leg_h"  | grep -i '^content-length:' | head -n1 | awk -F': ' '{print $2}')
+
+  if [[ -z "$new_etag" || -z "$leg_etag" ]]; then
+    printf "  ⚠ ERROR /%s · new_etag=%s · legacy_etag=%s\n" "$path" "${new_etag:-<missing>}" "${leg_etag:-<missing>}"
+    findings+=("/$path  one or both responses returned no etag")
+    errors=$((errors + 1))
+    continue
+  fi
+
+  if [[ "$new_etag" == "$leg_etag" && "$new_len" == "$leg_len" ]]; then
+    printf "  ✅ identical · etag=%s · %sB · /%s\n" "$new_etag" "$new_len" "$path"
+    identical=$((identical + 1))
+  else
+    printf "  ❌ DRIFT /%s\n" "$path"
+    printf "       new:    etag=%s · len=%s\n" "$new_etag" "$new_len"
+    printf "       legacy: etag=%s · len=%s\n" "$leg_etag" "$leg_len"
+    findings+=("/$path  new etag=$new_etag len=$new_len  legacy etag=$leg_etag len=$leg_len")
+    drifted=$((drifted + 1))
+  fi
+done
+
+echo ""
+echo "summary: $identical identical · $drifted drifted · $errors errors"
+
+if [[ $drifted -gt 0 || $errors -gt 0 ]]; then
+  echo ""
+  echo "findings:"
+  for f in "${findings[@]}"; do
+    echo "  - $f"
+  done
+  exit 1
+fi
+
+exit 0

--- a/scripts/cdn-parity.sh
+++ b/scripts/cdn-parity.sh
@@ -36,6 +36,16 @@ done
 # Sample paths — webp-direct fast path on both distributions.
 # Optimizer paths (/images/{proxy+}, /_next/image*) are NOT compared
 # because they intentionally diverge per ADR-006.
+#
+# ETag caveat (Bridgebuilder F010): for non-multipart S3 objects, ETag is
+# the MD5 of the object — both distributions reading the same object should
+# return identical ETags. For multipart-uploaded objects the ETag is
+# `<md5-of-md5s>-<part-count>`, also stable across distributions reading
+# the same object. ETag DRIFT here means the distributions are reading
+# DIFFERENT bytes (different bucket, different version, transformation in
+# the path), not encoding noise. CloudFront does not currently rewrite
+# ETags between distributions when both proxy the same S3 origin.
+# Content-Length is checked alongside as a secondary signal.
 PATHS=(
   "Mibera/generated/0.webp"
   "Mibera/generated/1.webp"


### PR DESCRIPTION
## Summary

Sprint 1 of the `mature-freeside-operator-and-cutover` cycle. Establishes the sovereign asset CDN at `assets.0xhoneyjar.xyz`, codifies the URL contract as a Tier-1 schema-bridge, and adds the smoke/parity hardening that surfaced from a 2026-04-30 production CORS incident.

The cycle's matured construct (`construct-freeside` + `KRANZ` persona + 3 lean SKILLs + `freeside-storage` ADR-001) lives in their own repos; this PR is the **infrastructure half** that lands in `loa-freeside`.

## What ships

### 🏗 New CloudFront distribution + alias

- `infrastructure/terraform/freeside-storage/` — module skeleton (T4) + parent `.tf` (T11)
- Distribution `EX3XFQSXORXM5` provisioned + `assets.0xhoneyjar.xyz` alias live since 2026-04-29
- Reuses the existing `*.0xhoneyjar.xyz` wildcard cert (avoided CAA-cache trap discovered during initial cert provision — see commit `fd7edd6f` body)
- Two cache behaviors: `*.webp` direct → S3, default → S3 direct (NO image optimizer chain — that stays at d163 per ADR-006)
- `Managed-CORS-With-Preflight` response headers policy attached to both behaviors (post-hotfix; commit `30bac01c`)

### 🔐 ADR-006 — image optimizer deferral

`decisions/006-image-optimizer-stays-on-d163.md` — documents why the legacy `d163aeqznbc6js.cloudfront.net` distribution stays alive. The image-optimizer chain (Image-resizer Lambda + tf-next-image Lambda) has 2-year stability and is out of scope for this cycle.

### 📐 Asset URL contract (public surface)

`docs/asset-url-contract.md` — human-facing companion to the JSON Schema in `freeside-storage/packages/protocol/url-contract.schema.json`. References [`construct-mibera-codex#54`](https://github.com/0xHoneyJar/construct-mibera-codex/issues/54) where Gumi shipped a 140k-ref migration PR using this contract.

### 🔑 gaib-cli (sovereign secrets surface)

`packages/gaib-cli/` — clipanion-based CLI for AWS Secrets Manager: `gaib secrets pull/push/help`. Per SDD §0 L3 (peer to existing `packages/cli/`).

> **Note**: discovered during execution that the canonical secrets path is `arrakis/{env}/worlds/{slug}/{key}` (per-key, via `scripts/load-honeyroad-secrets.sh`), not single-JSON-per-world. The shipped gaib-cli assumed the latter. Honeyroad secrets rotation went via the existing per-key script. gaib-cli's secret-shape will be reconciled in a future cycle.

### 🛡 T20 hardening (post-CORS incident)

`scripts/cdn-cors-smoke.sh` + `scripts/cdn-parity.sh` — Layer 2 of the SDD §10 validation gate. Both run in <10s, no AWS auth required (public CDN probes), zero external deps. README's "Pre-flip checklist" section calls them out as load-bearing.

### 🛣 Manual DNS audit trail

`decisions/cloudfront-dns-2026-04-29.md` — logs every Route53 change made by hand during T11 (per project memory `freeside-dns-state-untracked`).

## Why open this now (the "high-leverage hardening" framing)

A production CORS incident at ~13:30 UTC on 2026-04-30 surfaced that the new distribution was missing the response headers policy that the legacy d163 had on its `*.webp` behavior. Browser canvas consumers (`useTraitCanvas` hook → `<img crossOrigin="anonymous">` + `drawImage`) silently failed.

Root cause was the T4 terraform skeleton being authored without the policy. Bridgebuilder review on PR #89 (mibera-honeyroad cutover) didn't catch it because the diff didn't touch the distribution config — the gap was infra-side, latent. Closing this PR with bridgebuilder on the entire cycle branch surfaces any other latent gaps in the same shape.

Hardening in `31c58b9f` ensures this class of bug is caught BEFORE the consumer flip lands.

## Verification

```bash
# CORS live across representative paths
$ bash scripts/cdn-cors-smoke.sh
🌐 cdn-cors-smoke · 5 passed · 0 failed

# Bytes-identical with legacy
$ bash scripts/cdn-parity.sh
📐 cdn-parity · 5 identical · 0 drifted · 0 errors

# Honeyroad live (post-secrets-push + post-cdn-flip)
$ curl -I https://mibera.0xhoneyjar.xyz/api/health
HTTP/2 200
```

## Cycle work merged in worlds (downstream)

| World | PR | Status |
|---|---|---|
| `mibera-honeyroad` | [#89](https://github.com/0xHoneyJar/mibera-honeyroad/pull/89) | ✅ merged |
| `mibera-dimensions` | [#201](https://github.com/0xHoneyJar/mibera-dimensions/pull/201) | ✅ merged |
| `world-sprawl/rektdrop` | — | pending T16 |
| `world-sprawl/cubquests` | — | pending T17 |
| `world-purupuru/world` | — | pending T18 |
| `world-purupuru/fukuro` | — | pending T19 |

## Test plan

- [ ] CI build passes on this branch
- [ ] `bash scripts/cdn-cors-smoke.sh` returns exit 0
- [ ] `bash scripts/cdn-parity.sh` returns exit 0
- [ ] Terraform plan against module shows zero drift (live CORS hotfix is codified)
- [ ] Bridgebuilder review surfaces no BLOCKER
- [ ] No regressions on `mibera.0xhoneyjar.xyz/vm` (canvas-painting consumer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)