### PR TITLE
fix(operator-dash): registry path resolution + Dockerfile freeside-registry COPY

### DIFF
--- a/apps/freeside-operator-dash/Dockerfile
+++ b/apps/freeside-operator-dash/Dockerfile
@@ -18,6 +18,7 @@ RUN corepack enable && corepack prepare pnpm@9.15.9 --activate
 # The dash declares its own pnpm-workspace.yaml; the events package
 # must be reachable via the file:../../packages/events link.
 COPY packages/events ./packages/events
+COPY packages/freeside-registry ./packages/freeside-registry
 COPY apps/freeside-operator-dash ./apps/freeside-operator-dash
 
 # Build events package first (dash's tsc resolves it from packages/events/dist).
@@ -37,6 +38,11 @@ RUN corepack enable && corepack prepare pnpm@9.15.9 --activate
 COPY --from=builder /app/packages/events/package.json ./packages/events/package.json
 COPY --from=builder /app/packages/events/dist ./packages/events/dist
 COPY --from=builder /app/packages/events/node_modules ./packages/events/node_modules
+
+# freeside-registry is read at runtime (registry.yaml). Bring the whole
+# package so the dash's path-resolved load (REPO_ROOT/packages/freeside-registry/
+# registry.yaml) succeeds in the runtime image.
+COPY --from=builder /app/packages/freeside-registry ./packages/freeside-registry
 
 COPY --from=builder /app/apps/freeside-operator-dash/package.json ./apps/freeside-operator-dash/package.json
 COPY --from=builder /app/apps/freeside-operator-dash/dist ./apps/freeside-operator-dash/dist

--- a/apps/freeside-operator-dash/src/registry.ts
+++ b/apps/freeside-operator-dash/src/registry.ts
@@ -10,14 +10,14 @@ import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
 import type { RegistryCell, RuntimeState } from "./types.js";
 
-// dirname(import.meta.url) = .../apps/freeside-operator-dash/src
-// 3 levels up gets us to the repo root.
-const REPO_ROOT = join(
-  dirname(fileURLToPath(import.meta.url)),
-  "..", // src/ → apps/freeside-operator-dash/
-  "..", // apps/freeside-operator-dash/ → apps/
-  "..", // apps/ → repo root
-);
+// dirname(import.meta.url) at runtime:
+//   - dev (tsx, source):     .../apps/freeside-operator-dash/src
+//   - prod (compiled):       .../apps/freeside-operator-dash/dist/src
+// Handle both layouts so registry.yaml resolves correctly in either context.
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = MODULE_DIR.includes(`${"dist"}/src`) || MODULE_DIR.endsWith("dist/src")
+  ? join(MODULE_DIR, "..", "..", "..", "..") // dist/src → dist → app → apps → repo root
+  : join(MODULE_DIR, "..", "..", ".."); // src → app → apps → repo root
 
 const REGISTRY_PATH = join(REPO_ROOT, "packages", "freeside-registry", "registry.yaml");
 


### PR DESCRIPTION
Path bug + missing COPY caused / route 500. Diagnosed via Railway logs: ENOENT on /app/apps/packages/freeside-registry/registry.yaml (doubled apps/ from 3-vs-4-level path math + the registry package wasn't copied). Two-line fix in registry.ts + two COPYs in Dockerfile.