### PR TITLE
chore(auth-proxy): remove honey.0xhoneyjar.xyz from CORS allowlist

### DIFF
--- a/infrastructure/terraform/auth-proxy.tf
+++ b/infrastructure/terraform/auth-proxy.tf
@@ -35,7 +35,6 @@ resource "aws_apigatewayv2_api" "auth_proxy" {
     allow_origins = [
       "https://0xhoneyjar.xyz",
       "https://moneycomb.0xhoneyjar.xyz",
-      "https://honey.0xhoneyjar.xyz",
       "https://hub.0xhoneyjar.xyz",
       "https://midi.0xhoneyjar.xyz",
       "https://mibera.0xhoneyjar.xyz",


### PR DESCRIPTION
```yaml
hivemind:
  artifact_type: technical-rfc
  workstream: tech-debt
  priority: low
  product_area: Auth Proxy / Infrastructure
  jtbd:
    category: functional
    description: Keep the credentialed-CORS allowlist narrow — no phantom subdomains that don't host real services
  learning_status: strongly-validated
  source: team-internal
```

---

## Summary

Per operator clarification 2026-05-28: `honey.0xhoneyjar.xyz` is NOT a real subdomain. It was sitting in the auth-proxy CORS allowlist but no actual service runs there.

## Why

GECKO patrol surveyed the auth-proxy.tf CORS allowlist while building the cluster's [world atlas v0.4](https://github.com/0xHoneyJar/loa-freeside/blob/feat/freeside-grimoire-auth-territory/grimoires/freeside/atlases/world-atlas-v0.4.md) (see PR #251). Operator confirmed `honey.*` is not a real subdomain — likely an artifact from a prior plan or copy-paste residue.

Narrowing the credentialed-CORS allowlist to only the surfaces we actually deploy is the right hygiene. If/when `honey.*` gets provisioned as a real subdomain, it can be re-added with intent.

## Test plan
- [ ] No functional impact expected (no service was responding at that origin)
- [ ] `terraform plan` shows the in-place update on the API Gateway CORS config
- [ ] `terraform apply` (operator-decision) deploys the allowlist change

Reversible in one revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
