### PR TITLE
feat(packages/events): @0xhoneyjar/events Sprint 1 — ACVP envelope substrate

### DIFF
--- a/packages/events/.gitignore
+++ b/packages/events/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.tsbuildinfo
+.DS_Store

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -1,0 +1,105 @@
+# @0xhoneyjar/events
+
+> ACVP-enveloped cross-cell event substrate for the freeside cluster.
+
+The first instance of cycle-098 L1 envelope discipline applied to the service-plane: every cluster cell that publishes an event wraps it in a hash-chained + Ed25519-signed envelope; every consumer verifies before routing. **One built, N inherited** — future cell-to-cell integrations are subscribe-to-subject + decode-envelope, no per-pair contract.
+
+Lives in the [Events Pillar v1](../../grimoires/loa/specs/enhance-events-pillar-v1-nft-mints.md) cycle. Sibling to the [auth substitution roadmap](../../grimoires/loa/proposals/identity-api-sovereign-aggregator-substitution.md) — same shape (vendor-pattern → substrate → adoption), different plane (events vs identity).
+
+## Install
+
+```bash
+pnpm add @0xhoneyjar/events
+pnpm add nats  # peer dep — consumers bring their own connection
+```
+
+## Quick start (publisher)
+
+```typescript
+import { connect } from "nats";
+import {
+  publishEnvelope,
+  LocalEd25519Signer,
+  InMemoryPrevHashStore,
+  nftMintDetectedTopic,
+} from "@0xhoneyjar/events";
+
+const nats = await connect({ servers: process.env.NATS_URL });
+const signer = await LocalEd25519Signer.fromSeedHex(process.env.SIGNING_SEED_HEX!, "sonar-api-1");
+const prevHashStore = new InMemoryPrevHashStore();
+
+await publishEnvelope({
+  nats,
+  subject: nftMintDetectedTopic({ collectionSlug: "mibera-shadow" }),  // "nft.mint.detected.mibera-shadow.v1"
+  payload: {
+    chain_id: 80094,
+    contract: "0x048327A187b944ddac61c6e202BfccD20d17c008",
+    token_id: "234",
+    minter: "0xabc...",
+    block_number: 12345678,
+    transaction_hash: "0xdef...",
+    timestamp: new Date().toISOString(),
+  },
+  emittedBy: "sonar-api",
+  signer,
+  prevHashStore,
+});
+```
+
+## Quick start (subscriber)
+
+```typescript
+import { connect } from "nats";
+import {
+  subscribeEnvelope,
+  JwksVerifier,
+  NftMintDetectedSchema,
+} from "@0xhoneyjar/events";
+
+const nats = await connect({ servers: process.env.NATS_URL });
+const verifier = await JwksVerifier.fromUrl(process.env.JWKS_URL!);
+
+await subscribeEnvelope({
+  nats,
+  subject: "nft.mint.detected.>",  // wildcard catch-all
+  schema: NftMintDetectedSchema,
+  verifier,
+  handler: async ({ payload, envelope }) => {
+    // payload is typed as z.infer<typeof NftMintDetectedSchema>
+    console.log(`mint of token ${payload.token_id} on ${payload.contract}`);
+  },
+  onVerificationFailure: (reason, raw) => {
+    // surfaces broken-sig, broken-chain, schema-violation
+    // never throws — subscriber stays alive
+  },
+});
+```
+
+## Architecture
+
+| Layer | What | File |
+|-------|------|------|
+| Envelope | Zod schema for the wire-shape (event_id, type, hashes, sig, payload) | `src/envelope.ts` |
+| JCS | RFC 8785 canonicalization (byte-deterministic JSON) | `src/jcs.ts` |
+| Signer | Ed25519 sign/verify via @noble/curves; JWKS lookup | `src/signer.ts` |
+| Topics | Hounfour 3-segment topic builders (`{aggregate}.{noun}.{verb}.v{N}`) | `src/topics.ts` |
+| Publisher | publishEnvelope: canonicalize → hash → sign → publish → store prev_hash | `src/publisher.ts` |
+| Subscriber | subscribeEnvelope: receive → verify sig + chain + schema → route payload | `src/subscriber.ts` |
+| Schemas | Per-event Zod schemas (start: NftMintDetected) | `src/schemas/` |
+
+## Design invariants
+
+- **Hash chain is per-publisher.** Each publisher (e.g. `sonar-api`) maintains its own `prev_hash` chain. A subscriber that re-publishes (e.g. characters republishing enriched events) maintains a SEPARATE chain.
+- **JCS canonicalization is non-negotiable.** Payload hash MUST be computed from JCS-canonical JSON. Two implementations of this library MUST agree byte-for-byte on the canonical form of the same input.
+- **Versioned topic suffix is non-negotiable.** `nft.mint.detected.v1`. Schema evolution requires a NEW versioned subject; subscribers must coexist v1 + v2 during overlap (≥30d).
+- **Fail-soft, never crash.** Publisher: NATS down → caller's domain write still succeeds (the envelope publish is best-effort + logged). Subscriber: broken envelope → surface via callback, do NOT throw.
+- **TLS-only.** No plaintext NATS connections.
+- **Identity fallback for display**: nym → shortened address. NEVER ENS (per the auth substitution roadmap; ENS is excised from THJ surfaces).
+
+## Provenance
+
+- ACVP doctrine: `~/vault/wiki/concepts/agentic-cryptographically-verifiable-protocol.md`
+- L1 audit envelope prior art: `loa-freeside/.claude/scripts/audit-envelope.sh` + `.claude/data/trajectory-schemas/agent-network-envelope.schema.json`
+- Hounfour topic naming: `loa-hounfour/src/schemas/domain-event.ts` (`{aggregate}.{noun}.{verb}`)
+- Cluster topology: ADR-009 §D-5 federation discovery; §D-7 cluster-meta cycle type
+- TEND audit baseline: `loa-freeside/grimoires/freeside-network/cluster-2026-05-26-mint-announcement-tend/audit.md`

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -4,6 +4,10 @@
 
 The first instance of cycle-098 L1 envelope discipline applied to the service-plane: every cluster cell that publishes an event wraps it in a hash-chained + Ed25519-signed envelope; every consumer verifies before routing. **One built, N inherited** — future cell-to-cell integrations are subscribe-to-subject + decode-envelope, no per-pair contract.
 
+**Schema: Effect.Schema** (`@effect/schema`, NOT zod) — per cluster memory `freeside-effect-transition`, new protocol-layer types use Effect.Schema; legacy zod stays in identity-api's user-JWT and other established packages. Sibling pattern: `freeside-auth/packages/protocol/src/svc-jwt-claims.ts` (W2.5 T-2.1, the first Effect.Schema artifact in the cluster).
+
+**Wire-format version: `acvp-l1-v2`** — signature covers the JCS-canonical form of the full envelope (with `signature: ""` placeholder), so every semantically load-bearing field (event_type, emitted_by, schema_version, event_id, emitted_at, prev_hash, payload_hash, signing_key_id, payload) is cryptographically bound. v1 (PR #227 first commit) was never deployed — superseded in-PR after BB review found the routing-metadata forgery vector.
+
 Lives in the [Events Pillar v1](../../grimoires/loa/specs/enhance-events-pillar-v1-nft-mints.md) cycle. Sibling to the [auth substitution roadmap](../../grimoires/loa/proposals/identity-api-sovereign-aggregator-substitution.md) — same shape (vendor-pattern → substrate → adoption), different plane (events vs identity).
 
 ## Install
@@ -103,6 +107,16 @@ await subscribeEnvelope({
 | `StaticPubkeyVerifier` | Tests; bootstrap-time pinned keys; internal services with a small known publisher set. Fully in-memory; no network. |
 | `JwksVerifier` | Production subscribers consuming from the cluster's JWKS endpoint (per ADR-009 §D-5: `apps/gateway`). Fetches + caches; bounded by `timeoutMs` (default 5s) and refreshed on TTL expiry. Empty-but-200 responses preserve the existing cache rather than self-DoS. |
 
+## Bootstrap-time replay defense (EVT-002 BB#227)
+
+When `chainStore` is provided, the subscriber's behavior for the FIRST envelope from each publisher is controlled by `initialPrevHashPolicy`:
+
+| Value | Behavior |
+|---|---|
+| `'any'` (default) | Accept any `prev_hash` on first envelope. Appropriate for subscribers that intentionally late-join a publisher's chain. Backward-compatible. |
+| `'genesis'` | Require `prev_hash === GENESIS_PREV_HASH`. Replay of a mid-chain envelope as "first" is surfaced as `initial-anchor-policy-violation`. Choose this for subscribers that start at the beginning of a publisher's chain. |
+| `<hex-string>` | Pinned anchor — first envelope MUST have `prev_hash === <hex>`. Use when an out-of-band sync has established a known anchor (e.g. operator pinned the publisher's chain tip at restart time). |
+
 ## Sprint 1 known limitations
 
 The substrate is correct-by-construction in the happy path; these gaps are bounded and explicitly named for downstream consumers.
@@ -110,6 +124,7 @@ The substrate is correct-by-construction in the happy path; these gaps are bound
 - **Publish/store atomicity (F-003)** — `publishEnvelope` does `nats.publish` then `prevHashStore.set` as two non-atomic steps. A crash between them forks the publisher's chain. Single-instance publishers in healthy processes don't hit this in practice; the failure mode is bounded to crash/restart windows. Sprint 2+ mitigation: back `prevHashStore` with Redis using a CAS pipeline conditioned on JetStream's `PubAck.seq`, OR accept at-least-once + add subscriber-side chain reset (see below).
 - **Subscriber chain recovery (F-005)** — Once a chain gap is detected, every subsequent envelope from the same publisher will continue to fail the check (their `prev_hash` references the missed envelope). Recovery requires operator action — the `onVerificationFailure("prev-hash-broken-chain", ...)` callback can update the local chain store to admit the gap (see `subscriber.ts` for the exact reset pattern). Sprint 2+ adds a first-class `onChainGap` option.
 - **Multi-instance publishers** — `InMemoryPrevHashStore` is single-process only. Multi-instance publishers MUST provide a shared store (Redis, etc.) or all their chains will fork on every load-balancer round-trip.
+- **Deprecated transport package** — both `@effect/schema@0.75` (merged into main `effect` package post-publish) and `nats@2.x` (moved to `@nats-io/transport-node`) carry deprecation warnings on install. Tracked as follow-up beads in the coordinator. Not blocking; migration is a separate Sprint coordinated with downstream consumers.
 
 ## Provenance
 

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -89,12 +89,27 @@ await subscribeEnvelope({
 
 ## Design invariants
 
-- **Hash chain is per-publisher.** Each publisher (e.g. `sonar-api`) maintains its own `prev_hash` chain. A subscriber that re-publishes (e.g. characters republishing enriched events) maintains a SEPARATE chain.
-- **JCS canonicalization is non-negotiable.** Payload hash MUST be computed from JCS-canonical JSON. Two implementations of this library MUST agree byte-for-byte on the canonical form of the same input.
+- **Hash chain is per-publisher (scoped to signer, not topic).** Each `(emittedBy, signing_key_id)` pair maintains its own `prev_hash` chain. A subscriber that re-publishes (e.g. characters republishing enriched events) maintains a SEPARATE chain — chain ownership belongs to *who signed it*, not *where it was published*. This composes cleanly with ACVP's identity model and makes subscriber re-publish non-destructive by construction.
+- **JCS canonicalization is non-negotiable.** Payload hash MUST be computed from JCS-canonical JSON. Two implementations of this library MUST agree byte-for-byte on the canonical form of the same input. Do NOT substitute `JSON.stringify(payload)` — key ordering is unspecified.
 - **Versioned topic suffix is non-negotiable.** `nft.mint.detected.v1`. Schema evolution requires a NEW versioned subject; subscribers must coexist v1 + v2 during overlap (≥30d).
-- **Fail-soft, never crash.** Publisher: NATS down → caller's domain write still succeeds (the envelope publish is best-effort + logged). Subscriber: broken envelope → surface via callback, do NOT throw.
+- **Fail-soft, never crash.** Publisher: NATS errors propagate to the caller (caller decides fail-soft for the upstream domain write). Subscriber: broken envelope → surface via `onVerificationFailure` callback, NEVER throw. Typed `VerificationFailureReason` discriminates `envelope-schema-invalid` · `payload-schema-invalid` · `payload-hash-mismatch` · `signature-invalid` · `prev-hash-broken-chain` · `json-parse-error` · `handler-error` · `internal-error`.
 - **TLS-only.** No plaintext NATS connections.
 - **Identity fallback for display**: nym → shortened address. NEVER ENS (per the auth substitution roadmap; ENS is excised from THJ surfaces).
+
+## Verifier choice (StaticPubkeyVerifier vs JwksVerifier)
+
+| Verifier | Use when |
+|---|---|
+| `StaticPubkeyVerifier` | Tests; bootstrap-time pinned keys; internal services with a small known publisher set. Fully in-memory; no network. |
+| `JwksVerifier` | Production subscribers consuming from the cluster's JWKS endpoint (per ADR-009 §D-5: `apps/gateway`). Fetches + caches; bounded by `timeoutMs` (default 5s) and refreshed on TTL expiry. Empty-but-200 responses preserve the existing cache rather than self-DoS. |
+
+## Sprint 1 known limitations
+
+The substrate is correct-by-construction in the happy path; these gaps are bounded and explicitly named for downstream consumers.
+
+- **Publish/store atomicity (F-003)** — `publishEnvelope` does `nats.publish` then `prevHashStore.set` as two non-atomic steps. A crash between them forks the publisher's chain. Single-instance publishers in healthy processes don't hit this in practice; the failure mode is bounded to crash/restart windows. Sprint 2+ mitigation: back `prevHashStore` with Redis using a CAS pipeline conditioned on JetStream's `PubAck.seq`, OR accept at-least-once + add subscriber-side chain reset (see below).
+- **Subscriber chain recovery (F-005)** — Once a chain gap is detected, every subsequent envelope from the same publisher will continue to fail the check (their `prev_hash` references the missed envelope). Recovery requires operator action — the `onVerificationFailure("prev-hash-broken-chain", ...)` callback can update the local chain store to admit the gap (see `subscriber.ts` for the exact reset pattern). Sprint 2+ adds a first-class `onChainGap` option.
+- **Multi-instance publishers** — `InMemoryPrevHashStore` is single-process only. Multi-instance publishers MUST provide a shared store (Redis, etc.) or all their chains will fork on every load-balancer round-trip.
 
 ## Provenance
 

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -63,17 +63,19 @@ import {
 const nats = await connect({ servers: process.env.NATS_URL });
 const verifier = await JwksVerifier.fromUrl(process.env.JWKS_URL!);
 
+import type { NftMintDetected } from "@0xhoneyjar/events";
+
 await subscribeEnvelope({
   nats,
   subject: "nft.mint.detected.>",  // wildcard catch-all
   schema: NftMintDetectedSchema,
   verifier,
   handler: async ({ payload, envelope }) => {
-    // payload is typed as z.infer<typeof NftMintDetectedSchema>
+    // payload is typed as NftMintDetected (= S.Schema.Type<typeof NftMintDetectedSchema>)
     console.log(`mint of token ${payload.token_id} on ${payload.contract}`);
   },
   onVerificationFailure: (reason, raw) => {
-    // surfaces broken-sig, broken-chain, schema-violation
+    // surfaces subject-mismatch, broken-sig, broken-chain, schema-violation
     // never throws — subscriber stays alive
   },
 });
@@ -83,13 +85,13 @@ await subscribeEnvelope({
 
 | Layer | What | File |
 |-------|------|------|
-| Envelope | Zod schema for the wire-shape (event_id, type, hashes, sig, payload) | `src/envelope.ts` |
+| Envelope | Effect.Schema for the wire-shape (event_id, type, hashes, sig, payload) | `src/envelope.ts` |
 | JCS | RFC 8785 canonicalization (byte-deterministic JSON) | `src/jcs.ts` |
 | Signer | Ed25519 sign/verify via @noble/curves; JWKS lookup | `src/signer.ts` |
 | Topics | Hounfour 3-segment topic builders (`{aggregate}.{noun}.{verb}.v{N}`) | `src/topics.ts` |
 | Publisher | publishEnvelope: canonicalize → hash → sign → publish → store prev_hash | `src/publisher.ts` |
-| Subscriber | subscribeEnvelope: receive → verify sig + chain + schema → route payload | `src/subscriber.ts` |
-| Schemas | Per-event Zod schemas (start: NftMintDetected) | `src/schemas/` |
+| Subscriber | subscribeEnvelope: parse → schema → subject-bind → hash → sig → chain → payload-schema → advance → handler | `src/subscriber.ts` |
+| Schemas | Per-event Effect.Schema definitions (start: NftMintDetected) | `src/schemas/` |
 
 ## Design invariants
 

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,9 +1,12 @@
 {
   "name": "@0xhoneyjar/events",
   "version": "0.1.0",
-  "description": "ACVP-enveloped cross-cell event substrate for the freeside cluster. RFC 8785 JCS + Ed25519 sign/verify + Hounfour 3-segment topic helpers + per-event Zod schemas. Published on NATS JetStream; consumers subscribe and verify before routing payloads. cycle-098 L1 envelope shape, adapted for service-plane events.",
+  "description": "ACVP-enveloped cross-cell event substrate for the freeside cluster. RFC 8785 JCS + Ed25519 sign/verify + Hounfour 3-segment topic helpers + per-event Effect.Schema schemas. Published on NATS JetStream; consumers subscribe and verify before routing payloads. cycle-098 L1 envelope shape, adapted for service-plane events.",
   "license": "MIT",
   "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "exports": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -61,10 +61,11 @@
     }
   },
   "dependencies": {
+    "@effect/schema": "^0.75.0",
     "@noble/curves": "^1.7.0",
     "@noble/hashes": "^1.6.0",
     "canonicalize": "^2.0.0",
-    "zod": "^3.23.0"
+    "effect": "^3.10.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@0xhoneyjar/events",
+  "version": "0.1.0",
+  "description": "ACVP-enveloped cross-cell event substrate for the freeside cluster. RFC 8785 JCS + Ed25519 sign/verify + Hounfour 3-segment topic helpers + per-event Zod schemas. Published on NATS JetStream; consumers subscribe and verify before routing payloads. cycle-098 L1 envelope shape, adapted for service-plane events.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js"
+    },
+    "./envelope": {
+      "types": "./dist/src/envelope.d.ts",
+      "import": "./dist/src/envelope.js"
+    },
+    "./jcs": {
+      "types": "./dist/src/jcs.d.ts",
+      "import": "./dist/src/jcs.js"
+    },
+    "./signer": {
+      "types": "./dist/src/signer.d.ts",
+      "import": "./dist/src/signer.js"
+    },
+    "./topics": {
+      "types": "./dist/src/topics.d.ts",
+      "import": "./dist/src/topics.js"
+    },
+    "./publisher": {
+      "types": "./dist/src/publisher.d.ts",
+      "import": "./dist/src/publisher.js"
+    },
+    "./subscriber": {
+      "types": "./dist/src/subscriber.d.ts",
+      "import": "./dist/src/subscriber.js"
+    },
+    "./schemas/nft-mint-detected": {
+      "types": "./dist/src/schemas/nft-mint-detected.d.ts",
+      "import": "./dist/src/schemas/nft-mint-detected.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist",
+    "test:unit": "tsx --test tests/*.test.ts",
+    "test": "pnpm build && pnpm test:unit"
+  },
+  "peerDependencies": {
+    "nats": ">=2.28.0 <3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "nats": {
+      "optional": true
+    }
+  },
+  "dependencies": {
+    "@noble/curves": "^1.7.0",
+    "@noble/hashes": "^1.6.0",
+    "canonicalize": "^2.0.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "nats": "^2.28.0",
+    "tsx": "^4.20.0",
+    "typescript": "^5.4.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/events/pnpm-lock.yaml
+++ b/packages/events/pnpm-lock.yaml
@@ -1,0 +1,392 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@noble/curves':
+        specifier: ^1.7.0
+        version: 1.9.7
+      '@noble/hashes':
+        specifier: ^1.6.0
+        version: 1.8.0
+      canonicalize:
+        specifier: ^2.0.0
+        version: 2.1.0
+      zod:
+        specifier: ^3.23.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.19
+      nats:
+        specifier: ^2.28.0
+        version: 2.29.3
+      tsx:
+        specifier: ^4.20.0
+        version: 4.22.3
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@types/node@22.19.19':
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
+
+  canonicalize@2.1.0:
+    resolution: {integrity: sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  nats@2.29.3:
+    resolution: {integrity: sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA==}
+    engines: {node: '>= 14.0.0'}
+    deprecated: Package moved. Use @nats-io/transport-node from https://github.com/nats-io/nats.js
+
+  nkeys.js@1.1.0:
+    resolution: {integrity: sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg==}
+    engines: {node: '>=10.0.0'}
+
+  tsx@4.22.3:
+    resolution: {integrity: sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
+    optional: true
+
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.8.0': {}
+
+  '@types/node@22.19.19':
+    dependencies:
+      undici-types: 6.21.0
+
+  canonicalize@2.1.0: {}
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
+  fsevents@2.3.3:
+    optional: true
+
+  nats@2.29.3:
+    dependencies:
+      nkeys.js: 1.1.0
+
+  nkeys.js@1.1.0:
+    dependencies:
+      tweetnacl: 1.0.3
+
+  tsx@4.22.3:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  tweetnacl@1.0.3: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  zod@3.25.76: {}

--- a/packages/events/pnpm-lock.yaml
+++ b/packages/events/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@effect/schema':
+        specifier: ^0.75.0
+        version: 0.75.5(effect@3.21.2)
       '@noble/curves':
         specifier: ^1.7.0
         version: 1.9.7
@@ -17,9 +20,9 @@ importers:
       canonicalize:
         specifier: ^2.0.0
         version: 2.1.0
-      zod:
-        specifier: ^3.23.0
-        version: 3.25.76
+      effect:
+        specifier: ^3.10.0
+        version: 3.21.2
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -35,6 +38,12 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@effect/schema@0.75.5':
+    resolution: {integrity: sha512-TQInulTVCuF+9EIbJpyLP6dvxbQJMphrnRqgexm/Ze39rSjfhJuufF7XvU3SxTgg3HnL7B/kpORTJbHhlE6thw==}
+    deprecated: this package has been merged into the main effect package
+    peerDependencies:
+      effect: ^3.9.2
 
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
@@ -200,6 +209,9 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@types/node@22.19.19':
     resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
 
@@ -207,10 +219,17 @@ packages:
     resolution: {integrity: sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==}
     hasBin: true
 
+  effect@3.21.2:
+    resolution: {integrity: sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==}
+
   esbuild@0.28.0:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -225,6 +244,9 @@ packages:
   nkeys.js@1.1.0:
     resolution: {integrity: sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg==}
     engines: {node: '>=10.0.0'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   tsx@4.22.3:
     resolution: {integrity: sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==}
@@ -242,10 +264,12 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
 snapshots:
+
+  '@effect/schema@0.75.5(effect@3.21.2)':
+    dependencies:
+      effect: 3.21.2
+      fast-check: 3.23.2
 
   '@esbuild/aix-ppc64@0.28.0':
     optional: true
@@ -331,11 +355,18 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@types/node@22.19.19':
     dependencies:
       undici-types: 6.21.0
 
   canonicalize@2.1.0: {}
+
+  effect@3.21.2:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
 
   esbuild@0.28.0:
     optionalDependencies:
@@ -366,6 +397,10 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
 
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
   fsevents@2.3.3:
     optional: true
 
@@ -376,6 +411,8 @@ snapshots:
   nkeys.js@1.1.0:
     dependencies:
       tweetnacl: 1.0.3
+
+  pure-rand@6.1.0: {}
 
   tsx@4.22.3:
     dependencies:
@@ -388,5 +425,3 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
-
-  zod@3.25.76: {}

--- a/packages/events/src/envelope.ts
+++ b/packages/events/src/envelope.ts
@@ -1,50 +1,98 @@
-import { z } from "zod";
+import { Schema as S } from "@effect/schema";
+import { jcsCanonicalize, sha256Hex } from "./jcs.js";
 
-export const SCHEMA_VERSION = "acvp-l1-v1" as const;
+/**
+ * Envelope wire-format version. Schema-evolution discipline:
+ *
+ *   - acvp-l1-v1 — INITIAL (PR #227, cycle-events-pillar-v1 Sprint 1).
+ *                  signed: UTF-8(prev_hash || payload_hash). KNOWN GAP — routing
+ *                  metadata (event_type, emitted_by, etc.) was NOT covered by the
+ *                  signature (BB#227 EVT-001). NEVER deployed to production —
+ *                  superseded by v2 in the same PR before merge.
+ *
+ *   - acvp-l1-v2 — CURRENT. signed: sha256(JCS canonical of the envelope
+ *                  with `signature: ""` set). Covers ALL semantically
+ *                  load-bearing fields (event_id, event_type, schema_version,
+ *                  emitted_by, emitted_at, prev_hash, payload_hash,
+ *                  signing_key_id, payload). Closes EVT-001's routing-metadata
+ *                  forgery vector.
+ *
+ * Schema bumps for future fields use a NEW versioned subject + ≥30d v1/v2
+ * coexistence window (see build doc); subscribers may consume both via
+ * separate `subscribeEnvelope` calls.
+ */
+export const SCHEMA_VERSION = "acvp-l1-v2" as const;
 
-const Hex64 = z.string().regex(/^[0-9a-f]{64}$/, "must be 64 lowercase hex chars (sha256)");
-const Base64Url = z.string().regex(/^[A-Za-z0-9_-]+$/, "must be base64url-encoded (no padding)");
+// --- shape refinements -------------------------------------------------------
 
-const Iso8601Utc = z
-  .string()
-  .regex(
-    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/,
-    "must be ISO-8601 UTC with trailing Z (e.g. 2026-05-26T21:30:00.123Z)",
-  );
+const Hex64Schema = S.String.pipe(
+  S.pattern(/^[0-9a-f]{64}$/, { message: () => "must be 64 lowercase hex chars (sha256)" }),
+);
 
-const Topic3Segment = z
-  .string()
-  .regex(
-    /^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*){2,}\.v[1-9]\d*$/,
-    "must be Hounfour {aggregate}.{noun}.{verb}[.{specifier}].v{N>=1} (lowercase, dot-separated)",
-  );
+const Base64UrlSchema = S.String.pipe(
+  S.pattern(/^[A-Za-z0-9_-]+$/, { message: () => "must be base64url-encoded (no padding)" }),
+);
 
-const CellSlug = z
-  .string()
-  .regex(/^[a-z][a-z0-9-]*$/, "must be lowercase kebab-case cell slug (e.g. sonar-api)");
+const Iso8601UtcSchema = S.String.pipe(
+  S.pattern(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/, {
+    message: () => "must be ISO-8601 UTC with trailing Z (e.g. 2026-05-26T21:30:00.123Z)",
+  }),
+);
 
-const SigningKeyIdSchema = z
-  .string()
-  .regex(/^[A-Za-z0-9_.:-]{1,128}$/, "must be a stable opaque kid (alphanumeric + _.:- )");
+const Topic3SegmentSchema = S.String.pipe(
+  S.pattern(/^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*){2,}\.v[1-9]\d*$/, {
+    message: () =>
+      "must be Hounfour {aggregate}.{noun}.{verb}[.{specifier}].v{N>=1} (lowercase, dot-separated)",
+  }),
+);
 
-export const EventEnvelopeSchema = z
-  .object({
-    event_id: z.string().uuid(),
-    event_type: Topic3Segment,
-    schema_version: z.literal(SCHEMA_VERSION),
-    emitted_by: CellSlug,
-    emitted_at: Iso8601Utc,
+const CellSlugSchema = S.String.pipe(
+  S.pattern(/^[a-z][a-z0-9-]*$/, {
+    message: () => "must be lowercase kebab-case cell slug (e.g. sonar-api)",
+  }),
+);
 
-    prev_hash: Hex64,
-    payload_hash: Hex64,
-    signing_key_id: SigningKeyIdSchema,
-    signature: Base64Url,
+const SigningKeyIdSchema = S.String.pipe(
+  S.pattern(/^[A-Za-z0-9_.:-]{1,128}$/, {
+    message: () => "must be a stable opaque kid (alphanumeric + _.:- )",
+  }),
+);
 
-    payload: z.unknown(),
-  })
-  .strict();
+const EventIdSchema = S.String.pipe(
+  S.pattern(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/, {
+    message: () => "must be a UUID",
+  }),
+);
 
-export type EventEnvelope = z.infer<typeof EventEnvelopeSchema>;
+// --- envelope schema ---------------------------------------------------------
+
+/**
+ * Canonical event envelope. Effect.Schema enforces presence + type +
+ * primitive-shape refinements; semantic constraints (sig verification,
+ * chain continuity, per-event payload conformance) are the
+ * publisher/subscriber's responsibility.
+ *
+ * `S.Struct({...})` rejects undeclared fields by default — the cluster-098
+ * `.strict()` equivalent. Adding a field without a schema bump is a
+ * substrate violation and will fail decode at both the publisher's
+ * defense-in-depth gate and the subscriber's verify step.
+ */
+export const EventEnvelopeSchema = S.Struct({
+  event_id: EventIdSchema,
+  event_type: Topic3SegmentSchema,
+  schema_version: S.Literal(SCHEMA_VERSION),
+  emitted_by: CellSlugSchema,
+  emitted_at: Iso8601UtcSchema,
+
+  prev_hash: Hex64Schema,
+  payload_hash: Hex64Schema,
+  signing_key_id: SigningKeyIdSchema,
+  signature: Base64UrlSchema,
+
+  payload: S.Unknown,
+});
+
+export type EventEnvelope = S.Schema.Type<typeof EventEnvelopeSchema>;
 export type EventEnvelopePayload = unknown;
 
 /**
@@ -54,13 +102,34 @@ export type EventEnvelopePayload = unknown;
 export const GENESIS_PREV_HASH = "0".repeat(64);
 
 /**
- * Compute the bytes that get signed.
+ * Compute the bytes that get signed for an envelope.
  *
- * Spec: UTF-8 bytes of the concatenation `${prev_hash}${payload_hash}` (no separator).
- * Both sides are 64-char lowercase hex; concat is 128 chars (128 bytes UTF-8).
+ * **acvp-l1-v2 (current)**: returns the UTF-8 bytes of the SHA-256 hex of
+ * the JCS-canonical form of the envelope with the `signature` field set to
+ * the empty string. This binds EVERY non-signature field of the envelope
+ * to the signature — event_type, emitted_by, schema_version, event_id,
+ * emitted_at, prev_hash, payload_hash, signing_key_id, AND payload — so
+ * an attacker who tampers any of them invalidates the signature.
  *
- * Deterministic + simple — sender and receiver agree on what was signed without ambiguity.
+ * The empty-string convention (vs. omitting the `signature` key) keeps the
+ * JCS canonical form structurally identical to the eventual published
+ * envelope, which simplifies the verifier: it just substitutes `""` for
+ * the actual signature before recomputing.
+ *
+ * Closes BB#227 EVT-001 (routing-metadata forgery — superseded the
+ * acvp-l1-v1 `(prev_hash || payload_hash)` concatenation which left
+ * `event_type`/`emitted_by`/etc. unsigned).
  */
-export function envelopeSigningBytes(prevHash: string, payloadHash: string): Uint8Array {
-  return new TextEncoder().encode(`${prevHash}${payloadHash}`);
+export function envelopeSigningBytes(
+  envelopeWithoutSignature: Omit<EventEnvelope, "signature">,
+): Uint8Array {
+  // construct the "to-be-signed" envelope shape: signature is the empty
+  // string placeholder so both sides hash structurally-identical objects
+  const tbs: EventEnvelope = {
+    ...envelopeWithoutSignature,
+    signature: "",
+  };
+  const canonical = jcsCanonicalize(tbs);
+  const digestHex = sha256Hex(canonical);
+  return new TextEncoder().encode(digestHex);
 }

--- a/packages/events/src/envelope.ts
+++ b/packages/events/src/envelope.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+
+export const SCHEMA_VERSION = "acvp-l1-v1" as const;
+
+const Hex64 = z.string().regex(/^[0-9a-f]{64}$/, "must be 64 lowercase hex chars (sha256)");
+const Base64Url = z.string().regex(/^[A-Za-z0-9_-]+$/, "must be base64url-encoded (no padding)");
+
+const Iso8601Utc = z
+  .string()
+  .regex(
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/,
+    "must be ISO-8601 UTC with trailing Z (e.g. 2026-05-26T21:30:00.123Z)",
+  );
+
+const Topic3Segment = z
+  .string()
+  .regex(
+    /^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*){2,}\.v[1-9]\d*$/,
+    "must be Hounfour {aggregate}.{noun}.{verb}[.{specifier}].v{N>=1} (lowercase, dot-separated)",
+  );
+
+const CellSlug = z
+  .string()
+  .regex(/^[a-z][a-z0-9-]*$/, "must be lowercase kebab-case cell slug (e.g. sonar-api)");
+
+const SigningKeyIdSchema = z
+  .string()
+  .regex(/^[A-Za-z0-9_.:-]{1,128}$/, "must be a stable opaque kid (alphanumeric + _.:- )");
+
+export const EventEnvelopeSchema = z
+  .object({
+    event_id: z.string().uuid(),
+    event_type: Topic3Segment,
+    schema_version: z.literal(SCHEMA_VERSION),
+    emitted_by: CellSlug,
+    emitted_at: Iso8601Utc,
+
+    prev_hash: Hex64,
+    payload_hash: Hex64,
+    signing_key_id: SigningKeyIdSchema,
+    signature: Base64Url,
+
+    payload: z.unknown(),
+  })
+  .strict();
+
+export type EventEnvelope = z.infer<typeof EventEnvelopeSchema>;
+export type EventEnvelopePayload = unknown;
+
+/**
+ * Sentinel prev_hash for the first envelope in a per-publisher chain.
+ * Hex-encoded 32 zero bytes — cycle-098 L1 convention.
+ */
+export const GENESIS_PREV_HASH = "0".repeat(64);
+
+/**
+ * Compute the bytes that get signed.
+ *
+ * Spec: UTF-8 bytes of the concatenation `${prev_hash}${payload_hash}` (no separator).
+ * Both sides are 64-char lowercase hex; concat is 128 chars (128 bytes UTF-8).
+ *
+ * Deterministic + simple — sender and receiver agree on what was signed without ambiguity.
+ */
+export function envelopeSigningBytes(prevHash: string, payloadHash: string): Uint8Array {
+  return new TextEncoder().encode(`${prevHash}${payloadHash}`);
+}

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -10,9 +10,11 @@ export { jcsCanonicalize, sha256Hex } from "./jcs.js";
 export {
   LocalEd25519Signer,
   JwksVerifier,
+  StaticPubkeyVerifier,
   type Signer,
   type Verifier,
   type SigningKeyId,
+  type JwksVerifierOptions,
 } from "./signer.js";
 
 export {

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -1,0 +1,42 @@
+export {
+  EventEnvelopeSchema,
+  SCHEMA_VERSION,
+  type EventEnvelope,
+  type EventEnvelopePayload,
+} from "./envelope.js";
+
+export { jcsCanonicalize, sha256Hex } from "./jcs.js";
+
+export {
+  LocalEd25519Signer,
+  JwksVerifier,
+  type Signer,
+  type Verifier,
+  type SigningKeyId,
+} from "./signer.js";
+
+export {
+  nftMintDetectedTopic,
+  NFT_MINT_DETECTED_WILDCARD,
+  type TopicSegments,
+} from "./topics.js";
+
+export {
+  publishEnvelope,
+  InMemoryPrevHashStore,
+  type PrevHashStore,
+  type PublishOptions,
+  type PublishResult,
+} from "./publisher.js";
+
+export {
+  subscribeEnvelope,
+  type SubscribeOptions,
+  type EnvelopeHandler,
+  type VerificationFailureReason,
+} from "./subscriber.js";
+
+export {
+  NftMintDetectedSchema,
+  type NftMintDetected,
+} from "./schemas/nft-mint-detected.js";

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -1,6 +1,8 @@
 export {
   EventEnvelopeSchema,
+  GENESIS_PREV_HASH,
   SCHEMA_VERSION,
+  envelopeSigningBytes,
   type EventEnvelope,
   type EventEnvelopePayload,
 } from "./envelope.js";
@@ -20,6 +22,7 @@ export {
 export {
   nftMintDetectedTopic,
   NFT_MINT_DETECTED_WILDCARD,
+  buildTopic,
   type TopicSegments,
 } from "./topics.js";
 
@@ -35,7 +38,9 @@ export {
   subscribeEnvelope,
   type SubscribeOptions,
   type EnvelopeHandler,
+  type EnvelopeHandlerContext,
   type VerificationFailureReason,
+  type InitialPrevHashPolicy,
 } from "./subscriber.js";
 
 export {

--- a/packages/events/src/jcs.ts
+++ b/packages/events/src/jcs.ts
@@ -1,0 +1,42 @@
+import canonicalizeMod from "canonicalize";
+import { sha256 } from "@noble/hashes/sha2";
+import { bytesToHex } from "@noble/hashes/utils";
+
+// canonicalize@2 is a CJS module whose `module.exports = function`. Under
+// `module: NodeNext` TS reads its .d.ts as `export default function` — but
+// at runtime the default-import IS the function directly. The interop cast
+// here reconciles the two without pulling in createRequire boilerplate.
+const canonicalize = canonicalizeMod as unknown as (value: unknown) => string | undefined;
+
+/**
+ * RFC 8785 JSON Canonicalization Scheme.
+ *
+ * Wraps the `canonicalize` npm package — small (zero-dep), audited, widely used.
+ * The cycle-098 prior art (`.claude/scripts/lib/jcs.sh`) is a bash port of the
+ * same spec; a cross-runtime identity test (TypeScript ↔ bash) ensures both
+ * produce byte-identical output for the same input (R15 invariant).
+ *
+ * Throws if input contains values JSON cannot represent (functions, symbols,
+ * Infinity, NaN, BigInt without toJSON). Callers should validate payloads
+ * against a Zod schema BEFORE canonicalizing.
+ */
+export function jcsCanonicalize(value: unknown): string {
+  const out = canonicalize(value);
+  if (typeof out !== "string") {
+    throw new Error(
+      "jcsCanonicalize: input is not JSON-representable (functions, symbols, Infinity, NaN, BigInt without toJSON, or undefined at root)",
+    );
+  }
+  return out;
+}
+
+/**
+ * SHA-256 over a string, returned as 64-char lowercase hex.
+ *
+ * Used for payload_hash (over JCS-canonical payload) and prev_hash
+ * (over JCS-canonical envelope of the prior message).
+ */
+export function sha256Hex(input: string | Uint8Array): string {
+  const bytes = typeof input === "string" ? new TextEncoder().encode(input) : input;
+  return bytesToHex(sha256(bytes));
+}

--- a/packages/events/src/publisher.ts
+++ b/packages/events/src/publisher.ts
@@ -1,7 +1,21 @@
 import { randomUUID } from "node:crypto";
-import { EventEnvelopeSchema, GENESIS_PREV_HASH, SCHEMA_VERSION, envelopeSigningBytes, type EventEnvelope } from "./envelope.js";
+import { Schema as S } from "@effect/schema";
+import {
+  EventEnvelopeSchema,
+  GENESIS_PREV_HASH,
+  SCHEMA_VERSION,
+  envelopeSigningBytes,
+  type EventEnvelope,
+} from "./envelope.js";
 import { jcsCanonicalize, sha256Hex } from "./jcs.js";
 import type { Signer } from "./signer.js";
+
+// `onExcessProperty: "error"` mirrors Zod's `.strict()` — extra fields are
+// REJECTED at decode time. Critical for the envelope contract: an extra
+// field in a hashed envelope changes the hash and would silently break
+// chain continuity for any subscriber that recomputes.
+const decodeEnvelope = (input: unknown) =>
+  S.decodeUnknownSync(EventEnvelopeSchema)(input, { onExcessProperty: "error" });
 
 /**
  * Per-publisher hash-chain store.
@@ -71,14 +85,17 @@ export interface PublishResult {
 /**
  * Wrap a payload in an ACVP envelope, sign it, and publish on NATS.
  *
- * Flow:
+ * Flow (acvp-l1-v2):
  *   1. canonicalize payload via JCS → payload_hash = sha256(canonical)
  *   2. prev_hash = store.get(publisherKey) ?? GENESIS_PREV_HASH
- *   3. signature = sign(UTF-8(prev_hash || payload_hash))
- *   4. assemble envelope; validate via Zod (defense in depth)
- *   5. canonicalize envelope → envelopeHash = sha256(canonical)
- *   6. nats.publish(subject, canonical-envelope-bytes)
- *   7. store.set(publisherKey, envelopeHash)
+ *   3. assemble unsigned envelope (signature: "" placeholder)
+ *   4. signing bytes = UTF-8(sha256-hex(JCS(envelope-with-empty-sig))) —
+ *      this binds ALL non-signature fields to the signature (EVT-001 closed)
+ *   5. signature = sign(signing bytes)
+ *   6. attach real signature; validate via Effect.Schema (defense in depth)
+ *   7. canonicalize signed envelope → envelopeHash = sha256(canonical)
+ *   8. nats.publish(subject, canonical-envelope-bytes)
+ *   9. store.set(publisherKey, envelopeHash)
  *
  * Throws if envelope validation fails (defensive — should never happen if
  * inputs are well-formed). NATS publish errors propagate to the caller; the
@@ -118,10 +135,10 @@ export async function publishEnvelope<P>(opts: PublishOptions<P>): Promise<Publi
   const payloadHash = sha256Hex(canonicalPayload);
 
   const prevHash = (await opts.prevHashStore.get(publisherKey)) ?? GENESIS_PREV_HASH;
-  const sigBytes = envelopeSigningBytes(prevHash, payloadHash);
-  const signature = await opts.signer.sign(sigBytes);
 
-  const envelope: EventEnvelope = {
+  // EVT-001 closed: signing bytes derived from the FULL envelope (with
+  // signature placeholder), so any tamper to any field invalidates the sig.
+  const unsignedEnvelope: Omit<EventEnvelope, "signature"> = {
     event_id: newEventId(),
     event_type: opts.subject,
     schema_version: SCHEMA_VERSION,
@@ -130,20 +147,24 @@ export async function publishEnvelope<P>(opts: PublishOptions<P>): Promise<Publi
     prev_hash: prevHash,
     payload_hash: payloadHash,
     signing_key_id: opts.signer.keyId,
-    signature,
     payload: opts.payload,
   };
+
+  const sigBytes = envelopeSigningBytes(unsignedEnvelope);
+  const signature = await opts.signer.sign(sigBytes);
+
+  const envelope: EventEnvelope = { ...unsignedEnvelope, signature };
 
   // Defense in depth: ensure the envelope conforms to its own contract
   // before we hash + publish it. If any field is malformed, fail loud HERE
   // rather than propagating an invalid envelope into the chain.
-  EventEnvelopeSchema.parse(envelope);
+  const validated = decodeEnvelope(envelope);
 
-  const canonicalEnvelope = jcsCanonicalize(envelope);
+  const canonicalEnvelope = jcsCanonicalize(validated);
   const envelopeHash = sha256Hex(canonicalEnvelope);
 
   await opts.nats.publish(opts.subject, new TextEncoder().encode(canonicalEnvelope));
   await opts.prevHashStore.set(publisherKey, envelopeHash);
 
-  return { envelope, envelopeHash, subject: opts.subject };
+  return { envelope: validated, envelopeHash, subject: opts.subject };
 }

--- a/packages/events/src/publisher.ts
+++ b/packages/events/src/publisher.ts
@@ -84,6 +84,30 @@ export interface PublishResult {
  * inputs are well-formed). NATS publish errors propagate to the caller; the
  * caller is responsible for fail-soft behavior (log + continue without
  * breaking the upstream domain write).
+ *
+ * **Known limitation — publish/store atomicity (F-003 BB#227)**
+ *
+ * `nats.publish` and `prevHashStore.set` are two separate async steps with
+ * no rollback. A crash (or store-write failure) between them leaves the
+ * publisher's chain tip stale; the next publish reuses a `prev_hash` that
+ * was already consumed, forking the chain. Subscribers with `chainStore`
+ * enabled will surface `prev-hash-broken-chain` on the second envelope.
+ *
+ * Single-instance publishers running in healthy processes do not hit this
+ * gap in practice; the failure mode is bounded to crash/restart windows.
+ *
+ * The recommended Sprint-2+ mitigation:
+ *
+ *   1. Back `prevHashStore` with Redis using a CAS pipeline that conditions
+ *      the `SET publisherKey newHash` on the NATS publish acknowledgement
+ *      (e.g. via JetStream's PubAck.seq as the conditional token), OR
+ *   2. Accept at-least-once semantics and add subscriber-side chain reset
+ *      logic — wire `onVerificationFailure("prev-hash-broken-chain", ...)`
+ *      to a recovery callback that updates the subscriber's chain store to
+ *      the current envelope's hash and emits an audit event.
+ *
+ * Multi-instance publishers MUST use a shared store (Redis, etc.); the
+ * default `InMemoryPrevHashStore` is single-process only.
  */
 export async function publishEnvelope<P>(opts: PublishOptions<P>): Promise<PublishResult> {
   const publisherKey = opts.publisherKey ?? `${opts.emittedBy}:${opts.signer.keyId}`;

--- a/packages/events/src/publisher.ts
+++ b/packages/events/src/publisher.ts
@@ -1,0 +1,125 @@
+import { randomUUID } from "node:crypto";
+import { EventEnvelopeSchema, GENESIS_PREV_HASH, SCHEMA_VERSION, envelopeSigningBytes, type EventEnvelope } from "./envelope.js";
+import { jcsCanonicalize, sha256Hex } from "./jcs.js";
+import type { Signer } from "./signer.js";
+
+/**
+ * Per-publisher hash-chain store.
+ *
+ * Each publisher (e.g. `sonar-api`) maintains an ordered chain — every emitted
+ * envelope's `prev_hash` is the sha256 of the prior emitted envelope's full
+ * JCS-canonical form. The store persists the most-recent hash per publisher.
+ *
+ * In-memory implementations (e.g. {@link InMemoryPrevHashStore}) are fine for
+ * single-process publishers. Multi-instance publishers should back this with
+ * Redis or another shared substrate so the chain remains continuous across
+ * restarts and load-balanced sender instances.
+ */
+export interface PrevHashStore {
+  get(publisherKey: string): Promise<string | null>;
+  set(publisherKey: string, hash: string): Promise<void>;
+}
+
+export class InMemoryPrevHashStore implements PrevHashStore {
+  #map = new Map<string, string>();
+
+  async get(publisherKey: string): Promise<string | null> {
+    return this.#map.get(publisherKey) ?? null;
+  }
+
+  async set(publisherKey: string, hash: string): Promise<void> {
+    this.#map.set(publisherKey, hash);
+  }
+}
+
+// --- minimal NATS publisher interface (avoid hard nats.js dep) --------------
+
+interface NatsLike {
+  publish(subject: string, data: Uint8Array, opts?: { headers?: unknown }): void | Promise<unknown>;
+}
+
+// --- options + result -------------------------------------------------------
+
+export interface PublishOptions<P> {
+  nats: NatsLike;
+  subject: string;
+  payload: P;
+  /** Cell slug that emits — populates `emitted_by`. e.g. "sonar-api". */
+  emittedBy: string;
+  signer: Signer;
+  prevHashStore: PrevHashStore;
+  /**
+   * Logical identifier for this publisher's per-instance chain. Defaults to
+   * `${emittedBy}:${signer.keyId}` — most publishers want exactly one chain
+   * per (cell, signing key) pair.
+   */
+  publisherKey?: string;
+  /** Override timestamp (mostly for tests). */
+  nowIso?: () => string;
+  /** Override event_id generation (mostly for tests). */
+  newEventId?: () => string;
+}
+
+export interface PublishResult {
+  envelope: EventEnvelope;
+  /** sha256 of the JCS-canonical envelope — next publish's prev_hash. */
+  envelopeHash: string;
+  /** Subject the envelope was published on. */
+  subject: string;
+}
+
+/**
+ * Wrap a payload in an ACVP envelope, sign it, and publish on NATS.
+ *
+ * Flow:
+ *   1. canonicalize payload via JCS → payload_hash = sha256(canonical)
+ *   2. prev_hash = store.get(publisherKey) ?? GENESIS_PREV_HASH
+ *   3. signature = sign(UTF-8(prev_hash || payload_hash))
+ *   4. assemble envelope; validate via Zod (defense in depth)
+ *   5. canonicalize envelope → envelopeHash = sha256(canonical)
+ *   6. nats.publish(subject, canonical-envelope-bytes)
+ *   7. store.set(publisherKey, envelopeHash)
+ *
+ * Throws if envelope validation fails (defensive — should never happen if
+ * inputs are well-formed). NATS publish errors propagate to the caller; the
+ * caller is responsible for fail-soft behavior (log + continue without
+ * breaking the upstream domain write).
+ */
+export async function publishEnvelope<P>(opts: PublishOptions<P>): Promise<PublishResult> {
+  const publisherKey = opts.publisherKey ?? `${opts.emittedBy}:${opts.signer.keyId}`;
+  const nowIso = opts.nowIso ?? (() => new Date().toISOString());
+  const newEventId = opts.newEventId ?? randomUUID;
+
+  const canonicalPayload = jcsCanonicalize(opts.payload);
+  const payloadHash = sha256Hex(canonicalPayload);
+
+  const prevHash = (await opts.prevHashStore.get(publisherKey)) ?? GENESIS_PREV_HASH;
+  const sigBytes = envelopeSigningBytes(prevHash, payloadHash);
+  const signature = await opts.signer.sign(sigBytes);
+
+  const envelope: EventEnvelope = {
+    event_id: newEventId(),
+    event_type: opts.subject,
+    schema_version: SCHEMA_VERSION,
+    emitted_by: opts.emittedBy,
+    emitted_at: nowIso(),
+    prev_hash: prevHash,
+    payload_hash: payloadHash,
+    signing_key_id: opts.signer.keyId,
+    signature,
+    payload: opts.payload,
+  };
+
+  // Defense in depth: ensure the envelope conforms to its own contract
+  // before we hash + publish it. If any field is malformed, fail loud HERE
+  // rather than propagating an invalid envelope into the chain.
+  EventEnvelopeSchema.parse(envelope);
+
+  const canonicalEnvelope = jcsCanonicalize(envelope);
+  const envelopeHash = sha256Hex(canonicalEnvelope);
+
+  await opts.nats.publish(opts.subject, new TextEncoder().encode(canonicalEnvelope));
+  await opts.prevHashStore.set(publisherKey, envelopeHash);
+
+  return { envelope, envelopeHash, subject: opts.subject };
+}

--- a/packages/events/src/schemas/nft-mint-detected.ts
+++ b/packages/events/src/schemas/nft-mint-detected.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { Schema as S } from "@effect/schema";
 
 /**
  * Payload schema for `nft.mint.detected.*.v1` events.
@@ -11,44 +11,61 @@ import { z } from "zod";
  * non-additive way, publish under `nft.mint.detected.*.v2` alongside v1
  * during a ≥30d overlap window; subscribers may consume both via separate
  * `subscribeEnvelope` calls.
+ *
+ * Effect.Schema chosen here (vs zod) per cluster memory
+ * `freeside-effect-transition`: new protocol-layer types use @effect/schema;
+ * legacy zod stays for now. This payload schema travels across cells
+ * (cross-cell wire contract = protocol layer), so it falls on the
+ * Effect.Schema side of the line.
  */
-export const NftMintDetectedSchema = z
-  .object({
-    /** EVM chain id (e.g. 80094 = Berachain mainnet). */
-    chain_id: z.number().int().positive(),
+export const NftMintDetectedSchema = S.Struct({
+  /** EVM chain id (e.g. 80094 = Berachain mainnet). */
+  chain_id: S.Number.pipe(S.int(), S.positive()),
 
-    /** Contract address — lowercase 0x-prefixed 40 hex chars. */
-    contract: z.string().regex(/^0x[0-9a-f]{40}$/, "must be lowercase 0x-prefixed 40 hex chars"),
+  /** Contract address — lowercase 0x-prefixed 40 hex chars. */
+  contract: S.String.pipe(
+    S.pattern(/^0x[0-9a-f]{40}$/, {
+      message: () => "must be lowercase 0x-prefixed 40 hex chars",
+    }),
+  ),
 
-    /** Token id — string-encoded (uint256 doesn't fit in a JS number). */
-    token_id: z.string().regex(/^\d+$/, "must be a non-negative decimal integer string"),
+  /** Token id — string-encoded (uint256 doesn't fit in a JS number). */
+  token_id: S.String.pipe(
+    S.pattern(/^\d+$/, { message: () => "must be a non-negative decimal integer string" }),
+  ),
 
-    /** Minter (recipient of the from-0x0 transfer) — lowercase 0x-prefixed. */
-    minter: z.string().regex(/^0x[0-9a-f]{40}$/, "must be lowercase 0x-prefixed 40 hex chars"),
+  /** Minter (recipient of the from-0x0 transfer) — lowercase 0x-prefixed. */
+  minter: S.String.pipe(
+    S.pattern(/^0x[0-9a-f]{40}$/, {
+      message: () => "must be lowercase 0x-prefixed 40 hex chars",
+    }),
+  ),
 
-    /** Block number the mint landed in. */
-    block_number: z.number().int().nonnegative(),
+  /** Block number the mint landed in. */
+  block_number: S.Number.pipe(S.int(), S.nonNegative()),
 
-    /** Transaction hash — lowercase 0x-prefixed 64 hex chars. */
-    transaction_hash: z
-      .string()
-      .regex(/^0x[0-9a-f]{64}$/, "must be lowercase 0x-prefixed 64 hex chars"),
+  /** Transaction hash — lowercase 0x-prefixed 64 hex chars. */
+  transaction_hash: S.String.pipe(
+    S.pattern(/^0x[0-9a-f]{64}$/, {
+      message: () => "must be lowercase 0x-prefixed 64 hex chars",
+    }),
+  ),
 
-    /** Block timestamp as ISO-8601 UTC. */
-    timestamp: z
-      .string()
-      .regex(
-        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/,
-        "must be ISO-8601 UTC with trailing Z",
-      ),
+  /** Block timestamp as ISO-8601 UTC. */
+  timestamp: S.String.pipe(
+    S.pattern(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/, {
+      message: () => "must be ISO-8601 UTC with trailing Z",
+    }),
+  ),
 
-    /**
-     * MST-specific enrichment — present when the handler is `vm-minted.ts`
-     * (Mibera Shadows). Opaque hex string; downstream decoder lives in the
-     * Mibera codex.
-     */
-    encoded_traits: z.string().regex(/^0x[0-9a-f]+$/).optional(),
-  })
-  .strict();
+  /**
+   * MST-specific enrichment — present when the handler is `vm-minted.ts`
+   * (Mibera Shadows). Opaque hex string; downstream decoder lives in the
+   * Mibera codex.
+   */
+  encoded_traits: S.optional(
+    S.String.pipe(S.pattern(/^0x[0-9a-f]+$/, { message: () => "must be 0x-prefixed hex" })),
+  ),
+});
 
-export type NftMintDetected = z.infer<typeof NftMintDetectedSchema>;
+export type NftMintDetected = S.Schema.Type<typeof NftMintDetectedSchema>;

--- a/packages/events/src/schemas/nft-mint-detected.ts
+++ b/packages/events/src/schemas/nft-mint-detected.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+/**
+ * Payload schema for `nft.mint.detected.*.v1` events.
+ *
+ * Emitted by `sonar-api` when an EVM Transfer-from-0x0 (or other mint-shaped
+ * event per the indexer's per-contract handler) is detected. The publisher's
+ * handler decides which collection slug to route to.
+ *
+ * v2 evolution (future): if the payload shape needs to change in a
+ * non-additive way, publish under `nft.mint.detected.*.v2` alongside v1
+ * during a ≥30d overlap window; subscribers may consume both via separate
+ * `subscribeEnvelope` calls.
+ */
+export const NftMintDetectedSchema = z
+  .object({
+    /** EVM chain id (e.g. 80094 = Berachain mainnet). */
+    chain_id: z.number().int().positive(),
+
+    /** Contract address — lowercase 0x-prefixed 40 hex chars. */
+    contract: z.string().regex(/^0x[0-9a-f]{40}$/, "must be lowercase 0x-prefixed 40 hex chars"),
+
+    /** Token id — string-encoded (uint256 doesn't fit in a JS number). */
+    token_id: z.string().regex(/^\d+$/, "must be a non-negative decimal integer string"),
+
+    /** Minter (recipient of the from-0x0 transfer) — lowercase 0x-prefixed. */
+    minter: z.string().regex(/^0x[0-9a-f]{40}$/, "must be lowercase 0x-prefixed 40 hex chars"),
+
+    /** Block number the mint landed in. */
+    block_number: z.number().int().nonnegative(),
+
+    /** Transaction hash — lowercase 0x-prefixed 64 hex chars. */
+    transaction_hash: z
+      .string()
+      .regex(/^0x[0-9a-f]{64}$/, "must be lowercase 0x-prefixed 64 hex chars"),
+
+    /** Block timestamp as ISO-8601 UTC. */
+    timestamp: z
+      .string()
+      .regex(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/,
+        "must be ISO-8601 UTC with trailing Z",
+      ),
+
+    /**
+     * MST-specific enrichment — present when the handler is `vm-minted.ts`
+     * (Mibera Shadows). Opaque hex string; downstream decoder lives in the
+     * Mibera codex.
+     */
+    encoded_traits: z.string().regex(/^0x[0-9a-f]+$/).optional(),
+  })
+  .strict();
+
+export type NftMintDetected = z.infer<typeof NftMintDetectedSchema>;

--- a/packages/events/src/signer.ts
+++ b/packages/events/src/signer.ts
@@ -155,6 +155,13 @@ export interface JwksVerifierOptions {
 export class JwksVerifier implements Verifier {
   #cache: Map<SigningKeyId, Uint8Array> = new Map();
   #lastFetchMs = 0;
+  /**
+   * In-flight refresh dedup (EVT-003 BB#227). When a refresh is already
+   * mid-flight, subsequent callers await the same promise instead of
+   * launching parallel fetches; this prevents thundering herd on first
+   * verify after TTL expiry AND closes the last-write-wins rotation race.
+   */
+  #refreshInFlight: Promise<void> | null = null;
   readonly #ttlMs: number;
   readonly #timeoutMs: number;
   readonly #fetchImpl: typeof fetch;
@@ -170,10 +177,33 @@ export class JwksVerifier implements Verifier {
   static async fromUrl(jwksUrl: string, opts: JwksVerifierOptions = {}): Promise<JwksVerifier> {
     const v = new JwksVerifier(jwksUrl, opts);
     await v.refresh();
+    // EVT-004 (BB#227): empty-on-boot is almost always a misconfiguration
+    // (wrong URL, wrong key type, partial deploy). Fail loud at construction
+    // so operators get an immediately actionable deployment error rather
+    // than a silent stream of `signature-invalid` failures later.
+    if (v.#cache.size === 0) {
+      throw new Error(
+        `JwksVerifier.fromUrl: ${jwksUrl} returned zero OKP/Ed25519 keys — refusing to construct an empty-on-boot verifier (likely misconfiguration; pass an empty-tolerant verifier explicitly if intentional)`,
+      );
+    }
     return v;
   }
 
   async refresh(): Promise<void> {
+    // EVT-003 BB#227: coalesce concurrent callers onto the same in-flight
+    // promise. Without this, a burst of messages from a just-rotated key
+    // triggers O(burst-size) parallel fetches AND a last-write-wins race
+    // where a stale CDN-cached response can revert a just-loaded new key.
+    if (this.#refreshInFlight) {
+      return this.#refreshInFlight;
+    }
+    this.#refreshInFlight = this.#doRefresh().finally(() => {
+      this.#refreshInFlight = null;
+    });
+    return this.#refreshInFlight;
+  }
+
+  async #doRefresh(): Promise<void> {
     // F-001 (BB#227): bound the fetch — a hung JWKS endpoint must not stall
     // the subscriber's consume loop. AbortController + timer; clearTimeout
     // on completion in either branch.
@@ -201,14 +231,20 @@ export class JwksVerifier implements Verifier {
       }
     }
 
-    // F-004 (BB#227): non-empty guard. An empty-but-200 JWKS response (mid-
-    // rotation, partial deploy) must NOT wipe the cache — that would self-DoS
-    // verification until the next non-empty refresh lands. Keep the stale
-    // cache; notify the operator via onEmptyJwks; still advance lastFetchMs
-    // so we don't hot-loop the refresh on every verify() call.
-    if (next.size === 0 && this.#cache.size > 0) {
+    // EVT-004 (BB#227): fire onEmptyJwks WHENEVER the fetch returns zero
+    // keys, regardless of prior cache state. The earlier F-004 fix only
+    // fired this on subsequent-refresh empties — the initial-load empty
+    // was silent. Now operators always get the signal.
+    if (next.size === 0) {
       this.#onEmptyJwks(this.jwksUrl);
-    } else {
+    }
+
+    // Non-empty guard (F-004): only replace the cache when next has keys.
+    // An empty-but-200 response (mid-rotation, partial deploy) must NOT
+    // wipe the cache — that would self-DoS verification until the next
+    // non-empty refresh. Still advance lastFetchMs so we don't hot-loop
+    // refresh on every verify() call.
+    if (next.size > 0) {
       this.#cache = next;
     }
     this.#lastFetchMs = Date.now();

--- a/packages/events/src/signer.ts
+++ b/packages/events/src/signer.ts
@@ -136,31 +136,60 @@ interface Jwks {
  * Consumers pass that URL at construction time. The JWKS is cached in-memory
  * with a configurable TTL; cache misses re-fetch.
  */
+export interface JwksVerifierOptions {
+  /** Refresh TTL in milliseconds; default 5 minutes. */
+  ttlMs?: number;
+  /**
+   * Per-fetch timeout in milliseconds; default 5s. A hung JWKS endpoint
+   * would otherwise stall every subscriber's `consume()` loop indefinitely
+   * (verification is awaited per-message). Bound the blast radius here.
+   * Pass `0` to disable (NOT recommended in production).
+   */
+  timeoutMs?: number;
+  /** Injectable fetch — useful for tests. */
+  fetchImpl?: typeof fetch;
+  /** Optional warn-logger fired when a refresh returns zero keys; default no-op. */
+  onEmptyJwks?: (jwksUrl: string) => void;
+}
+
 export class JwksVerifier implements Verifier {
   #cache: Map<SigningKeyId, Uint8Array> = new Map();
   #lastFetchMs = 0;
   readonly #ttlMs: number;
+  readonly #timeoutMs: number;
   readonly #fetchImpl: typeof fetch;
+  readonly #onEmptyJwks: (jwksUrl: string) => void;
 
-  private constructor(
-    readonly jwksUrl: string,
-    opts: { ttlMs?: number; fetchImpl?: typeof fetch } = {},
-  ) {
-    this.#ttlMs = opts.ttlMs ?? 5 * 60 * 1000; // 5 min default
+  private constructor(readonly jwksUrl: string, opts: JwksVerifierOptions = {}) {
+    this.#ttlMs = opts.ttlMs ?? 5 * 60 * 1000;
+    this.#timeoutMs = opts.timeoutMs ?? 5_000;
     this.#fetchImpl = opts.fetchImpl ?? fetch;
+    this.#onEmptyJwks = opts.onEmptyJwks ?? (() => undefined);
   }
 
-  static async fromUrl(
-    jwksUrl: string,
-    opts: { ttlMs?: number; fetchImpl?: typeof fetch } = {},
-  ): Promise<JwksVerifier> {
+  static async fromUrl(jwksUrl: string, opts: JwksVerifierOptions = {}): Promise<JwksVerifier> {
     const v = new JwksVerifier(jwksUrl, opts);
     await v.refresh();
     return v;
   }
 
   async refresh(): Promise<void> {
-    const res = await this.#fetchImpl(this.jwksUrl, { headers: { accept: "application/json" } });
+    // F-001 (BB#227): bound the fetch — a hung JWKS endpoint must not stall
+    // the subscriber's consume loop. AbortController + timer; clearTimeout
+    // on completion in either branch.
+    const controller = this.#timeoutMs > 0 ? new AbortController() : null;
+    const timer = controller
+      ? setTimeout(() => controller.abort(), this.#timeoutMs)
+      : null;
+    let res: Response;
+    try {
+      res = await this.#fetchImpl(this.jwksUrl, {
+        headers: { accept: "application/json" },
+        ...(controller ? { signal: controller.signal } : {}),
+      });
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
     if (!res.ok) {
       throw new Error(`JwksVerifier.refresh: ${this.jwksUrl} returned ${res.status}`);
     }
@@ -171,7 +200,17 @@ export class JwksVerifier implements Verifier {
         next.set(k.kid, base64UrlToBytes(k.x));
       }
     }
-    this.#cache = next;
+
+    // F-004 (BB#227): non-empty guard. An empty-but-200 JWKS response (mid-
+    // rotation, partial deploy) must NOT wipe the cache — that would self-DoS
+    // verification until the next non-empty refresh lands. Keep the stale
+    // cache; notify the operator via onEmptyJwks; still advance lastFetchMs
+    // so we don't hot-loop the refresh on every verify() call.
+    if (next.size === 0 && this.#cache.size > 0) {
+      this.#onEmptyJwks(this.jwksUrl);
+    } else {
+      this.#cache = next;
+    }
     this.#lastFetchMs = Date.now();
   }
 

--- a/packages/events/src/signer.ts
+++ b/packages/events/src/signer.ts
@@ -1,0 +1,210 @@
+import { ed25519 } from "@noble/curves/ed25519.js";
+import { bytesToHex, hexToBytes } from "@noble/hashes/utils";
+
+export type SigningKeyId = string;
+
+/** Sign arbitrary bytes; return base64url signature. */
+export interface Signer {
+  readonly keyId: SigningKeyId;
+  sign(message: Uint8Array): Promise<string>;
+}
+
+/** Verify a base64url signature against a kid + message bytes. */
+export interface Verifier {
+  verify(keyId: SigningKeyId, message: Uint8Array, signatureBase64Url: string): Promise<boolean>;
+}
+
+// --- base64url helpers -------------------------------------------------------
+
+const PAD_RX = /=+$/;
+const STD_RX = /[+/]/g;
+const URL_RX = /[-_]/g;
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  const std = btoa(bin);
+  return std.replace(STD_RX, (c) => (c === "+" ? "-" : "_")).replace(PAD_RX, "");
+}
+
+function base64UrlToBytes(b64u: string): Uint8Array {
+  const std = b64u.replace(URL_RX, (c) => (c === "-" ? "+" : "/"));
+  // restore padding
+  const padLen = (4 - (std.length % 4)) % 4;
+  const padded = std + "=".repeat(padLen);
+  const bin = atob(padded);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+// --- LocalEd25519Signer ------------------------------------------------------
+
+export class LocalEd25519Signer implements Signer {
+  readonly keyId: SigningKeyId;
+  readonly #secretKey: Uint8Array;
+
+  private constructor(keyId: SigningKeyId, secretKey: Uint8Array) {
+    this.keyId = keyId;
+    this.#secretKey = secretKey;
+  }
+
+  static async fromSeedBytes(seed: Uint8Array, keyId: SigningKeyId): Promise<LocalEd25519Signer> {
+    if (seed.length !== 32) {
+      throw new Error(`LocalEd25519Signer: seed must be exactly 32 bytes (got ${seed.length})`);
+    }
+    return new LocalEd25519Signer(keyId, seed);
+  }
+
+  static async fromSeedHex(seedHex: string, keyId: SigningKeyId): Promise<LocalEd25519Signer> {
+    if (!/^[0-9a-fA-F]{64}$/.test(seedHex)) {
+      throw new Error("LocalEd25519Signer.fromSeedHex: expected 64 hex chars (32 bytes)");
+    }
+    return LocalEd25519Signer.fromSeedBytes(hexToBytes(seedHex.toLowerCase()), keyId);
+  }
+
+  async sign(message: Uint8Array): Promise<string> {
+    const sig = ed25519.sign(message, this.#secretKey);
+    return bytesToBase64Url(sig);
+  }
+
+  /** Public key bytes (32) — useful for tests, JWKS publishing, key rotation. */
+  publicKeyBytes(): Uint8Array {
+    return ed25519.getPublicKey(this.#secretKey);
+  }
+
+  publicKeyHex(): string {
+    return bytesToHex(this.publicKeyBytes());
+  }
+}
+
+// --- StaticPubkeyVerifier (for tests / fixed-key consumers) ------------------
+
+/**
+ * Verifier with a pinned in-memory map of `keyId → publicKey`.
+ * Useful for tests and for consumers that operate against a small known set
+ * of publishers; production consumers should use {@link JwksVerifier}.
+ */
+export class StaticPubkeyVerifier implements Verifier {
+  readonly #pubkeys: Map<SigningKeyId, Uint8Array>;
+
+  constructor(pubkeys: Record<SigningKeyId, Uint8Array> | Map<SigningKeyId, Uint8Array> = {}) {
+    this.#pubkeys =
+      pubkeys instanceof Map ? new Map(pubkeys) : new Map(Object.entries(pubkeys));
+  }
+
+  add(keyId: SigningKeyId, publicKey: Uint8Array): this {
+    if (publicKey.length !== 32) {
+      throw new Error(`StaticPubkeyVerifier.add: ed25519 pubkey must be 32 bytes (got ${publicKey.length})`);
+    }
+    this.#pubkeys.set(keyId, publicKey);
+    return this;
+  }
+
+  async verify(keyId: SigningKeyId, message: Uint8Array, signatureBase64Url: string): Promise<boolean> {
+    const pubkey = this.#pubkeys.get(keyId);
+    if (!pubkey) return false;
+    try {
+      const sigBytes = base64UrlToBytes(signatureBase64Url);
+      return ed25519.verify(sigBytes, message, pubkey);
+    } catch {
+      return false;
+    }
+  }
+}
+
+// --- JwksVerifier (fetches JWKS from a URL; caches) --------------------------
+
+interface JwksKey {
+  kty: string;
+  crv?: string;
+  kid: string;
+  x?: string; // base64url public key for OKP/Ed25519
+  use?: string;
+  alg?: string;
+}
+
+interface Jwks {
+  keys: JwksKey[];
+}
+
+/**
+ * Verifier that fetches a JWKS document from an HTTPS endpoint and verifies
+ * Ed25519 signatures against the resolved kid.
+ *
+ * Per ADR-009 §D-5, the cluster's JWKS endpoint lives at `apps/gateway`.
+ * Consumers pass that URL at construction time. The JWKS is cached in-memory
+ * with a configurable TTL; cache misses re-fetch.
+ */
+export class JwksVerifier implements Verifier {
+  #cache: Map<SigningKeyId, Uint8Array> = new Map();
+  #lastFetchMs = 0;
+  readonly #ttlMs: number;
+  readonly #fetchImpl: typeof fetch;
+
+  private constructor(
+    readonly jwksUrl: string,
+    opts: { ttlMs?: number; fetchImpl?: typeof fetch } = {},
+  ) {
+    this.#ttlMs = opts.ttlMs ?? 5 * 60 * 1000; // 5 min default
+    this.#fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  static async fromUrl(
+    jwksUrl: string,
+    opts: { ttlMs?: number; fetchImpl?: typeof fetch } = {},
+  ): Promise<JwksVerifier> {
+    const v = new JwksVerifier(jwksUrl, opts);
+    await v.refresh();
+    return v;
+  }
+
+  async refresh(): Promise<void> {
+    const res = await this.#fetchImpl(this.jwksUrl, { headers: { accept: "application/json" } });
+    if (!res.ok) {
+      throw new Error(`JwksVerifier.refresh: ${this.jwksUrl} returned ${res.status}`);
+    }
+    const jwks = (await res.json()) as Jwks;
+    const next = new Map<SigningKeyId, Uint8Array>();
+    for (const k of jwks.keys ?? []) {
+      if (k.kty === "OKP" && k.crv === "Ed25519" && k.x && k.kid) {
+        next.set(k.kid, base64UrlToBytes(k.x));
+      }
+    }
+    this.#cache = next;
+    this.#lastFetchMs = Date.now();
+  }
+
+  async verify(keyId: SigningKeyId, message: Uint8Array, signatureBase64Url: string): Promise<boolean> {
+    if (Date.now() - this.#lastFetchMs > this.#ttlMs) {
+      try {
+        await this.refresh();
+      } catch {
+        // best-effort refresh; fall through to cached lookup
+      }
+    }
+    const pubkey = this.#cache.get(keyId);
+    if (!pubkey) {
+      // unknown kid; try one forced refresh in case key was just rotated in
+      try {
+        await this.refresh();
+      } catch {
+        return false;
+      }
+      const retry = this.#cache.get(keyId);
+      if (!retry) return false;
+      try {
+        return ed25519.verify(base64UrlToBytes(signatureBase64Url), message, retry);
+      } catch {
+        return false;
+      }
+    }
+    try {
+      return ed25519.verify(base64UrlToBytes(signatureBase64Url), message, pubkey);
+    } catch {
+      return false;
+    }
+  }
+}
+
+export const _internal = { bytesToBase64Url, base64UrlToBytes };

--- a/packages/events/src/signer.ts
+++ b/packages/events/src/signer.ts
@@ -16,26 +16,23 @@ export interface Verifier {
 
 // --- base64url helpers -------------------------------------------------------
 
-const PAD_RX = /=+$/;
-const STD_RX = /[+/]/g;
-const URL_RX = /[-_]/g;
+// rd-3 F-003 BB#227: use Node's Buffer instead of browser globals btoa/atob.
+// The package is Node-targeted (NodeNext + nats.js peer dep); declaring a
+// dependency on browser globals would leak into edge runtimes that lack them
+// (e.g. Cloudflare Workers' older compat dates). Buffer's `'base64url'`
+// encoding is the idiomatic + portable Node choice (added in 16.0.0; the
+// package.json `engines` field caps at >=20 to be safe).
 
 function bytesToBase64Url(bytes: Uint8Array): string {
-  let bin = "";
-  for (const b of bytes) bin += String.fromCharCode(b);
-  const std = btoa(bin);
-  return std.replace(STD_RX, (c) => (c === "+" ? "-" : "_")).replace(PAD_RX, "");
+  return Buffer.from(bytes).toString("base64url");
 }
 
 function base64UrlToBytes(b64u: string): Uint8Array {
-  const std = b64u.replace(URL_RX, (c) => (c === "-" ? "+" : "/"));
-  // restore padding
-  const padLen = (4 - (std.length % 4)) % 4;
-  const padded = std + "=".repeat(padLen);
-  const bin = atob(padded);
-  const out = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
-  return out;
+  // `Buffer.from(str, 'base64url')` returns a Buffer that's also a Uint8Array
+  // (Buffer extends Uint8Array). We slice to a fresh Uint8Array so callers
+  // don't accidentally pin a larger underlying ArrayBuffer.
+  const buf = Buffer.from(b64u, "base64url");
+  return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
 }
 
 // --- LocalEd25519Signer ------------------------------------------------------

--- a/packages/events/src/subscriber.ts
+++ b/packages/events/src/subscriber.ts
@@ -1,0 +1,232 @@
+import { z } from "zod";
+import { EventEnvelopeSchema, envelopeSigningBytes, type EventEnvelope } from "./envelope.js";
+import { jcsCanonicalize, sha256Hex } from "./jcs.js";
+import type { Verifier } from "./signer.js";
+import type { PrevHashStore } from "./publisher.js";
+
+export type VerificationFailureReason =
+  | "envelope-schema-invalid"
+  | "payload-schema-invalid"
+  | "payload-hash-mismatch"
+  | "signature-invalid"
+  | "prev-hash-broken-chain"
+  | "json-parse-error";
+
+export interface EnvelopeHandlerContext<T> {
+  payload: T;
+  envelope: EventEnvelope;
+  subject: string;
+}
+
+export type EnvelopeHandler<T> = (ctx: EnvelopeHandlerContext<T>) => void | Promise<void>;
+
+// --- minimal NATS subscriber interface (avoid hard nats.js dep) --------------
+
+interface NatsMessageLike {
+  subject: string;
+  data: Uint8Array;
+}
+
+interface NatsSubscriptionLike extends AsyncIterable<NatsMessageLike> {
+  unsubscribe?: () => void;
+  drain?: () => Promise<void>;
+}
+
+interface NatsLike {
+  subscribe(subject: string, opts?: unknown): NatsSubscriptionLike;
+}
+
+// --- options + result -------------------------------------------------------
+
+export interface SubscribeOptions<T> {
+  nats: NatsLike;
+  subject: string;
+  /**
+   * Zod schema the payload must conform to AFTER envelope verification.
+   * The schema is validated against the parsed `payload` field of the envelope.
+   */
+  schema: z.ZodType<T>;
+  verifier: Verifier;
+  handler: EnvelopeHandler<T>;
+
+  /**
+   * Optional per-publisher chain store. When provided, the subscriber tracks
+   * each publisher's `prev_hash` continuity and surfaces `prev-hash-broken-chain`
+   * via {@link SubscribeOptions.onVerificationFailure} if the chain breaks
+   * (gap, replay, or tamper). Without a store, prev_hash is NOT checked by
+   * the subscriber — sig + schema validation still apply.
+   *
+   * The store key is the envelope's `emitted_by:signing_key_id`, matching the
+   * publisher's default `publisherKey`.
+   */
+  chainStore?: PrevHashStore;
+
+  /**
+   * Called for every verification failure. NEVER throws and is best-effort
+   * (failures here do not propagate). Subscriber stays alive across failures
+   * — this is the fail-soft surface the build doc calls for.
+   */
+  onVerificationFailure?: (
+    reason: VerificationFailureReason,
+    detail: { subject: string; rawBytes: Uint8Array; envelope?: EventEnvelope; error?: unknown },
+  ) => void | Promise<void>;
+
+  /**
+   * Optional NATS-level subscribe options (queue group, max, etc.). Passed
+   * through verbatim.
+   */
+  natsSubscribeOpts?: unknown;
+}
+
+export interface SubscribeHandle {
+  unsubscribe(): Promise<void>;
+  /** Resolves when the underlying NATS subscription's async iterator completes. */
+  done: Promise<void>;
+}
+
+/**
+ * Subscribe to a NATS subject, verifying every envelope before invoking the
+ * handler. Verification covers: envelope schema, signature, payload-hash
+ * recompute, per-event Zod schema, and (when `chainStore` is provided)
+ * per-publisher prev_hash continuity.
+ *
+ * The handler is awaited per-message in order; long-running handlers should
+ * either return quickly or use queue groups (`natsSubscribeOpts.queue`) for
+ * fan-out parallelism.
+ *
+ * Returns a {@link SubscribeHandle} for explicit teardown.
+ */
+export async function subscribeEnvelope<T>(opts: SubscribeOptions<T>): Promise<SubscribeHandle> {
+  const sub = opts.nats.subscribe(opts.subject, opts.natsSubscribeOpts);
+
+  const reportFailure = async (
+    reason: VerificationFailureReason,
+    detail: { subject: string; rawBytes: Uint8Array; envelope?: EventEnvelope; error?: unknown },
+  ): Promise<void> => {
+    if (!opts.onVerificationFailure) return;
+    try {
+      await opts.onVerificationFailure(reason, detail);
+    } catch {
+      // failure-callback failures are themselves silent — subscriber must stay alive
+    }
+  };
+
+  const consume = async (): Promise<void> => {
+    for await (const msg of sub) {
+      let envelope: EventEnvelope | undefined;
+      try {
+        // 1. parse JSON
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(new TextDecoder().decode(msg.data));
+        } catch (error) {
+          await reportFailure("json-parse-error", { subject: msg.subject, rawBytes: msg.data, error });
+          continue;
+        }
+
+        // 2. validate envelope shape
+        const envelopeResult = EventEnvelopeSchema.safeParse(parsed);
+        if (!envelopeResult.success) {
+          await reportFailure("envelope-schema-invalid", {
+            subject: msg.subject,
+            rawBytes: msg.data,
+            error: envelopeResult.error,
+          });
+          continue;
+        }
+        envelope = envelopeResult.data;
+
+        // 3. recompute payload hash and check against envelope's claim
+        const canonicalPayload = jcsCanonicalize(envelope.payload);
+        const recomputedPayloadHash = sha256Hex(canonicalPayload);
+        if (recomputedPayloadHash !== envelope.payload_hash) {
+          await reportFailure("payload-hash-mismatch", {
+            subject: msg.subject,
+            rawBytes: msg.data,
+            envelope,
+          });
+          continue;
+        }
+
+        // 4. verify signature
+        const sigBytes = envelopeSigningBytes(envelope.prev_hash, envelope.payload_hash);
+        const sigOk = await opts.verifier.verify(envelope.signing_key_id, sigBytes, envelope.signature);
+        if (!sigOk) {
+          await reportFailure("signature-invalid", { subject: msg.subject, rawBytes: msg.data, envelope });
+          continue;
+        }
+
+        // 5. (optional) per-publisher chain continuity
+        if (opts.chainStore) {
+          const publisherKey = `${envelope.emitted_by}:${envelope.signing_key_id}`;
+          const expectedPrev = await opts.chainStore.get(publisherKey);
+          if (expectedPrev !== null && expectedPrev !== envelope.prev_hash) {
+            await reportFailure("prev-hash-broken-chain", {
+              subject: msg.subject,
+              rawBytes: msg.data,
+              envelope,
+            });
+            // Do NOT update the store on broken chain — wait for the publisher
+            // to recover; the next valid envelope with a matching prev_hash
+            // will heal the local view.
+            continue;
+          }
+          // Advance our local view of the publisher's chain.
+          const envelopeHash = sha256Hex(jcsCanonicalize(envelope));
+          await opts.chainStore.set(publisherKey, envelopeHash);
+        }
+
+        // 6. per-event payload schema
+        const payloadResult = opts.schema.safeParse(envelope.payload);
+        if (!payloadResult.success) {
+          await reportFailure("payload-schema-invalid", {
+            subject: msg.subject,
+            rawBytes: msg.data,
+            envelope,
+            error: payloadResult.error,
+          });
+          continue;
+        }
+
+        // 7. hand off to the application handler. Application errors are
+        // swallowed (logged via the failure callback if provided) so a buggy
+        // handler does not take down the subscriber.
+        try {
+          await opts.handler({ payload: payloadResult.data, envelope, subject: msg.subject });
+        } catch (error) {
+          await reportFailure("envelope-schema-invalid", {
+            // re-using "envelope-schema-invalid" for handler errors would be
+            // misleading; instead emit raw + envelope with an `error` field
+            // — consumers can distinguish in the callback by inspecting it.
+            subject: msg.subject,
+            rawBytes: msg.data,
+            envelope,
+            error,
+          });
+        }
+      } catch (error) {
+        // any uncaught error in the loop body — keep the subscription alive
+        await reportFailure("envelope-schema-invalid", {
+          subject: msg.subject,
+          rawBytes: msg.data,
+          envelope,
+          error,
+        });
+      }
+    }
+  };
+
+  const done = consume();
+
+  return {
+    done,
+    async unsubscribe(): Promise<void> {
+      if (sub.drain) {
+        await sub.drain();
+      } else if (sub.unsubscribe) {
+        sub.unsubscribe();
+      }
+      await done.catch(() => undefined);
+    },
+  };
+}

--- a/packages/events/src/subscriber.ts
+++ b/packages/events/src/subscriber.ts
@@ -17,6 +17,15 @@ export type VerificationFailureReason =
   | "prev-hash-broken-chain"
   | "initial-anchor-policy-violation"
   | "json-parse-error"
+  /**
+   * Delivery subject doesn't match the envelope's claimed `event_type` (rd-3
+   * F-001 BB#227). A valid envelope republished onto a different NATS
+   * subject is rejected here — closes the cross-subject replay vector that
+   * EVT-001's metadata binding alone doesn't catch (sig still verifies
+   * because envelope contents are unchanged; only the NATS delivery channel
+   * differs).
+   */
+  | "subject-mismatch"
   /** Application handler threw an exception; subscriber stayed alive (F-002 BB#227). */
   | "handler-error"
   /** Uncaught exception inside the subscriber's verify-and-route loop body itself (F-002 BB#227). */
@@ -191,7 +200,25 @@ export async function subscribeEnvelope<T>(opts: SubscribeOptions<T>): Promise<S
         }
         envelope = envelopeResult.right;
 
-        // 3. recompute payload hash and check against envelope's claim
+        // 3. delivery-subject binding (rd-3 F-001 BB#227)
+        // Reject when the NATS subject the message arrived on does not
+        // match the envelope's claimed `event_type`. EVT-001 binds metadata
+        // INSIDE the envelope to the signature, but an attacker who keeps
+        // the envelope intact and republishes on a DIFFERENT subject would
+        // still produce a sig-valid message — the cross-subject replay
+        // vector. The subject-binding check closes it: a wildcard
+        // subscriber that catches the replay surfaces `subject-mismatch`
+        // BEFORE the handler runs.
+        if (msg.subject !== envelope.event_type) {
+          await reportFailure("subject-mismatch", {
+            subject: msg.subject,
+            rawBytes: msg.data,
+            envelope,
+          });
+          continue;
+        }
+
+        // 4. recompute payload hash and check against envelope's claim
         const canonicalPayload = jcsCanonicalize(envelope.payload);
         const recomputedPayloadHash = sha256Hex(canonicalPayload);
         if (recomputedPayloadHash !== envelope.payload_hash) {
@@ -203,7 +230,7 @@ export async function subscribeEnvelope<T>(opts: SubscribeOptions<T>): Promise<S
           continue;
         }
 
-        // 4. verify signature (acvp-l1-v2: full-envelope binding)
+        // 5. verify signature (acvp-l1-v2: full-envelope binding)
         // Reconstruct the unsigned envelope shape, derive signing bytes,
         // verify against the envelope's claimed signature + signing_key_id.
         const { signature, ...unsigned } = envelope;
@@ -214,14 +241,17 @@ export async function subscribeEnvelope<T>(opts: SubscribeOptions<T>): Promise<S
           continue;
         }
 
-        // 5. (optional) per-publisher chain continuity + EVT-002 bootstrap anchor
+        // 6. (optional) per-publisher chain continuity check + EVT-002
+        // bootstrap anchor. The chain TIP UPDATE is deferred to step 8 —
+        // after per-event payload schema validates — so the chain tracks
+        // APPLICATION-ACCEPTED envelopes, not merely cryptographically
+        // well-formed ones (rd-3 F-002 BB#227). A signed-but-payload-invalid
+        // envelope therefore does NOT advance the chain; the next valid
+        // envelope's prev_hash still references the last accepted entry.
         if (opts.chainStore) {
           const publisherKey = `${envelope.emitted_by}:${envelope.signing_key_id}`;
           const expectedPrev = await opts.chainStore.get(publisherKey);
           if (expectedPrev === null) {
-            // First time we see this publisher — apply initialPrevHashPolicy
-            // (EVT-002 BB#227): default 'any' = accept; 'genesis' = require
-            // GENESIS_PREV_HASH; <hex> = require pinned anchor.
             const requiredAnchor = initialPolicy === "any"
               ? null
               : initialPolicy === "genesis"
@@ -263,13 +293,9 @@ export async function subscribeEnvelope<T>(opts: SubscribeOptions<T>): Promise<S
             // returns `'skip' | 'reset'` for this exact recovery surface.
             continue;
           }
-          // Advance our local view of the publisher's chain (first valid msg
-          // OR continuous-chain successor — both update).
-          const envelopeHash = sha256Hex(jcsCanonicalize(envelope));
-          await opts.chainStore.set(publisherKey, envelopeHash);
         }
 
-        // 6. per-event payload schema
+        // 7. per-event payload schema (BEFORE chain advance per rd-3 F-002)
         const payloadResult = decodePayloadEither(envelope.payload);
         if (payloadResult._tag === "Left") {
           await reportFailure("payload-schema-invalid", {
@@ -281,7 +307,21 @@ export async function subscribeEnvelope<T>(opts: SubscribeOptions<T>): Promise<S
           continue;
         }
 
-        // 7. hand off to the application handler. Application errors are
+        // 8. advance the chain tip — only after EVERY check has passed
+        // (rd-3 F-002 BB#227). The chain tracks accepted envelopes, so
+        // semantic invariants like payload-schema-validity ARE part of
+        // "accepted". A future application-side acceptance signal could
+        // defer this further (e.g. only advance after handler returns),
+        // but Sprint 1 keeps the boundary at "library-accepted" — the
+        // application-level "processed" boundary is the consumer's
+        // responsibility (and trivially encodeable in the handler).
+        if (opts.chainStore) {
+          const publisherKey = `${envelope.emitted_by}:${envelope.signing_key_id}`;
+          const envelopeHash = sha256Hex(jcsCanonicalize(envelope));
+          await opts.chainStore.set(publisherKey, envelopeHash);
+        }
+
+        // 9. hand off to the application handler. Application errors are
         // routed via `handler-error` (F-002 BB#227) so consumers branching
         // on failure reason can distinguish a buggy handler from a bad
         // envelope.

--- a/packages/events/src/subscriber.ts
+++ b/packages/events/src/subscriber.ts
@@ -10,7 +10,11 @@ export type VerificationFailureReason =
   | "payload-hash-mismatch"
   | "signature-invalid"
   | "prev-hash-broken-chain"
-  | "json-parse-error";
+  | "json-parse-error"
+  /** Application handler threw an exception; subscriber stayed alive (F-002 BB#227). */
+  | "handler-error"
+  /** Uncaught exception inside the subscriber's verify-and-route loop body itself (F-002 BB#227). */
+  | "internal-error";
 
 export interface EnvelopeHandlerContext<T> {
   payload: T;
@@ -166,9 +170,26 @@ export async function subscribeEnvelope<T>(opts: SubscribeOptions<T>): Promise<S
               rawBytes: msg.data,
               envelope,
             });
-            // Do NOT update the store on broken chain — wait for the publisher
-            // to recover; the next valid envelope with a matching prev_hash
-            // will heal the local view.
+            // Do NOT auto-advance the store on broken chain.
+            //
+            // Known limitation (F-005 BB#227): once a gap is detected, every
+            // subsequent envelope from the same publisher will continue to
+            // fail this check (its prev_hash references the missed envelope's
+            // hash, which the subscriber never recorded). Recovery requires
+            // operator action — the recommended pattern is:
+            //
+            //   onVerificationFailure: async (reason, detail) => {
+            //     if (reason !== "prev-hash-broken-chain" || !detail.envelope) return;
+            //     // emit an audit / alert here for forensic forensics
+            //     // then unconditionally advance the local chain to admit the gap:
+            //     await chainStore.set(
+            //       `${detail.envelope.emitted_by}:${detail.envelope.signing_key_id}`,
+            //       sha256Hex(jcsCanonicalize(detail.envelope)),
+            //     );
+            //   };
+            //
+            // Sprint 2+ will add a first-class `onChainGap` option that
+            // returns `'skip' | 'reset'` for this exact recovery surface.
             continue;
           }
           // Advance our local view of the publisher's chain.
@@ -189,15 +210,13 @@ export async function subscribeEnvelope<T>(opts: SubscribeOptions<T>): Promise<S
         }
 
         // 7. hand off to the application handler. Application errors are
-        // swallowed (logged via the failure callback if provided) so a buggy
-        // handler does not take down the subscriber.
+        // routed via `handler-error` (F-002 BB#227) so consumers branching
+        // on failure reason can distinguish a buggy handler from a bad
+        // envelope.
         try {
           await opts.handler({ payload: payloadResult.data, envelope, subject: msg.subject });
         } catch (error) {
-          await reportFailure("envelope-schema-invalid", {
-            // re-using "envelope-schema-invalid" for handler errors would be
-            // misleading; instead emit raw + envelope with an `error` field
-            // — consumers can distinguish in the callback by inspecting it.
+          await reportFailure("handler-error", {
             subject: msg.subject,
             rawBytes: msg.data,
             envelope,
@@ -205,8 +224,10 @@ export async function subscribeEnvelope<T>(opts: SubscribeOptions<T>): Promise<S
           });
         }
       } catch (error) {
-        // any uncaught error in the loop body — keep the subscription alive
-        await reportFailure("envelope-schema-invalid", {
+        // any uncaught error in the verify-and-route loop body itself — keep
+        // the subscription alive (F-002 BB#227: distinct from handler-error,
+        // which is application-layer; internal-error is a library bug).
+        await reportFailure("internal-error", {
           subject: msg.subject,
           rawBytes: msg.data,
           envelope,

--- a/packages/events/src/subscriber.ts
+++ b/packages/events/src/subscriber.ts
@@ -1,5 +1,10 @@
-import { z } from "zod";
-import { EventEnvelopeSchema, envelopeSigningBytes, type EventEnvelope } from "./envelope.js";
+import { Schema as S } from "@effect/schema";
+import {
+  EventEnvelopeSchema,
+  GENESIS_PREV_HASH,
+  envelopeSigningBytes,
+  type EventEnvelope,
+} from "./envelope.js";
 import { jcsCanonicalize, sha256Hex } from "./jcs.js";
 import type { Verifier } from "./signer.js";
 import type { PrevHashStore } from "./publisher.js";
@@ -10,6 +15,7 @@ export type VerificationFailureReason =
   | "payload-hash-mismatch"
   | "signature-invalid"
   | "prev-hash-broken-chain"
+  | "initial-anchor-policy-violation"
   | "json-parse-error"
   /** Application handler threw an exception; subscriber stayed alive (F-002 BB#227). */
   | "handler-error"
@@ -23,6 +29,29 @@ export interface EnvelopeHandlerContext<T> {
 }
 
 export type EnvelopeHandler<T> = (ctx: EnvelopeHandlerContext<T>) => void | Promise<void>;
+
+/**
+ * Bootstrap-time replay defense for first-message-from-unknown-publisher
+ * (EVT-002 BB#227).
+ *
+ *   - `'any'` — DEFAULT, backward-compatible. The subscriber accepts any
+ *     `prev_hash` on the first envelope it sees from a publisher (the chain
+ *     check is skipped because there is no prior hash to compare against).
+ *     This is the historical behavior and is appropriate for subscribers
+ *     that intentionally late-join a publisher's chain.
+ *
+ *   - `'genesis'` — STRICT. The first envelope from a publisher MUST have
+ *     `prev_hash === GENESIS_PREV_HASH`. Replay of a mid-chain envelope is
+ *     surfaced as `initial-anchor-policy-violation`. Choose this for
+ *     subscribers that start at the beginning of a publisher's chain.
+ *
+ *   - `<hex-string>` — PINNED ANCHOR. The first envelope from a publisher
+ *     MUST have `prev_hash === <hex-string>`. Use this when an
+ *     out-of-band sync has established a known anchor (e.g. operator
+ *     pinned the publisher's chain tip at restart time). String must
+ *     match the 64-lowercase-hex format of `prev_hash`.
+ */
+export type InitialPrevHashPolicy = "any" | "genesis" | string;
 
 // --- minimal NATS subscriber interface (avoid hard nats.js dep) --------------
 
@@ -46,10 +75,10 @@ export interface SubscribeOptions<T> {
   nats: NatsLike;
   subject: string;
   /**
-   * Zod schema the payload must conform to AFTER envelope verification.
-   * The schema is validated against the parsed `payload` field of the envelope.
+   * Effect.Schema the payload must conform to AFTER envelope verification.
+   * Validated against the parsed `payload` field of the envelope.
    */
-  schema: z.ZodType<T>;
+  schema: S.Schema<T>;
   verifier: Verifier;
   handler: EnvelopeHandler<T>;
 
@@ -64,6 +93,15 @@ export interface SubscribeOptions<T> {
    * publisher's default `publisherKey`.
    */
   chainStore?: PrevHashStore;
+
+  /**
+   * Bootstrap policy for the FIRST envelope from each publisher (EVT-002
+   * BB#227). Defaults to `'any'` (backward-compatible — current behavior).
+   * Set to `'genesis'` to require the first envelope to carry
+   * `prev_hash === GENESIS_PREV_HASH`, closing the mid-chain-replay vector.
+   * Only relevant when `chainStore` is also provided.
+   */
+  initialPrevHashPolicy?: InitialPrevHashPolicy;
 
   /**
    * Called for every verification failure. NEVER throws and is best-effort
@@ -88,11 +126,22 @@ export interface SubscribeHandle {
   done: Promise<void>;
 }
 
+// --- prebuilt decoders -------------------------------------------------------
+
+// `onExcessProperty: "error"` — extra fields in the envelope are REJECTED
+// (mirrors zod's `.strict()`). Critical because the envelope is hashed:
+// an extra field would change the canonical form and silently break
+// chain continuity.
+const decodeEnvelopeEither = (input: unknown) =>
+  S.decodeUnknownEither(EventEnvelopeSchema)(input, { onExcessProperty: "error" });
+
 /**
  * Subscribe to a NATS subject, verifying every envelope before invoking the
- * handler. Verification covers: envelope schema, signature, payload-hash
- * recompute, per-event Zod schema, and (when `chainStore` is provided)
- * per-publisher prev_hash continuity.
+ * handler. Verification covers: envelope schema (Effect.Schema), full-envelope
+ * signature recompute (acvp-l1-v2 — closes EVT-001), payload-hash recompute,
+ * per-event Zod/Effect schema, optional per-publisher prev_hash continuity,
+ * and optional initial-anchor policy (EVT-002 closes mid-chain replay
+ * during bootstrap).
  *
  * The handler is awaited per-message in order; long-running handlers should
  * either return quickly or use queue groups (`natsSubscribeOpts.queue`) for
@@ -102,6 +151,8 @@ export interface SubscribeHandle {
  */
 export async function subscribeEnvelope<T>(opts: SubscribeOptions<T>): Promise<SubscribeHandle> {
   const sub = opts.nats.subscribe(opts.subject, opts.natsSubscribeOpts);
+  const initialPolicy: InitialPrevHashPolicy = opts.initialPrevHashPolicy ?? "any";
+  const decodePayloadEither = S.decodeUnknownEither(opts.schema);
 
   const reportFailure = async (
     reason: VerificationFailureReason,
@@ -129,16 +180,16 @@ export async function subscribeEnvelope<T>(opts: SubscribeOptions<T>): Promise<S
         }
 
         // 2. validate envelope shape
-        const envelopeResult = EventEnvelopeSchema.safeParse(parsed);
-        if (!envelopeResult.success) {
+        const envelopeResult = decodeEnvelopeEither(parsed);
+        if (envelopeResult._tag === "Left") {
           await reportFailure("envelope-schema-invalid", {
             subject: msg.subject,
             rawBytes: msg.data,
-            error: envelopeResult.error,
+            error: envelopeResult.left,
           });
           continue;
         }
-        envelope = envelopeResult.data;
+        envelope = envelopeResult.right;
 
         // 3. recompute payload hash and check against envelope's claim
         const canonicalPayload = jcsCanonicalize(envelope.payload);
@@ -152,19 +203,39 @@ export async function subscribeEnvelope<T>(opts: SubscribeOptions<T>): Promise<S
           continue;
         }
 
-        // 4. verify signature
-        const sigBytes = envelopeSigningBytes(envelope.prev_hash, envelope.payload_hash);
-        const sigOk = await opts.verifier.verify(envelope.signing_key_id, sigBytes, envelope.signature);
+        // 4. verify signature (acvp-l1-v2: full-envelope binding)
+        // Reconstruct the unsigned envelope shape, derive signing bytes,
+        // verify against the envelope's claimed signature + signing_key_id.
+        const { signature, ...unsigned } = envelope;
+        const sigBytes = envelopeSigningBytes(unsigned);
+        const sigOk = await opts.verifier.verify(envelope.signing_key_id, sigBytes, signature);
         if (!sigOk) {
           await reportFailure("signature-invalid", { subject: msg.subject, rawBytes: msg.data, envelope });
           continue;
         }
 
-        // 5. (optional) per-publisher chain continuity
+        // 5. (optional) per-publisher chain continuity + EVT-002 bootstrap anchor
         if (opts.chainStore) {
           const publisherKey = `${envelope.emitted_by}:${envelope.signing_key_id}`;
           const expectedPrev = await opts.chainStore.get(publisherKey);
-          if (expectedPrev !== null && expectedPrev !== envelope.prev_hash) {
+          if (expectedPrev === null) {
+            // First time we see this publisher — apply initialPrevHashPolicy
+            // (EVT-002 BB#227): default 'any' = accept; 'genesis' = require
+            // GENESIS_PREV_HASH; <hex> = require pinned anchor.
+            const requiredAnchor = initialPolicy === "any"
+              ? null
+              : initialPolicy === "genesis"
+                ? GENESIS_PREV_HASH
+                : initialPolicy;
+            if (requiredAnchor !== null && envelope.prev_hash !== requiredAnchor) {
+              await reportFailure("initial-anchor-policy-violation", {
+                subject: msg.subject,
+                rawBytes: msg.data,
+                envelope,
+              });
+              continue;
+            }
+          } else if (expectedPrev !== envelope.prev_hash) {
             await reportFailure("prev-hash-broken-chain", {
               subject: msg.subject,
               rawBytes: msg.data,
@@ -192,19 +263,20 @@ export async function subscribeEnvelope<T>(opts: SubscribeOptions<T>): Promise<S
             // returns `'skip' | 'reset'` for this exact recovery surface.
             continue;
           }
-          // Advance our local view of the publisher's chain.
+          // Advance our local view of the publisher's chain (first valid msg
+          // OR continuous-chain successor — both update).
           const envelopeHash = sha256Hex(jcsCanonicalize(envelope));
           await opts.chainStore.set(publisherKey, envelopeHash);
         }
 
         // 6. per-event payload schema
-        const payloadResult = opts.schema.safeParse(envelope.payload);
-        if (!payloadResult.success) {
+        const payloadResult = decodePayloadEither(envelope.payload);
+        if (payloadResult._tag === "Left") {
           await reportFailure("payload-schema-invalid", {
             subject: msg.subject,
             rawBytes: msg.data,
             envelope,
-            error: payloadResult.error,
+            error: payloadResult.left,
           });
           continue;
         }
@@ -214,7 +286,7 @@ export async function subscribeEnvelope<T>(opts: SubscribeOptions<T>): Promise<S
         // on failure reason can distinguish a buggy handler from a bad
         // envelope.
         try {
-          await opts.handler({ payload: payloadResult.data, envelope, subject: msg.subject });
+          await opts.handler({ payload: payloadResult.right, envelope, subject: msg.subject });
         } catch (error) {
           await reportFailure("handler-error", {
             subject: msg.subject,

--- a/packages/events/src/topics.ts
+++ b/packages/events/src/topics.ts
@@ -43,15 +43,34 @@ export function buildTopic(segments: TopicSegments): string {
 
 // --- pre-built topic helpers (NFT mint detection — v1 scope) -----------------
 
-/** Catch-all wildcard for any NFT mint event across all collections. */
+/**
+ * Wildcard subject for subscribing to all NFT mint events across all
+ * collections AND across all topic versions (`nft.mint.detected.>`).
+ *
+ * This is a NATS subject pattern — only use it with `subscribe`, never with
+ * `publish`. To get the actual subject for publishing a specific event, use
+ * {@link nftMintDetectedTopic}.
+ */
 export const NFT_MINT_DETECTED_WILDCARD = "nft.mint.detected.>";
 
 /**
- * Per-collection NFT-mint-detected subject.
+ * Build the publish subject for an NFT-mint-detected event.
+ *
+ * Returns a concrete subject string for use with `publish` — NOT a wildcard.
+ * To subscribe to all collections under this event family, use
+ * {@link NFT_MINT_DETECTED_WILDCARD} instead.
  *
  * Examples:
  *   nftMintDetectedTopic({collectionSlug: "mibera-shadow"}) → "nft.mint.detected.mibera-shadow.v1"
- *   nftMintDetectedTopic() (no slug) → "nft.mint.detected.v1" (catch-all per-version)
+ *   nftMintDetectedTopic()                                  → "nft.mint.detected.v1"
+ *     (the base versioned subject with no collection discriminator — for
+ *     events whose collection cannot be discriminated at publish time. A
+ *     subscriber to this exact string will NOT receive collection-specific
+ *     publishes; use NFT_MINT_DETECTED_WILDCARD for that.)
+ *   nftMintDetectedTopic({collectionSlug: "mibera-shadow", version: 2}) → "nft.mint.detected.mibera-shadow.v2"
+ *
+ * Per the build doc, schema evolution requires a new versioned subject + a
+ * ≥30d v1/v2 coexistence window.
  */
 export function nftMintDetectedTopic(
   opts: { collectionSlug?: string; version?: number } = {},

--- a/packages/events/src/topics.ts
+++ b/packages/events/src/topics.ts
@@ -1,0 +1,66 @@
+/**
+ * Hounfour 3-segment topic builders.
+ *
+ * Convention (per `loa-hounfour/src/schemas/domain-event.ts`):
+ *   {aggregate}.{noun}.{verb}[.{specifier}].v{N}
+ *
+ * - All segments lowercase kebab-case (a-z, 0-9, -)
+ * - Version suffix `.v{N}` non-negotiable — schema evolution = new versioned subject
+ * - Wildcard subscriptions use NATS `>` (e.g. `nft.mint.detected.>`)
+ */
+
+export interface TopicSegments {
+  aggregate: string;
+  noun: string;
+  verb: string;
+  specifier?: string;
+  version: number;
+}
+
+const SEGMENT_RX = /^[a-z][a-z0-9-]*$/;
+
+function assertSegment(name: string, value: string): void {
+  if (!SEGMENT_RX.test(value)) {
+    throw new Error(
+      `topic ${name} segment "${value}" must match /^[a-z][a-z0-9-]*$/ (lowercase kebab-case)`,
+    );
+  }
+}
+
+export function buildTopic(segments: TopicSegments): string {
+  assertSegment("aggregate", segments.aggregate);
+  assertSegment("noun", segments.noun);
+  assertSegment("verb", segments.verb);
+  if (segments.specifier !== undefined) assertSegment("specifier", segments.specifier);
+  if (!Number.isInteger(segments.version) || segments.version < 1) {
+    throw new Error(`topic version must be a positive integer (got ${segments.version})`);
+  }
+  const parts = [segments.aggregate, segments.noun, segments.verb];
+  if (segments.specifier !== undefined) parts.push(segments.specifier);
+  parts.push(`v${segments.version}`);
+  return parts.join(".");
+}
+
+// --- pre-built topic helpers (NFT mint detection — v1 scope) -----------------
+
+/** Catch-all wildcard for any NFT mint event across all collections. */
+export const NFT_MINT_DETECTED_WILDCARD = "nft.mint.detected.>";
+
+/**
+ * Per-collection NFT-mint-detected subject.
+ *
+ * Examples:
+ *   nftMintDetectedTopic({collectionSlug: "mibera-shadow"}) → "nft.mint.detected.mibera-shadow.v1"
+ *   nftMintDetectedTopic() (no slug) → "nft.mint.detected.v1" (catch-all per-version)
+ */
+export function nftMintDetectedTopic(
+  opts: { collectionSlug?: string; version?: number } = {},
+): string {
+  return buildTopic({
+    aggregate: "nft",
+    noun: "mint",
+    verb: "detected",
+    specifier: opts.collectionSlug,
+    version: opts.version ?? 1,
+  });
+}

--- a/packages/events/tests/envelope.test.ts
+++ b/packages/events/tests/envelope.test.ts
@@ -1,8 +1,20 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { EventEnvelopeSchema, GENESIS_PREV_HASH, SCHEMA_VERSION, envelopeSigningBytes } from "../src/envelope.js";
+import { Schema as S } from "@effect/schema";
+import {
+  EventEnvelopeSchema,
+  GENESIS_PREV_HASH,
+  SCHEMA_VERSION,
+  envelopeSigningBytes,
+  type EventEnvelope,
+} from "../src/envelope.js";
+import { jcsCanonicalize, sha256Hex } from "../src/jcs.js";
 
-const VALID_ENVELOPE = {
+// Match publisher/subscriber decode posture — extras REJECTED.
+const decode = (input: unknown) =>
+  S.decodeUnknownSync(EventEnvelopeSchema)(input, { onExcessProperty: "error" });
+
+const VALID_ENVELOPE: EventEnvelope = {
   event_id: "0e3a4a2f-1c9e-4a8e-9c20-1234567890ab",
   event_type: "nft.mint.detected.mibera-shadow.v1",
   schema_version: SCHEMA_VERSION,
@@ -17,20 +29,22 @@ const VALID_ENVELOPE = {
 
 describe("EventEnvelopeSchema", () => {
   it("accepts a well-formed envelope", () => {
-    const parsed = EventEnvelopeSchema.parse(VALID_ENVELOPE);
+    const parsed = decode(VALID_ENVELOPE);
     assert.equal(parsed.schema_version, SCHEMA_VERSION);
     assert.equal(parsed.event_type, "nft.mint.detected.mibera-shadow.v1");
   });
 
-  it("rejects a non-acvp-l1-v1 schema_version", () => {
-    const bad = { ...VALID_ENVELOPE, schema_version: "acvp-l2-v1" };
-    assert.throws(() => EventEnvelopeSchema.parse(bad));
+  it("rejects a non-acvp-l1-v2 schema_version (literal-locked)", () => {
+    const bad = { ...VALID_ENVELOPE, schema_version: "acvp-l1-v1" };
+    assert.throws(() => decode(bad));
+    const bad2 = { ...VALID_ENVELOPE, schema_version: "acvp-l2-v1" };
+    assert.throws(() => decode(bad2));
   });
 
-  it("rejects a non-3-segment event_type", () => {
-    for (const bad of ["foo.bar.v1", "foo.bar.baz", "FOO.BAR.BAZ.v1", "foo.bar.baz.v0", "foo.bar.baz"]) {
+  it("rejects non-3-segment event_types", () => {
+    for (const bad of ["foo.bar.v1", "foo.bar.baz", "FOO.BAR.BAZ.v1", "foo.bar.baz.v0"]) {
       assert.throws(
-        () => EventEnvelopeSchema.parse({ ...VALID_ENVELOPE, event_type: bad }),
+        () => decode({ ...VALID_ENVELOPE, event_type: bad }),
         new RegExp(""),
         `expected reject: ${bad}`,
       );
@@ -38,52 +52,83 @@ describe("EventEnvelopeSchema", () => {
   });
 
   it("accepts a 4-segment versioned event_type", () => {
-    const env = { ...VALID_ENVELOPE, event_type: "nft.mint.detected.mibera-shadow.v1" };
-    assert.doesNotThrow(() => EventEnvelopeSchema.parse(env));
-  });
-
-  it("rejects non-64-char prev_hash / payload_hash", () => {
-    assert.throws(() => EventEnvelopeSchema.parse({ ...VALID_ENVELOPE, prev_hash: "abc" }));
-    assert.throws(() => EventEnvelopeSchema.parse({ ...VALID_ENVELOPE, payload_hash: "ABC".repeat(21) + "X" }));
-  });
-
-  it("rejects uppercase hex in prev_hash", () => {
-    assert.throws(() => EventEnvelopeSchema.parse({ ...VALID_ENVELOPE, prev_hash: "A".repeat(64) }));
-  });
-
-  it("rejects non-base64url signature", () => {
-    assert.throws(() => EventEnvelopeSchema.parse({ ...VALID_ENVELOPE, signature: "has padding=" }));
-    assert.throws(() => EventEnvelopeSchema.parse({ ...VALID_ENVELOPE, signature: "has spaces in it" }));
-  });
-
-  it("rejects emitted_at without trailing Z", () => {
-    assert.throws(
-      () => EventEnvelopeSchema.parse({ ...VALID_ENVELOPE, emitted_at: "2026-05-26T21:30:00+00:00" }),
+    assert.doesNotThrow(() =>
+      decode({ ...VALID_ENVELOPE, event_type: "nft.mint.detected.mibera-shadow.v1" }),
     );
   });
 
-  it("rejects extra fields (strict)", () => {
-    assert.throws(() => EventEnvelopeSchema.parse({ ...VALID_ENVELOPE, extra: "no" }));
+  it("rejects non-64-char prev_hash / payload_hash", () => {
+    assert.throws(() => decode({ ...VALID_ENVELOPE, prev_hash: "abc" }));
+    assert.throws(() => decode({ ...VALID_ENVELOPE, payload_hash: "ABC".repeat(21) + "X" }));
+  });
+
+  it("rejects uppercase hex in prev_hash", () => {
+    assert.throws(() => decode({ ...VALID_ENVELOPE, prev_hash: "A".repeat(64) }));
+  });
+
+  it("rejects non-base64url signature", () => {
+    assert.throws(() => decode({ ...VALID_ENVELOPE, signature: "has padding=" }));
+    assert.throws(() => decode({ ...VALID_ENVELOPE, signature: "has spaces in it" }));
+  });
+
+  it("rejects emitted_at without trailing Z", () => {
+    assert.throws(() =>
+      decode({ ...VALID_ENVELOPE, emitted_at: "2026-05-26T21:30:00+00:00" }),
+    );
+  });
+
+  it("rejects extra fields (Struct rejects undeclared keys)", () => {
+    assert.throws(() => decode({ ...VALID_ENVELOPE, extra: "no" }));
   });
 
   it("rejects bad uuid", () => {
-    assert.throws(() => EventEnvelopeSchema.parse({ ...VALID_ENVELOPE, event_id: "not-a-uuid" }));
+    assert.throws(() => decode({ ...VALID_ENVELOPE, event_id: "not-a-uuid" }));
   });
 });
 
-describe("envelopeSigningBytes", () => {
-  it("produces deterministic bytes for the same (prev,payload) pair", () => {
-    const a = envelopeSigningBytes("a".repeat(64), "b".repeat(64));
-    const b = envelopeSigningBytes("a".repeat(64), "b".repeat(64));
+describe("envelopeSigningBytes (acvp-l1-v2 full-envelope binding)", () => {
+  it("produces deterministic bytes for the same envelope shape", () => {
+    const { signature: _s1, ...unsigned } = VALID_ENVELOPE;
+    void _s1;
+    const a = envelopeSigningBytes(unsigned);
+    const b = envelopeSigningBytes(unsigned);
     assert.deepEqual(a, b);
-    assert.equal(a.length, 128); // 64 + 64 UTF-8 bytes
   });
 
-  it("produces different bytes when either input changes", () => {
-    const a = envelopeSigningBytes("a".repeat(64), "b".repeat(64));
-    const b = envelopeSigningBytes("c".repeat(64), "b".repeat(64));
-    const c = envelopeSigningBytes("a".repeat(64), "d".repeat(64));
-    assert.notDeepEqual(a, b);
-    assert.notDeepEqual(a, c);
+  it("binds event_type to the signature (EVT-001 closed)", () => {
+    const { signature: _s, ...unsigned } = VALID_ENVELOPE;
+    void _s;
+    const a = envelopeSigningBytes(unsigned);
+    const tampered = { ...unsigned, event_type: "nft.mint.detected.other-collection.v1" };
+    const b = envelopeSigningBytes(tampered);
+    assert.notDeepEqual(a, b, "event_type tamper must change signing bytes");
+  });
+
+  it("binds emitted_by to the signature (EVT-001 closed)", () => {
+    const { signature: _s, ...unsigned } = VALID_ENVELOPE;
+    void _s;
+    const a = envelopeSigningBytes(unsigned);
+    const tampered = { ...unsigned, emitted_by: "fabricated-cell" };
+    const b = envelopeSigningBytes(tampered);
+    assert.notDeepEqual(a, b, "emitted_by tamper must change signing bytes");
+  });
+
+  it("binds payload to the signature (via payload_hash recompute)", () => {
+    const { signature: _s, ...unsigned } = VALID_ENVELOPE;
+    void _s;
+    const a = envelopeSigningBytes(unsigned);
+    const tampered = { ...unsigned, payload: { foo: "DIFFERENT" } };
+    const b = envelopeSigningBytes(tampered);
+    assert.notDeepEqual(a, b, "payload tamper must change signing bytes (because payload is in the canonical envelope)");
+  });
+
+  it("returns 64-byte UTF-8 of the sha256 hex digest", () => {
+    const { signature: _s, ...unsigned } = VALID_ENVELOPE;
+    void _s;
+    const bytes = envelopeSigningBytes(unsigned);
+    assert.equal(bytes.length, 64); // sha256 hex = 64 chars = 64 UTF-8 bytes
+    // sanity: the digest is sha256(JCS(env-with-empty-sig))
+    const expected = sha256Hex(jcsCanonicalize({ ...unsigned, signature: "" }));
+    assert.equal(new TextDecoder().decode(bytes), expected);
   });
 });

--- a/packages/events/tests/envelope.test.ts
+++ b/packages/events/tests/envelope.test.ts
@@ -1,0 +1,89 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { EventEnvelopeSchema, GENESIS_PREV_HASH, SCHEMA_VERSION, envelopeSigningBytes } from "../src/envelope.js";
+
+const VALID_ENVELOPE = {
+  event_id: "0e3a4a2f-1c9e-4a8e-9c20-1234567890ab",
+  event_type: "nft.mint.detected.mibera-shadow.v1",
+  schema_version: SCHEMA_VERSION,
+  emitted_by: "sonar-api",
+  emitted_at: "2026-05-26T21:30:00Z",
+  prev_hash: GENESIS_PREV_HASH,
+  payload_hash: "a".repeat(64),
+  signing_key_id: "sonar-api-1",
+  signature: "abcDEF-_123",
+  payload: { foo: "bar" },
+};
+
+describe("EventEnvelopeSchema", () => {
+  it("accepts a well-formed envelope", () => {
+    const parsed = EventEnvelopeSchema.parse(VALID_ENVELOPE);
+    assert.equal(parsed.schema_version, SCHEMA_VERSION);
+    assert.equal(parsed.event_type, "nft.mint.detected.mibera-shadow.v1");
+  });
+
+  it("rejects a non-acvp-l1-v1 schema_version", () => {
+    const bad = { ...VALID_ENVELOPE, schema_version: "acvp-l2-v1" };
+    assert.throws(() => EventEnvelopeSchema.parse(bad));
+  });
+
+  it("rejects a non-3-segment event_type", () => {
+    for (const bad of ["foo.bar.v1", "foo.bar.baz", "FOO.BAR.BAZ.v1", "foo.bar.baz.v0", "foo.bar.baz"]) {
+      assert.throws(
+        () => EventEnvelopeSchema.parse({ ...VALID_ENVELOPE, event_type: bad }),
+        new RegExp(""),
+        `expected reject: ${bad}`,
+      );
+    }
+  });
+
+  it("accepts a 4-segment versioned event_type", () => {
+    const env = { ...VALID_ENVELOPE, event_type: "nft.mint.detected.mibera-shadow.v1" };
+    assert.doesNotThrow(() => EventEnvelopeSchema.parse(env));
+  });
+
+  it("rejects non-64-char prev_hash / payload_hash", () => {
+    assert.throws(() => EventEnvelopeSchema.parse({ ...VALID_ENVELOPE, prev_hash: "abc" }));
+    assert.throws(() => EventEnvelopeSchema.parse({ ...VALID_ENVELOPE, payload_hash: "ABC".repeat(21) + "X" }));
+  });
+
+  it("rejects uppercase hex in prev_hash", () => {
+    assert.throws(() => EventEnvelopeSchema.parse({ ...VALID_ENVELOPE, prev_hash: "A".repeat(64) }));
+  });
+
+  it("rejects non-base64url signature", () => {
+    assert.throws(() => EventEnvelopeSchema.parse({ ...VALID_ENVELOPE, signature: "has padding=" }));
+    assert.throws(() => EventEnvelopeSchema.parse({ ...VALID_ENVELOPE, signature: "has spaces in it" }));
+  });
+
+  it("rejects emitted_at without trailing Z", () => {
+    assert.throws(
+      () => EventEnvelopeSchema.parse({ ...VALID_ENVELOPE, emitted_at: "2026-05-26T21:30:00+00:00" }),
+    );
+  });
+
+  it("rejects extra fields (strict)", () => {
+    assert.throws(() => EventEnvelopeSchema.parse({ ...VALID_ENVELOPE, extra: "no" }));
+  });
+
+  it("rejects bad uuid", () => {
+    assert.throws(() => EventEnvelopeSchema.parse({ ...VALID_ENVELOPE, event_id: "not-a-uuid" }));
+  });
+});
+
+describe("envelopeSigningBytes", () => {
+  it("produces deterministic bytes for the same (prev,payload) pair", () => {
+    const a = envelopeSigningBytes("a".repeat(64), "b".repeat(64));
+    const b = envelopeSigningBytes("a".repeat(64), "b".repeat(64));
+    assert.deepEqual(a, b);
+    assert.equal(a.length, 128); // 64 + 64 UTF-8 bytes
+  });
+
+  it("produces different bytes when either input changes", () => {
+    const a = envelopeSigningBytes("a".repeat(64), "b".repeat(64));
+    const b = envelopeSigningBytes("c".repeat(64), "b".repeat(64));
+    const c = envelopeSigningBytes("a".repeat(64), "d".repeat(64));
+    assert.notDeepEqual(a, b);
+    assert.notDeepEqual(a, c);
+  });
+});

--- a/packages/events/tests/jcs.test.ts
+++ b/packages/events/tests/jcs.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { jcsCanonicalize, sha256Hex } from "../src/jcs.js";
+
+describe("jcsCanonicalize", () => {
+  it("sorts object keys lexicographically", () => {
+    assert.equal(jcsCanonicalize({ b: 2, a: 1 }), '{"a":1,"b":2}');
+  });
+
+  it("strips insignificant whitespace", () => {
+    // canonicalize() ignores input formatting; we pass an object directly
+    assert.equal(jcsCanonicalize({ x: { y: 1 } }), '{"x":{"y":1}}');
+  });
+
+  it("produces the same output regardless of input key order", () => {
+    const a = jcsCanonicalize({ a: 1, b: { c: 3, d: 4 } });
+    const b = jcsCanonicalize({ b: { d: 4, c: 3 }, a: 1 });
+    assert.equal(a, b);
+  });
+
+  it("handles arrays without sorting them (positional)", () => {
+    assert.equal(jcsCanonicalize([3, 1, 2]), "[3,1,2]");
+  });
+
+  it("preserves string Unicode", () => {
+    // RFC 8785 §3.2.2.2: strings are emitted verbatim (no escape minimization)
+    const out = jcsCanonicalize({ msg: "hello, 世界" });
+    assert.match(out, /"msg":/);
+    assert.ok(out.includes("hello"));
+  });
+
+  it("throws on non-JSON-representable values", () => {
+    assert.throws(() => jcsCanonicalize(undefined));
+    assert.throws(() => jcsCanonicalize(() => 1));
+  });
+});
+
+describe("sha256Hex", () => {
+  it("produces 64-char lowercase hex", () => {
+    const out = sha256Hex("hello");
+    assert.match(out, /^[0-9a-f]{64}$/);
+  });
+
+  it("matches a known RFC test vector", () => {
+    // sha256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    assert.equal(
+      sha256Hex(""),
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    );
+  });
+
+  it("is deterministic", () => {
+    const a = sha256Hex("the quick brown fox");
+    const b = sha256Hex("the quick brown fox");
+    assert.equal(a, b);
+  });
+
+  it("accepts Uint8Array as well as string", () => {
+    const s = sha256Hex("hi");
+    const b = sha256Hex(new TextEncoder().encode("hi"));
+    assert.equal(s, b);
+  });
+});

--- a/packages/events/tests/jwks-verifier.test.ts
+++ b/packages/events/tests/jwks-verifier.test.ts
@@ -1,0 +1,123 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { JwksVerifier, LocalEd25519Signer } from "../src/signer.js";
+
+// --- helpers ----------------------------------------------------------------
+
+async function makeKidA() {
+  const signer = await LocalEd25519Signer.fromSeedHex("a".repeat(64), "kid-A");
+  // base64url-encoded raw 32-byte ed25519 pubkey (the same shape JWKS x emits)
+  const bin = String.fromCharCode(...signer.publicKeyBytes());
+  const x = btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return { signer, jwksEntry: { kty: "OKP", crv: "Ed25519", kid: "kid-A", x } };
+}
+
+function fakeFetch(
+  responder: (url: string, init?: RequestInit) => Promise<Response> | Response,
+): typeof fetch {
+  return ((url: string, init?: RequestInit) => Promise.resolve(responder(url, init))) as unknown as typeof fetch;
+}
+
+function jsonResp(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+}
+
+// --- F-001: fetch timeout --------------------------------------------------
+
+describe("JwksVerifier — fetch timeout (F-001 BB#227)", () => {
+  it("aborts when the JWKS endpoint hangs longer than timeoutMs", async () => {
+    let abortFired = false;
+    const hangingFetch: typeof fetch = ((url: string, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        const signal = init?.signal;
+        signal?.addEventListener("abort", () => {
+          abortFired = true;
+          reject(new DOMException("aborted", "AbortError"));
+        });
+        // intentionally never resolves
+      });
+    }) as unknown as typeof fetch;
+
+    await assert.rejects(
+      JwksVerifier.fromUrl("https://hung.example/jwks", {
+        timeoutMs: 50,
+        fetchImpl: hangingFetch,
+      }),
+      (err: Error) => err.name === "AbortError" || /aborted/i.test(err.message),
+    );
+    assert.equal(abortFired, true);
+  });
+
+  it("does not abort fast responses (clearTimeout fires)", async () => {
+    const { jwksEntry } = await makeKidA();
+    const v = await JwksVerifier.fromUrl("https://fast.example/jwks", {
+      timeoutMs: 5_000,
+      fetchImpl: fakeFetch(() => jsonResp({ keys: [jwksEntry] })),
+    });
+    // verify it loaded the key
+    const sig = await (await LocalEd25519Signer.fromSeedHex("a".repeat(64), "kid-A")).sign(
+      new TextEncoder().encode("x"),
+    );
+    assert.equal(await v.verify("kid-A", new TextEncoder().encode("x"), sig), true);
+  });
+});
+
+// --- F-004: non-empty cache guard ------------------------------------------
+
+describe("JwksVerifier — non-empty cache guard (F-004 BB#227)", () => {
+  it("preserves cached keys when refresh returns an empty key set", async () => {
+    const { signer, jwksEntry } = await makeKidA();
+    let onEmptyFired = 0;
+    let phase: "good" | "empty" = "good";
+    const v = await JwksVerifier.fromUrl("https://flaky.example/jwks", {
+      timeoutMs: 5_000,
+      ttlMs: 0, // force refresh on every verify() so we can drive the empty branch
+      onEmptyJwks: () => {
+        onEmptyFired++;
+      },
+      fetchImpl: fakeFetch(() => jsonResp(phase === "good" ? { keys: [jwksEntry] } : { keys: [] })),
+    });
+
+    const msg = new TextEncoder().encode("preserve me");
+    const sig = await signer.sign(msg);
+
+    // baseline: verify works against the loaded key
+    assert.equal(await v.verify("kid-A", msg, sig), true);
+
+    // now flip the endpoint to return an empty key set; verify must still succeed
+    // (cache preserved) and onEmptyJwks must fire
+    phase = "empty";
+    assert.equal(await v.verify("kid-A", msg, sig), true);
+    assert.ok(onEmptyFired >= 1, `expected onEmptyJwks to fire at least once (fired ${onEmptyFired})`);
+  });
+
+  it("replaces the cache when refresh returns a non-empty (rotated) key set", async () => {
+    const { signer: signerA, jwksEntry: entryA } = await makeKidA();
+    const signerB = await LocalEd25519Signer.fromSeedHex("b".repeat(64), "kid-B");
+    const binB = String.fromCharCode(...signerB.publicKeyBytes());
+    const xB = btoa(binB).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    const entryB = { kty: "OKP", crv: "Ed25519", kid: "kid-B", x: xB };
+
+    let serving: "A" | "B" = "A";
+    const v = await JwksVerifier.fromUrl("https://rotating.example/jwks", {
+      timeoutMs: 5_000,
+      ttlMs: 0,
+      fetchImpl: fakeFetch(() => jsonResp({ keys: serving === "A" ? [entryA] : [entryB] })),
+    });
+
+    const msg = new TextEncoder().encode("rotate me");
+    const sigA = await signerA.sign(msg);
+    const sigB = await signerB.sign(msg);
+
+    // baseline: A works, B does not
+    assert.equal(await v.verify("kid-A", msg, sigA), true);
+    assert.equal(await v.verify("kid-B", msg, sigB), false);
+
+    // rotate: now JWKS serves B only
+    serving = "B";
+
+    // B works (rotation took effect); A should fail (cache replaced)
+    assert.equal(await v.verify("kid-B", msg, sigB), true);
+    assert.equal(await v.verify("kid-A", msg, sigA), false);
+  });
+});

--- a/packages/events/tests/jwks-verifier.test.ts
+++ b/packages/events/tests/jwks-verifier.test.ts
@@ -6,7 +6,6 @@ import { JwksVerifier, LocalEd25519Signer } from "../src/signer.js";
 
 async function makeKidA() {
   const signer = await LocalEd25519Signer.fromSeedHex("a".repeat(64), "kid-A");
-  // base64url-encoded raw 32-byte ed25519 pubkey (the same shape JWKS x emits)
   const bin = String.fromCharCode(...signer.publicKeyBytes());
   const x = btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
   return { signer, jwksEntry: { kty: "OKP", crv: "Ed25519", kid: "kid-A", x } };
@@ -15,11 +14,15 @@ async function makeKidA() {
 function fakeFetch(
   responder: (url: string, init?: RequestInit) => Promise<Response> | Response,
 ): typeof fetch {
-  return ((url: string, init?: RequestInit) => Promise.resolve(responder(url, init))) as unknown as typeof fetch;
+  return ((url: string, init?: RequestInit) =>
+    Promise.resolve(responder(url, init))) as unknown as typeof fetch;
 }
 
 function jsonResp(body: unknown): Response {
-  return new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
 }
 
 // --- F-001: fetch timeout --------------------------------------------------
@@ -34,7 +37,6 @@ describe("JwksVerifier — fetch timeout (F-001 BB#227)", () => {
           abortFired = true;
           reject(new DOMException("aborted", "AbortError"));
         });
-        // intentionally never resolves
       });
     }) as unknown as typeof fetch;
 
@@ -54,24 +56,23 @@ describe("JwksVerifier — fetch timeout (F-001 BB#227)", () => {
       timeoutMs: 5_000,
       fetchImpl: fakeFetch(() => jsonResp({ keys: [jwksEntry] })),
     });
-    // verify it loaded the key
-    const sig = await (await LocalEd25519Signer.fromSeedHex("a".repeat(64), "kid-A")).sign(
-      new TextEncoder().encode("x"),
-    );
+    const sig = await (
+      await LocalEd25519Signer.fromSeedHex("a".repeat(64), "kid-A")
+    ).sign(new TextEncoder().encode("x"));
     assert.equal(await v.verify("kid-A", new TextEncoder().encode("x"), sig), true);
   });
 });
 
-// --- F-004: non-empty cache guard ------------------------------------------
+// --- F-004 / EVT-004: non-empty cache guard + fire onEmptyJwks --------------
 
-describe("JwksVerifier — non-empty cache guard (F-004 BB#227)", () => {
+describe("JwksVerifier — non-empty cache guard + onEmptyJwks (F-004 / EVT-004 BB#227)", () => {
   it("preserves cached keys when refresh returns an empty key set", async () => {
     const { signer, jwksEntry } = await makeKidA();
     let onEmptyFired = 0;
     let phase: "good" | "empty" = "good";
     const v = await JwksVerifier.fromUrl("https://flaky.example/jwks", {
       timeoutMs: 5_000,
-      ttlMs: 0, // force refresh on every verify() so we can drive the empty branch
+      ttlMs: 0,
       onEmptyJwks: () => {
         onEmptyFired++;
       },
@@ -80,12 +81,8 @@ describe("JwksVerifier — non-empty cache guard (F-004 BB#227)", () => {
 
     const msg = new TextEncoder().encode("preserve me");
     const sig = await signer.sign(msg);
-
-    // baseline: verify works against the loaded key
     assert.equal(await v.verify("kid-A", msg, sig), true);
 
-    // now flip the endpoint to return an empty key set; verify must still succeed
-    // (cache preserved) and onEmptyJwks must fire
     phase = "empty";
     assert.equal(await v.verify("kid-A", msg, sig), true);
     assert.ok(onEmptyFired >= 1, `expected onEmptyJwks to fire at least once (fired ${onEmptyFired})`);
@@ -109,15 +106,82 @@ describe("JwksVerifier — non-empty cache guard (F-004 BB#227)", () => {
     const sigA = await signerA.sign(msg);
     const sigB = await signerB.sign(msg);
 
-    // baseline: A works, B does not
     assert.equal(await v.verify("kid-A", msg, sigA), true);
     assert.equal(await v.verify("kid-B", msg, sigB), false);
 
-    // rotate: now JWKS serves B only
     serving = "B";
-
-    // B works (rotation took effect); A should fail (cache replaced)
     assert.equal(await v.verify("kid-B", msg, sigB), true);
     assert.equal(await v.verify("kid-A", msg, sigA), false);
+  });
+
+  it("EVT-004: throws from fromUrl when initial JWKS load is empty", async () => {
+    let onEmptyFired = 0;
+    await assert.rejects(
+      JwksVerifier.fromUrl("https://misconfigured.example/jwks", {
+        timeoutMs: 5_000,
+        onEmptyJwks: () => {
+          onEmptyFired++;
+        },
+        fetchImpl: fakeFetch(() => jsonResp({ keys: [] })),
+      }),
+      /zero OKP\/Ed25519 keys/,
+    );
+    assert.equal(onEmptyFired, 1, "onEmptyJwks should fire BEFORE the throw");
+  });
+
+  it("EVT-004: throws from fromUrl when initial JWKS load has only non-Ed25519 keys", async () => {
+    // RSA key in the JWKS — gets filtered out, leaving an empty Ed25519 map
+    const rsaEntry = {
+      kty: "RSA",
+      kid: "rsa-key",
+      n: "modulus-base64url",
+      e: "AQAB",
+    };
+    await assert.rejects(
+      JwksVerifier.fromUrl("https://wrong-key-type.example/jwks", {
+        timeoutMs: 5_000,
+        fetchImpl: fakeFetch(() => jsonResp({ keys: [rsaEntry] })),
+      }),
+      /zero OKP\/Ed25519 keys/,
+    );
+  });
+});
+
+// --- EVT-003: in-flight refresh dedup ---------------------------------------
+
+describe("JwksVerifier — concurrent refresh dedup (EVT-003 BB#227)", () => {
+  it("collapses N parallel refresh-triggering verify() calls to ONE fetch", async () => {
+    const { signer, jwksEntry } = await makeKidA();
+    let fetchCount = 0;
+
+    // Initial load needs one fetch
+    const v = await JwksVerifier.fromUrl("https://dedup.example/jwks", {
+      timeoutMs: 5_000,
+      ttlMs: 0, // every verify triggers a refresh
+      fetchImpl: fakeFetch(async () => {
+        fetchCount++;
+        // small async hop so concurrent calls actually overlap
+        await new Promise((r) => setTimeout(r, 5));
+        return jsonResp({ keys: [jwksEntry] });
+      }),
+    });
+    assert.equal(fetchCount, 1, "initial fromUrl uses 1 fetch");
+
+    const msg = new TextEncoder().encode("herd");
+    const sig = await signer.sign(msg);
+
+    // Burst 10 concurrent verifies — all hit ttl=0 → refresh trigger
+    const before = fetchCount;
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () => v.verify("kid-A", msg, sig)),
+    );
+    const refreshesTriggered = fetchCount - before;
+
+    assert.deepEqual(results, Array(10).fill(true), "all verifies succeed");
+    assert.equal(
+      refreshesTriggered,
+      1,
+      `expected exactly 1 in-flight refresh across 10 concurrent verifies, got ${refreshesTriggered}`,
+    );
   });
 });

--- a/packages/events/tests/roundtrip.test.ts
+++ b/packages/events/tests/roundtrip.test.ts
@@ -251,6 +251,120 @@ describe("publish → subscribe roundtrip (acvp-l1-v2)", () => {
     sub.unsubscribe();
   });
 
+  it("rd-3 F-001: surfaces subject-mismatch when envelope replayed onto a different NATS subject", async () => {
+    // Attacker captures a valid envelope for subject-A and republishes on
+    // subject-B. The envelope is byte-identical (sig still verifies) but
+    // the delivery channel differs. A wildcard subscriber that catches the
+    // replay must surface subject-mismatch BEFORE running the handler.
+    const nats = new FakeNats();
+    const { signer, verifier } = await buildSigner();
+    const originalSubject = nftMintDetectedTopic({ collectionSlug: "mibera-shadow" });
+    const otherSubject = nftMintDetectedTopic({ collectionSlug: "purupuru-apiculture" });
+
+    // Produce a valid envelope on the original subject (via discard nats)
+    const discardNats = new FakeNats();
+    const issued = await publishEnvelope({
+      nats: discardNats,
+      subject: originalSubject,
+      payload: VALID_PAYLOAD,
+      emittedBy: "sonar-api",
+      signer,
+      prevHashStore: new InMemoryPrevHashStore(),
+    });
+
+    const failures: VerificationFailureReason[] = [];
+    let handlerCalled = 0;
+    const sub = await subscribeEnvelope({
+      nats,
+      // wildcard so the subscriber receives the replay regardless of subject
+      subject: "nft.mint.detected.>",
+      schema: NftMintDetectedSchema,
+      verifier,
+      handler: async () => {
+        handlerCalled++;
+      },
+      onVerificationFailure: (reason) => {
+        failures.push(reason);
+      },
+    });
+
+    // Replay the byte-identical envelope onto the WRONG subject
+    const replayBytes = new TextEncoder().encode(jcsCanonicalize(issued.envelope));
+    nats.publish(otherSubject, replayBytes);
+
+    await tick();
+    assert.equal(handlerCalled, 0, "handler must not be invoked for subject-mismatched replay");
+    assert.deepEqual(failures, ["subject-mismatch"]);
+    sub.unsubscribe();
+  });
+
+  it("rd-3 F-002: chain tip does NOT advance when payload schema validation fails", async () => {
+    // A signed-but-payload-invalid envelope should be rejected by per-event
+    // schema check AND must NOT advance the subscriber's chain — otherwise
+    // the next valid envelope appears continuous after an event the
+    // application never accepted.
+    const nats = new FakeNats();
+    const { signer, verifier } = await buildSigner();
+    const subscriberChain = new InMemoryPrevHashStore();
+    const subject = nftMintDetectedTopic({ collectionSlug: "mibera-shadow" });
+    const publisherKey = "sonar-api:sonar-api-1";
+
+    let handled = 0;
+    const failures: VerificationFailureReason[] = [];
+    const sub = await subscribeEnvelope({
+      nats,
+      subject,
+      schema: NftMintDetectedSchema,
+      verifier,
+      chainStore: subscriberChain,
+      handler: async () => {
+        handled++;
+      },
+      onVerificationFailure: (reason) => {
+        failures.push(reason);
+      },
+    });
+
+    // 1. publish a VALID envelope — chain advances to envHash1
+    const publisherStore = new InMemoryPrevHashStore();
+    const valid1 = await publishEnvelope({
+      nats,
+      subject,
+      payload: VALID_PAYLOAD,
+      emittedBy: "sonar-api",
+      signer,
+      prevHashStore: publisherStore,
+    });
+
+    await tick();
+    assert.equal(handled, 1);
+    assert.equal(await subscriberChain.get(publisherKey), valid1.envelopeHash);
+
+    // 2. publish a SIGNED but SCHEMA-INVALID envelope (chain MUST NOT advance)
+    const bad = { ...VALID_PAYLOAD, token_id: undefined } as unknown as NftMintDetected;
+    await publishEnvelope({
+      nats,
+      subject,
+      payload: bad,
+      emittedBy: "sonar-api",
+      signer,
+      prevHashStore: publisherStore,
+    });
+
+    await tick();
+    // payload-schema-invalid was surfaced; handler still at 1
+    assert.equal(handled, 1);
+    assert.deepEqual(failures, ["payload-schema-invalid"]);
+    // critical: chain tip is STILL valid1 — not advanced past the bad envelope
+    assert.equal(
+      await subscriberChain.get(publisherKey),
+      valid1.envelopeHash,
+      "chain must not advance on payload-schema-invalid",
+    );
+
+    sub.unsubscribe();
+  });
+
   it("EVT-001: surfaces signature-invalid when event_type is tampered in transit", async () => {
     // Simulate an attacker who captures a valid envelope and modifies the
     // event_type before re-publishing on the new subject. Under acvp-l1-v1

--- a/packages/events/tests/roundtrip.test.ts
+++ b/packages/events/tests/roundtrip.test.ts
@@ -1,13 +1,14 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { z } from "zod";
+import { Schema as S } from "@effect/schema";
 
 import { publishEnvelope, InMemoryPrevHashStore } from "../src/publisher.js";
 import { subscribeEnvelope, type VerificationFailureReason } from "../src/subscriber.js";
 import { LocalEd25519Signer, StaticPubkeyVerifier } from "../src/signer.js";
 import { nftMintDetectedTopic } from "../src/topics.js";
-import { NftMintDetectedSchema } from "../src/schemas/nft-mint-detected.js";
+import { NftMintDetectedSchema, type NftMintDetected } from "../src/schemas/nft-mint-detected.js";
 import { GENESIS_PREV_HASH, type EventEnvelope } from "../src/envelope.js";
+import { jcsCanonicalize, sha256Hex } from "../src/jcs.js";
 
 // --- minimal in-memory fake NATS for roundtrip tests -------------------------
 
@@ -17,11 +18,8 @@ interface FakeMessage {
 }
 
 class FakeNats {
-  // subject → queue of messages
   #queues = new Map<string, FakeMessage[]>();
-  // subject → pending-resolvers waiting for a message
   #waiters = new Map<string, Array<(msg: FakeMessage) => void>>();
-  // subject → "subscribed" flag (so we know to flush a queue into an iterator)
   #subscriptions = new Set<string>();
 
   publish(subject: string, data: Uint8Array): void {
@@ -43,18 +41,16 @@ class FakeNats {
   subscribe(subject: string): AsyncIterable<FakeMessage> & { unsubscribe: () => void } {
     this.#subscriptions.add(subject);
     let cancelled = false;
-    const iter = {
+    return {
       [Symbol.asyncIterator]: () => ({
         next: async () => {
           if (cancelled) return { value: undefined, done: true as const };
-          // drain queue first
           const q = this.#queues.get(subject) ?? [];
           if (q.length > 0) {
             const msg = q.shift()!;
             this.#queues.set(subject, q);
             return { value: msg, done: false as const };
           }
-          // wait
           return new Promise<{ value: FakeMessage; done: false }>((resolve) => {
             const waiters = this.#waiters.get(subject) ?? [];
             waiters.push((m) => resolve({ value: m, done: false as const }));
@@ -67,31 +63,24 @@ class FakeNats {
         this.#subscriptions.delete(subject);
       },
     };
-    return iter;
   }
 }
 
 function matchingSubscriptions(subs: Set<string>, subject: string): string[] {
   const out: string[] = [];
-  for (const sub of subs) {
-    if (subjectMatches(sub, subject)) out.push(sub);
-  }
+  for (const sub of subs) if (subjectMatches(sub, subject)) out.push(sub);
   return out;
 }
 
-/** Minimal NATS subject matcher — supports `>` (multi-token catch-all). */
 function subjectMatches(pattern: string, subject: string): boolean {
   if (pattern === subject) return true;
-  if (pattern.endsWith(">")) {
-    const prefix = pattern.slice(0, -1); // includes trailing dot
-    return subject.startsWith(prefix);
-  }
+  if (pattern.endsWith(">")) return subject.startsWith(pattern.slice(0, -1));
   return false;
 }
 
 // --- valid synthetic payload -------------------------------------------------
 
-const VALID_PAYLOAD = {
+const VALID_PAYLOAD: NftMintDetected = {
   chain_id: 80094,
   contract: "0x048327a187b944ddac61c6e202bfccd20d17c008",
   token_id: "234",
@@ -107,16 +96,22 @@ async function buildSigner() {
   return { signer, verifier };
 }
 
+// --- helpers for waiting (deterministic — TODO follow-up bead wdd) -----------
+
+async function tick(ms = 10): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
 // --- the actual roundtrip + failure-mode tests ------------------------------
 
-describe("publish → subscribe roundtrip", () => {
+describe("publish → subscribe roundtrip (acvp-l1-v2)", () => {
   it("delivers a valid envelope through verify + schema and into the handler", async () => {
     const nats = new FakeNats();
     const { signer, verifier } = await buildSigner();
     const prevHashStore = new InMemoryPrevHashStore();
     const subject = nftMintDetectedTopic({ collectionSlug: "mibera-shadow" });
 
-    const received: Array<{ payload: typeof VALID_PAYLOAD; envelope: EventEnvelope }> = [];
+    const received: Array<{ payload: NftMintDetected; envelope: EventEnvelope }> = [];
     const sub = await subscribeEnvelope({
       nats,
       subject,
@@ -136,14 +131,13 @@ describe("publish → subscribe roundtrip", () => {
       prevHashStore,
     });
 
-    // give the async loop a tick
-    await new Promise((r) => setTimeout(r, 10));
+    await tick();
 
     assert.equal(received.length, 1);
     assert.equal(received[0]!.payload.token_id, "234");
     assert.equal(received[0]!.envelope.prev_hash, GENESIS_PREV_HASH);
-
-    sub.unsubscribe(); // best-effort cleanup; we don't await done
+    assert.equal(received[0]!.envelope.schema_version, "acvp-l1-v2");
+    sub.unsubscribe();
   });
 
   it("delivers via wildcard subscription", async () => {
@@ -172,10 +166,9 @@ describe("publish → subscribe roundtrip", () => {
       prevHashStore,
     });
 
-    await new Promise((r) => setTimeout(r, 10));
+    await tick();
     assert.equal(received.length, 1);
     assert.equal(received[0]!.event_type, subject);
-
     sub.unsubscribe();
   });
 
@@ -213,13 +206,12 @@ describe("publish → subscribe roundtrip", () => {
       prevHashStore,
     });
 
-    await new Promise((r) => setTimeout(r, 10));
+    await tick();
 
     assert.equal(received.length, 2);
     assert.equal(received[0]!.prev_hash, GENESIS_PREV_HASH);
     assert.equal(received[1]!.prev_hash, a.envelopeHash);
     assert.equal(b.envelope.prev_hash, a.envelopeHash);
-
     sub.unsubscribe();
   });
 
@@ -227,7 +219,6 @@ describe("publish → subscribe roundtrip", () => {
     const nats = new FakeNats();
     const goodSigner = await LocalEd25519Signer.fromSeedHex("0".repeat(64), "sonar-api-1");
     const wrongSigner = await LocalEd25519Signer.fromSeedHex("1".repeat(64), "sonar-api-1");
-    // Verifier knows the GOOD key under sonar-api-1
     const verifier = new StaticPubkeyVerifier().add("sonar-api-1", goodSigner.publicKeyBytes());
 
     const subject = nftMintDetectedTopic({ collectionSlug: "mibera-shadow" });
@@ -251,11 +242,69 @@ describe("publish → subscribe roundtrip", () => {
       subject,
       payload: VALID_PAYLOAD,
       emittedBy: "sonar-api",
-      signer: wrongSigner, // signs with a key the verifier doesn't have
+      signer: wrongSigner,
       prevHashStore: new InMemoryPrevHashStore(),
     });
 
-    await new Promise((r) => setTimeout(r, 10));
+    await tick();
+    assert.deepEqual(failures, ["signature-invalid"]);
+    sub.unsubscribe();
+  });
+
+  it("EVT-001: surfaces signature-invalid when event_type is tampered in transit", async () => {
+    // Simulate an attacker who captures a valid envelope and modifies the
+    // event_type before re-publishing on the new subject. Under acvp-l1-v1
+    // this was an undetectable forgery; under acvp-l1-v2 the sig binds the
+    // full envelope so signature verification MUST fail.
+    const nats = new FakeNats();
+    const { signer, verifier } = await buildSigner();
+    const originalSubject = nftMintDetectedTopic({ collectionSlug: "mibera-shadow" });
+    const tamperedSubject = nftMintDetectedTopic({ collectionSlug: "other-collection" });
+
+    // Publish into a discard nats to get a valid envelope, then replay-with-tamper
+    const discardNats = new FakeNats();
+    await publishEnvelope({
+      nats: discardNats,
+      subject: originalSubject,
+      payload: VALID_PAYLOAD,
+      emittedBy: "sonar-api",
+      signer,
+      prevHashStore: new InMemoryPrevHashStore(),
+    });
+
+    // Manually publish a tampered version of the same envelope on a different
+    // subject (signature stays the same but event_type is swapped)
+    const failures: VerificationFailureReason[] = [];
+    const sub = await subscribeEnvelope({
+      nats,
+      subject: tamperedSubject,
+      schema: NftMintDetectedSchema,
+      verifier,
+      handler: async () => {
+        throw new Error("handler should not be called for forged event_type");
+      },
+      onVerificationFailure: (reason) => {
+        failures.push(reason);
+      },
+    });
+
+    // Manually craft the tampered envelope (event_type swapped, signature kept)
+    const signedEnvelope = (
+      await publishEnvelope({
+        nats: discardNats,
+        subject: originalSubject,
+        payload: VALID_PAYLOAD,
+        emittedBy: "sonar-api",
+        signer,
+        prevHashStore: new InMemoryPrevHashStore(),
+      })
+    ).envelope;
+
+    const tamperedEnvelope = { ...signedEnvelope, event_type: tamperedSubject };
+    const tamperedBytes = new TextEncoder().encode(jcsCanonicalize(tamperedEnvelope));
+    nats.publish(tamperedSubject, tamperedBytes);
+
+    await tick();
     assert.deepEqual(failures, ["signature-invalid"]);
     sub.unsubscribe();
   });
@@ -279,8 +328,7 @@ describe("publish → subscribe roundtrip", () => {
       },
     });
 
-    // Publish with a missing required field (token_id)
-    const bad = { ...VALID_PAYLOAD, token_id: undefined } as unknown as typeof VALID_PAYLOAD;
+    const bad = { ...VALID_PAYLOAD, token_id: undefined } as unknown as NftMintDetected;
     await publishEnvelope({
       nats,
       subject,
@@ -290,7 +338,7 @@ describe("publish → subscribe roundtrip", () => {
       prevHashStore: new InMemoryPrevHashStore(),
     });
 
-    await new Promise((r) => setTimeout(r, 10));
+    await tick();
     assert.deepEqual(failures, ["payload-schema-invalid"]);
     sub.unsubscribe();
   });
@@ -324,8 +372,6 @@ describe("publish → subscribe roundtrip", () => {
       signer,
       prevHashStore: new InMemoryPrevHashStore(),
     });
-
-    // publish a second time to confirm the subscriber stays alive after a handler throw
     await publishEnvelope({
       nats,
       subject,
@@ -335,7 +381,7 @@ describe("publish → subscribe roundtrip", () => {
       prevHashStore: new InMemoryPrevHashStore(),
     });
 
-    await new Promise((r) => setTimeout(r, 20));
+    await tick(20);
     assert.equal(handlerInvocations, 2, "subscriber stays alive across handler throws");
     assert.deepEqual(failures, ["handler-error", "handler-error"]);
     sub.unsubscribe();
@@ -374,15 +420,11 @@ describe("publish → subscribe roundtrip", () => {
       prevHashStore: publisherStore,
     });
 
-    // Simulate publisher OR subscriber missing message #2:
-    // publisher emits a 2nd envelope (advances publisher store) but we DROP it
-    // before it reaches NATS. We do this by directly advancing the publisher
-    // store without publishing.
-    const ghostPublisherStore = new InMemoryPrevHashStore();
-    // copy current hash forward, then publish a "ghost" envelope to advance the chain in our local store
+    // Simulate a missing envelope by advancing the publisher's chain
+    // without actually delivering the envelope to `nats`.
+    const ghostStore = new InMemoryPrevHashStore();
     const currentHash = await publisherStore.get("sonar-api:sonar-api-1");
-    if (currentHash) await ghostPublisherStore.set("sonar-api:sonar-api-1", currentHash);
-    // emit ghost to discard (different nats instance — never sees it)
+    if (currentHash) await ghostStore.set("sonar-api:sonar-api-1", currentHash);
     const discardNats = new FakeNats();
     await publishEnvelope({
       nats: discardNats,
@@ -390,16 +432,12 @@ describe("publish → subscribe roundtrip", () => {
       payload: { ...VALID_PAYLOAD, token_id: "235" },
       emittedBy: "sonar-api",
       signer,
-      prevHashStore: ghostPublisherStore,
+      prevHashStore: ghostStore,
     });
-
-    // Now the publisher's CHAIN view has advanced (ghostPublisherStore knows the
-    // ghost envelope's hash). Sync that forward to the real publisher store.
-    const advancedHash = await ghostPublisherStore.get("sonar-api:sonar-api-1");
+    const advancedHash = await ghostStore.get("sonar-api:sonar-api-1");
     if (advancedHash) await publisherStore.set("sonar-api:sonar-api-1", advancedHash);
 
-    // 2nd visible publish — prev_hash now references the ghost envelope the
-    // subscriber NEVER SAW. Subscriber's chain check must surface the gap.
+    // 2nd visible publish — prev_hash points at the ghost envelope subscriber never saw
     await publishEnvelope({
       nats,
       subject,
@@ -409,9 +447,151 @@ describe("publish → subscribe roundtrip", () => {
       prevHashStore: publisherStore,
     });
 
-    await new Promise((r) => setTimeout(r, 10));
+    await tick();
     assert.equal(handledCount, 1, "only the first envelope reaches the handler");
     assert.deepEqual(failures, ["prev-hash-broken-chain"]);
+    sub.unsubscribe();
+  });
+
+  it("EVT-002: initialPrevHashPolicy 'genesis' rejects mid-chain replay as first envelope", async () => {
+    // Attacker captures envelope from publisher who has been running a while
+    // (so its prev_hash is some non-genesis value) and replays it as the
+    // FIRST envelope a fresh subscriber sees. With initialPrevHashPolicy='any'
+    // (default) this is accepted (legacy behavior); with 'genesis' it's
+    // rejected with `initial-anchor-policy-violation`.
+    const nats = new FakeNats();
+    const { signer, verifier } = await buildSigner();
+    const subject = nftMintDetectedTopic({ collectionSlug: "mibera-shadow" });
+
+    const failures: VerificationFailureReason[] = [];
+    let handled = 0;
+    const sub = await subscribeEnvelope({
+      nats,
+      subject,
+      schema: NftMintDetectedSchema,
+      verifier,
+      chainStore: new InMemoryPrevHashStore(),
+      initialPrevHashPolicy: "genesis",
+      handler: async () => {
+        handled++;
+      },
+      onVerificationFailure: (reason) => {
+        failures.push(reason);
+      },
+    });
+
+    // Advance the publisher's chain past genesis (3 publishes into a discard nats)
+    const publisherStore = new InMemoryPrevHashStore();
+    const discardNats = new FakeNats();
+    for (let i = 0; i < 3; i++) {
+      await publishEnvelope({
+        nats: discardNats,
+        subject,
+        payload: { ...VALID_PAYLOAD, token_id: String(100 + i) },
+        emittedBy: "sonar-api",
+        signer,
+        prevHashStore: publisherStore,
+      });
+    }
+    // Now publish the "replay" to the live subscriber — first time seeing this
+    // publisher, but prev_hash is NOT genesis.
+    await publishEnvelope({
+      nats,
+      subject,
+      payload: { ...VALID_PAYLOAD, token_id: "999" },
+      emittedBy: "sonar-api",
+      signer,
+      prevHashStore: publisherStore,
+    });
+
+    await tick();
+    assert.equal(handled, 0);
+    assert.deepEqual(failures, ["initial-anchor-policy-violation"]);
+    sub.unsubscribe();
+  });
+
+  it("EVT-002: initialPrevHashPolicy 'genesis' accepts a genesis-anchored first envelope", async () => {
+    const nats = new FakeNats();
+    const { signer, verifier } = await buildSigner();
+    const subject = nftMintDetectedTopic({ collectionSlug: "mibera-shadow" });
+
+    const received: EventEnvelope[] = [];
+    const sub = await subscribeEnvelope({
+      nats,
+      subject,
+      schema: NftMintDetectedSchema,
+      verifier,
+      chainStore: new InMemoryPrevHashStore(),
+      initialPrevHashPolicy: "genesis",
+      handler: async ({ envelope }) => {
+        received.push(envelope);
+      },
+    });
+
+    await publishEnvelope({
+      nats,
+      subject,
+      payload: VALID_PAYLOAD,
+      emittedBy: "sonar-api",
+      signer,
+      prevHashStore: new InMemoryPrevHashStore(),
+    });
+
+    await tick();
+    assert.equal(received.length, 1);
+    assert.equal(received[0]!.prev_hash, GENESIS_PREV_HASH);
+    sub.unsubscribe();
+  });
+
+  it("EVT-002: initialPrevHashPolicy <hex-string> accepts pinned anchor only", async () => {
+    const nats = new FakeNats();
+    const { signer, verifier } = await buildSigner();
+    const subject = nftMintDetectedTopic({ collectionSlug: "mibera-shadow" });
+
+    // Advance publisher chain by 1 to get a known non-genesis anchor
+    const publisherStore = new InMemoryPrevHashStore();
+    const discardNats = new FakeNats();
+    const first = await publishEnvelope({
+      nats: discardNats,
+      subject,
+      payload: VALID_PAYLOAD,
+      emittedBy: "sonar-api",
+      signer,
+      prevHashStore: publisherStore,
+    });
+    const anchor = first.envelopeHash; // this is what publisher's NEXT prev_hash will be
+
+    // Subscriber pins this anchor as the expected first prev_hash
+    const failures: VerificationFailureReason[] = [];
+    let handled = 0;
+    const sub = await subscribeEnvelope({
+      nats,
+      subject,
+      schema: NftMintDetectedSchema,
+      verifier,
+      chainStore: new InMemoryPrevHashStore(),
+      initialPrevHashPolicy: anchor,
+      handler: async () => {
+        handled++;
+      },
+      onVerificationFailure: (reason) => {
+        failures.push(reason);
+      },
+    });
+
+    // Publish the next envelope (whose prev_hash WILL be `anchor`)
+    await publishEnvelope({
+      nats,
+      subject,
+      payload: { ...VALID_PAYLOAD, token_id: "777" },
+      emittedBy: "sonar-api",
+      signer,
+      prevHashStore: publisherStore,
+    });
+
+    await tick();
+    assert.equal(handled, 1);
+    assert.equal(failures.length, 0);
     sub.unsubscribe();
   });
 });

--- a/packages/events/tests/roundtrip.test.ts
+++ b/packages/events/tests/roundtrip.test.ts
@@ -295,6 +295,52 @@ describe("publish → subscribe roundtrip", () => {
     sub.unsubscribe();
   });
 
+  it("surfaces handler-error when the application handler throws (F-002)", async () => {
+    const nats = new FakeNats();
+    const { signer, verifier } = await buildSigner();
+    const subject = nftMintDetectedTopic({ collectionSlug: "mibera-shadow" });
+
+    const failures: VerificationFailureReason[] = [];
+    let handlerInvocations = 0;
+    const sub = await subscribeEnvelope({
+      nats,
+      subject,
+      schema: NftMintDetectedSchema,
+      verifier,
+      handler: async () => {
+        handlerInvocations++;
+        throw new Error("application code is buggy");
+      },
+      onVerificationFailure: (reason) => {
+        failures.push(reason);
+      },
+    });
+
+    await publishEnvelope({
+      nats,
+      subject,
+      payload: VALID_PAYLOAD,
+      emittedBy: "sonar-api",
+      signer,
+      prevHashStore: new InMemoryPrevHashStore(),
+    });
+
+    // publish a second time to confirm the subscriber stays alive after a handler throw
+    await publishEnvelope({
+      nats,
+      subject,
+      payload: { ...VALID_PAYLOAD, token_id: "235" },
+      emittedBy: "sonar-api",
+      signer,
+      prevHashStore: new InMemoryPrevHashStore(),
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+    assert.equal(handlerInvocations, 2, "subscriber stays alive across handler throws");
+    assert.deepEqual(failures, ["handler-error", "handler-error"]);
+    sub.unsubscribe();
+  });
+
   it("surfaces prev-hash-broken-chain when chainStore detects a gap", async () => {
     const nats = new FakeNats();
     const { signer, verifier } = await buildSigner();

--- a/packages/events/tests/roundtrip.test.ts
+++ b/packages/events/tests/roundtrip.test.ts
@@ -1,0 +1,371 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { z } from "zod";
+
+import { publishEnvelope, InMemoryPrevHashStore } from "../src/publisher.js";
+import { subscribeEnvelope, type VerificationFailureReason } from "../src/subscriber.js";
+import { LocalEd25519Signer, StaticPubkeyVerifier } from "../src/signer.js";
+import { nftMintDetectedTopic } from "../src/topics.js";
+import { NftMintDetectedSchema } from "../src/schemas/nft-mint-detected.js";
+import { GENESIS_PREV_HASH, type EventEnvelope } from "../src/envelope.js";
+
+// --- minimal in-memory fake NATS for roundtrip tests -------------------------
+
+interface FakeMessage {
+  subject: string;
+  data: Uint8Array;
+}
+
+class FakeNats {
+  // subject → queue of messages
+  #queues = new Map<string, FakeMessage[]>();
+  // subject → pending-resolvers waiting for a message
+  #waiters = new Map<string, Array<(msg: FakeMessage) => void>>();
+  // subject → "subscribed" flag (so we know to flush a queue into an iterator)
+  #subscriptions = new Set<string>();
+
+  publish(subject: string, data: Uint8Array): void {
+    const msg: FakeMessage = { subject, data };
+    const subs = matchingSubscriptions(this.#subscriptions, subject);
+    for (const s of subs) {
+      const waiters = this.#waiters.get(s);
+      if (waiters && waiters.length > 0) {
+        const resolve = waiters.shift()!;
+        resolve(msg);
+      } else {
+        const q = this.#queues.get(s) ?? [];
+        q.push(msg);
+        this.#queues.set(s, q);
+      }
+    }
+  }
+
+  subscribe(subject: string): AsyncIterable<FakeMessage> & { unsubscribe: () => void } {
+    this.#subscriptions.add(subject);
+    let cancelled = false;
+    const iter = {
+      [Symbol.asyncIterator]: () => ({
+        next: async () => {
+          if (cancelled) return { value: undefined, done: true as const };
+          // drain queue first
+          const q = this.#queues.get(subject) ?? [];
+          if (q.length > 0) {
+            const msg = q.shift()!;
+            this.#queues.set(subject, q);
+            return { value: msg, done: false as const };
+          }
+          // wait
+          return new Promise<{ value: FakeMessage; done: false }>((resolve) => {
+            const waiters = this.#waiters.get(subject) ?? [];
+            waiters.push((m) => resolve({ value: m, done: false as const }));
+            this.#waiters.set(subject, waiters);
+          });
+        },
+      }),
+      unsubscribe: () => {
+        cancelled = true;
+        this.#subscriptions.delete(subject);
+      },
+    };
+    return iter;
+  }
+}
+
+function matchingSubscriptions(subs: Set<string>, subject: string): string[] {
+  const out: string[] = [];
+  for (const sub of subs) {
+    if (subjectMatches(sub, subject)) out.push(sub);
+  }
+  return out;
+}
+
+/** Minimal NATS subject matcher — supports `>` (multi-token catch-all). */
+function subjectMatches(pattern: string, subject: string): boolean {
+  if (pattern === subject) return true;
+  if (pattern.endsWith(">")) {
+    const prefix = pattern.slice(0, -1); // includes trailing dot
+    return subject.startsWith(prefix);
+  }
+  return false;
+}
+
+// --- valid synthetic payload -------------------------------------------------
+
+const VALID_PAYLOAD = {
+  chain_id: 80094,
+  contract: "0x048327a187b944ddac61c6e202bfccd20d17c008",
+  token_id: "234",
+  minter: "0x000000000000000000000000000000000000abcd",
+  block_number: 12345678,
+  transaction_hash: "0x" + "ab".repeat(32),
+  timestamp: "2026-05-26T21:30:00Z",
+};
+
+async function buildSigner() {
+  const signer = await LocalEd25519Signer.fromSeedHex("0".repeat(64), "sonar-api-1");
+  const verifier = new StaticPubkeyVerifier().add("sonar-api-1", signer.publicKeyBytes());
+  return { signer, verifier };
+}
+
+// --- the actual roundtrip + failure-mode tests ------------------------------
+
+describe("publish → subscribe roundtrip", () => {
+  it("delivers a valid envelope through verify + schema and into the handler", async () => {
+    const nats = new FakeNats();
+    const { signer, verifier } = await buildSigner();
+    const prevHashStore = new InMemoryPrevHashStore();
+    const subject = nftMintDetectedTopic({ collectionSlug: "mibera-shadow" });
+
+    const received: Array<{ payload: typeof VALID_PAYLOAD; envelope: EventEnvelope }> = [];
+    const sub = await subscribeEnvelope({
+      nats,
+      subject,
+      schema: NftMintDetectedSchema,
+      verifier,
+      handler: async ({ payload, envelope }) => {
+        received.push({ payload, envelope });
+      },
+    });
+
+    await publishEnvelope({
+      nats,
+      subject,
+      payload: VALID_PAYLOAD,
+      emittedBy: "sonar-api",
+      signer,
+      prevHashStore,
+    });
+
+    // give the async loop a tick
+    await new Promise((r) => setTimeout(r, 10));
+
+    assert.equal(received.length, 1);
+    assert.equal(received[0]!.payload.token_id, "234");
+    assert.equal(received[0]!.envelope.prev_hash, GENESIS_PREV_HASH);
+
+    sub.unsubscribe(); // best-effort cleanup; we don't await done
+  });
+
+  it("delivers via wildcard subscription", async () => {
+    const nats = new FakeNats();
+    const { signer, verifier } = await buildSigner();
+    const prevHashStore = new InMemoryPrevHashStore();
+    const subject = nftMintDetectedTopic({ collectionSlug: "purupuru-apiculture" });
+
+    const received: Array<EventEnvelope> = [];
+    const sub = await subscribeEnvelope({
+      nats,
+      subject: "nft.mint.detected.>",
+      schema: NftMintDetectedSchema,
+      verifier,
+      handler: async ({ envelope }) => {
+        received.push(envelope);
+      },
+    });
+
+    await publishEnvelope({
+      nats,
+      subject,
+      payload: VALID_PAYLOAD,
+      emittedBy: "sonar-api",
+      signer,
+      prevHashStore,
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+    assert.equal(received.length, 1);
+    assert.equal(received[0]!.event_type, subject);
+
+    sub.unsubscribe();
+  });
+
+  it("advances prev_hash across two consecutive publishes (per-publisher chain)", async () => {
+    const nats = new FakeNats();
+    const { signer, verifier } = await buildSigner();
+    const prevHashStore = new InMemoryPrevHashStore();
+    const subject = nftMintDetectedTopic({ collectionSlug: "mibera-shadow" });
+
+    const received: Array<EventEnvelope> = [];
+    const sub = await subscribeEnvelope({
+      nats,
+      subject,
+      schema: NftMintDetectedSchema,
+      verifier,
+      handler: async ({ envelope }) => {
+        received.push(envelope);
+      },
+    });
+
+    const a = await publishEnvelope({
+      nats,
+      subject,
+      payload: VALID_PAYLOAD,
+      emittedBy: "sonar-api",
+      signer,
+      prevHashStore,
+    });
+    const b = await publishEnvelope({
+      nats,
+      subject,
+      payload: { ...VALID_PAYLOAD, token_id: "235", block_number: 12345679 },
+      emittedBy: "sonar-api",
+      signer,
+      prevHashStore,
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    assert.equal(received.length, 2);
+    assert.equal(received[0]!.prev_hash, GENESIS_PREV_HASH);
+    assert.equal(received[1]!.prev_hash, a.envelopeHash);
+    assert.equal(b.envelope.prev_hash, a.envelopeHash);
+
+    sub.unsubscribe();
+  });
+
+  it("surfaces signature-invalid when a wrong key signs the envelope", async () => {
+    const nats = new FakeNats();
+    const goodSigner = await LocalEd25519Signer.fromSeedHex("0".repeat(64), "sonar-api-1");
+    const wrongSigner = await LocalEd25519Signer.fromSeedHex("1".repeat(64), "sonar-api-1");
+    // Verifier knows the GOOD key under sonar-api-1
+    const verifier = new StaticPubkeyVerifier().add("sonar-api-1", goodSigner.publicKeyBytes());
+
+    const subject = nftMintDetectedTopic({ collectionSlug: "mibera-shadow" });
+
+    const failures: VerificationFailureReason[] = [];
+    const sub = await subscribeEnvelope({
+      nats,
+      subject,
+      schema: NftMintDetectedSchema,
+      verifier,
+      handler: async () => {
+        throw new Error("handler should not be called for invalid sig");
+      },
+      onVerificationFailure: (reason) => {
+        failures.push(reason);
+      },
+    });
+
+    await publishEnvelope({
+      nats,
+      subject,
+      payload: VALID_PAYLOAD,
+      emittedBy: "sonar-api",
+      signer: wrongSigner, // signs with a key the verifier doesn't have
+      prevHashStore: new InMemoryPrevHashStore(),
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+    assert.deepEqual(failures, ["signature-invalid"]);
+    sub.unsubscribe();
+  });
+
+  it("surfaces payload-schema-invalid when payload fails the per-event schema", async () => {
+    const nats = new FakeNats();
+    const { signer, verifier } = await buildSigner();
+    const subject = nftMintDetectedTopic({ collectionSlug: "mibera-shadow" });
+
+    const failures: VerificationFailureReason[] = [];
+    const sub = await subscribeEnvelope({
+      nats,
+      subject,
+      schema: NftMintDetectedSchema,
+      verifier,
+      handler: async () => {
+        throw new Error("handler should not be called for invalid schema");
+      },
+      onVerificationFailure: (reason) => {
+        failures.push(reason);
+      },
+    });
+
+    // Publish with a missing required field (token_id)
+    const bad = { ...VALID_PAYLOAD, token_id: undefined } as unknown as typeof VALID_PAYLOAD;
+    await publishEnvelope({
+      nats,
+      subject,
+      payload: bad,
+      emittedBy: "sonar-api",
+      signer,
+      prevHashStore: new InMemoryPrevHashStore(),
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+    assert.deepEqual(failures, ["payload-schema-invalid"]);
+    sub.unsubscribe();
+  });
+
+  it("surfaces prev-hash-broken-chain when chainStore detects a gap", async () => {
+    const nats = new FakeNats();
+    const { signer, verifier } = await buildSigner();
+    const publisherStore = new InMemoryPrevHashStore();
+    const subscriberStore = new InMemoryPrevHashStore();
+    const subject = nftMintDetectedTopic({ collectionSlug: "mibera-shadow" });
+
+    const failures: VerificationFailureReason[] = [];
+    let handledCount = 0;
+    const sub = await subscribeEnvelope({
+      nats,
+      subject,
+      schema: NftMintDetectedSchema,
+      verifier,
+      chainStore: subscriberStore,
+      handler: async () => {
+        handledCount++;
+      },
+      onVerificationFailure: (reason) => {
+        failures.push(reason);
+      },
+    });
+
+    // 1st publish lands cleanly
+    await publishEnvelope({
+      nats,
+      subject,
+      payload: VALID_PAYLOAD,
+      emittedBy: "sonar-api",
+      signer,
+      prevHashStore: publisherStore,
+    });
+
+    // Simulate publisher OR subscriber missing message #2:
+    // publisher emits a 2nd envelope (advances publisher store) but we DROP it
+    // before it reaches NATS. We do this by directly advancing the publisher
+    // store without publishing.
+    const ghostPublisherStore = new InMemoryPrevHashStore();
+    // copy current hash forward, then publish a "ghost" envelope to advance the chain in our local store
+    const currentHash = await publisherStore.get("sonar-api:sonar-api-1");
+    if (currentHash) await ghostPublisherStore.set("sonar-api:sonar-api-1", currentHash);
+    // emit ghost to discard (different nats instance — never sees it)
+    const discardNats = new FakeNats();
+    await publishEnvelope({
+      nats: discardNats,
+      subject,
+      payload: { ...VALID_PAYLOAD, token_id: "235" },
+      emittedBy: "sonar-api",
+      signer,
+      prevHashStore: ghostPublisherStore,
+    });
+
+    // Now the publisher's CHAIN view has advanced (ghostPublisherStore knows the
+    // ghost envelope's hash). Sync that forward to the real publisher store.
+    const advancedHash = await ghostPublisherStore.get("sonar-api:sonar-api-1");
+    if (advancedHash) await publisherStore.set("sonar-api:sonar-api-1", advancedHash);
+
+    // 2nd visible publish — prev_hash now references the ghost envelope the
+    // subscriber NEVER SAW. Subscriber's chain check must surface the gap.
+    await publishEnvelope({
+      nats,
+      subject,
+      payload: { ...VALID_PAYLOAD, token_id: "236" },
+      emittedBy: "sonar-api",
+      signer,
+      prevHashStore: publisherStore,
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+    assert.equal(handledCount, 1, "only the first envelope reaches the handler");
+    assert.deepEqual(failures, ["prev-hash-broken-chain"]);
+    sub.unsubscribe();
+  });
+});

--- a/packages/events/tests/signer.test.ts
+++ b/packages/events/tests/signer.test.ts
@@ -1,0 +1,80 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { LocalEd25519Signer, StaticPubkeyVerifier, _internal } from "../src/signer.js";
+
+const ZERO_SEED = "0".repeat(64);
+const ONE_SEED = "1".repeat(64);
+
+describe("LocalEd25519Signer", () => {
+  it("signs + verifies a roundtrip via StaticPubkeyVerifier", async () => {
+    const signer = await LocalEd25519Signer.fromSeedHex(ZERO_SEED, "kid-A");
+    const verifier = new StaticPubkeyVerifier().add("kid-A", signer.publicKeyBytes());
+
+    const msg = new TextEncoder().encode("the cluster awakens");
+    const sig = await signer.sign(msg);
+
+    assert.equal(await verifier.verify("kid-A", msg, sig), true);
+  });
+
+  it("verify fails for the wrong kid", async () => {
+    const signerA = await LocalEd25519Signer.fromSeedHex(ZERO_SEED, "kid-A");
+    const signerB = await LocalEd25519Signer.fromSeedHex(ONE_SEED, "kid-B");
+    const verifier = new StaticPubkeyVerifier()
+      .add("kid-A", signerA.publicKeyBytes())
+      .add("kid-B", signerB.publicKeyBytes());
+
+    const msg = new TextEncoder().encode("the cluster awakens");
+    const sigByA = await signerA.sign(msg);
+
+    // Same message, but the kid is wrong → verify must fail (sig is over A's key, lookup picks B's)
+    assert.equal(await verifier.verify("kid-B", msg, sigByA), false);
+  });
+
+  it("verify fails for an unknown kid", async () => {
+    const signer = await LocalEd25519Signer.fromSeedHex(ZERO_SEED, "kid-A");
+    const verifier = new StaticPubkeyVerifier();
+
+    const sig = await signer.sign(new TextEncoder().encode("x"));
+    assert.equal(await verifier.verify("kid-unknown", new TextEncoder().encode("x"), sig), false);
+  });
+
+  it("verify fails for a corrupted signature", async () => {
+    const signer = await LocalEd25519Signer.fromSeedHex(ZERO_SEED, "kid-A");
+    const verifier = new StaticPubkeyVerifier().add("kid-A", signer.publicKeyBytes());
+
+    const msg = new TextEncoder().encode("payload");
+    const sig = await signer.sign(msg);
+    // flip a char in the signature
+    const corrupted = sig.slice(0, -1) + (sig.slice(-1) === "A" ? "B" : "A");
+    assert.equal(await verifier.verify("kid-A", msg, corrupted), false);
+  });
+
+  it("verify fails when the message changes", async () => {
+    const signer = await LocalEd25519Signer.fromSeedHex(ZERO_SEED, "kid-A");
+    const verifier = new StaticPubkeyVerifier().add("kid-A", signer.publicKeyBytes());
+
+    const sig = await signer.sign(new TextEncoder().encode("original"));
+    assert.equal(await verifier.verify("kid-A", new TextEncoder().encode("tampered"), sig), false);
+  });
+
+  it("rejects non-32-byte seeds", async () => {
+    await assert.rejects(() => LocalEd25519Signer.fromSeedHex("ab", "x"));
+  });
+
+  it("publicKeyHex is 64 lowercase hex chars", async () => {
+    const signer = await LocalEd25519Signer.fromSeedHex(ZERO_SEED, "kid-A");
+    assert.match(signer.publicKeyHex(), /^[0-9a-f]{64}$/);
+  });
+});
+
+describe("base64url roundtrip (internal helpers)", () => {
+  it("encodes + decodes arbitrary bytes losslessly", () => {
+    for (const seed of [new Uint8Array([0, 1, 2, 250, 251, 252]), new Uint8Array(64).fill(0xff)]) {
+      const enc = _internal.bytesToBase64Url(seed);
+      const dec = _internal.base64UrlToBytes(enc);
+      assert.deepEqual(dec, seed);
+      assert.ok(!enc.includes("="), "no padding");
+      assert.ok(!enc.includes("+") && !enc.includes("/"), "url-safe alphabet");
+    }
+  });
+});

--- a/packages/events/tests/topics.test.ts
+++ b/packages/events/tests/topics.test.ts
@@ -42,7 +42,10 @@ describe("buildTopic", () => {
 });
 
 describe("nftMintDetectedTopic", () => {
-  it("defaults to catch-all v1 when no slug given", () => {
+  it("returns the base versioned subject (NOT a wildcard) when no slug given", () => {
+    // F-007 BB#227: the no-slug return is a SPECIFIC subject for publishing
+    // events with no collection discriminator — it is NOT a NATS wildcard.
+    // To subscribe to all collections, use NFT_MINT_DETECTED_WILDCARD.
     assert.equal(nftMintDetectedTopic(), "nft.mint.detected.v1");
   });
 

--- a/packages/events/tests/topics.test.ts
+++ b/packages/events/tests/topics.test.ts
@@ -1,0 +1,68 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildTopic, nftMintDetectedTopic, NFT_MINT_DETECTED_WILDCARD } from "../src/topics.js";
+
+describe("buildTopic", () => {
+  it("builds a 3-segment versioned topic", () => {
+    const topic = buildTopic({ aggregate: "nft", noun: "mint", verb: "detected", version: 1 });
+    assert.equal(topic, "nft.mint.detected.v1");
+  });
+
+  it("builds a 4-segment (with specifier) versioned topic", () => {
+    const topic = buildTopic({
+      aggregate: "nft",
+      noun: "mint",
+      verb: "detected",
+      specifier: "mibera-shadow",
+      version: 1,
+    });
+    assert.equal(topic, "nft.mint.detected.mibera-shadow.v1");
+  });
+
+  it("rejects uppercase segments", () => {
+    assert.throws(() =>
+      buildTopic({ aggregate: "NFT", noun: "mint", verb: "detected", version: 1 }),
+    );
+  });
+
+  it("rejects underscores in segments", () => {
+    assert.throws(() =>
+      buildTopic({ aggregate: "nft", noun: "mint_event", verb: "detected", version: 1 }),
+    );
+  });
+
+  it("rejects version 0 and negative versions", () => {
+    assert.throws(() => buildTopic({ aggregate: "a", noun: "b", verb: "c", version: 0 }));
+    assert.throws(() => buildTopic({ aggregate: "a", noun: "b", verb: "c", version: -1 }));
+  });
+
+  it("rejects non-integer versions", () => {
+    assert.throws(() => buildTopic({ aggregate: "a", noun: "b", verb: "c", version: 1.5 }));
+  });
+});
+
+describe("nftMintDetectedTopic", () => {
+  it("defaults to catch-all v1 when no slug given", () => {
+    assert.equal(nftMintDetectedTopic(), "nft.mint.detected.v1");
+  });
+
+  it("includes the slug when given", () => {
+    assert.equal(
+      nftMintDetectedTopic({ collectionSlug: "purupuru-apiculture" }),
+      "nft.mint.detected.purupuru-apiculture.v1",
+    );
+  });
+
+  it("supports an explicit version override", () => {
+    assert.equal(
+      nftMintDetectedTopic({ collectionSlug: "mibera-shadow", version: 2 }),
+      "nft.mint.detected.mibera-shadow.v2",
+    );
+  });
+});
+
+describe("wildcard constant", () => {
+  it("is the NATS catch-all under the nft-mint-detected hierarchy", () => {
+    assert.equal(NFT_MINT_DETECTED_WILDCARD, "nft.mint.detected.>");
+  });
+});

--- a/packages/events/tsconfig.json
+++ b/packages/events/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "noImplicitAny": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}


### PR DESCRIPTION
## Summary

- **`@0xhoneyjar/events`** workspace package — the first instance of cycle-098 L1 envelope discipline applied to the service-plane (per-cell typed events). One built, N inherited.
- 7 source files (envelope · jcs · signer · topics · publisher · subscriber · schemas/nft-mint-detected) + 46 passing tests covering roundtrip and every verification-failure mode (broken-sig · broken-chain · payload-hash-mismatch · schema-violation).
- Unblocks **sonar DEP-1** (publish on Mibera-family + PuruPuru handlers) + **characters DEP-1** (subscriber + verify) per the events-pillar-v1 build doc.

## What this is (and is not)

This is **Sprint 1** of the `cluster-events-pillar-v1` cluster-meta cycle (ADR-009 §D-7). It is the substrate library only — no sonar publish wiring, no characters subscriber wiring, no operator-dash extension. Those land in subsequent sprints, one per cell, dispatched via the coordinator at `~/bonfire/cluster-events-pillar-coordinator/`.

Service-plane sibling to the user-plane auth substitution that landed in #225. Same shape (vendor-pattern → substrate → adoption), different plane (events vs identity).

## API surface

```typescript
// publisher (sonar will call this from each Mibera-family / PuruPuru handler)
await publishEnvelope({
  nats, subject: nftMintDetectedTopic({ collectionSlug: "mibera-shadow" }),
  payload, emittedBy: "sonar-api", signer, prevHashStore,
});

// subscriber (characters bot + operator-dash trace panel)
await subscribeEnvelope({
  nats, subject: "nft.mint.detected.>",
  schema: NftMintDetectedSchema, verifier,
  handler: ({ payload, envelope }) => { /* typed payload */ },
  onVerificationFailure: (reason, detail) => { /* surface drift, never throw */ },
});
```

## Design invariants enforced

- **Topic naming**: Hounfour 3-segment (`{aggregate}.{noun}.{verb}[.{specifier}].v{N>=1}`); validated in `topics.ts` AND in `envelope.ts` Zod schema
- **Schema version literal-locked** to `acvp-l1-v1`; envelope is `.strict()` (no extras allowed)
- **Per-publisher hash chain**: every publish advances `prevHashStore[emittedBy:keyId]`; subscriber with `chainStore` enforces continuity (gap → `prev-hash-broken-chain` callback; missing store → skip the check, sig + schema still apply)
- **Fail-soft contract**: publisher errors bubble to caller (caller decides fail-soft); subscriber NEVER throws — all failures route through `onVerificationFailure`
- **TLS-only at the NATS layer** (enforced by the consumer's connection config, not by this library; library is transport-agnostic and accepts any `NatsLike` shape)

## Provenance

| | |
|---|---|
| Cycle | `cluster-events-pillar-v1` (cluster-meta per ADR-009 §D-7) |
| Build doc | `grimoires/loa/specs/enhance-events-pillar-v1-nft-mints.md` |
| TEND audit | `grimoires/freeside-network/cluster-2026-05-26-mint-announcement-tend/audit.md` |
| ACVP doctrine | `~/vault/wiki/concepts/agentic-cryptographically-verifiable-protocol.md` |
| L1 envelope prior art | `.claude/scripts/audit-envelope.sh` + `.claude/data/trajectory-schemas/agent-network-envelope.schema.json` |
| Sibling user-plane substitution | #225 (auth-substitution roadmap) |
| Coord cockpit | `~/bonfire/cluster-events-pillar-coordinator/` |
| Coord issues | 0xHoneyJar/sonar-api#20 · 0xHoneyJar/freeside-characters#102 |

## Test plan

- [x] `pnpm install` (independent per-package lockfile per loa-freeside convention)
- [x] `pnpm build` (tsc -b clean)
- [x] `pnpm test` (46/46 passing: envelope · jcs · signer · topics · roundtrip)
- [ ] Reviewer: confirm `@0xhoneyjar/` scope (vs existing `@freeside/*` packages) — chosen per build doc + memory `project_freeside-npm-scope-and-consume.md` that names `@0xhoneyjar` as canonical
- [ ] Reviewer: confirm the canonicalize@2 NodeNext escape-hatch cast in `src/jcs.ts` is acceptable (alt: write a ~30-line JCS impl + drop the dep)
- [ ] Post-merge: dispatch sonar DEP-1 (NATS publish) + characters DEP-1 (subscriber) via `~/bonfire/cluster-events-pillar-coordinator/cockpit.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)