### PR TITLE
fix(network/dns): identity.0xhoneyjar.xyz → Railway (closes BERA→Soju visibility gap)

### DIFF
--- a/infrastructure/terraform/dns/honeyjar-xyz-railway.tf
+++ b/infrastructure/terraform/dns/honeyjar-xyz-railway.tf
@@ -1,0 +1,33 @@
+# =============================================================================
+# DNS Root — Railway-hosted Service Records
+# =============================================================================
+# Explicit CNAMEs for services deployed on Railway. Without these, the
+# wildcard CNAME (*.0xhoneyjar.xyz → cname.vercel-dns.com, declared in
+# honeyjar-xyz-vercel.tf:8) catches the subdomain and routes it to Vercel —
+# which 404s for any subdomain Vercel doesn't have a project for.
+#
+# Per RFC 4592 + the established pattern in honeyjar-xyz-worlds.tf:7,
+# specific records win over the wildcard. This file mirrors the
+# vercel/worlds separation: distinct file per upstream class, so the
+# wildcard's blast radius is legible at-a-glance.
+#
+# Service-side requirement: the Railway service MUST also have the custom
+# domain configured on its end (verified for identity-api via `railway
+# domain` 2026-05-25: identity.0xhoneyjar.xyz IS present alongside the
+# *.up.railway.app default). Without Railway-side registration, Railway's
+# router won't accept the request even if DNS resolves correctly.
+# =============================================================================
+
+# identity-api — central identity SoR per ADR-009 §D-2.
+# Without this record, the wildcard sends identity.0xhoneyjar.xyz to Vercel,
+# breaking the PRODUCTION_BASE_URL fallback in
+# mibera-honeyroad/lib/identity/client.ts (BERA→Soju visibility bug,
+# diagnosed 2026-05-25, captured in
+# grimoires/freeside-network/cluster-2026-05-25-operator-dash/README.md).
+resource "aws_route53_record" "identity_api" {
+  zone_id = aws_route53_zone.honeyjar.zone_id
+  name    = "identity.${var.domain}"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["identity-api-production-317b.up.railway.app"]
+}


### PR DESCRIPTION
**One-line change.** Adds an explicit `aws_route53_record` for `identity.0xhoneyjar.xyz` in `infrastructure/terraform/dns/honeyjar-xyz-railway.tf` so the subdomain stops falling through the wildcard `*.0xhoneyjar.xyz → cname.vercel-dns.com` and instead points at the Railway identity-api service.

## Root cause chain (diagnosed 2026-05-25)

```
honey-road production (Vercel project mibera-interface):
  IDENTITY_API_URL = (unset) → falls back to PRODUCTION_BASE_URL
                               = "https://identity.0xhoneyjar.xyz"
                               (see mibera-honeyroad/lib/identity/client.ts:30)

DNS authority for 0xhoneyjar.xyz: AWS Route53
  (terraform-managed at infrastructure/terraform/dns/)

Records resolved at identity.0xhoneyjar.xyz:
  EXPLICIT  →  (none, until this PR)
  WILDCARD  →  *.0xhoneyjar.xyz CNAME → cname.vercel-dns.com
               (honeyjar-xyz-vercel.tf:8)

→ Vercel returns 404 (no project for identity.*)
→ honey-road identity-api client fetch fails
→ degrades to alchemy fallback
→ operator's BERA name shows on Honey Road instead of "Soju"
```

Per [RFC 4592](https://datatracker.ietf.org/doc/html/rfc4592) and the existing pattern at `honeyjar-xyz-worlds.tf:7` (the comment literally says *"specific records win over the wildcard"*), an explicit record overrides the wildcard. This is the canonical Route53 pattern in this codebase.

## What the PR adds

A single new file: `infrastructure/terraform/dns/honeyjar-xyz-railway.tf` with one resource:

```hcl
resource "aws_route53_record" "identity_api" {
  zone_id = aws_route53_zone.honeyjar.zone_id
  name    = "identity.${var.domain}"
  type    = "CNAME"
  ttl     = 300
  records = ["identity-api-production-317b.up.railway.app"]
}
```

The file naming follows the established `honeyjar-xyz-<upstream>.tf` pattern (vercel.tf for Vercel, worlds.tf for AWS-hosted ECS worlds, agents.tf for the agent wildcard) — separates Railway-hosted services from other upstream classes so the wildcard's blast radius stays legible at-a-glance.

## Railway-side already configured (verified)

```bash
$ cd ~/Documents/GitHub/freeside-auth && railway domain
Domains already exist on the service:
- https://identity.0xhoneyjar.xyz                           ← configured Railway-side
- https://identity-api-production-317b.up.railway.app       ← default
```

So Railway's router will accept the request + provision the TLS cert once DNS resolves to it.

## Expected terraform plan

```
# aws_route53_record.identity_api will be created
+ resource "aws_route53_record" "identity_api" {
    + fqdn       = "identity.0xhoneyjar.xyz"
    + name       = "identity.0xhoneyjar.xyz"
    + records    = ["identity-api-production-317b.up.railway.app"]
    + ttl        = 300
    + type       = "CNAME"
    + zone_id    = <aws_route53_zone.honeyjar.zone_id>
  }

Plan: 1 to add, 0 to change, 0 to destroy.
```

Single resource, no destroys, no replacements. Safe shape.

## Post-apply verification

```bash
# DNS propagation (give it 5-15 min for TTL=300)
dig +short CNAME identity.0xhoneyjar.xyz @8.8.8.8
# expect: identity-api-production-317b.up.railway.app

# Railway cert issuance (give it a few more minutes after DNS resolves)
curl -sI https://identity.0xhoneyjar.xyz/health
# expect: HTTP/2 200

# End-to-end: honey-road now shows operator name from identity-api spine
# (instead of Alchemy ENS fallback). Operator wallet → "Soju" not "BERA".
```

## Rollback

```bash
git revert <this commit> && terraform apply
# OR remove the resource manually in Route53 console — wildcard re-asserts.
# Total downtime to roll back: ~5 min DNS propagation.
```

## Anchors

- Distilled cycle artifact: `grimoires/freeside-network/cluster-2026-05-25-operator-dash/README.md`
- Operator-dash PR (in-flight, sibling): #223
- The honey-road client whose fallback hits the broken URL: [`mibera-honeyroad/lib/identity/client.ts:30-46`](https://github.com/0xHoneyJar/mibera-honeyroad/blob/main/lib/identity/client.ts#L30-L46)
- Wildcard declaration: `infrastructure/terraform/dns/honeyjar-xyz-vercel.tf:8`
- Specific-records-win precedent: `infrastructure/terraform/dns/honeyjar-xyz-worlds.tf:7`

## Reviewer ask

1. Confirm the Railway CNAME target — `identity-api-production-317b.up.railway.app` is the visible Railway default subdomain, but Railway sometimes uses a different proxy-routing target for custom domains. If different, swap the `records` value before apply.
2. TTL=300 matches the existing pattern (worlds.tf, wildcard.tf use the same). Confirm or override.
3. Should this land on its own (low-risk) or stack with PR #223 (the operator-dash work)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)