### PR TITLE
feat(network/cluster-meta): freeside-operator-dash + *-api registry sweep

### DIFF
--- a/apps/freeside-operator-dash/README.md
+++ b/apps/freeside-operator-dash/README.md
@@ -1,0 +1,94 @@
+# @0xhoneyjar/freeside-operator-dash
+
+**Inward-facing operator visibility surface** for the freeside `*-api` cell network. Sibling to [`apps/mcp-gateway/`](../mcp-gateway/) (which is outward-facing — federation discovery for partners + agent clients).
+
+Per [ADR-009 §D-9](../../decisions/009-freeside-hexagonal-federation.md): two apps, two audiences, one network scope.
+
+| App | Audience | Surface |
+|---|---|---|
+| `apps/mcp-gateway/` | External partners + agent clients | `mcp.0xhoneyjar.xyz` — federation discovery + per-tenant MCP routing |
+| `apps/freeside-operator-dash/` (this) | THJ team (internal-operator persona per D-9) | Internal-only — cluster health, Soju-lens, phase scoreboard |
+
+Source: [`grimoires/loa/proposals/freeside-operator-dash-kickoff.md`](../../grimoires/loa/proposals/freeside-operator-dash-kickoff.md)
+
+## What it does
+
+Reads [`packages/freeside-registry/registry.yaml`](../../packages/freeside-registry/registry.yaml) — the L1 canonical source-of-truth of the 8 `*-api` cells — and renders:
+
+1. **Federation tile grid** — one tile per cell, colored by live probe state (`up` · `auth-gated` · `degraded` · `scaffold` · `down` · `unreachable`). Tiles show actual deployment URL + probed health path + latency.
+
+2. **identity-api phase scoreboard** — G-1 through G-6 status with live evidence + beads references. Makes the BERA→Soju path immediately legible (Phase 1 deployed ✓, Phase 2 compose endpoint 400, Phase 3 Mibera dimensions 400, Phase 4 backfill not built).
+
+3. **🌸 Soju-lens** (when `OPERATOR_WALLET` env var is set) — the actually-novel observability primitive. Parallel-fetches operator identity across every surface that exposes one (identity-api spine / compose / mibera-dims, honey-road), groups by field, surfaces DISCREPANCIES. The BERA→Soju gap is the visual headline: until Phase 3 lands, honey-road's Alchemy fallback will be the only non-null `displayName`.
+
+## Run
+
+```bash
+# Local development (port 3030)
+cd apps/freeside-operator-dash
+pnpm install
+pnpm dev
+
+# With Soju-lens enabled
+OPERATOR_WALLET=0xYourWalletAddress pnpm dev
+```
+
+Open http://localhost:3030/ in a browser.
+
+### Routes
+
+| Path | Returns |
+|---|---|
+| `GET /` | HTML dashboard (30s TTL cache) |
+| `GET /healthz` | `{ ok: true, generatedAt: "..." }` (for self-monitoring) |
+| `GET /api/state` | Full `DashState` JSON (for future client-side consumers) |
+
+## Architecture
+
+```
+apps/freeside-operator-dash/
+├── bin/http.ts           # @hono/node-server entry (PORT, default 3030)
+├── src/
+│   ├── app.ts            # Hono routes + cache orchestration
+│   ├── registry.ts       # reads packages/freeside-registry/registry.yaml (server-side, in-process)
+│   ├── probe.ts          # per-cell health probe (with HEALTH_PATH_OVERRIDES for gateway-mismatch-aware probing)
+│   ├── soju-lens.ts      # parallel-fetch + discrepancy detection
+│   ├── render.ts         # HTML rendering (fully baked, no browser fetches)
+│   └── types.ts          # shared shapes (DashState, RegistryCell, ProbeStateKind, etc.)
+├── package.json          # workspace dep on @0xhoneyjar/beacon-schema; adds `yaml`
+└── tsconfig.json         # mirrors mcp-gateway's tsconfig
+```
+
+### Probe path overrides (gateway-mismatch-aware)
+
+`apps/mcp-gateway/src/app.ts:51-74` (`probeTenant()`) hardcodes `/healthz` as the probe path, which 404s for several cells whose runtime serves health at `/`. Until `apps/mcp-gateway/src/tenants.ts` grows a per-tenant `health_path` field, this dashboard maintains `HEALTH_PATH_OVERRIDES` in `src/probe.ts`:
+
+| Cell | Probe path | Why |
+|---|---|---|
+| `score-api` | `/` | Returns full status JSON (db: connected, scoring_version, etc.). `/healthz` 404s. |
+| `sonar-api` | `/` | Returns `{"message":"Sonar API"}`. |
+| `storage-api` | `/` | GraphQL playground HTML; non-404 means alive. |
+| `inventory-api` | `/` | MCP server. 401 is the expected auth-gated response → state = `auth-gated` (not `down`). |
+| All others | `/health` | Default (matches identity-api convention). |
+
+## Scope & out-of-scope
+
+In:
+- Cluster health visualization for the 8 `*-api` cells
+- Soju-lens cross-surface identity reconciliation
+- identity-api phase scoreboard (G-1..G-6)
+
+Out:
+- Auth (deferred to T4 of the kickoff — until then, run behind Tailscale or guard with `OPERATOR_TOKEN`)
+- The marketplace UI for external CMs (that's `score-dashboard` with `(cm-shell)` per ADR-009 §D-8 — different audience, different repo)
+- Replacement for Grafana / CloudWatch — this is operator-context awareness, not infrastructure metrics
+- Multi-tenant operator scoping (single THJ operator persona only for v0.1-v1.0)
+
+## Related
+
+- Kickoff proposal: [`grimoires/loa/proposals/freeside-operator-dash-kickoff.md`](../../grimoires/loa/proposals/freeside-operator-dash-kickoff.md)
+- Bridgebuilder verdict (audit trail): [`grimoires/loa/proposals/archive/freeside-federation-topology.md`](../../grimoires/loa/proposals/archive/freeside-federation-topology.md)
+- v0 spike (superseded by this): [`tools/operator-dash/`](../../tools/operator-dash/)
+- Registry source: [`packages/freeside-registry/registry.yaml`](../../packages/freeside-registry/registry.yaml)
+- Sibling app: [`apps/mcp-gateway/`](../mcp-gateway/)
+- ADR-009: [`decisions/009-freeside-hexagonal-federation.md`](../../decisions/009-freeside-hexagonal-federation.md)

--- a/apps/freeside-operator-dash/bin/http.ts
+++ b/apps/freeside-operator-dash/bin/http.ts
@@ -1,0 +1,14 @@
+import { serve } from "@hono/node-server";
+import app from "../src/app.js";
+
+process.on("unhandledRejection", (reason) => {
+  console.error("[freeside-operator-dash] unhandledRejection:", reason);
+});
+
+const port = Number.parseInt(process.env.PORT ?? "3030", 10);
+
+serve({ fetch: app.fetch, port }, (info) => {
+  console.log(
+    `[freeside-operator-dash] listening on http://0.0.0.0:${info.port} · operator-wallet=${process.env.OPERATOR_WALLET ? `${process.env.OPERATOR_WALLET.slice(0, 6)}…${process.env.OPERATOR_WALLET.slice(-4)}` : "(unset — Soju-lens disabled)"}`,
+  );
+});

--- a/apps/freeside-operator-dash/package.json
+++ b/apps/freeside-operator-dash/package.json
@@ -16,7 +16,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@0xhoneyjar/beacon-schema": "workspace:*",
     "@hono/node-server": "^1.14.1",
     "effect": "^3.21.2",
     "hono": "^4.7.0",

--- a/apps/freeside-operator-dash/package.json
+++ b/apps/freeside-operator-dash/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@0xhoneyjar/freeside-operator-dash",
+  "version": "0.1.0",
+  "description": "Inward-facing operator visibility for the freeside *-api cell network. Sibling to apps/mcp-gateway/. Sources from packages/freeside-registry/registry.yaml.",
+  "type": "module",
+  "private": true,
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "packageManager": "pnpm@8.15.9",
+  "scripts": {
+    "dev": "tsx watch bin/http.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/bin/http.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@0xhoneyjar/beacon-schema": "workspace:*",
+    "@hono/node-server": "^1.14.1",
+    "effect": "^3.21.2",
+    "hono": "^4.7.0",
+    "yaml": "^2.5.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.20.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/apps/freeside-operator-dash/pnpm-lock.yaml
+++ b/apps/freeside-operator-dash/pnpm-lock.yaml
@@ -1,0 +1,391 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.14.1
+        version: 1.19.14(hono@4.12.23)
+      effect:
+        specifier: ^3.21.2
+        version: 3.21.2
+      hono:
+        specifier: ^4.7.0
+        version: 4.12.23
+      yaml:
+        specifier: ^2.5.0
+        version: 2.9.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.19
+      tsx:
+        specifier: ^4.20.0
+        version: 4.22.3
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/node@22.19.19':
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
+
+  effect@3.21.2:
+    resolution: {integrity: sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==}
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+    engines: {node: '>=16.9.0'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  tsx@4.22.3:
+    resolution: {integrity: sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
+    optional: true
+
+  '@hono/node-server@1.19.14(hono@4.12.23)':
+    dependencies:
+      hono: 4.12.23
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/node@22.19.19':
+    dependencies:
+      undici-types: 6.21.0
+
+  effect@3.21.2:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
+  fsevents@2.3.3:
+    optional: true
+
+  hono@4.12.23: {}
+
+  pure-rand@6.1.0: {}
+
+  tsx@4.22.3:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  yaml@2.9.0: {}

--- a/apps/freeside-operator-dash/pnpm-workspace.yaml
+++ b/apps/freeside-operator-dash/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "packages/*"

--- a/apps/freeside-operator-dash/src/app.ts
+++ b/apps/freeside-operator-dash/src/app.ts
@@ -111,8 +111,12 @@ function buildIdentityPhases(probes: ReturnType<typeof probeAll> extends Promise
   ];
 }
 
-async function buildDashState(): Promise<DashState> {
-  const wallet = getOperatorWallet();
+async function buildDashState(walletOverride?: string | null): Promise<DashState> {
+  // Wallet precedence: explicit per-request query/form param > OPERATOR_WALLET env.
+  // walletOverride === null means "explicitly cleared via UI"; undefined means
+  // "no override, use env default."
+  const wallet =
+    walletOverride === undefined ? getOperatorWallet() : (walletOverride && walletOverride.length > 0 ? walletOverride : null);
   const cells = loadRegistry();
   const [probes, sojuLens] = await Promise.all([probeAll(cells), collectSojuLens(wallet)]);
   const identityPhases = buildIdentityPhases(probes);
@@ -145,7 +149,14 @@ async function buildDashState(): Promise<DashState> {
   };
 }
 
-async function getCached(): Promise<{ state: DashState; html: string }> {
+async function getCached(walletOverride?: string | null): Promise<{ state: DashState; html: string }> {
+  // Only cache the default (env-wallet) view. Per-request wallet overrides
+  // are computed fresh to avoid cross-wallet contamination + cache poisoning.
+  if (walletOverride !== undefined) {
+    const state = await buildDashState(walletOverride);
+    const html = renderHTML(state);
+    return { state, html };
+  }
   const now = Date.now();
   if (cached && now - cached.at < CACHE_TTL_MS) return cached;
   const state = await buildDashState();
@@ -154,8 +165,19 @@ async function getCached(): Promise<{ state: DashState; html: string }> {
   return cached;
 }
 
+function parseWalletParam(raw: string | undefined): string | null | undefined {
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === "") return null; // explicit clear
+  // Loose hex address shape — reject obvious garbage but don't hard-validate
+  // (identity-api will reject + the Soju-lens row will show the error).
+  if (!/^0x[a-fA-F0-9]{4,}$/.test(trimmed)) return null;
+  return trimmed.toLowerCase();
+}
+
 app.get("/", async (c) => {
-  const { html } = await getCached();
+  const walletOverride = parseWalletParam(c.req.query("wallet"));
+  const { html } = await getCached(walletOverride);
   return c.html(html);
 });
 
@@ -164,7 +186,8 @@ app.get("/healthz", (c) => {
 });
 
 app.get("/api/state", async (c) => {
-  const { state } = await getCached();
+  const walletOverride = parseWalletParam(c.req.query("wallet"));
+  const { state } = await getCached(walletOverride);
   return c.json(state);
 });
 

--- a/apps/freeside-operator-dash/src/app.ts
+++ b/apps/freeside-operator-dash/src/app.ts
@@ -41,9 +41,14 @@ function getOperatorWallet(): string | null {
 }
 
 function buildIdentityPhases(probes: ReturnType<typeof probeAll> extends Promise<infer R> ? R : never): IdentityApiPhase[] {
-  // Phase scoreboard derives from observed Phase 1-3 endpoint behavior at runtime
-  // (live-probed against identity-api each refresh). The endpoint probes happen
-  // in soju-lens too; here we do a lightweight category check.
+  // Phase status reflects ground truth as of 2026-05-25:
+  //   Phases 1-4 substrate work is BUILT + deployed (T1.*-T4.4 closed in
+  //   ~/bonfire/identity-api-coordinator beads); T4.E2E (P0 end-to-end goal
+  //   validation, bead arrakis-hito) is the only OPEN task. Phase 2/3
+  //   endpoints respond correctly when called with proper params:
+  //     /v1/profile requires (world + wallet|userId)
+  //     /v1/mibera/dimensions requires (wallet|userId), world implicit
+  //   The Soju-lens panel below proves this by probing each surface live.
   const identityProbe = probes.find((p) => p.slug === "identity-api");
   const phase1Deployed = identityProbe?.state === "up";
 
@@ -61,49 +66,46 @@ function buildIdentityPhases(probes: ReturnType<typeof probeAll> extends Promise
       evidence: phase1Deployed
         ? [`identity-api /health → ${identityProbe?.statusCode} in ${identityProbe?.latencyMs}ms`]
         : ["identity-api /health not reachable"],
-      beadsRefs: ["arrakis-zhq2 (Sprint 396, P1, 12 tasks ⚠ still OPEN — beads stale vs reality)"],
+      beadsRefs: ["arrakis-zhq2 (Sprint 396) — all 12 P1 tasks closed in coord"],
     },
     {
       phase: 2,
       name: "Serve (compose endpoint)",
       goalIds: ["G-5"],
-      goalNotes: ["G-5: /v1/profile degrades (200 with degraded[]) not 5xx"],
-      // Phase 2 status comes from Soju-lens probe of /v1/profile (currently 400)
-      status: "scaffolded",
+      goalNotes: ["G-5: /v1/profile composes spine+inventory+score+codex, degrades 200 with degraded[] not 5xx"],
+      status: "deployed",
       evidence: [
-        "/v1/profile registered in OpenAPI but compose orchestrator NOT wired",
-        "returns 400 today — Phase 2 sprint 397 not built",
+        "/v1/profile mounted with composeProfile orchestrator + circuit breakers (freeside-auth/src/api/routes/profile.ts)",
+        "tests cover happy-path + downstream-blackout + 4xx subject-validation",
       ],
-      beadsRefs: [
-        "arrakis-pgoo (Sprint 397, 4 P1 tasks open)",
-        "arrakis-eqxj T2.3 / arrakis-l06n T2.2 / arrakis-ok93 T2.1 / arrakis-wqzd T2.TEST",
-      ],
+      beadsRefs: ["arrakis-pgoo (Sprint 397) — all 4 P1 tasks closed (T2.1/T2.2/T2.3/T2.TEST)"],
     },
     {
       phase: 3,
       name: "Mibera Dimensions on Honey Road (Soju headline)",
       goalIds: ["G-6"],
       goalNotes: ["G-6: honey-road renders 7-dim Mibera from @0xhoneyjar/identity not Alchemy"],
-      status: "scaffolded",
+      status: "deployed",
       evidence: [
-        "/v1/mibera/dimensions scaffolded but Codex 7-dim resolver (T3.1) NOT wired",
-        "honey-road still reads from lib/alchemy.ts (T3.3 swap not landed)",
+        "/v1/mibera/dimensions mounted with Codex 7-dim resolver + tests (freeside-auth/src/api/__tests__/mibera-dimensions-route.test.ts)",
+        "honey-road swap landed: lib/identity/mibera-dimensions.ts reads identity-api by default (HONEYROAD_PROFILE_SOURCE env, alchemy is kill-switch fallback)",
+        "if BERA name still appears on Honey Road UI: check HONEYROAD_PROFILE_SOURCE env in prod + Vercel deploy SHA + whether identity-api is degrading to alchemy fallback for the operator's wallet (Soju-lens above shows which)",
       ],
-      beadsRefs: [
-        "arrakis-eul7 (Sprint 398, 3 P1 tasks open)",
-        "arrakis-8qpm T3.1 codex resolver / arrakis-g407 T3.2 endpoint / arrakis-cdwx T3.3 honey-road swap",
-      ],
+      beadsRefs: ["arrakis-eul7 (Sprint 398) — all 3 P1 tasks closed (T3.1/T3.2/T3.3)"],
     },
     {
       phase: 4,
       name: "cycle-c redirect + midi_profiles backfill",
       goalIds: ["G-4"],
       goalNotes: ["G-4: /verify completion writes spine row"],
-      status: "not-built",
-      evidence: ["spine empty until T4.4 backfill migration 0003 runs"],
+      status: "deployed",
+      evidence: [
+        "Phase 4 tasks T4.1/T4.3/T4.4/T4.TEST all closed in coord beads",
+        "T4.E2E (arrakis-hito, P0) is the LAST open task — end-to-end goal validation against G-1..G-6",
+      ],
       beadsRefs: [
-        "arrakis-oujo (Sprint 399, 5 P1 tasks open)",
-        "arrakis-hito T4.E2E P0 end-to-end goal validation",
+        "arrakis-oujo (Sprint 399) — 4/5 P1 tasks closed",
+        "arrakis-hito T4.E2E (P0) — STILL OPEN — drive: cd ~/Documents/GitHub/freeside-auth && claude /implement T4.E2E",
       ],
     },
   ];
@@ -125,9 +127,10 @@ async function buildDashState(): Promise<DashState> {
       `${deployedDown.length} cell(s) registry-marked deployed but probed down: ${deployedDown.map((p) => p.slug).join(", ")}`,
     );
   }
-  if (identityPhases.find((p) => p.phase === 3)?.status !== "deployed") {
+  const lastOpenTask = identityPhases.find((p) => p.status === "deployed" && p.beadsRefs.some((r) => r.includes("STILL OPEN")));
+  if (lastOpenTask) {
     warnings.push(
-      "Phase 3 (G-6 Soju headline) NOT built — Honey Road will continue showing Alchemy fallback until T3.1 → T3.2 → T3.3 land",
+      `identity-api: only T4.E2E (arrakis-hito, P0) remains — substrate Phases 1-4 deployed. If Honey Road still shows BERA fallback, the issue is config/deploy-side (HONEYROAD_PROFILE_SOURCE env, Vercel deploy SHA, or degraded-fallback to alchemy for operator's wallet). Soju-lens above proves which.`,
     );
   }
 

--- a/apps/freeside-operator-dash/src/app.ts
+++ b/apps/freeside-operator-dash/src/app.ts
@@ -1,0 +1,168 @@
+/**
+ * freeside-operator-dash — inward-facing operator visibility surface.
+ *
+ * Sibling to apps/mcp-gateway/ (outward-facing federation discovery for
+ * partners + agent clients). This app serves the THJ team's operator
+ * persona per ADR-009 §D-9: cluster health, Soju-lens identity
+ * reconciliation, identity-api phase scoreboard, federation tile grid.
+ *
+ * Reads packages/freeside-registry/registry.yaml as the source of truth
+ * for which cells exist + their deployment URLs.
+ *
+ * Routes:
+ *   GET /          → HTML dashboard (30s TTL cache)
+ *   GET /healthz   → JSON {ok, generatedAt}
+ *   GET /api/state → JSON DashState (for future client-side consumers)
+ *
+ * v0.1 caveats:
+ *   - No auth. Run behind Tailscale / local OPERATOR_TOKEN check until T4
+ *     (Privy + cm-internal role per ADR-009 §D-9) lands.
+ *   - Soju-lens disabled unless OPERATOR_WALLET env var is set.
+ *   - Single-instance only; no Redis-backed state, no multi-operator scoping.
+ */
+
+import { Hono } from "hono";
+import type { DashState, IdentityApiPhase } from "./types.js";
+import { loadRegistry } from "./registry.js";
+import { probeAll } from "./probe.js";
+import { collectSojuLens } from "./soju-lens.js";
+import { renderHTML } from "./render.js";
+
+const app = new Hono();
+
+const CACHE_TTL_MS = 30_000;
+
+let cached: { state: DashState; html: string; at: number } | null = null;
+
+function getOperatorWallet(): string | null {
+  const w = process.env.OPERATOR_WALLET;
+  if (!w || w.length === 0) return null;
+  return w;
+}
+
+function buildIdentityPhases(probes: ReturnType<typeof probeAll> extends Promise<infer R> ? R : never): IdentityApiPhase[] {
+  // Phase scoreboard derives from observed Phase 1-3 endpoint behavior at runtime
+  // (live-probed against identity-api each refresh). The endpoint probes happen
+  // in soju-lens too; here we do a lightweight category check.
+  const identityProbe = probes.find((p) => p.slug === "identity-api");
+  const phase1Deployed = identityProbe?.state === "up";
+
+  return [
+    {
+      phase: 1,
+      name: "Spine + Auth",
+      goalIds: ["G-1", "G-2", "G-3"],
+      goalNotes: [
+        "G-1: beacon valid + registered + SDK + gateway reachable",
+        "G-2: 1 human / 2 wallets / 2 nyms → 1 user_id",
+        "G-3: zero Dynamic in live auth path",
+      ],
+      status: phase1Deployed ? "deployed" : "not-built",
+      evidence: phase1Deployed
+        ? [`identity-api /health → ${identityProbe?.statusCode} in ${identityProbe?.latencyMs}ms`]
+        : ["identity-api /health not reachable"],
+      beadsRefs: ["arrakis-zhq2 (Sprint 396, P1, 12 tasks ⚠ still OPEN — beads stale vs reality)"],
+    },
+    {
+      phase: 2,
+      name: "Serve (compose endpoint)",
+      goalIds: ["G-5"],
+      goalNotes: ["G-5: /v1/profile degrades (200 with degraded[]) not 5xx"],
+      // Phase 2 status comes from Soju-lens probe of /v1/profile (currently 400)
+      status: "scaffolded",
+      evidence: [
+        "/v1/profile registered in OpenAPI but compose orchestrator NOT wired",
+        "returns 400 today — Phase 2 sprint 397 not built",
+      ],
+      beadsRefs: [
+        "arrakis-pgoo (Sprint 397, 4 P1 tasks open)",
+        "arrakis-eqxj T2.3 / arrakis-l06n T2.2 / arrakis-ok93 T2.1 / arrakis-wqzd T2.TEST",
+      ],
+    },
+    {
+      phase: 3,
+      name: "Mibera Dimensions on Honey Road (Soju headline)",
+      goalIds: ["G-6"],
+      goalNotes: ["G-6: honey-road renders 7-dim Mibera from @0xhoneyjar/identity not Alchemy"],
+      status: "scaffolded",
+      evidence: [
+        "/v1/mibera/dimensions scaffolded but Codex 7-dim resolver (T3.1) NOT wired",
+        "honey-road still reads from lib/alchemy.ts (T3.3 swap not landed)",
+      ],
+      beadsRefs: [
+        "arrakis-eul7 (Sprint 398, 3 P1 tasks open)",
+        "arrakis-8qpm T3.1 codex resolver / arrakis-g407 T3.2 endpoint / arrakis-cdwx T3.3 honey-road swap",
+      ],
+    },
+    {
+      phase: 4,
+      name: "cycle-c redirect + midi_profiles backfill",
+      goalIds: ["G-4"],
+      goalNotes: ["G-4: /verify completion writes spine row"],
+      status: "not-built",
+      evidence: ["spine empty until T4.4 backfill migration 0003 runs"],
+      beadsRefs: [
+        "arrakis-oujo (Sprint 399, 5 P1 tasks open)",
+        "arrakis-hito T4.E2E P0 end-to-end goal validation",
+      ],
+    },
+  ];
+}
+
+async function buildDashState(): Promise<DashState> {
+  const wallet = getOperatorWallet();
+  const cells = loadRegistry();
+  const [probes, sojuLens] = await Promise.all([probeAll(cells), collectSojuLens(wallet)]);
+  const identityPhases = buildIdentityPhases(probes);
+
+  const warnings: string[] = [];
+  if (!wallet) warnings.push("OPERATOR_WALLET not set — Soju-lens disabled");
+  const deployedDown = probes.filter(
+    (p) => p.state === "down" && cells.find((c) => c.slug === p.slug)?.runtime_state === "deployed",
+  );
+  if (deployedDown.length > 0) {
+    warnings.push(
+      `${deployedDown.length} cell(s) registry-marked deployed but probed down: ${deployedDown.map((p) => p.slug).join(", ")}`,
+    );
+  }
+  if (identityPhases.find((p) => p.phase === 3)?.status !== "deployed") {
+    warnings.push(
+      "Phase 3 (G-6 Soju headline) NOT built — Honey Road will continue showing Alchemy fallback until T3.1 → T3.2 → T3.3 land",
+    );
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    generatorVersion: "0.1.0",
+    cells,
+    probes,
+    identityPhases,
+    sojuLens,
+    warnings,
+  };
+}
+
+async function getCached(): Promise<{ state: DashState; html: string }> {
+  const now = Date.now();
+  if (cached && now - cached.at < CACHE_TTL_MS) return cached;
+  const state = await buildDashState();
+  const html = renderHTML(state);
+  cached = { state, html, at: now };
+  return cached;
+}
+
+app.get("/", async (c) => {
+  const { html } = await getCached();
+  return c.html(html);
+});
+
+app.get("/healthz", (c) => {
+  return c.json({ ok: true, generatedAt: cached?.state.generatedAt ?? null });
+});
+
+app.get("/api/state", async (c) => {
+  const { state } = await getCached();
+  return c.json(state);
+});
+
+export default app;

--- a/apps/freeside-operator-dash/src/probe.ts
+++ b/apps/freeside-operator-dash/src/probe.ts
@@ -1,0 +1,112 @@
+/**
+ * Probe each cell's deployment_url for liveness.
+ *
+ * gateway-probe-mismatch-aware: per-cell HEALTH_PATH_OVERRIDES table corrects
+ * the path the gateway's probeTenant() gets wrong (score-api serves health
+ * at `/`, not `/healthz`). Until tenants.ts grows a `health_path` field, this
+ * override map is the source of truth.
+ */
+
+import type { RegistryCell, CellProbe, ProbeStateKind } from "./types.js";
+
+const PROBE_TIMEOUT_MS = 6000;
+
+/**
+ * Per-cell path override. Default probe path is `/health`; override for cells
+ * whose runtime serves health at a different path.
+ */
+const HEALTH_PATH_OVERRIDES: Record<string, string> = {
+  "score-api": "/", // returns full status JSON: {status:"ok", db:"connected", ...}
+  "sonar-api": "/", // returns {message:"Sonar API"}
+  "storage-api": "/", // GraphQL playground HTML; non-404 means alive
+  "inventory-api": "/", // MCP server; 401 expected (auth-gated → still "up")
+};
+
+function probePathFor(slug: string): string {
+  return HEALTH_PATH_OVERRIDES[slug] ?? "/health";
+}
+
+function interpret(
+  slug: string,
+  statusCode: number | null,
+  latencyMs: number | null,
+): { state: ProbeStateKind; note: string | null } {
+  if (statusCode === null) return { state: "unreachable", note: "DNS/network/timeout" };
+
+  // inventory-api specifically: 401 is the auth-gated MCP server's expected response
+  if (slug === "inventory-api" && (statusCode === 401 || statusCode === 403)) {
+    return { state: "auth-gated", note: "MCP server alive (auth required)" };
+  }
+
+  if (statusCode >= 200 && statusCode < 400) {
+    const slow = latencyMs !== null && latencyMs > 1500;
+    return { state: slow ? "degraded" : "up", note: slow ? `slow ${latencyMs}ms` : null };
+  }
+  if (statusCode === 401 || statusCode === 403) {
+    return { state: "auth-gated", note: `auth-gated (HTTP ${statusCode})` };
+  }
+  if (statusCode === 404) return { state: "scaffold", note: "endpoint 404 — not deployed at this URL" };
+  if (statusCode >= 500) return { state: "down", note: `5xx ${statusCode}` };
+  return { state: "degraded", note: `unexpected ${statusCode}` };
+}
+
+async function probeOne(cell: RegistryCell): Promise<CellProbe> {
+  if (!cell.deployment_url) {
+    return {
+      slug: cell.slug,
+      url: null,
+      state: cell.runtime_state === "not-built" ? "down" : "unreachable",
+      statusCode: null,
+      latencyMs: null,
+      bodyExcerpt: null,
+      error: cell.runtime_state === "not-built" ? "no runtime — not built" : "no deployment_url in registry",
+      note: cell.runtime_state === "not-built" ? "registry marks this cell not-built" : null,
+      probedPath: "(none)",
+    };
+  }
+  const path = probePathFor(cell.slug);
+  const url = `${cell.deployment_url}${path}`;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), PROBE_TIMEOUT_MS);
+  const start = Date.now();
+  try {
+    const res = await fetch(url, { method: "GET", signal: ctrl.signal });
+    clearTimeout(timer);
+    const latencyMs = Date.now() - start;
+    let body = "";
+    try {
+      body = (await res.text()).slice(0, 200).replace(/\s+/g, " ").trim();
+    } catch {
+      body = "";
+    }
+    const { state, note } = interpret(cell.slug, res.status, latencyMs);
+    return {
+      slug: cell.slug,
+      url,
+      state,
+      statusCode: res.status,
+      latencyMs,
+      bodyExcerpt: body || null,
+      error: null,
+      note,
+      probedPath: path,
+    };
+  } catch (err) {
+    clearTimeout(timer);
+    return {
+      slug: cell.slug,
+      url,
+      state: "unreachable",
+      statusCode: null,
+      latencyMs: null,
+      bodyExcerpt: null,
+      error: err instanceof Error ? err.message : String(err),
+      note: "DNS/network/timeout",
+      probedPath: path,
+    };
+  }
+}
+
+export async function probeAll(cells: RegistryCell[]): Promise<CellProbe[]> {
+  return Promise.all(cells.map((c) => probeOne(c)));
+}

--- a/apps/freeside-operator-dash/src/registry.ts
+++ b/apps/freeside-operator-dash/src/registry.ts
@@ -10,12 +10,13 @@ import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
 import type { RegistryCell, RuntimeState } from "./types.js";
 
+// dirname(import.meta.url) = .../apps/freeside-operator-dash/src
+// 3 levels up gets us to the repo root.
 const REPO_ROOT = join(
   dirname(fileURLToPath(import.meta.url)),
-  "..", // src
-  "..", // apps/freeside-operator-dash
-  "..", // apps
-  "..", // repo root
+  "..", // src/ → apps/freeside-operator-dash/
+  "..", // apps/freeside-operator-dash/ → apps/
+  "..", // apps/ → repo root
 );
 
 const REGISTRY_PATH = join(REPO_ROOT, "packages", "freeside-registry", "registry.yaml");

--- a/apps/freeside-operator-dash/src/registry.ts
+++ b/apps/freeside-operator-dash/src/registry.ts
@@ -1,0 +1,62 @@
+/**
+ * Read packages/freeside-registry/registry.yaml.
+ *
+ * Done server-side, in-process. Repo-relative path. No browser fetch.
+ */
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+import type { RegistryCell, RuntimeState } from "./types.js";
+
+const REPO_ROOT = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..", // src
+  "..", // apps/freeside-operator-dash
+  "..", // apps
+  "..", // repo root
+);
+
+const REGISTRY_PATH = join(REPO_ROOT, "packages", "freeside-registry", "registry.yaml");
+
+type RawCell = {
+  git_url: string;
+  beacon_url: string;
+  deployment_url?: string | null;
+  visibility: "public" | "unlisted" | "internal";
+  owner: string;
+  added: string;
+  runtime_state?: RuntimeState;
+  notes?: string;
+};
+
+type RawRegistry = {
+  version: number;
+  modules?: Record<string, RawCell>;
+};
+
+function normalize(slug: string, raw: RawCell): RegistryCell {
+  return {
+    slug,
+    git_url: raw.git_url,
+    beacon_url: raw.beacon_url,
+    deployment_url: raw.deployment_url ?? null,
+    visibility: raw.visibility,
+    owner: raw.owner,
+    added: raw.added,
+    runtime_state: raw.runtime_state ?? "not-built",
+    notes: raw.notes ?? null,
+  };
+}
+
+export function loadRegistry(): RegistryCell[] {
+  const txt = readFileSync(REGISTRY_PATH, "utf8");
+  const yaml = parseYaml(txt) as RawRegistry;
+  const modules = yaml.modules ?? {};
+  return Object.entries(modules)
+    .map(([slug, raw]) => normalize(slug, raw))
+    .sort((a, b) => a.slug.localeCompare(b.slug));
+}
+
+export const REGISTRY_PATH_DEBUG = REGISTRY_PATH;

--- a/apps/freeside-operator-dash/src/render.ts
+++ b/apps/freeside-operator-dash/src/render.ts
@@ -1,0 +1,195 @@
+/**
+ * HTML renderer for the dashboard. Server-side, fully baked.
+ * No browser-side JS fetches (no CORS).
+ */
+
+import type { DashState, CellProbe, ProbeStateKind, RegistryCell, IdentityApiPhase } from "./types.js";
+
+function esc(s: string | null | undefined): string {
+  if (s == null) return "";
+  return String(s).replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!,
+  );
+}
+
+function stateColor(s: ProbeStateKind): string {
+  return ({
+    up: "#1f8a3f",
+    "auth-gated": "#7c6cff",
+    degraded: "#e3a008",
+    scaffold: "#f97316",
+    down: "#dc2626",
+    unreachable: "#71717a",
+  } as const)[s];
+}
+
+function cellAccent(cell: RegistryCell, probe: CellProbe | undefined): string {
+  if (probe) return stateColor(probe.state);
+  if (cell.runtime_state === "deployed") return "#1f8a3f";
+  if (cell.runtime_state === "scaffolded") return "#e3a008";
+  return "#71717a";
+}
+
+function phaseColor(p: IdentityApiPhase): string {
+  if (p.status === "deployed") return "#1f8a3f";
+  if (p.status === "scaffolded") return "#e3a008";
+  return "#dc2626";
+}
+
+export function renderHTML(state: DashState): string {
+  const probeBySlug = new Map(state.probes.map((p) => [p.slug, p]));
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>🦎 freeside operator-dash</title>
+<style>
+  :root {
+    --bg: #0a0a0b; --panel: #131316; --panel-hi: #1c1c20; --line: #262629;
+    --text: #ededed; --text-dim: #9a9a9e; --accent: #f9c846; --soju: #ff6b9d;
+    --mono: "SF Mono","JetBrains Mono","Fira Code",ui-monospace,monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 24px; background: var(--bg); color: var(--text);
+    font-family: -apple-system,BlinkMacSystemFont,"Inter","Segoe UI",sans-serif;
+    font-size: 14px; line-height: 1.5;
+  }
+  header { display: flex; align-items: baseline; gap: 12px; margin-bottom: 24px; flex-wrap: wrap; }
+  header h1 { margin: 0; font-size: 22px; font-weight: 700; letter-spacing: -0.01em; }
+  header .meta { color: var(--text-dim); font-family: var(--mono); font-size: 12px; }
+  .grid { display: grid; gap: 16px; }
+  .grid.two { grid-template-columns: 1fr 1fr; }
+  @media (max-width: 900px) { .grid.two { grid-template-columns: 1fr; } }
+  .panel {
+    background: var(--panel); border: 1px solid var(--line); border-radius: 8px;
+    padding: 16px;
+  }
+  .panel h2 {
+    margin: 0 0 12px 0; font-size: 13px; font-weight: 600; letter-spacing: 0.04em;
+    text-transform: uppercase; color: var(--text-dim);
+  }
+  .panel h2 .badge { color: var(--accent); margin-left: 6px; font-weight: 700; font-size: 11px; }
+  .warning {
+    background: #2a1b00; border: 1px solid #5a3a00; color: #ffb84d;
+    padding: 10px 14px; border-radius: 6px; margin-bottom: 12px; font-size: 13px;
+  }
+  .discrepancy {
+    background: #2a0010; border: 1px solid #5a0020; color: var(--soju);
+    padding: 10px 14px; border-radius: 6px; margin-bottom: 12px; font-size: 13px;
+    font-family: var(--mono);
+  }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  th, td { text-align: left; padding: 8px 6px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { color: var(--text-dim); font-weight: 500; font-size: 11px; letter-spacing: 0.04em; text-transform: uppercase; }
+  td.mono { font-family: var(--mono); font-size: 12px; }
+  .pill { display: inline-block; padding: 2px 8px; border-radius: 99px; font-size: 11px; font-weight: 600; letter-spacing: 0.02em; color: white; }
+  .tiles { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 12px; }
+  .tile {
+    background: var(--panel-hi); border: 1px solid var(--line); border-radius: 6px;
+    padding: 12px; position: relative; overflow: hidden;
+  }
+  .tile .slug { font-weight: 600; margin-bottom: 4px; display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
+  .tile .slug .lat { color: var(--text-dim); font-family: var(--mono); font-size: 11px; font-weight: 400; }
+  .tile .body { color: var(--text-dim); font-family: var(--mono); font-size: 11px; line-height: 1.5; word-break: break-all; }
+  .phase {
+    background: var(--panel-hi); border: 1px solid var(--line); border-radius: 6px;
+    padding: 14px; margin-bottom: 10px;
+  }
+  .phase .row1 { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 6px; gap: 8px; }
+  .phase .name { font-weight: 600; }
+  .phase .goals { color: var(--accent); font-family: var(--mono); font-size: 12px; }
+  .phase ul { margin: 6px 0 0; padding-left: 18px; color: var(--text-dim); font-size: 12px; }
+  .phase ul li { margin: 2px 0; }
+  .footer { color: var(--text-dim); font-family: var(--mono); font-size: 11px; margin-top: 24px; text-align: right; }
+  details summary { cursor: pointer; color: var(--text-dim); font-size: 12px; }
+  details summary:hover { color: var(--text); }
+  pre.body { background: var(--bg); padding: 8px; border-radius: 4px; font-size: 11px; overflow-x: auto; margin: 4px 0 0; color: var(--text-dim); }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+</style>
+</head>
+<body>
+<header>
+  <h1>🦎 freeside operator-dash</h1>
+  <span class="meta">v${esc(state.generatorVersion)} · ${esc(state.generatedAt)} · inward-facing · ADR-009 §D-5</span>
+</header>
+
+${state.warnings.map((w) => `<div class="warning">⚠ ${esc(w)}</div>`).join("")}
+${state.sojuLens.discrepancies.map((d) => `<div class="discrepancy">🌸 ${esc(d)}</div>`).join("")}
+
+<div class="grid two">
+
+  <div class="panel">
+    <h2>identity-api · phase scoreboard <span class="badge">BERA→Soju path · G-1..G-6</span></h2>
+    ${state.identityPhases.map((p) => `
+      <div class="phase">
+        <div class="row1">
+          <span class="name">Phase ${p.phase}: ${esc(p.name)}</span>
+          <span class="pill" style="background:${phaseColor(p)}">${p.status === "deployed" ? "DEPLOYED" : p.status === "scaffolded" ? "SCAFFOLDED" : "NOT BUILT"}</span>
+        </div>
+        <div class="goals">${esc(p.goalIds.join(" · "))}</div>
+        <ul>${p.goalNotes.map((n) => `<li>${esc(n)}</li>`).join("")}</ul>
+        <details>
+          <summary>evidence + beads (${p.evidence.length + p.beadsRefs.length})</summary>
+          <ul>
+            ${p.evidence.map((e) => `<li>📡 ${esc(e)}</li>`).join("")}
+            ${p.beadsRefs.map((b) => `<li>🔗 ${esc(b)}</li>`).join("")}
+          </ul>
+        </details>
+      </div>`).join("")}
+  </div>
+
+  <div class="panel">
+    <h2>🌸 soju-lens · operator identity across surfaces ${state.sojuLens.wallet ? `<span class="badge">wallet ${esc(state.sojuLens.wallet.slice(0, 6))}…${esc(state.sojuLens.wallet.slice(-4))}</span>` : ""}</h2>
+    <table>
+      <thead><tr><th>surface</th><th>field</th><th>observed</th><th>source</th><th>error</th></tr></thead>
+      <tbody>
+        ${state.sojuLens.rows.map((r) => `
+          <tr>
+            <td>${esc(r.surface)}</td>
+            <td class="mono">${esc(r.field)}</td>
+            <td class="mono" style="color:${r.observed ? "var(--text)" : "var(--text-dim)"}">${esc(r.observed) || "—"}</td>
+            <td class="mono" style="color:var(--text-dim);font-size:11px">${esc(r.source)}</td>
+            <td class="mono" style="color:${r.error ? "var(--soju)" : "var(--text-dim)"};font-size:11px">${esc(r.error) || "—"}</td>
+          </tr>`).join("")}
+      </tbody>
+    </table>
+    ${!state.sojuLens.wallet ? `<div style="margin-top:10px;color:var(--text-dim);font-size:12px">enable with <code style="background:var(--bg);padding:1px 6px;border-radius:3px">OPERATOR_WALLET=0xABC tsx bin/http.ts</code></div>` : ""}
+  </div>
+
+</div>
+
+<div class="panel" style="margin-top:16px">
+  <h2>federation tiles · ${state.cells.length} cells <span class="badge">registry.yaml · *-api per ADR-009 §D-2</span></h2>
+  <div class="tiles">
+    ${state.cells.map((cell) => {
+      const probe = probeBySlug.get(cell.slug);
+      const accent = cellAccent(cell, probe);
+      const probeNote = probe?.note ?? (cell.deployment_url ? "no probe" : "no deployment_url");
+      return `
+        <div class="tile">
+          <div style="position:absolute;left:0;top:0;bottom:0;width:3px;background:${accent}"></div>
+          <div style="margin-left:8px">
+            <div class="slug"><span>${esc(cell.slug)}</span><span class="lat">${probe?.latencyMs != null ? `${probe.latencyMs}ms` : ""}</span></div>
+            <div class="body">
+              <strong style="color:${accent}">${probe ? probe.state.toUpperCase().replace("-", " ") : cell.runtime_state.toUpperCase()}</strong>
+              ${probe?.statusCode ? ` · HTTP ${probe.statusCode}` : ""}<br>
+              ${cell.deployment_url ? `URL: <a href="${esc(cell.deployment_url)}" target="_blank">${esc(cell.deployment_url.replace(/^https?:\/\//, ""))}</a>${probe?.probedPath && probe.probedPath !== "(none)" ? ` <span style="opacity:.6">probe ${esc(probe.probedPath)}</span>` : ""}<br>` : ""}
+              visibility: ${esc(cell.visibility)} · owner: ${esc(cell.owner)}<br>
+              <span style="opacity:.6">${esc(probeNote)}</span>
+            </div>
+          </div>
+        </div>`;
+    }).join("")}
+  </div>
+</div>
+
+<div class="footer">
+  freeside operator-dash @ apps/freeside-operator-dash/ · ${esc(state.generatedAt)}
+</div>
+
+</body>
+</html>`;
+}

--- a/apps/freeside-operator-dash/src/render.ts
+++ b/apps/freeside-operator-dash/src/render.ts
@@ -108,12 +108,32 @@ export function renderHTML(state: DashState): string {
   pre.body { background: var(--bg); padding: 8px; border-radius: 4px; font-size: 11px; overflow-x: auto; margin: 4px 0 0; color: var(--text-dim); }
   a { color: var(--accent); text-decoration: none; }
   a:hover { text-decoration: underline; }
+  form.wallet { display: flex; align-items: center; gap: 8px; margin-left: auto; }
+  form.wallet input {
+    background: var(--panel-hi); color: var(--text); border: 1px solid var(--line);
+    border-radius: 4px; padding: 6px 10px; font-family: var(--mono); font-size: 12px;
+    min-width: 320px;
+  }
+  form.wallet input:focus { outline: none; border-color: var(--accent); }
+  form.wallet button {
+    background: var(--soju); color: white; border: 0; border-radius: 4px;
+    padding: 6px 14px; font-size: 12px; font-weight: 600; cursor: pointer;
+    font-family: inherit;
+  }
+  form.wallet button:hover { opacity: 0.9; }
+  form.wallet a.clear { color: var(--text-dim); font-size: 11px; text-decoration: none; padding: 0 4px; }
+  form.wallet a.clear:hover { color: var(--soju); }
 </style>
 </head>
 <body>
 <header>
   <h1>🦎 freeside operator-dash</h1>
   <span class="meta">v${esc(state.generatorVersion)} · ${esc(state.generatedAt)} · inward-facing · ADR-009 §D-5</span>
+  <form class="wallet" method="GET" action="/">
+    <input type="text" name="wallet" placeholder="0xYourWalletAddress (Soju-lens)" value="${esc(state.sojuLens.wallet ?? "")}" pattern="0x[a-fA-F0-9]{4,}" autocomplete="off" />
+    <button type="submit">🌸 lens</button>
+    ${state.sojuLens.wallet ? `<a class="clear" href="/" title="clear wallet">clear</a>` : ""}
+  </form>
 </header>
 
 ${state.warnings.map((w) => `<div class="warning">⚠ ${esc(w)}</div>`).join("")}

--- a/apps/freeside-operator-dash/src/soju-lens.ts
+++ b/apps/freeside-operator-dash/src/soju-lens.ts
@@ -1,0 +1,161 @@
+/**
+ * Soju-lens — parallel-fetch the operator's identity across every surface
+ * that exposes one. Group by field, surface DISCREPANCIES.
+ *
+ * The actually-novel observability primitive per bridgebuilder F6. Status
+ * display is solved 100 ways; cross-surface identity reconciliation isn't.
+ *
+ * Probes (when wallet supplied):
+ *   identity-api /v1/resolve/wallet/:address   → userId (Phase 1, deployed)
+ *   identity-api /v1/profile?wallet=…           → displayName (Phase 2, currently 400)
+ *   identity-api /v1/mibera/dimensions?wallet=… → miberaDimensions (Phase 3, currently 400)
+ *   honey-road  /api/profile?wallet=…           → displayName (Alchemy fallback today)
+ *
+ * BERA→Soju gap: until identity-api Phases 2-3 land, honey-road's Alchemy
+ * fallback will be the ONLY non-null displayName. That discrepancy is the
+ * Soju headline G-6 blocker, immediately legible in the table.
+ */
+
+import type { SojuLens, SojuLensRow } from "./types.js";
+
+const FETCH_TIMEOUT_MS = 6000;
+const IDENTITY_API = "https://identity-api-production-317b.up.railway.app";
+const HONEY_ROAD = "https://mibera.honeyjar.xyz";
+
+type FetchResult = { observed: string | null; error: string | null };
+
+async function safeFetchJSON<T>(
+  url: string,
+  extractor: (body: unknown) => string | null,
+  errorPrefix: string,
+): Promise<FetchResult> {
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+    const res = await fetch(url, { signal: ctrl.signal });
+    clearTimeout(timer);
+    if (!res.ok) {
+      let body = "";
+      try { body = (await res.text()).slice(0, 100); } catch { /* noop */ }
+      return { observed: null, error: `${errorPrefix} HTTP ${res.status}${body ? ` — ${body}` : ""}` };
+    }
+    const ct = res.headers.get("content-type") ?? "";
+    if (!ct.includes("application/json")) {
+      return { observed: null, error: `${errorPrefix} non-JSON content-type (${ct})` };
+    }
+    const body = (await res.json().catch(() => null)) as unknown;
+    if (body === null) return { observed: null, error: `${errorPrefix} body unparseable` };
+    return { observed: extractor(body), error: null };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { observed: null, error: `${errorPrefix} ${msg}` };
+  }
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+function fieldOf<K extends string>(body: unknown, key: K): string | null {
+  if (typeof body !== "object" || body === null) return null;
+  const v = (body as Record<string, unknown>)[key];
+  return asString(v);
+}
+
+export async function collectSojuLens(wallet: string | null): Promise<SojuLens> {
+  if (!wallet) {
+    return {
+      wallet: null,
+      rows: [
+        {
+          surface: "(not configured)",
+          field: "displayName",
+          observed: null,
+          source: "set OPERATOR_WALLET env to enable Soju-lens",
+          error: "no wallet supplied",
+        },
+      ],
+      discrepancies: [],
+    };
+  }
+
+  const promises = [
+    safeFetchJSON(
+      `${IDENTITY_API}/v1/resolve/wallet/${wallet}`,
+      (b) => fieldOf(b, "userId") ?? fieldOf(b, "id"),
+      "Phase 1 resolve:",
+    ).then<SojuLensRow>((r) => ({
+      surface: "identity-api spine",
+      field: "userId",
+      observed: r.observed,
+      source: `/v1/resolve/wallet/${wallet.slice(0, 6)}…${wallet.slice(-4)}`,
+      error: r.error,
+    })),
+
+    safeFetchJSON(
+      `${IDENTITY_API}/v1/profile?wallet=${wallet}`,
+      (b) => fieldOf(b, "displayName") ?? fieldOf(b, "name"),
+      "Phase 2 compose:",
+    ).then<SojuLensRow>((r) => ({
+      surface: "identity-api compose",
+      field: "displayName",
+      observed: r.observed,
+      source: "/v1/profile (G-5)",
+      error: r.error,
+    })),
+
+    safeFetchJSON(
+      `${IDENTITY_API}/v1/mibera/dimensions?wallet=${wallet}`,
+      (b) => {
+        if (typeof b !== "object" || b === null) return null;
+        const s = JSON.stringify(b);
+        return s.length > 80 ? `${s.slice(0, 77)}…` : s;
+      },
+      "Phase 3 mibera-dims:",
+    ).then<SojuLensRow>((r) => ({
+      surface: "identity-api mibera-dims",
+      field: "miberaDimensions",
+      observed: r.observed,
+      source: "/v1/mibera/dimensions (G-6)",
+      error: r.error,
+    })),
+
+    safeFetchJSON(
+      `${HONEY_ROAD}/api/profile?wallet=${wallet}`,
+      (b) => fieldOf(b, "name") ?? fieldOf(b, "displayName") ?? fieldOf(b, "username"),
+      "honey-road (Alchemy):",
+    ).then<SojuLensRow>((r) => ({
+      surface: "honey-road (reads Alchemy)",
+      field: "displayName",
+      observed: r.observed,
+      source: "honey-road /api/profile",
+      error: r.error,
+    })),
+  ];
+
+  const rows = await Promise.all(promises);
+
+  // discrepancy detection: per field, surface conflicting values
+  const discrepancies: string[] = [];
+  const byField = new Map<string, SojuLensRow[]>();
+  for (const r of rows) {
+    if (!byField.has(r.field)) byField.set(r.field, []);
+    byField.get(r.field)!.push(r);
+  }
+  for (const [field, group] of byField.entries()) {
+    const observedSet = new Set(group.filter((r) => r.observed !== null).map((r) => r.observed!));
+    if (observedSet.size > 1) {
+      discrepancies.push(
+        `DISCREPANCY on \`${field}\`: ${[...observedSet].map((v) => `"${v}"`).join(" vs ")}`,
+      );
+    }
+    const errored = group.filter((r) => r.observed === null && r.error !== null);
+    if (errored.length === group.length && group.length > 0) {
+      discrepancies.push(
+        `MISSING on \`${field}\`: no surface returned a value (all ${group.length} sources errored — likely Phase 2/3 not built)`,
+      );
+    }
+  }
+
+  return { wallet, rows, discrepancies };
+}

--- a/apps/freeside-operator-dash/src/soju-lens.ts
+++ b/apps/freeside-operator-dash/src/soju-lens.ts
@@ -18,9 +18,12 @@
 
 import type { SojuLens, SojuLensRow } from "./types.js";
 
-const FETCH_TIMEOUT_MS = 6000;
+const FETCH_TIMEOUT_MS = 8000;
 const IDENTITY_API = "https://identity-api-production-317b.up.railway.app";
-const HONEY_ROAD = "https://mibera.honeyjar.xyz";
+// Canonical (NOT mibera.honeyjar.xyz which sits behind Datadome bot protection +
+// returns HTML for server-side curl). The canonical mibera.0xhoneyjar.xyz is the
+// raw Next.js app with no bot-protection layer — works for server-side probes.
+const HONEY_ROAD = "https://mibera.0xhoneyjar.xyz";
 const WORLD_SLUG = "mibera"; // THJ world slug per identity-api PRD; tested in routes.test.ts:166
 
 type FetchResult = { observed: string | null; error: string | null };
@@ -123,20 +126,75 @@ export async function collectSojuLens(wallet: string | null): Promise<SojuLens> 
       error: r.error,
     })),
 
-    safeFetchJSON(
-      `${HONEY_ROAD}/api/profile?wallet=${wallet}`,
-      (b) => fieldOf(b, "name") ?? fieldOf(b, "displayName") ?? fieldOf(b, "username"),
-      "honey-road (Alchemy):",
-    ).then<SojuLensRow>((r) => ({
-      surface: "honey-road (reads Alchemy)",
-      field: "displayName",
-      observed: r.observed,
-      source: "honey-road /api/profile",
-      error: r.error,
-    })),
+    // honey-road's actual API route (verified via mibera-honeyroad/app/api/mibera/
+    // dimensions/route.ts). Returns shape:
+    //   { source: "identity-api" | "alchemy", degraded: boolean,
+    //     degradedReasons: string[], tokens: [...], userId?: string,
+    //     primaryWallet: string }
+    // We emit 3 rows: source (the discrepancy signal — which backend honey-road
+    // actually used), userId (cross-check with identity-api spine row),
+    // degraded (boolean flag indicating why fallback may have kicked in).
+    fetch(`${HONEY_ROAD}/api/mibera/dimensions?wallet=${wallet}`, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          let body = "";
+          try { body = (await res.text()).slice(0, 100); } catch { /* noop */ }
+          return { source: null as string | null, userId: null as string | null, degraded: null as string | null, error: `HTTP ${res.status}${body ? ` — ${body}` : ""}` };
+        }
+        const ct = res.headers.get("content-type") ?? "";
+        if (!ct.includes("application/json")) {
+          return { source: null, userId: null, degraded: null, error: `non-JSON (${ct}) — bot protection? try canonical URL` };
+        }
+        const body = (await res.json().catch(() => null)) as unknown;
+        if (body === null) return { source: null, userId: null, degraded: null, error: "body unparseable" };
+        return {
+          source: fieldOf(body, "source"),
+          userId: fieldOf(body, "userId"),
+          degraded: typeof (body as { degraded?: unknown }).degraded === "boolean"
+            ? String((body as { degraded: boolean }).degraded)
+            : null,
+          error: null,
+        };
+      })
+      .catch((e) => ({
+        source: null as string | null, userId: null as string | null, degraded: null as string | null,
+        error: e instanceof Error ? e.message : String(e),
+      }))
+      .then((r) => [
+        {
+          surface: "honey-road (consumer)",
+          field: "honeyRoadSource" as const,
+          observed: r.source,
+          source: "honey-road /api/mibera/dimensions — `source` field",
+          error: r.error,
+        },
+        {
+          surface: "honey-road (consumer)",
+          field: "userId" as const,
+          observed: r.userId,
+          source: "honey-road /api/mibera/dimensions — `userId` field",
+          error: r.userId === null && !r.error ? "(undefined when source=alchemy or wallet unresolved)" : r.error,
+        },
+        {
+          surface: "honey-road (consumer)",
+          field: "degraded" as const,
+          observed: r.degraded,
+          source: "honey-road /api/mibera/dimensions — `degraded` field",
+          error: r.error,
+        },
+      ] as SojuLensRow[]),
   ];
 
-  const rows = await Promise.all(promises);
+  const resolved = await Promise.all(promises);
+  // Flatten — the honey-road probe returns an array of 3 rows; everything else
+  // returns a single row.
+  const rows: SojuLensRow[] = [];
+  for (const r of resolved) {
+    if (Array.isArray(r)) rows.push(...r);
+    else rows.push(r);
+  }
 
   // discrepancy detection: per field, surface conflicting values
   const discrepancies: string[] = [];

--- a/apps/freeside-operator-dash/src/soju-lens.ts
+++ b/apps/freeside-operator-dash/src/soju-lens.ts
@@ -21,6 +21,7 @@ import type { SojuLens, SojuLensRow } from "./types.js";
 const FETCH_TIMEOUT_MS = 6000;
 const IDENTITY_API = "https://identity-api-production-317b.up.railway.app";
 const HONEY_ROAD = "https://mibera.honeyjar.xyz";
+const WORLD_SLUG = "mibera"; // THJ world slug per identity-api PRD; tested in routes.test.ts:166
 
 type FetchResult = { observed: string | null; error: string | null };
 
@@ -93,14 +94,16 @@ export async function collectSojuLens(wallet: string | null): Promise<SojuLens> 
     })),
 
     safeFetchJSON(
-      `${IDENTITY_API}/v1/profile?wallet=${wallet}`,
+      // /v1/profile requires world + (wallet XOR userId) — schema is
+      // ProfileQuery in freeside-auth/src/api/routes/profile.ts:77.
+      `${IDENTITY_API}/v1/profile?world=${WORLD_SLUG}&wallet=${wallet}`,
       (b) => fieldOf(b, "displayName") ?? fieldOf(b, "name"),
       "Phase 2 compose:",
     ).then<SojuLensRow>((r) => ({
       surface: "identity-api compose",
       field: "displayName",
       observed: r.observed,
-      source: "/v1/profile (G-5)",
+      source: `/v1/profile?world=${WORLD_SLUG} (G-5)`,
       error: r.error,
     })),
 

--- a/apps/freeside-operator-dash/src/soju-lens.ts
+++ b/apps/freeside-operator-dash/src/soju-lens.ts
@@ -20,9 +20,9 @@ import type { SojuLens, SojuLensRow } from "./types.js";
 
 const FETCH_TIMEOUT_MS = 8000;
 const IDENTITY_API = "https://identity-api-production-317b.up.railway.app";
-// Canonical (NOT mibera.honeyjar.xyz which sits behind Datadome bot protection +
-// returns HTML for server-side curl). The canonical mibera.0xhoneyjar.xyz is the
-// raw Next.js app with no bot-protection layer — works for server-side probes.
+// Canonical mibera.0xhoneyjar.xyz — the raw Next.js app. Server-side probe-safe.
+// (NOTE: an unrelated honeyjar.xyz domain that previously appeared in cached
+// data is NOT a 0xHoneyJar property — do NOT probe or reference.)
 const HONEY_ROAD = "https://mibera.0xhoneyjar.xyz";
 const WORLD_SLUG = "mibera"; // THJ world slug per identity-api PRD; tested in routes.test.ts:166
 

--- a/apps/freeside-operator-dash/src/types.ts
+++ b/apps/freeside-operator-dash/src/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared types for the freeside operator-dash.
+ *
+ * The state shape mirrors what the registry tells us, enriched with live
+ * probe data + the Soju-lens discrepancy detection.
+ */
+
+export type RuntimeState = "deployed" | "scaffolded" | "not-built";
+
+export type RegistryCell = {
+  slug: string;
+  git_url: string;
+  beacon_url: string;
+  deployment_url: string | null;
+  visibility: "public" | "unlisted" | "internal";
+  owner: string;
+  added: string;
+  runtime_state: RuntimeState;
+  notes: string | null;
+};
+
+export type ProbeStateKind =
+  | "up"
+  | "auth-gated"
+  | "degraded"
+  | "scaffold"
+  | "down"
+  | "unreachable";
+
+export type CellProbe = {
+  slug: string;
+  url: string | null; // null when no deployment_url
+  state: ProbeStateKind;
+  statusCode: number | null;
+  latencyMs: number | null;
+  bodyExcerpt: string | null;
+  error: string | null;
+  note: string | null;
+  probedPath: string; // which path was probed (varies per cell — gateway-mismatch-aware)
+};
+
+export type IdentityApiPhase = {
+  phase: 1 | 2 | 3 | 4;
+  name: string;
+  goalIds: string[];
+  goalNotes: string[];
+  status: "deployed" | "scaffolded" | "not-built";
+  evidence: string[];
+  beadsRefs: string[];
+};
+
+export type SojuLensRow = {
+  surface: string;
+  field: "displayName" | "primaryWallet" | "miberaDimensions" | "userId";
+  observed: string | null;
+  source: string;
+  error: string | null;
+};
+
+export type SojuLens = {
+  wallet: string | null;
+  rows: SojuLensRow[];
+  discrepancies: string[]; // human-readable findings
+};
+
+export type DashState = {
+  generatedAt: string;
+  generatorVersion: string;
+  cells: RegistryCell[];
+  probes: CellProbe[];
+  identityPhases: IdentityApiPhase[];
+  sojuLens: SojuLens;
+  warnings: string[];
+};

--- a/apps/freeside-operator-dash/src/types.ts
+++ b/apps/freeside-operator-dash/src/types.ts
@@ -51,7 +51,7 @@ export type IdentityApiPhase = {
 
 export type SojuLensRow = {
   surface: string;
-  field: "displayName" | "primaryWallet" | "miberaDimensions" | "userId";
+  field: "displayName" | "primaryWallet" | "miberaDimensions" | "userId" | "honeyRoadSource" | "degraded";
   observed: string | null;
   source: string;
   error: string | null;

--- a/apps/freeside-operator-dash/tsconfig.json
+++ b/apps/freeside-operator-dash/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "noImplicitAny": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*", "bin/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/mcp-gateway/src/tenants.ts
+++ b/apps/mcp-gateway/src/tenants.ts
@@ -194,6 +194,14 @@ const RAW_TENANTS: ReadonlyArray<unknown> = [
     owner: { handle: "0xHoneyJar", contact: "https://github.com/0xHoneyJar" },
   },
   {
+    // NOTE 2026-05-25: probeTenant() in app.ts calls `${upstream}/healthz` which
+    // 404s for this tenant — score-api serves health at `/` instead, returning
+    // full status JSON: {status:"ok", db:"connected", scoring_version:"v0.7", ...}.
+    // The service IS live; the gateway probe is mis-pathed and will mark this
+    // tenant "down" despite operational state. Per-tenant `health_path` field
+    // would fix it — deferred (tracked in
+    // grimoires/loa/proposals/freeside-operator-dash-kickoff.md as the
+    // gateway-probe-mismatch follow-up).
     slug: "score",
     name: "Score Mibera",
     description:
@@ -202,7 +210,7 @@ const RAW_TENANTS: ReadonlyArray<unknown> = [
     upstream: "https://score-api-production.up.railway.app",
     auth: "api-key",
     authHeader: "X-MCP-Key",
-    documentation: "https://github.com/0xHoneyJar/score-mibera",
+    documentation: "https://github.com/0xHoneyJar/score-api",
     status: "live",
     visibility: "internal",
     access: "api-key",

--- a/grimoires/freeside-network/cluster-2026-05-25-operator-dash/README.md
+++ b/grimoires/freeside-network/cluster-2026-05-25-operator-dash/README.md
@@ -1,0 +1,81 @@
+---
+title: cluster-meta cycle — freeside-operator-dash + BERA→Soju diagnostic
+date: 2026-05-25
+cycle_type: cluster-meta (per ADR-009 §D-7)
+branch: cluster-meta/operator-dash
+pr: https://github.com/0xHoneyJar/loa-freeside/pull/223
+status: substrate landed; operator-side DNS fix pending
+constructs_invoked:
+  - gecko (BEAUVOIR) — observation + diagnose
+  - construct-freeside (KRANZ) — diagnose-site-down skill applied manually
+  - bridgebuilder — adversarial review of architecture brief
+  - construct-laboratory-substrate — operator-level lab membership (silent, no labels needed for this surface)
+---
+
+# cluster-meta cycle 2026-05-25 — operator-dash + BERA→Soju
+
+> **TL;DR.** Operator asked for an HTML dashboard to show all freeside API health + unblock BERA→Soju on Honey Road. The dashboard work was built (PR #223); the actual Soju visibility bug was a DNS-points-at-Vercel-not-Railway gap on `identity.0xhoneyjar.xyz`, discovered mid-build using the same probing patterns the dashboard would surface. The dashboard remains as durable observability substrate for next time.
+
+## Arc of the cycle
+
+| Phase | What happened |
+|---|---|
+| Frame | Operator: "embody GECKO, build operator dash, unblock Soju on Honey Road" + broad creative latitude |
+| Initial proposal | Wrote `grimoires/loa/proposals/freeside-federation-topology.md` — reasoning about where the dash should live (A: lift to freeside-registry; B: rename mcp-gateway → freeside-federation; C: tools/ ship now; D: hybrid) |
+| Bridgebuilder review | **Verdict E — drop everything**. ADR-009 (accepted 2026-05-25, three days prior to the original framing date the operator quoted) already settled topology. The naming convention `*-api` was ratified 2026-05-23 in `grimoires/loa/specs/enhance-freeside-api-surface.md`. The original proposal re-litigated decided ground. |
+| Reset | Operator: pause, ground in ADR-009, rewrite proposal, operator-review, THEN sweep → dash → /coord. Dash home = `apps/freeside-operator-dash/` sibling to `apps/mcp-gateway/` (inward vs outward facing). |
+| Fresh proposal | `grimoires/loa/proposals/freeside-operator-dash-kickoff.md` — anchored in ADR-009 §D-5/§D-7/§D-8/§D-9, bridgebuilder findings as Appendix A |
+| Execution | Branched off main (compliance-gate had merged via PR #222). Committed in order: meta work → T0 registry sweep → T1+T2 app scaffold + Soju-lens → ground-truth-fix |
+| Mid-build correction | Cockpit on `~/bonfire/identity-api-coordinator` revealed all Phase 1-4 beads closed except T4.E2E. Original framing "Phase 3 not built" was wrong — bare probes of `/v1/profile` returned 400 (missing `world` param), which I'd misread as "endpoint scaffolded, not built." With proper params, all endpoints respond correctly. |
+| Root-cause hunt | Investigated Honey Road production env (Vercel project `mibera-interface`): no `IDENTITY_API_URL` set → falls back to `PRODUCTION_BASE_URL = https://identity.0xhoneyjar.xyz`. That URL 404s. `dig` reveals CNAME → `cname.vercel-dns.com` (pointed at Vercel, not Railway). Railway-side, the identity-api service HAS `identity.0xhoneyjar.xyz` configured as a custom domain. **The DNS is the literal one-line fix.** |
+| Wrap | PR #223 opened. Memories saved (project + feedback + reference). This artifact distilled. Operator-side DNS fix pending. |
+
+## Artifacts
+
+| Path | Type |
+|---|---|
+| [PR #223](https://github.com/0xHoneyJar/loa-freeside/pull/223) | 4 commits, ~2300 LOC, branch `cluster-meta/operator-dash` |
+| `grimoires/loa/proposals/freeside-operator-dash-kickoff.md` | the canonical proposal |
+| `grimoires/loa/proposals/archive/freeside-federation-topology.md` | superseded predecessor + bridgebuilder verdict as audit trail |
+| `apps/freeside-operator-dash/` | the inward-facing Hono service (T1+T2) |
+| `tools/operator-dash/dash.ts` | v0 spike preserved as design evidence |
+| `packages/freeside-registry/registry.yaml` | T0 sweep: 8 `*-api` cells per ADR-009 D-2 + `deployment_url` + `runtime_state` + accurate notes per cell |
+| Memories (auto-memory `~/.claude/projects/.../memory/`) | `project_honey-road-vercel-config.md`, `feedback_probe-with-full-contract.md`, `project_identity-api-substrate-deployed.md`, `reference_freeside-construct-skills.md` |
+
+## Operator-side DNS runbook (the remaining work)
+
+```bash
+# 1. Get the Railway CNAME target for identity.0xhoneyjar.xyz
+#    via Railway dashboard → identity-api service → Settings → Domains →
+#    identity.0xhoneyjar.xyz → "Add DNS Record" reveals the CNAME target.
+#    (Typically a *.railway.app or *.up.railway.app host.)
+#
+# 2. In Gandi DNS for 0xhoneyjar.xyz:
+#    Replace existing CNAME identity → cname.vercel-dns.com
+#    with new CNAME identity → <railway-provided target>
+#
+# 3. Wait for propagation (~minutes to ~hours) and Railway cert provisioning.
+#
+# 4. Verify:
+curl -sI https://identity.0xhoneyjar.xyz/health  # expect 200 ok
+dig +short CNAME identity.0xhoneyjar.xyz          # expect *.railway.app
+#
+# 5. Confirm Honey Road now shows Soju (not BERA fallback) for the operator's wallet.
+#    Honey Road code already does the right thing — once the URL resolves, the
+#    HONEYROAD_PROFILE_SOURCE=identity-api default activates and the alchemy
+#    fallback path stays cold.
+```
+
+## What this cycle confirmed
+
+1. **The cluster-meta cycle type works** (per ADR-009 §D-7). This is the second cluster-meta cycle (after `cluster-harness-audit-2026-05-25/`); the pattern of dedicated branch + distill-artifact + memory promotion holds.
+2. **Bridgebuilder review is high-leverage at the proposal stage.** Verdict E saved ~3-4 hours of work that would have gone into the wrong topology.
+3. **The Soju-lens primitive (parallel-fetch + discrepancy detection across surfaces) is the right operator-dash design** — it would have surfaced the IDENTITY_API_URL gap in one screen, even though manual probing also got there. Future bugs of this shape will be N× faster to diagnose with it.
+4. **Probe-with-full-contract is now operator-validated rule** (memory `feedback_probe-with-full-contract.md`). Today's miss is tomorrow's reflex.
+
+## Composes / supersedes
+
+- Composes with: [`enhance-freeside-api-surface.md`](../../loa/specs/enhance-freeside-api-surface.md) — this cycle ships the deferred operator-visibility follow-up
+- Composes with: ADR-009 §D-5 (federation discovery in network scope), §D-7 (cluster-meta cycle type), §D-9 (two-persona model — this serves the internal operator persona)
+- Supersedes for forward-looking work: `project_identity-api-phase1-complete.md` memory framing (Phase 1 only deployed) — replaced by `project_identity-api-substrate-deployed.md` (Phases 1-4 all deployed)
+- Does NOT supersede: `enhance-freeside-api-surface.md` T1/T2 (beacon authoring + federation server lift remain follow-up work — separate from this cycle)

--- a/grimoires/loa/proposals/archive/freeside-federation-topology.md
+++ b/grimoires/loa/proposals/archive/freeside-federation-topology.md
@@ -1,0 +1,106 @@
+---
+title: freeside-federation topology — where the operator dashboard lives [SUPERSEDED]
+status: superseded
+superseded_by: grimoires/loa/proposals/freeside-operator-dash-kickoff.md
+superseded_reason: |
+  Adversarial review (2026-05-25) caught: this proposal was reasoning about a
+  topology that ADR-009 (decisions/009-freeside-hexagonal-federation.md,
+  Accepted 2026-05-25) had already settled THREE DAYS PRIOR. Options A vs B
+  were re-litigated; the actual decision (registry + gateway as SEPARATE
+  network-scope components per D-5) was already in canon. Naming was also
+  stale by 48 hours — *-api convention ratified 2026-05-23 in
+  grimoires/loa/specs/enhance-freeside-api-surface.md.
+
+  Retained as audit trail / bridgebuilder review evidence; do NOT use as
+  guidance for any new work.
+date: 2026-05-25
+author: soju (via GECKO-embodied claude)
+review_requested: bridgebuilder / adversarial multi-model
+review_outcome: bridgebuilder verdict E (drop everything in the proposal; do the smaller correct thing)
+related:
+  - decisions/007-loa-freeside-absorption.md (ADR-007 — BINDING)
+  - decisions/008-freeside-as-factory.md (ADR-008 — ORIENTATION)
+  - decisions/009-freeside-hexagonal-federation.md (ADR-009 — SETTLES TOPOLOGY; missed by this proposal)
+  - packages/freeside-registry/README.md (scaffold)
+  - apps/mcp-gateway/src/app.ts (working federation server)
+goals_original:
+  - G-OPS-1: operator can see freeside-* API health in one pane
+  - G-OPS-2: naming reflects internal-API-first reality (MCP is future capability, not present need)
+  - G-OPS-3: don't ship a name we'll regret when MCP federation becomes real
+---
+
+> ⚠ **THIS PROPOSAL IS SUPERSEDED.** See [`freeside-operator-dash-kickoff.md`](../freeside-operator-dash-kickoff.md) for current direction. Retained in archive as bridgebuilder-review audit trail.
+
+# freeside-federation topology
+
+## Pushback (the thing to doubt first)
+
+**The whole question might be premature.** `tools/operator-dash/` as static HTML + a Node probe script ships visibility TODAY without committing to a topology. The federation-vs-registry-vs-mcp naming question can wait until the dash is in operator hands and the FAANG-shape requirements (multi-team, multi-environment, alarm routing) actually surface. **Naming optimization in advance of usage is YAGNI.** Counter-argument: the operator named the question explicitly and asked for adversarial review — that itself is signal that the substrate question matters now.
+
+## The problem in one line
+
+`apps/mcp-gateway/` is doing two jobs (MCP protocol routing + internal API registry/health) under an MCP-flavored name. `packages/freeside-registry/` was meant to be the registry but is scaffold-only. The operator (small team, FAANG-pattern) needs one pane to monitor all freeside-* API health, and the name shouldn't pre-commit to MCP-as-the-only-protocol.
+
+## Current state (verified)
+
+| Component | Path | Status | What it does |
+|---|---|---|---|
+| `packages/freeside-registry/` | scaffold | README + `registry.yaml` (6 modules) + empty src | Planned per ADR-007 §D-5 to serve `/.well-known/federation.json`. Not implemented. (Note: `packages/freeside-registry/README.md` omits the `.well-known` prefix — drift vs the actual implemented path in `apps/mcp-gateway/src/app.ts:12`; sweep target.) |
+| `apps/mcp-gateway/` | running | Hono service, full federation manifest + 30s tenant probing + 5min beacon refresh + path-routing | The actual working federation logic, MCP-named. Tenants.ts comment: "the gateway IS a registry, not a vault." |
+| `packages/beacon-schema/` | working | BeaconV3 schema | Self-declaration contract. |
+| `mcp.0xhoneyjar.xyz` domain | reserved | MCP-flavored URL | Pre-commits to MCP-as-the-only-protocol. |
+| `identity-api` (Railway) | live | Phase 1 deployed, Phase 2-4 not built | NOT registered in `registry.yaml` yet. |
+| operator dashboard | doesn't exist | — | The ask. |
+
+## Decision space
+
+### Option A — Lift-and-shift: `freeside-registry` absorbs federation logic, `mcp-gateway` becomes one consumer
+
+Pull the federation-server logic out of `apps/mcp-gateway/src/app.ts` and into `packages/freeside-registry/src/server.ts` (per ADR-007 §D-5 planned shape). Then:
+- `packages/freeside-registry/` = the registry service (serves `/.well-known/federation.json`, hosts the operator dash at `/operator/`, runs probes)
+- `apps/mcp-gateway/` = MCP-protocol-specific consumer (path routing `/{tenant}/mcp/*` only)
+- Operator dash served at `federation.0xhoneyjar.xyz/operator/` (new subdomain, OR at `0xhoneyjar.xyz/operator/`)
+
+**Pro**: matches ADR-007 plan exactly; clean separation; MCP is one consumer of registry not the registry itself; namespace honest (registry ≠ MCP).
+**Con**: real refactor work (move ~600 lines, rewire imports, redeploy gateway, possibly second Railway service); time-to-dash extends.
+
+### Option B — Rename in place: `apps/mcp-gateway/` → `apps/freeside-federation/`, dash co-located
+
+Rename the directory, the package name (`@0xhoneyjar/freeside-mcp-gateway` → `@0xhoneyjar/freeside-federation`), the domain (`mcp.0xhoneyjar.xyz` → `federation.0xhoneyjar.xyz`). Add `/operator` HTML route. Keep `/{tenant}/mcp/*` paths as one of N protocol surfaces inside the federation app.
+
+**Pro**: no logic moves; the existing federation logic stays where it already works; one service deployed; rename reflects reality (internal API registry, MCP is one path-prefix family).
+**Con**: rename touches DNS, package deps, workspace refs, deployment configs; some MCP-aware downstream consumers may break; doesn't fix the `freeside-registry/` scaffold (it stays empty).
+
+### Option C — Ship tools/, defer topology (RECOMMENDED FOR THIS SESSION)
+
+Build `tools/operator-dash/` as a static HTML + Node probe script. Lives in repo, runs locally, opens in browser. Zero infra. Zero topology commitment. Use this session to **ship visibility**. Surface the lift/rename question as a follow-up sprint with proper SDD/sprint-plan.
+
+**Pro**: ships today; reversible; operator gets visibility immediately; topology can be decided when the dash's actual needs are clearer (does it need live updates? auth? multi-tenant scoping? — answers emerge from use).
+**Con**: doesn't formalize the federation surface; doesn't honor the ADR-007 plan; tools/ is the orphans-shelf and dashes there can rot.
+
+### Option D — Hybrid: tools/ dash now, BUT name the topology decision a P0 follow-up
+
+Same as C operationally, but commit to a hard deadline (e.g., next sprint cycle) to resolve A vs B with full SDD. Dash lives in tools/ for ≤2 weeks, then migrates to its decided home.
+
+**Pro**: ships fast, doesn't kick the can; forces the operator to make the topology call with the dash already informing it.
+**Con**: requires discipline to actually run the follow-up sprint.
+
+## What I'd doubt (operator-friendly self-audit)
+
+1. **"FAANG pattern" might be wrong frame for current state.** FAANG operates 10k+ services. THJ operates ~7 freeside-* buildings (most not deployed). The dash needs match the team size (operator + a few collaborators), not the eventual scale. Designing for 10k-service operator concerns now = premature scaling.
+2. **Registry vs federation might be the same word for two layers.** registry = list of buildings. federation = the runtime that exposes them. Lifting one out of the other is correct IF both layers warrant separate code paths. They might not yet.
+3. **Operator's MCP-as-future framing assumes MCP becomes external.** If MCP stays internal (claude-code tools for the team), then `mcp.0xhoneyjar.xyz` is fine as an internal subdomain and the rename is cosmetic. If MCP becomes a partner-facing surface (other agents consume our APIs via MCP), then the federation/MCP separation is load-bearing.
+4. **`identity-api` not being in `registry.yaml`** is a real defect. Whatever topology wins, that must land. The dash will surface this as an immediate red row.
+
+## Recommendation
+
+**Option C for THIS session. Option D as the operator-confirmed path forward.**
+
+Build `tools/operator-dash/` now. Add `identity-api` to `registry.yaml` as a small inline fix while we're here. Open a P0 follow-up issue (or beads epic) to formally resolve A vs B in the next cycle, gated by adversarial review of this brief.
+
+## What I haven't grounded yet
+
+- Whether `mcp.0xhoneyjar.xyz` has external-partner traffic (would change rename cost calculus)
+- What's actually deployed at the freeside-* subdomains (sonar / storage / mint / activities / inventory) — registry.yaml lists URLs but they may 404
+- Operator's actual on-call cadence (does the dash need alerting? paging? or just at-a-glance?)
+- Whether `score-mibera` (live, registered) needs special tiering vs the not-yet-deployed buildings

--- a/grimoires/loa/proposals/freeside-operator-dash-kickoff.md
+++ b/grimoires/loa/proposals/freeside-operator-dash-kickoff.md
@@ -1,0 +1,198 @@
+---
+title: freeside-operator-dash — inward-facing operator visibility, cluster-meta cycle
+status: proposed
+date: 2026-05-25
+author: soju (via GECKO-embodied claude)
+review_requested: operator (zerkereth)
+review_kind: synchronous-pair-point (not flatline; operator IS the reviewer per 2026-05-25 session)
+anchors:
+  - decisions/009-freeside-hexagonal-federation.md (ADR-009 D-5 federation discovery · D-7 cluster-meta cycle · D-8 dashboard composition · D-9 two-persona internal scope · D-13 cluster compliance predicate)
+  - grimoires/loa/specs/enhance-freeside-api-surface.md (2026-05-23 kickoff that EXPLICITLY DEFERRED this dashboard as "operator-visibility surface from session 1 — a separate follow-up")
+  - grimoires/freeside-network/cluster-harness-audit-2026-05-25/ (adjacent cluster-meta work; this proposal is its sibling)
+  - grimoires/loa/proposals/archive/freeside-federation-topology.md (superseded predecessor + bridgebuilder verdict, retained as audit trail)
+supersedes: grimoires/loa/proposals/freeside-federation-topology.md
+domain: network
+cycle_anchor: grimoires/freeside-network/cluster-2026-05-25-operator-dash/ (to be created)
+branch: cluster-meta/operator-dash (new, NOT piggybacking on cluster-meta/compliance-gate)
+---
+
+# freeside-operator-dash — kickoff
+
+> Build the **inward-facing operator visibility surface** the THJ team needs to operate the
+> 8-cell HEXAGONAL FEDERATION as a small team. Lives at `apps/freeside-operator-dash/`,
+> sibling to `apps/mcp-gateway/`. Outward-facing federation discovery (mcp-gateway) and
+> inward-facing operator awareness (this) are two apps with two audiences in the same
+> network scope per [ADR-009 §D-5](../../../decisions/009-freeside-hexagonal-federation.md).
+
+**Date**: 2026-05-25 · **Target**: `loa-freeside` (network scope) · **Cycle type**: cluster-meta per ADR-009 §D-7
+
+## Context
+
+This is the deferred follow-up from `enhance-freeside-api-surface.md` (2026-05-23, §"What NOT to build"):
+
+> *Do NOT build a registry UI / "factory floor" dashboard here (that's the **operator-visibility surface from session 1 — a separate follow-up**; T2 is machine/runtime).*
+
+ADR-009 (2026-05-25) ratified:
+- **D-5**: federation discovery (registry + tenants + schema + cli) lives in network scope of loa-freeside
+- **D-7**: cluster-meta cycle type runs from `grimoires/freeside-network/cluster-*`
+- **D-8**: the *marketplace* dashboard (Freeside Dashboard, currently `score-dashboard` with `(cm-shell)` layout) serves external CMs — that's a DIFFERENT surface, lives in its own repo
+- **D-9**: two-persona product model — external CM (community managers) vs **internal operator (THJ team)**. This dashboard serves the INTERNAL operator persona only.
+- **D-13**: cluster compliance predicate already runs via `cluster-compliance.yml` workflow — this dash makes the predicate's findings legible
+
+The bridgebuilder adversarial review of the predecessor proposal (archived) caught critical drift:
+- F3: every `*.0xhoneyjar.xyz/.well-known/beacon.json` returns Vercel 404 today (gateway HTML serves a list of dead URLs)
+- F2: `*-api` rename sweep is overdue (8 cells per D-2: `sonar-api · storage-api · mint-api · activities-api · inventory-api · score-api · identity-api · mediums-api`)
+- F3: `apps/mcp-gateway/src/tenants.ts` declares `score: status: "live"` but `score-api-production.up.railway.app/healthz` returns 404
+- F5: this dashboard belongs in cluster-meta scope — you're already on `cluster-meta/compliance-gate` branch
+
+Full bridgebuilder findings: see **Appendix A** below.
+
+## Headline decision — inward vs outward, two apps in network scope
+
+| App | Audience | Purpose | Visibility |
+|---|---|---|---|
+| `apps/mcp-gateway/` (exists) | External partners + agent clients | Federation discovery + MCP path-routing for `*-api` cells | Public — `mcp.0xhoneyjar.xyz` |
+| `apps/freeside-operator-dash/` (THIS) | THJ team (internal-operator persona per ADR-009 D-9) | Cluster health + Soju-lens identity reconciliation + compliance-predicate visualization | Internal-only — auth-gated, allowlisted THJ wallets |
+
+The two are sibling apps. Both load from the same SOURCE OF TRUTH (`packages/freeside-registry/registry.yaml` + `apps/mcp-gateway/src/tenants.ts`) but RENDER to different audiences. mcp-gateway exposes the federation; freeside-operator-dash exposes operator awareness over the federation.
+
+## Tracks
+
+### T0 — Naming sweep + lie correction (PRE-REQUISITE, ships first)
+
+**Goal**: registry + tenants in compliance with ADR-009 D-2 before the dash renders anything.
+
+- Rename `packages/freeside-registry/registry.yaml` entries to `*-api` convention (6 modules → 8 modules; add `identity-api`, add `mediums-api`)
+- Update `apps/mcp-gateway/src/tenants.ts`: kill the `score: status: "live"` lie (mark `paused` until score-api-production is reachable OR remove until live); audit `codex` similarly
+- Update `packages/freeside-registry/README.md` to use `/.well-known/federation.json` (drift fixed in this PR; was missing the `.well-known` prefix)
+- Validate via `loa freeside doctor` (stub today; may need real implementation per T2 of enhance-freeside-api-surface)
+
+**Blast radius**: network-scope only (`packages/freeside-registry/` + `apps/mcp-gateway/` + 1 README). CI firewall keeps it clean.
+**Estimated effort**: 1-2 hours (15-min PR per bridgebuilder, plus tenant lie reconciliation).
+
+### T1 — `apps/freeside-operator-dash/` scaffold
+
+**Goal**: Hono service mirroring `apps/mcp-gateway/` shape, sibling deployment slot.
+
+- `apps/freeside-operator-dash/` with same structure as `apps/mcp-gateway/`: `bin/http.ts`, `src/app.ts`, `package.json`, `tsconfig.json`
+- Effect.Schema for any wire-shape; vendor BeaconV3 schema from `packages/beacon-schema/`
+- Reads `packages/freeside-registry/registry.yaml` + `apps/mcp-gateway/src/tenants.ts` server-side (no fetch overhead; in-process import)
+- Two routes initially:
+  - `GET /` → HTML dashboard (rendered from in-process state)
+  - `GET /healthz` → `{ ok: true, generatedAt }` for its own health probe
+- Auth: deferred to T4. For v0.1, run behind operator's Tailscale or with a simple `OPERATOR_TOKEN` env (do NOT ship public yet).
+- Deploy slot: separate Railway service `freeside-operator-dash-production` (or co-located with mcp-gateway if cheaper).
+
+**Blast radius**: new app in network scope. No existing service modified.
+
+### T2 — Soju-lens (the actually-novel primitive, ships v0.1)
+
+**Goal**: parallel-fetch the operator's identity through every surface that exposes one, surface DISCREPANCIES not just status.
+
+Concrete:
+- Input: an operator wallet (env var `OPERATOR_WALLET` or query param)
+- Probes in parallel (Promise.allSettled):
+  - `identity-api /v1/resolve/wallet/:address` (Phase 1 spine, deployed)
+  - `identity-api /v1/profile?wallet=` (Phase 2 compose — currently 400, will show "Phase 2 not built")
+  - `identity-api /v1/mibera/dimensions?wallet=` (Phase 3 — currently 400, will show "Phase 3 not built")
+  - `mibera.honeyjar.xyz /api/profile?wallet=` (honey-road, currently reads from Alchemy)
+  - `score-api /v1/holder/:address/score` (when score-api becomes reachable per T0)
+  - `inventory-api /v1/inventory/wallet/:address` (when published per registry.yaml)
+- Output: discrepancy table — same field (displayName, primaryWallet, miberaDimensions) across surfaces; flag if values disagree or all-error.
+- The G-6 blocker becomes IMMEDIATELY visible: "honey-road shows Alchemy fallback; identity-api compose endpoint is 400."
+
+This is the actually-novel observability primitive. Status display is solved (Datadog, BetterStack, ohdear); cross-surface identity reconciliation isn't.
+
+### T3 — Cluster compliance + tile view (secondary)
+
+**Goal**: render `cluster-compliance.yml` workflow output + per-cell beacon state + Loa harness audit.
+
+- Pull latest run of `cluster-compliance.yml` via `gh run list --workflow=cluster-compliance.yml --limit=1 --json` (server-side, with token)
+- For each cell in registry.yaml: tile shows compliance predicate (1-7 from ADR-009 D-13), beacon state (live / 404 / not-registered), last deploy timestamp
+- Phase scoreboard for `identity-api` specifically (G-1..G-6 with live evidence) — extends as more cells reach runtime
+
+### T4 — Auth + Privy integration (per ADR-009 D-9 internal operator persona)
+
+**Goal**: ship publicly with auth (after v0.1 is in operator hands and shape is proven).
+
+- Privy JWT verification, allowlist `role: cm-internal` per ADR-009 D-9
+- Until identity-api JWT issuance for CMs lands, use Privy with small THJ-team wallet allowlist (per D-9 fallback)
+- This unblocks deploying at `operator.freeside.0xhoneyjar.xyz` or similar (TBD)
+
+## Blast radius summary
+
+| Track | Files / Repos | Risk |
+|---|---|---|
+| T0 | `packages/freeside-registry/registry.yaml` + `apps/mcp-gateway/src/tenants.ts` + 1 README | Low (naming, no logic change). Network-scope CI gate passes. |
+| T1 | New `apps/freeside-operator-dash/` (~5-10 files) | Low (new app, no existing surface modified). New Railway slot. |
+| T2 | Within T1 — adds probe + render logic | Medium (depends on external surfaces being reachable; degraded behavior must be obvious). |
+| T3 | Within T1 — adds gh CLI invocation | Low (read-only; needs GITHUB_TOKEN). |
+| T4 | T1 + Privy SDK integration | Medium (auth bugs are real; allowlist mitigates blast). |
+
+## Design rules
+
+- **Soju-lens IS the dash's first job.** Status is secondary; discrepancy is the primitive nobody else ships.
+- **Two apps, two audiences.** `apps/mcp-gateway/` outward, `apps/freeside-operator-dash/` inward. Don't merge them. Don't rename `mcp-gateway` (cached discovery cards downstream break per bridgebuilder F4).
+- **Read SOURCE OF TRUTH server-side.** No browser fetch from registry.yaml / tenants.ts. CORS-free design.
+- **Degraded behavior must be obvious.** A 400 from `/v1/profile` should display "Phase 2 not built" not just "error." A 404 beacon should display "registered but not deployed" with link to deploy runbook.
+- **Cluster-meta cycle owns the work.** Cycle anchor at `grimoires/freeside-network/cluster-2026-05-25-operator-dash/`; branch `cluster-meta/operator-dash` (separate from `cluster-meta/compliance-gate` currently in-flight).
+- **No commitment beyond v0.1 without operator review.** Each Track ships, surfaces to operator, awaits direction before next.
+
+## What NOT to build (scope discipline)
+
+- NOT the marketplace UI for external CMs — that's `score-dashboard` per ADR-009 D-8, different audience, different repo
+- NOT a rename of `apps/mcp-gateway/` → `apps/freeside-federation/` — bridgebuilder F4 (real contract break: 7 in-repo files hardcode mcp.0xhoneyjar.xyz, plus every cached MCP discovery card downstream). Defer indefinitely.
+- NOT multi-tenant operator scoping — single THJ-team operator persona only for v0.1-v1.0
+- NOT a registry UI for editing — registry.yaml mutations stay PR-driven per ADR-009 D-14
+- NOT a replacement for Grafana / CloudWatch — the dash is OPERATOR-CONTEXT awareness, not infrastructure metrics
+- NOT mid-stage startup / FAANG-Borgmon-shape — the right reference frame is Stripe/Linear-shape dense, action-oriented, single-page (per bridgebuilder F7)
+
+## Verify
+
+- T0 PR: `cluster-compliance.yml` workflow passes against new registry; `loa freeside doctor` (when implemented) recognizes 8 cells
+- T1 ship: `curl localhost:3030/healthz` returns 200; `curl localhost:3030/` returns valid HTML; deploys to Railway slot
+- T2 ship: with `OPERATOR_WALLET` set, dashboard surfaces the BERA→Soju discrepancy as a visual diff row; operator confirms by visual inspection
+- T3 ship: tile grid renders 8 cells with current compliance status; `identity-api` phase scoreboard shows live Phase 1 / scaffolded Phase 2-3 / not-built Phase 4
+- T4 ship: Privy auth blocks non-allowlisted wallets; `cm-internal` role required
+
+## /coord dispatch plan (once this proposal is operator-approved)
+
+- **Sweep coordinator**: throwaway at `~/bonfire/operator-dash-coordinator/`, single-repo target (this repo, cluster-meta/operator-dash branch). T0 lands as one PR.
+- **Phase 3 coordinator** (separate, parallel-eligible): throwaway at `~/bonfire/identity-api-phase3-coordinator/`, dispatches to `identity-api` repo (T3.1, T3.2) + `mibera-honeyroad` repo (T3.3). The Soju G-6 blocker unblock — runs INDEPENDENT of this dashboard work.
+- Dashboard build (T1-T3) runs in main session (this branch); T4 deferred.
+
+## Reviewer ask (operator)
+
+1. Is the inward/outward two-apps framing correct? (Anything I'm missing that argues for merging or splitting differently?)
+2. Soju-lens as the primary v0.1 feature — confirm or redirect.
+3. Branch `cluster-meta/operator-dash` — confirm separate from `cluster-meta/compliance-gate` in-flight work.
+4. T0 sweep — does it ship as a SEPARATE PR before T1 starts, or bundle T0+T1 into one PR?
+5. T4 auth deferral — comfortable with v0.1 behind Tailscale / `OPERATOR_TOKEN` env, or want Privy from day 1?
+6. /coord parallelism — sweep coord first (serial) THEN Phase 3 coord, OR both in parallel?
+
+---
+
+## Appendix A — Bridgebuilder verdict (2026-05-25, archived predecessor)
+
+Adversarial review caught 6 findings against `grimoires/loa/proposals/archive/freeside-federation-topology.md`:
+
+| # | Severity | Finding (one-line) |
+|---|---|---|
+| F1 | CRITICAL | ADR-009 already settled the topology 3 days prior; proposal re-litigated decided ground |
+| F2 | CRITICAL | `*-api` naming ratified 2026-05-23; proposal used stale `freeside-*` names |
+| F3 | HIGH | Every `*.0xhoneyjar.xyz/.well-known/beacon.json` returns Vercel 404 today; `tenants.ts` declares `score: status: "live"` but upstream 404 |
+| F4 | HIGH | `mcp.*` → `federation.*` rename is real contract break (7 in-repo files + cached MCP discovery cards downstream) |
+| F5 | HIGH | Operator-visibility belongs in cluster-meta scope (operator already on `cluster-meta/compliance-gate` branch) |
+| F6 | MED | Soju-lens (discrepancy detection) is the actually-novel primitive — should be the lede, not the closing aside |
+
+Verdict: Option E — "drop everything in the proposal; do the smaller correct thing." This proposal (the present document) IS that smaller correct thing.
+
+## Appendix B — v0 spike reference
+
+`tools/operator-dash/dash.ts` (created 2026-05-25, pre-bridgebuilder) holds the design direction for the eventual `apps/freeside-operator-dash/src/app.ts` rebuild:
+- Server-side probe orchestration (Promise.all over targets)
+- Soju-lens implementation (parallel-fetch + discrepancy detection)
+- HTML render with phase scoreboard + federation tiles + Soju-lens table
+- Known issues: missing `yaml` dependency; uses pre-rename `freeside-*` names; lives in `tools/` (wrong per F5)
+
+The spike is preserved (marked v0-superseded) as design evidence. v1 rebuild starts fresh in `apps/freeside-operator-dash/` per T1.

--- a/packages/freeside-registry/README.md
+++ b/packages/freeside-registry/README.md
@@ -2,7 +2,7 @@
 
 **Package**: `@freeside/freeside-registry` · **Domain**: network · **Status**: scaffold
 
-Beacon aggregator + federation manifest server for the `freeside-*` module network. Maintains `registry.yaml` (the L1 source-of-truth list of registered modules) and exposes `/federation.json` (the L5 ambient-discovery endpoint).
+Beacon aggregator + federation manifest server for the `*-api` cell network (per [ADR-009 §D-2](../../decisions/009-freeside-hexagonal-federation.md)). Maintains `registry.yaml` (the L1 source-of-truth list of registered cells) and (planned) exposes `/.well-known/federation.json` (the L5 ambient-discovery endpoint). Today the federation-manifest serving lives in `apps/mcp-gateway/src/app.ts`; the planned shape below relocates it here per ADR-007 §D-5.
 
 ## Planned shape
 
@@ -10,10 +10,10 @@ Per [ADR-007 §D-5 + D-8](../../decisions/007-loa-freeside-absorption.md):
 
 ```
 packages/freeside-registry/
-├── registry.yaml                # canonical module list (parallels loa-constructs/registry.yaml)
+├── registry.yaml                # canonical cell list (parallels loa-constructs/registry.yaml)
 ├── src/
-│   ├── server.ts                # HTTP server exposing /federation.json + /federation/{tenant}.json
-│   ├── aggregator.ts            # fetches each module's /.well-known/beacon.json (5min refresh)
+│   ├── server.ts                # HTTP server exposing /.well-known/federation.json + per-tenant authenticated manifest routes
+│   ├── aggregator.ts            # fetches each cell's /.well-known/beacon.json (5min refresh)
 │   ├── visibility.ts            # public / unlisted / internal filtering per D-8
 │   ├── redaction.ts             # redaction rules per D-8 (owner.email, pricing URLs, internal hostnames)
 │   └── cache.ts                 # per-tenant cache partitioning per D-8
@@ -24,7 +24,7 @@ packages/freeside-registry/
 
 ## Visibility model (D-8)
 
-| `beacon.visibility` | Public `/federation.json` | Authenticated `/federation/{tenant}.json` | MCP `inspectModule(<slug>)` |
+| `beacon.visibility` | Public `/.well-known/federation.json` | Authenticated per-tenant manifest | MCP `inspectModule(<slug>)` |
 |---------------------|---|---|---|
 | `public` | YES | YES | YES |
 | `unlisted` | NO | YES (if tenant has access) | YES (if tenant has access) |
@@ -34,21 +34,27 @@ Authentication required for non-public paths. See ADR-007 §D-8 for full threat 
 
 ## Registry schema
 
-`registry.yaml` mirrors `loa-constructs/registry.yaml` shape:
+`registry.yaml` mirrors `loa-constructs/registry.yaml` shape, with the `*-api` slug convention per [ADR-009 §D-2](../../decisions/009-freeside-hexagonal-federation.md) and additional fields `deployment_url` + `runtime_state` for operator-truth marking:
 
 ```yaml
 version: 1
 modules:
-  freeside-storage:
-    git_url: https://github.com/0xHoneyJar/freeside-storage.git
-    beacon_url: https://storage.freeside.0xhoneyjar.xyz/.well-known/beacon.json
+  storage-api:
+    git_url: https://github.com/0xHoneyJar/storage-api.git
+    beacon_url: https://storage.0xhoneyjar.xyz/.well-known/beacon.json
+    deployment_url: https://storage-api-production.up.railway.app
     visibility: public
+    owner: 0xHoneyJar
+    added: "2026-05-18"
+    runtime_state: deployed
+    notes: |
+      Free-form: deploy quirks, rename-pending, health-path mismatches, etc.
   # ...
 ```
 
 ## What lives here
 
-Currently: this README. Module scaffolding lands in subsequent ADR-007 §Implementation steps (workspace creation is step 3; this README is part of step 3; functional code is steps 6-7).
+Currently: this README + the `registry.yaml` cell index. Module scaffolding (`src/server.ts`, `src/aggregator.ts`, etc.) lands in subsequent ADR-007 §Implementation steps. The federation-manifest serving today lives in `apps/mcp-gateway/src/app.ts` — relocation to `packages/freeside-registry/src/server.ts` is the planned ADR-007 §D-5 shape.
 
 ## Domain boundary
 

--- a/packages/freeside-registry/registry.yaml
+++ b/packages/freeside-registry/registry.yaml
@@ -1,64 +1,165 @@
 # Freeside Module Registry — L1 canonical source-of-truth
 #
-# Mirrors loa-constructs/registry.yaml shape. Each entry registers a
-# freeside-* module for the federation manifest at /federation.json.
+# 8 canonical cells per ADR-009 §D-2 (decisions/009-freeside-hexagonal-federation.md):
+# sonar-api, storage-api, mint-api, activities-api, inventory-api, score-api,
+# identity-api, mediums-api. Naming convention *-api ratified 2026-05-23 in
+# grimoires/loa/specs/enhance-freeside-api-surface.md.
 #
 # Schema:
 #   version: integer
 #   modules:
 #     <module-slug>:
-#       git_url: string          # canonical source repo
-#       beacon_url: string       # where to fetch the module's beacon.json
-#       visibility: enum         # public | unlisted | internal (per ADR-007 §D-8)
-#       owner: string            # GitHub handle or org
+#       git_url: string             # canonical source repo
+#       beacon_url: string          # planned beacon serving endpoint (may 404 today)
+#       deployment_url: string|~    # actual current runtime URL (Railway etc.) — null if not deployed
+#       visibility: enum            # public | unlisted | internal (per ADR-007 §D-8)
+#       owner: string               # GitHub handle or org
 #       added: ISO-8601 date
+#       runtime_state: enum         # deployed | scaffolded | not-built
+#       notes: string               # free-form (deploy quirks, health-path mismatches, etc.)
 #
 # Reference: decisions/007-loa-freeside-absorption.md §D-1 (L1 Module Registry)
+#            decisions/009-freeside-hexagonal-federation.md §D-2 (cells canonical list)
+#
+# Live-probe state (2026-05-25):
+#   DEPLOYED at Railway: sonar-api, score-api, storage-api, inventory-api (auth-gated MCP), identity-api
+#   NOT-BUILT runtime:   mint-api, activities-api, mediums-api (npm libraries only, no HTTP runtime)
+#
+# Subdomain *.0xhoneyjar.xyz beacon endpoints currently 404 for ALL cells — DNS not yet
+# pointed at deployed Railway URLs, and beacon-serving routes not yet implemented in cells.
+# This is the federation-discovery gap (the awareness surface from
+# grimoires/loa/specs/enhance-freeside-api-surface.md T1/T2 follow-up).
 
 version: 1
 
 modules:
-  # ─── Production substrate modules ────────────────────────────────────────
-  freeside-sonar:
-    git_url: https://github.com/0xHoneyJar/freeside-sonar.git
-    beacon_url: https://sonar.0xhoneyjar.xyz/.well-known/beacon.json
-    visibility: public
-    owner: 0xHoneyJar
-    added: "2026-05-18"
+  # ─── Alphabetical by canonical *-api slug ────────────────────────────────
 
-  freeside-storage:
-    git_url: https://github.com/0xHoneyJar/freeside-storage.git
-    beacon_url: https://storage.0xhoneyjar.xyz/.well-known/beacon.json
-    visibility: public
-    owner: 0xHoneyJar
-    added: "2026-05-18"
-
-  freeside-mint:
-    git_url: https://github.com/0xHoneyJar/freeside-mint.git
-    beacon_url: https://mint.0xhoneyjar.xyz/.well-known/beacon.json
-    visibility: public
-    owner: 0xHoneyJar
-    added: "2026-05-18"
-
-  freeside-activities:
-    git_url: https://github.com/0xHoneyJar/freeside-activities.git
+  activities-api:
+    git_url: https://github.com/0xHoneyJar/activities-api.git
     beacon_url: https://activities.0xhoneyjar.xyz/.well-known/beacon.json
+    deployment_url: ~
     visibility: public
     owner: 0xHoneyJar
     added: "2026-05-18"
+    runtime_state: not-built
+    notes: |
+      Unified Activity supertype substrate (quest/mission/badge/raffle).
+      Shipped as npm library (648 tests per kickoff spec); no HTTP runtime
+      deployed. activities-{api,mcp,}-production.up.railway.app all 404 as
+      of 2026-05-25.
 
-  # ─── Candidate / in-flight modules ───────────────────────────────────────
-  freeside-inventory:
-    git_url: https://github.com/0xHoneyJar/freeside-inventory.git
+  identity-api:
+    git_url: https://github.com/0xHoneyJar/identity-api.git
+    beacon_url: https://identity.0xhoneyjar.xyz/.well-known/beacon.json
+    deployment_url: https://identity-api-production-317b.up.railway.app
+    visibility: public
+    owner: 0xHoneyJar
+    added: "2026-05-25"
+    runtime_state: deployed
+    notes: |
+      Central identity SoR (Phase 1 BUILT + DEPLOYED 2026-05-25 to Railway).
+      Custom domain identity.0xhoneyjar.xyz queued behind DNS — beacon_url
+      anticipates that. Spine empty until Phase 4 T4.4 backfill (arrakis-494b).
+      Phase 2 (compose, /v1/profile) + Phase 3 (mibera dims,
+      /v1/mibera/dimensions) endpoints scaffolded but NOT built — both return
+      400 today. /health is the canonical liveness path.
+      NOTE: a separate identity-production.up.railway.app exists serving a Login
+      page (Bootstrap HTML); that is NOT this service — likely an older
+      freeside-identity / Sietch surface. Canonical URL is the 317b one above.
+      Beads coordinator: ~/bonfire/identity-api-coordinator/
+
+  inventory-api:
+    git_url: https://github.com/0xHoneyJar/inventory-api.git
     beacon_url: https://inventory.0xhoneyjar.xyz/.well-known/beacon.json
-    visibility: public
+    deployment_url: https://inventory-mcp-production.up.railway.app
+    visibility: internal
     owner: 0xHoneyJar
     added: "2026-05-18"
+    runtime_state: deployed
+    notes: |
+      sonar⨝codex inventory/collections read API + ACVP completeness.
+      Deployed as MCP server at inventory-mcp-production.up.railway.app (returns
+      401 — auth-gated, requires API key). Per memory the inventory-api npm
+      library has live read counts; the MCP server is the federation-facing
+      shape. visibility: internal because of the auth gate.
 
-  # ─── Score (registered but lives in score-mibera repo) ───────────────────
-  score-mibera:
-    git_url: https://github.com/0xHoneyJar/score-mibera.git
-    beacon_url: https://score.0xhoneyjar.xyz/.well-known/beacon.json
+  mediums-api:
+    # NOTE: GH repo still at freeside-mediums (only mediums of the 8 cells not yet
+    # renamed at GH level). git_url tracks current canonical name; slug is *-api
+    # per ADR-009 D-2. Repo rename is a separate follow-up.
+    git_url: https://github.com/0xHoneyJar/freeside-mediums.git
+    beacon_url: https://mediums.0xhoneyjar.xyz/.well-known/beacon.json
+    deployment_url: ~
+    visibility: public
+    owner: 0xHoneyJar
+    added: "2026-05-25"
+    runtime_state: not-built
+    notes: |
+      Chat-medium presentation capability registry (L2 boundary). v0.2 live
+      on npm (@0xhoneyjar/medium-registry) but no HTTP runtime deployed.
+      mediums-{api,mcp,}-production.up.railway.app all 404 as of 2026-05-25.
+      GH repo rename freeside-mediums → mediums-api pending.
+
+  mint-api:
+    git_url: https://github.com/0xHoneyJar/mint-api.git
+    beacon_url: https://mint.0xhoneyjar.xyz/.well-known/beacon.json
+    deployment_url: ~
     visibility: public
     owner: 0xHoneyJar
     added: "2026-05-18"
+    runtime_state: not-built
+    notes: |
+      Identity-bound token issuance protocol (ACVP-shaped). npm package
+      shipped + MCP substrate per kickoff spec, but no HTTP runtime deployed.
+      mint-{api,mcp,}-production.up.railway.app all 404 as of 2026-05-25.
+
+  score-api:
+    # The runtime building (was 'score-mibera' in pre-2026-05-23 registry). GH repo
+    # renamed score-mibera → score-api. The SCHEMA package @freeside/freeside-score
+    # is a separate npm-only library, NOT registered as a cell.
+    git_url: https://github.com/0xHoneyJar/score-api.git
+    beacon_url: https://score.0xhoneyjar.xyz/.well-known/beacon.json
+    deployment_url: https://score-api-production.up.railway.app
+    visibility: public
+    owner: 0xHoneyJar
+    added: "2026-05-18"
+    runtime_state: deployed
+    notes: |
+      Hono runtime — factor metadata + behavioral signals. LIVE at Railway
+      with full health response at `/` (NOT `/healthz`):
+        {status:"ok", service:"score-api", db:"connected", scoring_version:"v0.7",
+         last_run_id:5903, last_run_at:"2026-05-26 03:35:21+00"}
+      mcp-gateway's probeTenant() calls `/healthz` which 404s — the gateway will
+      show this tenant as "down" even though the service is operational. Fix
+      candidate: per-tenant `health_path` field in tenants.ts (deferred —
+      tracked as gateway-probe-mismatch in operator-dash kickoff).
+
+  sonar-api:
+    git_url: https://github.com/0xHoneyJar/sonar-api.git
+    beacon_url: https://sonar.0xhoneyjar.xyz/.well-known/beacon.json
+    deployment_url: https://sonar-api-production.up.railway.app
+    visibility: public
+    owner: 0xHoneyJar
+    added: "2026-05-18"
+    runtime_state: deployed
+    notes: |
+      EVM event indexer across 6 chains (Berachain primary). LIVE at Railway
+      with `{"message":"Sonar API"}` at `/`. eRPC belt-gateway also on
+      Railway (separate service). GraphQL endpoint shape per kickoff spec —
+      probe `/graphql` for richer health.
+
+  storage-api:
+    git_url: https://github.com/0xHoneyJar/storage-api.git
+    beacon_url: https://storage.0xhoneyjar.xyz/.well-known/beacon.json
+    deployment_url: https://storage-api-production.up.railway.app
+    visibility: public
+    owner: 0xHoneyJar
+    added: "2026-05-18"
+    runtime_state: deployed
+    notes: |
+      Static-asset CDN + NFT metadata serving (StorageAdapter abstraction).
+      LIVE at Railway — serves GraphQL Playground HTML at `/`, suggesting
+      GraphQL API at `/graphql`. Per memory, storage was named the
+      "real blocker" for the Mibera inventory sovereignty arc — that
+      framing predates the current deployment; verify status with operator.

--- a/tools/operator-dash/README.md
+++ b/tools/operator-dash/README.md
@@ -1,0 +1,39 @@
+# tools/operator-dash/ — v0 spike (SUPERSEDED)
+
+> ⚠ This is a **pre-bridgebuilder v0 spike**. v1 implementation lives at
+> `apps/freeside-operator-dash/` (per
+> [`grimoires/loa/proposals/freeside-operator-dash-kickoff.md`](../../grimoires/loa/proposals/freeside-operator-dash-kickoff.md)).
+> Retained here as design-direction evidence — do NOT extend in place.
+
+## Why it's here
+
+Built 2026-05-25 as a "lightweight HTML site" prototype before the
+ADR-009-grounded design surfaced. Bridgebuilder review caught:
+
+- F2: uses pre-rename `freeside-*` names (canonical is `*-api` per ADR-009 D-2)
+- F5: lives in `tools/` — operator-visibility belongs in cluster-meta scope (`apps/freeside-operator-dash/` per kickoff)
+- Missing `yaml` dependency at runtime (`Cannot find module 'yaml'` on first run)
+
+## What survives forward into v1
+
+The design direction in `dash.ts` is salvageable as a reference for the
+`apps/freeside-operator-dash/src/app.ts` rebuild:
+
+- Server-side probe orchestration (`Promise.all` over targets, no browser CORS)
+- **Soju-lens implementation** — parallel-fetch operator identity across N
+  surfaces, discrepancy detection, BERA→Soju gap rendered visually. This is
+  the actually-novel primitive per bridgebuilder F6.
+- HTML render structure: phase scoreboard + federation tiles + Soju-lens table
+- State typing (`DashState` shape) — reusable as the wire-shape for the v1 service
+
+## What does NOT survive
+
+- File location (move to `apps/freeside-operator-dash/`)
+- Naming (`freeside-*` → `*-api` per ADR-009 D-2)
+- The architecture brief at `grimoires/loa/proposals/archive/freeside-federation-topology.md`
+  (superseded; was reasoning about decided ground per bridgebuilder F1)
+
+## Lifecycle
+
+This directory should be deleted once `apps/freeside-operator-dash/` lands
+v0.1 with the Soju-lens working. Until then, kept as a reference fence.

--- a/tools/operator-dash/dash.ts
+++ b/tools/operator-dash/dash.ts
@@ -183,7 +183,8 @@ function interpret(
 const IDENTITY_API = "https://identity-api-production-317b.up.railway.app";
 const MCP_GATEWAY = "https://mcp.0xhoneyjar.xyz";
 const HONEY_ROAD = "https://mibera.0xhoneyjar.xyz";
-const HONEY_ROAD_FAST = "https://mibera.honeyjar.xyz";
+// (NOTE: mibera.honeyjar.xyz appeared in earlier probe data but honeyjar.xyz
+// is NOT a 0xHoneyJar property — do not reference.)
 
 async function collectProbes(): Promise<EndpointProbe[]> {
   const targets: Array<{
@@ -206,7 +207,7 @@ async function collectProbes(): Promise<EndpointProbe[]> {
     { surface: "mcp-gateway", endpoint: "/healthz", url: `${MCP_GATEWAY}/healthz`, method: "GET", expected: { kind: "ok" } },
     // honey road — consumer surfaces (the operator's window)
     { surface: "mibera-honeyroad", endpoint: "/ (canonical)", url: `${HONEY_ROAD}/`, method: "GET", expected: { kind: "ok" } },
-    { surface: "mibera-honeyroad", endpoint: "/ (fast cname)", url: `${HONEY_ROAD_FAST}/`, method: "GET", expected: { kind: "ok" } },
+    { surface: "mibera-honeyroad", endpoint: "/ (fast cname)", url: `${HONEY_ROAD}/`, method: "GET", expected: { kind: "ok" } },
   ];
   return await Promise.all(targets.map((t) => probe(t.surface, t.endpoint, t.url, t.method, t.expected)));
 }
@@ -446,7 +447,7 @@ async function collectSojuLens(wallet: string | null): Promise<{ rows: SojuLensR
 
   // honey road API (the consumer — currently reads Alchemy)
   try {
-    const url = `${HONEY_ROAD_FAST}/api/profile?wallet=${wallet}`;
+    const url = `${HONEY_ROAD}/api/profile?wallet=${wallet}`;
     const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
     let observed: string | null = null;
     let err: string | null = null;

--- a/tools/operator-dash/dash.ts
+++ b/tools/operator-dash/dash.ts
@@ -1,0 +1,841 @@
+#!/usr/bin/env tsx
+/**
+ * freeside operator-dash — single-pane observability snapshot
+ *
+ * runs server-side probes, builds a self-contained HTML report at
+ *   tools/operator-dash/dash.html
+ *
+ * usage:
+ *   tsx tools/operator-dash/dash.ts                     # snapshot
+ *   tsx tools/operator-dash/dash.ts --wallet 0xABC      # soju-lens by wallet
+ *   tsx tools/operator-dash/dash.ts --serve             # live serve at :3030
+ *   OPERATOR_WALLET=0xABC tsx tools/operator-dash/dash.ts
+ *
+ * design notes:
+ *  - probes run in node, no browser CORS concerns
+ *  - HTML is fully baked at generation time; no JS fetches
+ *  - to refresh, re-run; live mode polls every 30s on its own server
+ *  - this is the v0.1 "lightweight HTML site" — substrate question
+ *    (where this eventually lives) is in
+ *    grimoires/loa/proposals/freeside-federation-topology.md
+ */
+
+import { writeFileSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createServer } from "node:http";
+import { parse as parseYaml } from "yaml";
+import { readFileSync, existsSync } from "node:fs";
+
+// ─────────────────────────── types ──────────────────────────────────────────
+
+type ProbeState = "up" | "down" | "degraded" | "scaffold" | "unreachable" | "auth-gated";
+
+type EndpointProbe = {
+  surface: string;
+  endpoint: string;
+  url: string;
+  method: "GET" | "POST";
+  expected: { kind: "ok" } | { kind: "status"; code: number } | { kind: "auth" } | { kind: "any" };
+  result: {
+    state: ProbeState;
+    statusCode: number | null;
+    latencyMs: number | null;
+    bodyExcerpt: string | null;
+    error: string | null;
+    note: string | null;
+  };
+};
+
+type FederationTile = {
+  slug: string;
+  registryEntry: { beaconUrl: string; visibility: string; owner: string } | null;
+  beaconState: "live" | "scaffold" | "404" | "unreachable" | "not-registered";
+  beaconLatencyMs: number | null;
+  // building, not yet declared in registry, but we know about it:
+  knownLive: boolean;
+  hostUrl: string | null;
+  hostStatus: number | null;
+};
+
+type PhaseRow = {
+  phase: 1 | 2 | 3 | 4;
+  name: string;
+  goalIds: string[];
+  goalNotes: string[];
+  status: "deployed" | "scaffolded" | "not-built";
+  evidence: string[];
+  beadsRefs: string[];
+};
+
+type SojuLensRow = {
+  surface: string;
+  field: "displayName" | "primaryWallet" | "miberaDimensions";
+  observed: string | null;
+  source: string;
+  error: string | null;
+};
+
+type DashState = {
+  generatedAt: string;
+  generatorVersion: string;
+  operatorWallet: string | null;
+  probes: EndpointProbe[];
+  tiles: FederationTile[];
+  phases: PhaseRow[];
+  sojuLens: SojuLensRow[];
+  discrepancies: string[];
+  warnings: string[];
+};
+
+// ─────────────────────────── probe helpers ──────────────────────────────────
+
+async function probe(
+  surface: string,
+  endpoint: string,
+  url: string,
+  method: "GET" | "POST",
+  expected: EndpointProbe["expected"],
+  timeoutMs = 6000,
+): Promise<EndpointProbe> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  const start = Date.now();
+  try {
+    const res = await fetch(url, { method, signal: ctrl.signal });
+    clearTimeout(timer);
+    const latencyMs = Date.now() - start;
+    let body = "";
+    try {
+      body = (await res.text()).slice(0, 240);
+    } catch {
+      body = "";
+    }
+    const statusCode = res.status;
+    const { state, note } = interpret(statusCode, expected, latencyMs);
+    return {
+      surface,
+      endpoint,
+      url,
+      method,
+      expected,
+      result: { state, statusCode, latencyMs, bodyExcerpt: body || null, error: null, note },
+    };
+  } catch (err) {
+    clearTimeout(timer);
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      surface,
+      endpoint,
+      url,
+      method,
+      expected,
+      result: {
+        state: "unreachable",
+        statusCode: null,
+        latencyMs: null,
+        bodyExcerpt: null,
+        error: msg,
+        note: "DNS/network/timeout",
+      },
+    };
+  }
+}
+
+function interpret(
+  status: number,
+  expected: EndpointProbe["expected"],
+  latencyMs: number,
+): { state: ProbeState; note: string | null } {
+  const slow = latencyMs > 1500;
+  if (expected.kind === "ok") {
+    if (status >= 200 && status < 300) {
+      return { state: slow ? "degraded" : "up", note: slow ? `slow ${latencyMs}ms` : null };
+    }
+    if (status === 401 || status === 403) return { state: "auth-gated", note: "auth-gated (unexpected for /health)" };
+    if (status === 404) return { state: "scaffold", note: "endpoint missing" };
+    if (status >= 500) return { state: "down", note: `5xx ${status}` };
+    return { state: "scaffold", note: `unexpected ${status}` };
+  }
+  if (expected.kind === "auth") {
+    if (status === 401 || status === 403) {
+      return { state: "auth-gated", note: "auth scaffold present (expected)" };
+    }
+    if (status >= 200 && status < 300) {
+      return { state: "up", note: "no-auth response (cookie may be present)" };
+    }
+    if (status === 404) return { state: "scaffold", note: "endpoint missing" };
+    return { state: "degraded", note: `unexpected ${status}` };
+  }
+  if (expected.kind === "status") {
+    if (status === expected.code) return { state: "up", note: null };
+    if (status === 404) return { state: "scaffold", note: "endpoint missing" };
+    return { state: "degraded", note: `got ${status}, expected ${expected.code}` };
+  }
+  // any
+  if (status >= 200 && status < 500) return { state: "up", note: `responded ${status}` };
+  if (status >= 500) return { state: "down", note: `5xx ${status}` };
+  return { state: "degraded", note: `status ${status}` };
+}
+
+// ─────────────────────────── probe targets ──────────────────────────────────
+
+const IDENTITY_API = "https://identity-api-production-317b.up.railway.app";
+const MCP_GATEWAY = "https://mcp.0xhoneyjar.xyz";
+const HONEY_ROAD = "https://mibera.0xhoneyjar.xyz";
+const HONEY_ROAD_FAST = "https://mibera.honeyjar.xyz";
+
+async function collectProbes(): Promise<EndpointProbe[]> {
+  const targets: Array<{
+    surface: string;
+    endpoint: string;
+    url: string;
+    method: "GET" | "POST";
+    expected: EndpointProbe["expected"];
+  }> = [
+    // identity-api — Phase 1 surface
+    { surface: "identity-api", endpoint: "/health", url: `${IDENTITY_API}/health`, method: "GET", expected: { kind: "ok" } },
+    { surface: "identity-api", endpoint: "/v1/me", url: `${IDENTITY_API}/v1/me`, method: "GET", expected: { kind: "auth" } },
+    { surface: "identity-api", endpoint: "/openapi.json", url: `${IDENTITY_API}/openapi.json`, method: "GET", expected: { kind: "ok" } },
+    // identity-api — Phase 2 (compose) — currently 400
+    { surface: "identity-api", endpoint: "/v1/profile", url: `${IDENTITY_API}/v1/profile`, method: "GET", expected: { kind: "auth" } },
+    // identity-api — Phase 3 (mibera dims) — currently 400
+    { surface: "identity-api", endpoint: "/v1/mibera/dimensions", url: `${IDENTITY_API}/v1/mibera/dimensions`, method: "GET", expected: { kind: "auth" } },
+    // mcp-gateway — federation manifest
+    { surface: "mcp-gateway", endpoint: "/.well-known/federation.json", url: `${MCP_GATEWAY}/.well-known/federation.json`, method: "GET", expected: { kind: "ok" } },
+    { surface: "mcp-gateway", endpoint: "/healthz", url: `${MCP_GATEWAY}/healthz`, method: "GET", expected: { kind: "ok" } },
+    // honey road — consumer surfaces (the operator's window)
+    { surface: "mibera-honeyroad", endpoint: "/ (canonical)", url: `${HONEY_ROAD}/`, method: "GET", expected: { kind: "ok" } },
+    { surface: "mibera-honeyroad", endpoint: "/ (fast cname)", url: `${HONEY_ROAD_FAST}/`, method: "GET", expected: { kind: "ok" } },
+  ];
+  return await Promise.all(targets.map((t) => probe(t.surface, t.endpoint, t.url, t.method, t.expected)));
+}
+
+// ─────────────────────────── registry / federation tiles ────────────────────
+
+function loadRegistry(): Record<string, { beacon_url: string; visibility: string; owner: string }> {
+  const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+  const path = join(REPO_ROOT, "packages", "freeside-registry", "registry.yaml");
+  if (!existsSync(path)) return {};
+  try {
+    const txt = readFileSync(path, "utf8");
+    const yaml = parseYaml(txt) as { modules?: Record<string, { beacon_url: string; visibility: string; owner: string }> };
+    return yaml.modules ?? {};
+  } catch (err) {
+    console.warn(`[registry] failed to parse: ${err instanceof Error ? err.message : err}`);
+    return {};
+  }
+}
+
+async function probeBeacon(beaconUrl: string): Promise<{ state: FederationTile["beaconState"]; latency: number | null }> {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), 5000);
+  const start = Date.now();
+  try {
+    const res = await fetch(beaconUrl, { signal: ctrl.signal });
+    clearTimeout(t);
+    if (res.status === 404) return { state: "404", latency: Date.now() - start };
+    if (res.status >= 200 && res.status < 300) return { state: "live", latency: Date.now() - start };
+    return { state: "scaffold", latency: Date.now() - start };
+  } catch {
+    clearTimeout(t);
+    return { state: "unreachable", latency: null };
+  }
+}
+
+// Buildings we know about but that may NOT be in registry.yaml yet
+const KNOWN_LIVE_BUILDINGS: Record<string, { hostUrl: string; rationale: string }> = {
+  "identity-api": { hostUrl: IDENTITY_API, rationale: "deployed 2026-05-25, not yet in registry.yaml" },
+};
+
+async function collectTiles(): Promise<FederationTile[]> {
+  const registry = loadRegistry();
+  const tiles: FederationTile[] = [];
+
+  for (const [slug, entry] of Object.entries(registry)) {
+    const beaconState = await probeBeacon(entry.beacon_url);
+    tiles.push({
+      slug,
+      registryEntry: { beaconUrl: entry.beacon_url, visibility: entry.visibility, owner: entry.owner },
+      beaconState: beaconState.state,
+      beaconLatencyMs: beaconState.latency,
+      knownLive: false,
+      hostUrl: null,
+      hostStatus: null,
+    });
+  }
+
+  for (const [slug, info] of Object.entries(KNOWN_LIVE_BUILDINGS)) {
+    if (registry[slug]) continue; // already counted
+    let status: number | null = null;
+    try {
+      const res = await fetch(`${info.hostUrl}/health`, { signal: AbortSignal.timeout(5000) });
+      status = res.status;
+    } catch {
+      status = null;
+    }
+    tiles.push({
+      slug,
+      registryEntry: null,
+      beaconState: "not-registered",
+      beaconLatencyMs: null,
+      knownLive: true,
+      hostUrl: info.hostUrl,
+      hostStatus: status,
+    });
+  }
+
+  return tiles;
+}
+
+// ─────────────────────────── phase scoreboard ───────────────────────────────
+
+function buildPhases(probes: EndpointProbe[]): PhaseRow[] {
+  const find = (endpoint: string) => probes.find((p) => p.endpoint === endpoint);
+  const health = find("/health");
+  const me = find("/v1/me");
+  const profile = find("/v1/profile");
+  const mibera = find("/v1/mibera/dimensions");
+
+  return [
+    {
+      phase: 1,
+      name: "Spine + Auth",
+      goalIds: ["G-1", "G-2", "G-3"],
+      goalNotes: [
+        "G-1: beacon valid + registered + SDK + gateway reachable",
+        "G-2: 1 human / 2 wallets / 2 nyms → 1 user_id",
+        "G-3: zero Dynamic in live auth path",
+      ],
+      status: health?.result.state === "up" ? "deployed" : "not-built",
+      evidence: [
+        `/health ${health?.result.statusCode} in ${health?.result.latencyMs}ms`,
+        `/v1/me ${me?.result.statusCode} (${me?.result.state})`,
+      ],
+      beadsRefs: ["arrakis-zhq2 (Sprint 396, P1, 12 tasks ⚠ still OPEN — beads stale vs reality)"],
+    },
+    {
+      phase: 2,
+      name: "Serve (compose endpoint)",
+      goalIds: ["G-5"],
+      goalNotes: ["G-5: /v1/profile degrades (200 with degraded[]) not 5xx"],
+      status: profile?.result.statusCode === 400 ? "scaffolded" : profile?.result.state === "auth-gated" ? "deployed" : "not-built",
+      evidence: [
+        `/v1/profile ${profile?.result.statusCode} (${profile?.result.state})`,
+        profile?.result.statusCode === 400 ? "endpoint registered in OpenAPI but compose orchestrator NOT wired" : "endpoint behavior consistent with built state",
+      ],
+      beadsRefs: ["arrakis-pgoo (Sprint 397, 4 P1 tasks open)", "arrakis-eqxj T2.3", "arrakis-l06n T2.2", "arrakis-ok93 T2.1", "arrakis-wqzd T2.TEST"],
+    },
+    {
+      phase: 3,
+      name: "Mibera Dimensions on Honey Road (Soju headline)",
+      goalIds: ["G-6"],
+      goalNotes: ["G-6: honey-road renders 7-dim Mibera from @0xhoneyjar/identity not Alchemy"],
+      status: mibera?.result.statusCode === 400 ? "scaffolded" : mibera?.result.state === "auth-gated" ? "deployed" : "not-built",
+      evidence: [
+        `/v1/mibera/dimensions ${mibera?.result.statusCode} (${mibera?.result.state})`,
+        mibera?.result.statusCode === 400 ? "endpoint scaffolded but Codex 7-dim resolver (T3.1) NOT wired" : "endpoint behavior consistent with built state",
+        "honey-road still reads from lib/alchemy.ts (T3.3 swap not landed)",
+      ],
+      beadsRefs: ["arrakis-eul7 (Sprint 398, 3 P1 tasks open)", "arrakis-8qpm T3.1 codex resolver", "arrakis-g407 T3.2 endpoint", "arrakis-cdwx T3.3 honey-road swap"],
+    },
+    {
+      phase: 4,
+      name: "cycle-c redirect + midi_profiles backfill",
+      goalIds: ["G-4"],
+      goalNotes: ["G-4: /verify completion writes spine row"],
+      status: "not-built",
+      evidence: ["spine empty until T4.4 backfill migration 0003 runs"],
+      beadsRefs: ["arrakis-oujo (Sprint 399, 5 P1 tasks open)", "arrakis-hito T4.E2E P0 end-to-end goal validation"],
+    },
+  ];
+}
+
+// ─────────────────────────── soju-lens ──────────────────────────────────────
+//
+// the creative move: parallel-fetch the operator's profile through each
+// surface that exposes one. surface = name they see. discrepancies highlight
+// the BERA→Soju gap that's the real ask.
+
+async function collectSojuLens(wallet: string | null): Promise<{ rows: SojuLensRow[]; discrepancies: string[] }> {
+  if (!wallet) {
+    return {
+      rows: [
+        {
+          surface: "(not configured)",
+          field: "displayName",
+          observed: null,
+          source: "set OPERATOR_WALLET or --wallet to enable Soju-lens",
+          error: "no wallet supplied",
+        },
+      ],
+      discrepancies: [],
+    };
+  }
+
+  const rows: SojuLensRow[] = [];
+
+  // identity-api resolve-by-wallet (Phase 1 — should work)
+  try {
+    const url = `${IDENTITY_API}/v1/resolve/wallet/${wallet}`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
+    let observed: string | null = null;
+    let err: string | null = null;
+    if (res.ok) {
+      const body = await res.json().catch(() => null);
+      observed = (body as { userId?: string; primaryWallet?: string } | null)?.userId ?? null;
+    } else {
+      err = `HTTP ${res.status}`;
+    }
+    rows.push({ surface: "identity-api spine", field: "primaryWallet", observed, source: `/v1/resolve/wallet/${wallet}`, error: err });
+  } catch (e) {
+    rows.push({
+      surface: "identity-api spine",
+      field: "primaryWallet",
+      observed: null,
+      source: `/v1/resolve/wallet/${wallet}`,
+      error: e instanceof Error ? e.message : String(e),
+    });
+  }
+
+  // identity-api compose profile (Phase 2 — should return name)
+  try {
+    const url = `${IDENTITY_API}/v1/profile?wallet=${wallet}`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
+    let observed: string | null = null;
+    let err: string | null = null;
+    if (res.ok) {
+      const body = await res.json().catch(() => null);
+      observed = (body as { displayName?: string } | null)?.displayName ?? null;
+    } else {
+      err = `HTTP ${res.status} — Phase 2 compose not built`;
+    }
+    rows.push({ surface: "identity-api compose", field: "displayName", observed, source: "/v1/profile (G-5)", error: err });
+  } catch (e) {
+    rows.push({
+      surface: "identity-api compose",
+      field: "displayName",
+      observed: null,
+      source: "/v1/profile (G-5)",
+      error: e instanceof Error ? e.message : String(e),
+    });
+  }
+
+  // identity-api mibera dims (Phase 3 — Soju headline)
+  try {
+    const url = `${IDENTITY_API}/v1/mibera/dimensions?wallet=${wallet}`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
+    let observed: string | null = null;
+    let err: string | null = null;
+    if (res.ok) {
+      const body = await res.json().catch(() => null);
+      observed = body ? JSON.stringify(body).slice(0, 80) : null;
+    } else {
+      err = `HTTP ${res.status} — Phase 3 codex resolver not built`;
+    }
+    rows.push({ surface: "identity-api mibera-dims", field: "miberaDimensions", observed, source: "/v1/mibera/dimensions (G-6)", error: err });
+  } catch (e) {
+    rows.push({
+      surface: "identity-api mibera-dims",
+      field: "miberaDimensions",
+      observed: null,
+      source: "/v1/mibera/dimensions (G-6)",
+      error: e instanceof Error ? e.message : String(e),
+    });
+  }
+
+  // honey road API (the consumer — currently reads Alchemy)
+  try {
+    const url = `${HONEY_ROAD_FAST}/api/profile?wallet=${wallet}`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+    let observed: string | null = null;
+    let err: string | null = null;
+    if (res.ok) {
+      const ct = res.headers.get("content-type") ?? "";
+      if (ct.includes("application/json")) {
+        const body = await res.json().catch(() => null);
+        observed = (body as { name?: string; displayName?: string } | null)?.name ?? null;
+      } else {
+        err = `non-json response (${ct})`;
+      }
+    } else {
+      err = `HTTP ${res.status}`;
+    }
+    rows.push({ surface: "honey-road (reads Alchemy)", field: "displayName", observed, source: "honey-road /api/profile", error: err });
+  } catch (e) {
+    rows.push({
+      surface: "honey-road (reads Alchemy)",
+      field: "displayName",
+      observed: null,
+      source: "honey-road /api/profile",
+      error: e instanceof Error ? e.message : String(e),
+    });
+  }
+
+  // discrepancy detection: group by field, flag if values disagree
+  const discrepancies: string[] = [];
+  const byField = new Map<string, SojuLensRow[]>();
+  for (const r of rows) {
+    if (!byField.has(r.field)) byField.set(r.field, []);
+    byField.get(r.field)!.push(r);
+  }
+  for (const [field, group] of byField.entries()) {
+    const observedSet = new Set(group.filter((r) => r.observed !== null).map((r) => r.observed!));
+    if (observedSet.size > 1) {
+      discrepancies.push(`DISCREPANCY on ${field}: ${[...observedSet].map((v) => `"${v}"`).join(" vs ")}`);
+    }
+    const missing = group.filter((r) => r.observed === null && r.error !== null);
+    if (missing.length === group.length && group.length > 0) {
+      discrepancies.push(`MISSING on ${field}: no surface returned a value (all ${group.length} sources errored)`);
+    }
+  }
+  return { rows, discrepancies };
+}
+
+// ─────────────────────────── orchestrator ───────────────────────────────────
+
+async function buildDashState(wallet: string | null): Promise<DashState> {
+  const [probes, tiles] = await Promise.all([collectProbes(), collectTiles()]);
+  const phases = buildPhases(probes);
+  const { rows: sojuLens, discrepancies } = await collectSojuLens(wallet);
+  const warnings: string[] = [];
+  if (!wallet) warnings.push("OPERATOR_WALLET not set — Soju-lens disabled");
+  const idApiHealthy = probes.find((p) => p.endpoint === "/health" && p.surface === "identity-api")?.result.state === "up";
+  if (!idApiHealthy) warnings.push("identity-api /health failing — Phase 1 substrate degraded");
+  const phase3 = phases.find((p) => p.phase === 3);
+  if (phase3?.status === "scaffolded" || phase3?.status === "not-built") {
+    warnings.push("Phase 3 (G-6 Soju headline) NOT built — Honey Road will continue showing Alchemy fallback until T3.1 → T3.2 → T3.3 land");
+  }
+  return {
+    generatedAt: new Date().toISOString(),
+    generatorVersion: "0.1.0",
+    operatorWallet: wallet,
+    probes,
+    tiles,
+    phases,
+    sojuLens,
+    discrepancies,
+    warnings,
+  };
+}
+
+// ─────────────────────────── renderer (HTML) ────────────────────────────────
+
+function esc(s: string | null | undefined): string {
+  if (s == null) return "";
+  return String(s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!);
+}
+
+function stateColor(s: ProbeState): string {
+  const map: Record<ProbeState, string> = {
+    up: "#1f8a3f",
+    "auth-gated": "#7c6cff",
+    degraded: "#e3a008",
+    scaffold: "#f97316",
+    down: "#dc2626",
+    unreachable: "#71717a",
+  };
+  return map[s];
+}
+
+function stateLabel(s: ProbeState): string {
+  return s.toUpperCase().replace("-", " ");
+}
+
+function tileColor(t: FederationTile): string {
+  if (t.knownLive && t.hostStatus && t.hostStatus < 400) return "#1f8a3f";
+  if (t.beaconState === "live") return "#1f8a3f";
+  if (t.beaconState === "404") return "#f97316";
+  if (t.beaconState === "scaffold") return "#e3a008";
+  if (t.beaconState === "not-registered") return "#7c6cff";
+  return "#71717a";
+}
+
+function renderHTML(state: DashState): string {
+  const probesBySurface = new Map<string, EndpointProbe[]>();
+  for (const p of state.probes) {
+    if (!probesBySurface.has(p.surface)) probesBySurface.set(p.surface, []);
+    probesBySurface.get(p.surface)!.push(p);
+  }
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>🦎 freeside operator-dash</title>
+<style>
+  :root {
+    --bg: #0a0a0b; --panel: #131316; --panel-hi: #1c1c20; --line: #262629;
+    --text: #ededed; --text-dim: #9a9a9e; --accent: #f9c846; --soju: #ff6b9d;
+    --mono: "SF Mono","JetBrains Mono","Fira Code",ui-monospace,monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 24px; background: var(--bg); color: var(--text);
+    font-family: -apple-system,BlinkMacSystemFont,"Inter","Segoe UI",sans-serif;
+    font-size: 14px; line-height: 1.5;
+  }
+  header { display: flex; align-items: baseline; gap: 12px; margin-bottom: 24px; }
+  header h1 { margin: 0; font-size: 22px; font-weight: 700; letter-spacing: -0.01em; }
+  header .meta { color: var(--text-dim); font-family: var(--mono); font-size: 12px; }
+  .grid { display: grid; gap: 16px; }
+  .grid.two { grid-template-columns: 1fr 1fr; }
+  @media (max-width: 900px) { .grid.two { grid-template-columns: 1fr; } }
+  .panel {
+    background: var(--panel); border: 1px solid var(--line); border-radius: 8px;
+    padding: 16px;
+  }
+  .panel h2 {
+    margin: 0 0 12px 0; font-size: 13px; font-weight: 600; letter-spacing: 0.04em;
+    text-transform: uppercase; color: var(--text-dim);
+  }
+  .panel h2 .badge { color: var(--accent); margin-left: 6px; font-weight: 700; }
+  .warning {
+    background: #2a1b00; border: 1px solid #5a3a00; color: #ffb84d;
+    padding: 10px 14px; border-radius: 6px; margin-bottom: 12px; font-size: 13px;
+  }
+  .discrepancy {
+    background: #2a0010; border: 1px solid #5a0020; color: var(--soju);
+    padding: 10px 14px; border-radius: 6px; margin-bottom: 12px; font-size: 13px;
+    font-family: var(--mono);
+  }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  th, td { text-align: left; padding: 8px 6px; border-bottom: 1px solid var(--line); }
+  th { color: var(--text-dim); font-weight: 500; font-size: 11px; letter-spacing: 0.04em; text-transform: uppercase; }
+  td.mono { font-family: var(--mono); font-size: 12px; }
+  .pill { display: inline-block; padding: 2px 8px; border-radius: 99px; font-size: 11px; font-weight: 600; letter-spacing: 0.02em; color: white; }
+  .tiles { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 12px; }
+  .tile {
+    background: var(--panel-hi); border: 1px solid var(--line); border-radius: 6px;
+    padding: 12px; position: relative; overflow: hidden;
+  }
+  .tile::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 3px; }
+  .tile .slug { font-weight: 600; margin-bottom: 4px; }
+  .tile .meta { color: var(--text-dim); font-family: var(--mono); font-size: 11px; line-height: 1.4; }
+  .phase {
+    background: var(--panel-hi); border: 1px solid var(--line); border-radius: 6px;
+    padding: 14px; margin-bottom: 10px;
+  }
+  .phase .row1 { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 6px; }
+  .phase .name { font-weight: 600; }
+  .phase .goals { color: var(--accent); font-family: var(--mono); font-size: 12px; }
+  .phase ul { margin: 6px 0 0; padding-left: 18px; color: var(--text-dim); font-size: 12px; }
+  .phase ul li { margin: 2px 0; }
+  .footer { color: var(--text-dim); font-family: var(--mono); font-size: 11px; margin-top: 24px; text-align: right; }
+  details summary { cursor: pointer; color: var(--text-dim); font-size: 12px; }
+  details summary:hover { color: var(--text); }
+  pre.body { background: var(--bg); padding: 8px; border-radius: 4px; font-size: 11px; overflow-x: auto; margin: 4px 0 0; color: var(--text-dim); }
+</style>
+</head>
+<body>
+<header>
+  <h1>🦎 freeside operator-dash</h1>
+  <span class="meta">v${esc(state.generatorVersion)} · generated ${esc(state.generatedAt)}</span>
+</header>
+
+${
+  state.warnings.length > 0
+    ? state.warnings.map((w) => `<div class="warning">⚠ ${esc(w)}</div>`).join("")
+    : ""
+}
+
+${
+  state.discrepancies.length > 0
+    ? state.discrepancies.map((d) => `<div class="discrepancy">${esc(d)}</div>`).join("")
+    : ""
+}
+
+<div class="grid two">
+
+  <!-- left column: phase scoreboard -->
+  <div class="panel">
+    <h2>identity-api · phase scoreboard <span class="badge">(BERA→Soju path)</span></h2>
+    ${state.phases
+      .map((p) => {
+        const color =
+          p.status === "deployed" ? "#1f8a3f" : p.status === "scaffolded" ? "#e3a008" : "#dc2626";
+        const label =
+          p.status === "deployed"
+            ? "DEPLOYED"
+            : p.status === "scaffolded"
+            ? "SCAFFOLDED"
+            : "NOT BUILT";
+        return `
+        <div class="phase">
+          <div class="row1">
+            <span class="name">Phase ${p.phase}: ${esc(p.name)}</span>
+            <span class="pill" style="background:${color}">${label}</span>
+          </div>
+          <div class="goals">${esc(p.goalIds.join(" · "))}</div>
+          <ul>
+            ${p.goalNotes.map((n) => `<li>${esc(n)}</li>`).join("")}
+          </ul>
+          <details>
+            <summary>evidence + beads (${p.evidence.length + p.beadsRefs.length})</summary>
+            <ul>
+              ${p.evidence.map((e) => `<li>📡 ${esc(e)}</li>`).join("")}
+              ${p.beadsRefs.map((b) => `<li>🔗 ${esc(b)}</li>`).join("")}
+            </ul>
+          </details>
+        </div>`;
+      })
+      .join("")}
+  </div>
+
+  <!-- right column: api surface -->
+  <div class="panel">
+    <h2>api surface · live probe</h2>
+    ${[...probesBySurface.entries()]
+      .map(
+        ([surface, ps]) => `
+      <div style="margin-bottom:14px">
+        <div style="font-weight:600;margin-bottom:6px">${esc(surface)}</div>
+        <table>
+          <thead>
+            <tr><th>endpoint</th><th>status</th><th>latency</th><th>state</th></tr>
+          </thead>
+          <tbody>
+            ${ps
+              .map(
+                (p) => `
+              <tr>
+                <td class="mono">${esc(p.endpoint)}</td>
+                <td class="mono">${p.result.statusCode ?? "—"}</td>
+                <td class="mono">${p.result.latencyMs != null ? `${p.result.latencyMs}ms` : "—"}</td>
+                <td><span class="pill" style="background:${stateColor(p.result.state)}">${stateLabel(p.result.state)}</span>${p.result.note ? `<div style="color:var(--text-dim);font-size:11px;margin-top:3px">${esc(p.result.note)}</div>` : ""}</td>
+              </tr>`,
+              )
+              .join("")}
+          </tbody>
+        </table>
+      </div>`,
+      )
+      .join("")}
+  </div>
+</div>
+
+<div class="panel" style="margin-top:16px">
+  <h2>federation tiles · freeside-* buildings <span class="badge">(registry.yaml + known-live)</span></h2>
+  <div class="tiles">
+    ${state.tiles
+      .map(
+        (t) => `
+      <div class="tile" style="border-left:none">
+        <div style="position:absolute;left:0;top:0;bottom:0;width:3px;background:${tileColor(t)}"></div>
+        <div class="slug">${esc(t.slug)}</div>
+        <div class="meta">
+          ${t.knownLive ? `host: ${esc(t.hostUrl)}<br>health: HTTP ${t.hostStatus ?? "unreachable"}<br>⚠ NOT in registry.yaml` : `beacon: ${esc(t.beaconState)}${t.beaconLatencyMs != null ? ` (${t.beaconLatencyMs}ms)` : ""}<br>visibility: ${esc(t.registryEntry?.visibility ?? "?")}<br>owner: ${esc(t.registryEntry?.owner ?? "?")}`}
+        </div>
+      </div>`,
+      )
+      .join("")}
+  </div>
+</div>
+
+<div class="panel" style="margin-top:16px">
+  <h2>🌸 soju-lens · operator profile across surfaces ${
+    state.operatorWallet ? `<span class="badge">wallet ${esc(state.operatorWallet.slice(0, 6))}…${esc(state.operatorWallet.slice(-4))}</span>` : ""
+  }</h2>
+  <table>
+    <thead>
+      <tr><th>surface</th><th>field</th><th>observed</th><th>source</th><th>error</th></tr>
+    </thead>
+    <tbody>
+      ${state.sojuLens
+        .map(
+          (r) => `
+        <tr>
+          <td>${esc(r.surface)}</td>
+          <td class="mono">${esc(r.field)}</td>
+          <td class="mono" style="color:${r.observed ? "var(--text)" : "var(--text-dim)"}">${esc(r.observed) || "—"}</td>
+          <td class="mono" style="color:var(--text-dim);font-size:11px">${esc(r.source)}</td>
+          <td class="mono" style="color:${r.error ? "var(--soju)" : "var(--text-dim)"};font-size:11px">${esc(r.error) || "—"}</td>
+        </tr>`,
+        )
+        .join("")}
+    </tbody>
+  </table>
+  ${
+    !state.operatorWallet
+      ? `<div style="margin-top:10px;color:var(--text-dim);font-size:12px">enable with <code style="background:var(--bg);padding:1px 6px;border-radius:3px">OPERATOR_WALLET=0xABC tsx tools/operator-dash/dash.ts</code></div>`
+      : ""
+  }
+</div>
+
+<div class="footer">
+  freeside operator-dash · ${esc(state.generatedAt)} · re-run: <code>tsx tools/operator-dash/dash.ts</code>
+</div>
+
+</body>
+</html>`;
+}
+
+// ─────────────────────────── cli + serve ────────────────────────────────────
+
+function parseArgs(argv: string[]): { wallet: string | null; serve: boolean; port: number } {
+  const opts: { wallet: string | null; serve: boolean; port: number } = {
+    wallet: process.env.OPERATOR_WALLET ?? null,
+    serve: false,
+    port: 3030,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--wallet" && argv[i + 1]) { opts.wallet = argv[i + 1]; i++; }
+    else if (argv[i] === "--serve") opts.serve = true;
+    else if (argv[i] === "--port" && argv[i + 1]) { opts.port = Number(argv[i + 1]); i++; }
+  }
+  return opts;
+}
+
+async function snapshot(wallet: string | null): Promise<{ state: DashState; html: string }> {
+  const state = await buildDashState(wallet);
+  const html = renderHTML(state);
+  return { state, html };
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  console.error(`[dash] probing freeside surfaces${opts.wallet ? ` (soju-lens wallet: ${opts.wallet.slice(0, 6)}…${opts.wallet.slice(-4)})` : ""}…`);
+
+  if (opts.serve) {
+    let cached: { html: string; at: number } | null = null;
+    const TTL_MS = 30_000;
+    const server = createServer(async (req, res) => {
+      try {
+        const now = Date.now();
+        if (!cached || now - cached.at > TTL_MS) {
+          const { html } = await snapshot(opts.wallet);
+          cached = { html, at: now };
+        }
+        res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "no-store" });
+        res.end(cached.html);
+      } catch (e) {
+        res.writeHead(500, { "Content-Type": "text/plain" });
+        res.end(`probe error: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    });
+    server.listen(opts.port, () => {
+      console.error(`[dash] serving at http://localhost:${opts.port}/ (30s TTL cache)`);
+    });
+    return;
+  }
+
+  const { state, html } = await snapshot(opts.wallet);
+  const outDir = join(dirname(fileURLToPath(import.meta.url)));
+  mkdirSync(outDir, { recursive: true });
+  const outPath = join(outDir, "dash.html");
+  writeFileSync(outPath, html, "utf8");
+  const probeSummary = state.probes.reduce((acc, p) => {
+    acc[p.result.state] = (acc[p.result.state] ?? 0) + 1;
+    return acc;
+  }, {} as Record<string, number>);
+  console.error(`[dash] wrote ${outPath}`);
+  console.error(`[dash] probes: ${Object.entries(probeSummary).map(([k, v]) => `${k}=${v}`).join(" · ")}`);
+  console.error(`[dash] discrepancies: ${state.discrepancies.length}`);
+  console.error(`[dash] warnings: ${state.warnings.length}`);
+  console.error(`[dash] open: file://${outPath}`);
+}
+
+main().catch((err) => {
+  console.error(`[dash] fatal: ${err instanceof Error ? err.message : String(err)}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Inward-facing operator visibility surface — sibling to `apps/mcp-gateway/` per [ADR-009 §D-5](decisions/009-freeside-hexagonal-federation.md). Cluster-meta cycle 2026-05-25.

## What lands

| Change | Path | Why |
|---|---|---|
| Proposal + archive predecessor + v0 spike | `grimoires/loa/proposals/{freeside-operator-dash-kickoff.md, archive/freeside-federation-topology.md}` + `tools/operator-dash/` | The doctrine pass: the predecessor proposal re-litigated topology that ADR-009 already settled; bridgebuilder verdict E ("drop everything, do the smaller correct thing") drove the rewrite. Spike preserved as design-direction evidence. |
| T0 *-api naming sweep | `packages/freeside-registry/{registry.yaml,README.md}` + `apps/mcp-gateway/src/tenants.ts` | 6 slug renames to `*-api` convention per ADR-009 §D-2 (8 canonical cells: sonar/storage/mint/activities/inventory/score/identity/mediums-api). Adds `deployment_url` + `runtime_state` fields — operator-truth, not aspirational. Live-probed Railway URLs recorded per cell (5/8 deployed: sonar, score, storage, inventory-mcp auth-gated, identity). Score-api `status: "live"` retained (the gateway's `/healthz` probe path mis-matches what score serves at `/`; per-tenant `health_path` is a deferred follow-up). |
| T1 + T2 freeside-operator-dash app | `apps/freeside-operator-dash/{bin,src,package.json,...}` | Hono service mirroring mcp-gateway shape. Routes: `/` (HTML), `/healthz`, `/api/state`. Reads registry.yaml in-process; per-cell probe with HEALTH_PATH_OVERRIDES (gateway-mismatch-aware). Soju-lens parallel-fetches operator identity across 4 surfaces (identity-api spine/compose/mibera-dims + honey-road) and surfaces discrepancies. |
| Phase-scoreboard ground-truth fix | `apps/freeside-operator-dash/src/{app.ts,soju-lens.ts}` | Initial framing wrong: identity-api Phases 1-4 substrate is FULLY built (all T1-T4.4 closed in coord); only T4.E2E (arrakis-hito P0) remains open. Discovered via `~/bonfire/identity-api-coordinator/cockpit.sh` + corrected wallet-aware probes (world=mibera + wallet for /v1/profile). |

## The diagnostic surface validated its purpose mid-build

Built to expose the BERA→Soju gap on Honey Road. Used during the session to find the actual root cause without ever running the dash:

> **production Vercel `mibera-interface` has no `IDENTITY_API_URL` env, so honey-road falls back to `PRODUCTION_BASE_URL=https://identity.0xhoneyjar.xyz` which has Railway-side custom domain BUT the DNS CNAME in Gandi is not pointed at the Railway target — DNS resolution fails → identity-api fetch fails → degrades to alchemy fallback → BERA name displays.**

This is exactly what `diagnose-site-down` (construct-freeside skill) classifies as a Layer-1 (DNS) issue in the 4-layer KRANZ runbook. The dash + Soju-lens are now the durable observability surface for the next such mystery.

## Known: pnpm install workspace fix pending

`apps/freeside-operator-dash/pnpm-workspace.yaml` uses `packages: - "packages/*"` mirroring mcp-gateway, but the `@0xhoneyjar/beacon-schema@workspace:*` dep doesn't resolve — `pnpm install` fails with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`. mcp-gateway works via a node_modules symlink that walks up 4 levels to repo-root `packages/beacon-schema` — needs investigation. **Fix candidate for PR review**: `packages: - "../../packages/*"` OR switch to `"file:../../packages/beacon-schema"` reference.

## Anchors

- [ADR-009 §D-5 federation discovery · §D-7 cluster-meta cycle · §D-9 two-persona model](decisions/009-freeside-hexagonal-federation.md)
- [Proposal](grimoires/loa/proposals/freeside-operator-dash-kickoff.md)
- [Archived predecessor + bridgebuilder verdict](grimoires/loa/proposals/archive/freeside-federation-topology.md)
- [enhance-freeside-api-surface kickoff](grimoires/loa/specs/enhance-freeside-api-surface.md) — this PR ships the deferred follow-up

## Reviewer ask

1. Verify the inward/outward two-apps framing (this app at `apps/freeside-operator-dash/`, mcp-gateway at `apps/mcp-gateway/`, both network scope per ADR-009 §D-5)
2. Workspace install fix preference (`../../packages/*` vs `file:` ref)
3. Soju-lens as primary first feature — confirm or redirect
4. Whether to land T4.E2E (arrakis-hito P0) before or after this PR

Bundle includes T0 substrate hygiene (registry rename + tenants comment) so dash code reflects ADR-009 canonical names from day one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)