### PR TITLE
fix(cutover-b): remove invalid export from CF Function (live-fix follow-up)

### DIFF
--- a/infrastructure/terraform/freeside-storage/metadata-resolver.js
+++ b/infrastructure/terraform/freeside-storage/metadata-resolver.js
@@ -91,8 +91,9 @@ function notFound() {
   };
 }
 
-// Bridgebuilder F1: explicit export for cloudfront-js-2.0 ES Module runtime.
-// While AWS examples sometimes omit it (the runtime auto-discovers a top-level
-// `handler` function), the explicit export removes ambiguity and is harmless
-// if redundant.
-export { handler };
+// Note: cloudfront-js-2.0 auto-discovers a top-level `handler` function by
+// name. An explicit `export { handler };` was tried (Bridgebuilder F1) but
+// causes the runtime to error with "The CloudFront function associated with
+// the CloudFront distribution is invalid or could not run." Confirmed via
+// 2026-05-01 production smoke (503 on metadata.* requests). Convention: no
+// export statement; the runtime discovers `handler` automatically.


### PR DESCRIPTION
## Summary

Live-fix follow-up to loa-freeside#195. Bridgebuilder F1 from that PR recommended adding \`export { handler };\` for ES Module compliance. Production smoke 2026-05-01 proved this wrong — cloudfront-js-2.0 returns 503 with the runtime error \"The CloudFront function associated with the CloudFront distribution is invalid or could not run.\"

cloudfront-js-2.0 auto-discovers a top-level \`handler\` function by name. The explicit ES Module export breaks the runtime's discovery.

## Telemetry

```
2026-05-01T02:26 — Route53 alias for metadata.0xhoneyjar.xyz INSYNC
2026-05-01T02:27 — first smoke: HTTP 503 across all 5 samples
                   error body: \"The CloudFront function associated with the
                   CloudFront distribution is invalid or could not run.\"
2026-05-01T02:39 — fix applied (export removed), terraform apply targeted
                   the function resource, --publish triggered re-deploy
2026-05-01T02:40 — smoke green: 200 + application/json + ACAO * across
                   1, 100, 5000, 9999, 1606 (grail token)
```

## Fix

Removed the \`export { handler };\` line + replaced with a comment documenting
the lesson:

> Note: cloudfront-js-2.0 auto-discovers a top-level \`handler\` function by name.
> An explicit \`export { handler };\` was tried (Bridgebuilder F1) but causes the
> runtime to error with \"The CloudFront function associated with the CloudFront
> distribution is invalid or could not run.\" Confirmed via 2026-05-01 production
> smoke (503 on metadata.* requests). Convention: no export statement; the
> runtime discovers \`handler\` automatically.

The function code in the deployed CloudFront Function and in this PR are
now in sync. terraform state matches reality.

## Test plan

- [x] Production smoke: 5/5 sample tokens return 200 + application/json + CORS
- [x] Full payload validates ERC-721 schema
- [x] Image URL in payload resolves canonical \`reveal_phase8/images/<hash>.png\`
- [x] Grail token (#1606) resolves via slug-named path

🤖 Generated with [Claude Code](https://claude.com/claude-code)