### PR TITLE
feat(network): per-cell resolution bridge + FL-B0 receipt freshness (doctor-acvp step 3)

### DIFF
--- a/packages/beacon-schema/src/acvp-bindings.ts
+++ b/packages/beacon-schema/src/acvp-bindings.ts
@@ -79,6 +79,23 @@ export interface ValidateAcvpBindingsInput {
   readonly proofReceipts?: ReadonlyArray<AcvpProofReceipt> | null;
   /** null = unknown → freshness unconfirmed, do NOT downgrade (FL-B0) */
   readonly buildingHeadSha?: string | null;
+  /**
+   * injected (FL-B0 restored, sprint-400 step 3): for a MATCHED receipt whose
+   * commit_sha is not exactly buildingHeadSha, decide whether the receipt still
+   * attests the code at the audited HEAD:
+   *   "fresh"   = the attested state still holds at HEAD          → ok (bound)
+   *   "stale"   = the cell advanced/changed since the receipt     → warn (aspirational)
+   *   "unknown" = undeterminable (shallow clone / missing history) → fall back to
+   *               the strict head-equality guard (never auto-pass)
+   * Consulted ONLY when buildingHeadSha is non-null (an audited pin exists). A
+   * COMMITTED in-repo receipt advances HEAD past the commit_sha it recorded, so
+   * exact-HEAD match alone can never accept one — this resolver is what lets a
+   * real receipt resolve to `bound`. Absent the resolver the validator keeps the
+   * exact-HEAD behaviour, so all prior call-sites and tests are unchanged. HOW
+   * freshness is determined is the caller's concern (the CLI compares the cell
+   * tree at the receipt commit vs HEAD); the core only consumes the verdict.
+   */
+  readonly checkReceiptFreshness?: (receipt: AcvpProofReceipt) => "fresh" | "stale" | "unknown";
   readonly aspirationalAllowlist: ReadonlyArray<AcvpAllowlistEntry>;
   /** injected for deterministic expiry checks (FL-D0); defaults to new Date() */
   readonly now?: Date;
@@ -140,6 +157,28 @@ function rawProofFinding(inv: AcvpInvariantT, input: ValidateAcvpBindingsInput):
         severity: "ok",
         message: `proof receipt fresh (commit ${short(receipt.commit_sha)} == building HEAD)`,
       };
+    }
+    // FL-B0 (restored): consult the injected freshness resolver — but ONLY with
+    // an audited HEAD pin (FAGAN composer: a "fresh" verdict under a null head
+    // would yield `bound` with no commit binding, re-opening the null-head hole).
+    // The resolver's contract lives on ValidateAcvpBindingsInput.checkReceiptFreshness;
+    // "unknown" falls through to the strict guard below — only a positive "fresh"
+    // under a real pin yields ok.
+    if (head != null && input.checkReceiptFreshness) {
+      const verdict = input.checkReceiptFreshness(receipt);
+      if (verdict === "fresh") {
+        return {
+          severity: "ok",
+          message: `proof receipt commit-bound: '${inv.proof_artifact}' unchanged since receipt commit ${short(receipt.commit_sha)} (${receipt.test_runner})`,
+        };
+      }
+      if (verdict === "stale") {
+        return {
+          severity: "warn",
+          message: `proof receipt STALE: '${inv.proof_artifact}' changed since receipt commit ${short(receipt.commit_sha)} — re-run the proof (promote) or it stays aspirational`,
+        };
+      }
+      // "unknown" → undeterminable; fall through to the FAGAN head guard below.
     }
     // FAGAN iter-2 (opus): a receipt that is NOT commit-bound to current code
     // cannot be reported `ok`/bound — it degrades to `warn` (aspirational). This

--- a/packages/beacon-schema/tests/acvp-bindings.test.ts
+++ b/packages/beacon-schema/tests/acvp-bindings.test.ts
@@ -222,6 +222,93 @@ test("proof receipt present, head == commit_sha → fresh, ok", () => {
   assert.ok(r.findings.some((f) => /fresh/.test(f.message)));
 });
 
+// ─── FL-B0 restored: checkReceiptFreshness resolver (sprint-400 step 3) ──────
+
+test("receipt + checkReceiptFreshness 'fresh' (proof unchanged since receipt commit) → ok, bound — committed receipt resolves green (FL-B0)", () => {
+  const r = validateAcvpBindings(
+    mkInput({
+      invariants: [inv({ id: "monotonicity" })],
+      fileExists: () => false,
+      // committed receipt: HEAD has advanced PAST the recorded commit_sha
+      proofReceipts: [receipt({ invariant_id: "monotonicity", commit_sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" })],
+      buildingHeadSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      checkReceiptFreshness: () => "fresh", // CLI git-diff: proof_artifact unchanged since receipt commit
+    }),
+  );
+  assert.equal(r.contract_status, "bound");
+  assert.equal(r.summary.error, 0);
+  assert.equal(r.summary.warn, 0);
+  assert.ok(r.findings.some((f) => f.severity === "ok" && /commit-bound/.test(f.message)));
+});
+
+test("receipt + checkReceiptFreshness 'stale' (proof changed since receipt commit) → warn, aspirational", () => {
+  const r = validateAcvpBindings(
+    mkInput({
+      invariants: [inv({ id: "monotonicity" })],
+      fileExists: () => false,
+      proofReceipts: [receipt({ invariant_id: "monotonicity", commit_sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" })],
+      buildingHeadSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      checkReceiptFreshness: () => "stale",
+    }),
+  );
+  assert.equal(r.contract_status, "aspirational");
+  assert.equal(r.summary.error, 0);
+  assert.ok(r.findings.some((f) => f.severity === "warn" && /STALE/.test(f.message)));
+});
+
+test("checkReceiptFreshness 'fresh' is IGNORED when buildingHeadSha is null → warn, NOT bound (no pin, no auto-pass — FAGAN composer)", () => {
+  let consulted = false;
+  const r = validateAcvpBindings(
+    mkInput({
+      invariants: [inv({ id: "monotonicity" })],
+      fileExists: () => false,
+      proofReceipts: [receipt({ invariant_id: "monotonicity" })],
+      buildingHeadSha: null, // no audited pin → resolver must not be honored
+      checkReceiptFreshness: () => {
+        consulted = true;
+        return "fresh";
+      },
+    }),
+  );
+  assert.equal(r.contract_status, "aspirational"); // NOT bound
+  assert.equal(consulted, false); // resolver never consulted without a pin
+  assert.ok(r.findings.some((f) => f.severity === "warn" && /UNCONFIRMABLE|not commit-bound/.test(f.message)));
+});
+
+test("receipt + checkReceiptFreshness 'unknown' → falls back to FAGAN head guard (warn, NOT auto-pass)", () => {
+  const r = validateAcvpBindings(
+    mkInput({
+      invariants: [inv({ id: "monotonicity" })],
+      fileExists: () => false,
+      proofReceipts: [receipt({ invariant_id: "monotonicity" })],
+      buildingHeadSha: null, // unknown → FAGAN guard
+      checkReceiptFreshness: () => "unknown",
+    }),
+  );
+  assert.equal(r.contract_status, "aspirational");
+  assert.equal(r.summary.error, 0);
+  assert.ok(r.findings.some((f) => f.severity === "warn" && /UNCONFIRMABLE|not commit-bound/.test(f.message)));
+});
+
+test("exact-HEAD match short-circuits BEFORE the freshness resolver (resolver not consulted)", () => {
+  const sha = "cafebabecafebabecafebabecafebabecafebabe";
+  let consulted = false;
+  const r = validateAcvpBindings(
+    mkInput({
+      invariants: [inv({ id: "monotonicity" })],
+      fileExists: () => false,
+      proofReceipts: [receipt({ invariant_id: "monotonicity", commit_sha: sha })],
+      buildingHeadSha: sha,
+      checkReceiptFreshness: () => {
+        consulted = true;
+        return "stale";
+      },
+    }),
+  );
+  assert.equal(r.contract_status, "bound"); // exact match wins
+  assert.equal(consulted, false); // resolver never called — fast path
+});
+
 test("hash_chain + eventsPin present but resolver → null → runtime warn (runtime_pin_unresolved), aspirational (FL-HC1)", () => {
   const r = validateAcvpBindings(
     mkInput({

--- a/packages/beacon-schema/tests/acvp-bindings.test.ts
+++ b/packages/beacon-schema/tests/acvp-bindings.test.ts
@@ -275,6 +275,30 @@ test("checkReceiptFreshness 'fresh' is IGNORED when buildingHeadSha is null → 
   assert.ok(r.findings.some((f) => f.severity === "warn" && /UNCONFIRMABLE|not commit-bound/.test(f.message)));
 });
 
+test("receipt + checkReceiptFreshness 'unknown' WITH a non-null head → resolver consulted, falls through to FAGAN guard (warn) [BR-1]", () => {
+  // BR-1 (bridgebuilder): the null-head test below exercises the head==null
+  // guard, NOT the unknown-verdict fall-through. This covers the real path —
+  // non-null head (≠ receipt commit) + resolver returns "unknown" → the
+  // resolver IS consulted, then falls through to the FAGAN not-commit-bound warn.
+  let consulted = false;
+  const r = validateAcvpBindings(
+    mkInput({
+      invariants: [inv({ id: "monotonicity" })],
+      fileExists: () => false,
+      proofReceipts: [receipt({ invariant_id: "monotonicity", commit_sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" })],
+      buildingHeadSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", // non-null, ≠ commit_sha
+      checkReceiptFreshness: () => {
+        consulted = true;
+        return "unknown";
+      },
+    }),
+  );
+  assert.equal(consulted, true); // resolver consulted (non-null head)
+  assert.equal(r.contract_status, "aspirational");
+  assert.equal(r.summary.error, 0);
+  assert.ok(r.findings.some((f) => f.severity === "warn" && /not commit-bound|UNCONFIRMABLE/i.test(f.message)));
+});
+
 test("receipt + checkReceiptFreshness 'unknown' → falls back to FAGAN head guard (warn, NOT auto-pass)", () => {
   const r = validateAcvpBindings(
     mkInput({

--- a/packages/freeside-cli/bin/freeside-cli.ts
+++ b/packages/freeside-cli/bin/freeside-cli.ts
@@ -19,8 +19,12 @@ const usage = `freeside-cli — ecosystem CLI for freeside-* module network
 Usage:
   freeside-cli list                  Show registered modules with one-liners
   freeside-cli inspect <slug>        Show beacon for a specific module
-  freeside-cli doctor [--remote] [--acvp] [--baseline <reg>] [--registry <reg>]
-                                     Audit all modules against BeaconV3 + ACVP bindings
+  freeside-cli doctor [--remote] [--acvp] [--baseline <reg>] [--registry <reg>] [--cells-dir <dir>]
+                                     Audit all modules against BeaconV3 + ACVP bindings.
+                                     --cells-dir <dir>: resolve each cell's beacon + ACVP
+                                       inputs from a per-cell clone at <dir>/cell-<slug>/
+                                       (the per-cell resolution bridge — backed buildings
+                                       report contract_status: bound).
 
 Reference: decisions/007-loa-freeside-absorption.md §D-6
 `;
@@ -63,6 +67,7 @@ const main = async (): Promise<number> => {
         acvpOnly: flags.includes("--acvp"),
         baselineRegistryPath: flagValue(flags, "--baseline"),
         registryPath: flagValue(flags, "--registry"),
+        cellsDir: flagValue(flags, "--cells-dir"),
       });
       console.log(JSON.stringify(report, null, 2));
       // Exit non-zero if any errors found

--- a/packages/freeside-cli/src/verbs/doctor.ts
+++ b/packages/freeside-cli/src/verbs/doctor.ts
@@ -23,6 +23,7 @@ import { execFileSync } from "node:child_process";
 import {
   loadRegistry,
   loadBeacon,
+  loadBeaconFromText,
   type Registry,
 } from "@freeside/freeside-registry";
 import {
@@ -30,6 +31,7 @@ import {
   validateAcvpBindings,
   type BeaconV3,
   type AcvpAllowlistEntry,
+  type AcvpProofReceipt,
 } from "@freeside/beacon-schema";
 import { jcsCanonicalize, sha256Hex } from "../lib/jcs.js";
 
@@ -84,6 +86,14 @@ export interface DoctorOptions {
   /** --acvp: run ONLY beacon-resolve + the ACVP binding sub-check; skip
    *  cycle/compose/sealed so the report-only ACVP CI reflects binding scope (FAGAN). */
   readonly acvpOnly?: boolean;
+  /**
+   * --cells-dir: directory holding per-cell git clones as `<cellsDir>/cell-<slug>/`
+   * (the cluster-compliance clone convention). When set, doctor resolves each
+   * module's beacon + ACVP inputs (eventsPin · proof receipts · HEAD · proof
+   * freshness) FROM the clone — the per-cell resolution bridge (sprint-400
+   * step 3) that makes receipts actually consumed and backed buildings report
+   * `bound`. Unset (or a clone absent) → unchanged fixture/null posture. */
+  readonly cellsDir?: string;
 }
 
 const ALL_ZEROS_64 = "0".repeat(64);
@@ -241,6 +251,12 @@ export function checkSealedSchemas(
 }
 
 // ── impure resolver: events SCHEMA_VERSION for a pin SHA (G-4: no events import) ──
+// NB (FAGAN composer B3): the cell's `cluster.eventsPin` points at THIS repo
+// (`0xHoneyJar/loa-freeside`, subdir packages/events) — the pin sha is a
+// loa-freeside commit, NOT a commit in the cell's own tree. So it is correctly
+// resolved against `repoRoot` (the loa-freeside checkout doctor runs in), never
+// the cell clone. A shallow loa-freeside checkout that lacks the pinned events
+// commit → null → FL-HC1 `runtime_pin_unresolved` warn (documented, SDD R-5).
 function makeResolvePinSchemaVersion(repoRoot: string): (sha: string) => string | null {
   return (sha: string): string | null => {
     try {
@@ -255,6 +271,170 @@ function makeResolvePinSchemaVersion(repoRoot: string): (sha: string) => string 
       return null; // shallow clone / unknown sha → FL-HC1 warn at the validator
     }
   };
+}
+
+// ── per-cell resolution (sprint-400 step 3) ─────────────────────────────────
+// Cells are cloned as `<cellsDir>/cell-<slug>/` (cluster-compliance convention).
+// Both shipped cells declare their beacon at packages/protocol/beacon.yaml.
+const CELL_BEACON_REL = "packages/protocol/beacon.yaml";
+/** Receipt path within a cell — repo-relative, git's forward slashes. */
+const CELL_RECEIPT_REL = "app/.well-known/acvp-proof-receipt.json";
+/** Bound git over an untrusted clone — a pathological repo must not HANG the
+ *  single-threaded audit (FAGAN composer: the try/catch catches throws, not hangs). */
+const CELL_GIT_TIMEOUT_MS = 15_000;
+
+/**
+ * Resolve a cell clone to its realpath via `safeResolve` (which does realpath +
+ * cellsDir-containment, so a symlinked `cell-<slug>` cannot escape the cells
+ * dir), or null when the clone is absent / escapes containment (→ the caller
+ * surfaces it as unreachable; doctor never substitutes a fixture cluster-side).
+ */
+function resolveCellRoot(cellsDir: string, slug: string): string | null {
+  return safeResolve(cellsDir, `cell-${slug}`);
+}
+
+/** Soft read: fn()'s value, or `fallback` if it throws — keeps the "never throw
+ *  into the audit loop" contract in one place (FAGAN composer cleanup). */
+function softRead<T>(fn: () => T, fallback: T): T {
+  try {
+    return fn();
+  } catch {
+    return fallback;
+  }
+}
+
+// Read-only git over an UNTRUSTED cell clone, hardened + time-bounded:
+//   -c core.fsmonitor=false → ignore the clone's local fsmonitor hook (FAGAN opus)
+//   GIT_LITERAL_PATHSPECS=1 → a crafted path is never read as a pathspec glob
+//   timeout                 → a pathological commit graph can't hang the audit (FAGAN)
+// Returns stdout on exit 0, or null on ANY failure (non-zero exit, timeout, spawn).
+function cellGit(cellRoot: string, args: ReadonlyArray<string>): string | null {
+  try {
+    return execFileSync("git", ["-c", "core.fsmonitor=false", ...args], {
+      cwd: cellRoot,
+      env: { ...process.env, GIT_LITERAL_PATHSPECS: "1" },
+      encoding: "utf-8",
+      timeout: CELL_GIT_TIMEOUT_MS,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+/** The clone's committed HEAD (full 40-hex) or null. ALL cell evidence (beacon,
+ *  receipt, eventsPin, sealed schemas, freshness diff) is read AT this commit, so
+ *  a working-tree mutation cannot influence the verdict (FAGAN opus: committed-only). */
+function resolveCellHead(cellRoot: string): string | null {
+  const head = (cellGit(cellRoot, ["rev-parse", "HEAD"]) ?? "").trim();
+  return /^[0-9a-fA-F]{40}$/.test(head) ? head : null;
+}
+
+/** A repo-relative path's content AT the audited commit (committed evidence). */
+function cellShow(cellRoot: string, head: string, rel: string): string | null {
+  return cellGit(cellRoot, ["show", `${head}:${rel}`]);
+}
+
+/** Per-cell ACVP inputs for validateAcvpBindings (sprint-400 step 3). */
+type CellAcvpInputs = {
+  eventsPin: { package: string; sha: string } | null;
+  proofReceipts: ReadonlyArray<AcvpProofReceipt> | null;
+  buildingHeadSha: string | null;
+  checkReceiptFreshness?: (receipt: AcvpProofReceipt) => "fresh" | "stale" | "unknown";
+};
+
+/** The safe null posture: no per-cell evidence → every binding un-backed
+ *  (default-FAIL) or aspirational-allowlisted (extracted — FAGAN composer). */
+const NULL_CELL_INPUTS: CellAcvpInputs = {
+  eventsPin: null,
+  proofReceipts: null,
+  buildingHeadSha: null,
+};
+
+/**
+ * Shape-guard a proof receipt parsed from an UNTRUSTED cell clone (FAGAN opus):
+ * every required field MUST be a string before it may reach validateAcvpBindings
+ * (which formats/compares them) — a malformed element must never throw mid-audit
+ * or mis-bind on a wrong-typed field. `pipeline_id` is optional.
+ */
+function isProofReceipt(x: unknown): x is AcvpProofReceipt {
+  if (typeof x !== "object" || x === null) return false;
+  const r = x as Record<string, unknown>;
+  return (
+    typeof r.slug === "string" &&
+    typeof r.invariant_id === "string" &&
+    typeof r.proof_artifact === "string" &&
+    typeof r.test_runner === "string" &&
+    typeof r.passed_at === "string" &&
+    typeof r.commit_sha === "string"
+  );
+}
+
+/**
+ * Read a cell clone's ACVP inputs for validateAcvpBindings, ALL from the AUDITED
+ * COMMITTED HEAD `head` (never the working tree — FAGAN gpt/opus: an uncommitted
+ * OR working-tree-mutated receipt/eventsPin must not be able to fabricate `bound`;
+ * the beacon + sealed schemas are read committed-only at the call site too): the
+ * events pin (committed package.json `cluster.eventsPin`), the per-invariant proof
+ * receipts (committed receipt ARRAY, each element shape-validated at this trust
+ * boundary — FAGAN opus), and a git freshness resolver. Freshness (FL-B0, FAGAN
+ * opus): "fresh" iff NOTHING changed between the receipt commit and `head` except
+ * the receipt file itself — checking only the proof FILE is fail-open (the code
+ * under test can change while the test stays byte-identical). Fails soft to the
+ * un-backed default (null / "unknown").
+ *
+ * KNOWN LIMITATION (FAGAN composer B1, tracked follow-up): the receipt is an
+ * UNSIGNED self-assertion whose commit_sha the cell controls — a first-party cell
+ * CAN commit a forged receipt (clean tree + a receipt claiming bound). This check
+ * binds the verdict to the COMMITTED state (forgery requires an attributable,
+ * reviewable commit), which fits the first-party drift-detection threat model;
+ * full non-repudiation requires SIGNED receipts (Ed25519, as the ACVP runtime
+ * envelope already does). Out of scope for this verb.
+ */
+function resolveCellAcvpInputs(cellRoot: string, head: string): CellAcvpInputs {
+  // eventsPin ← committed package.json cluster.eventsPin (sovereign pin)
+  const eventsPin = softRead<{ package: string; sha: string } | null>(() => {
+    const txt = cellShow(cellRoot, head, "package.json");
+    if (txt == null) return null;
+    const pkg = JSON.parse(txt) as { cluster?: { eventsPin?: { package?: unknown; sha?: unknown } } };
+    const ep = pkg.cluster?.eventsPin;
+    return ep && typeof ep.package === "string" && typeof ep.sha === "string"
+      ? { package: ep.package, sha: ep.sha }
+      : null;
+  }, null);
+
+  // proofReceipts ← committed receipt ARRAY (FL-HC0); each element shape-validated
+  const proofReceipts = softRead<ReadonlyArray<AcvpProofReceipt> | null>(() => {
+    const txt = cellShow(cellRoot, head, CELL_RECEIPT_REL);
+    if (txt == null) return null;
+    const parsed = JSON.parse(txt);
+    if (!Array.isArray(parsed)) return null;
+    const valid = parsed.filter(isProofReceipt);
+    return valid.length > 0 ? valid : null;
+  }, null);
+
+  // freshness ← did the cell drift since the receipt? "fresh" iff the ONLY change
+  // between the receipt commit and the audited `head` is the receipt file itself
+  // (the off-by-one that publishing it adds); ANY other changed path → "stale".
+  // Full-40-hex sha; receipt commit must be reachable from head (ancestor/==).
+  const checkReceiptFreshness = (receipt: AcvpProofReceipt): "fresh" | "stale" | "unknown" => {
+    const sha = receipt.commit_sha;
+    if (!/^[0-9a-fA-F]{40}$/.test(sha)) return "unknown";
+    // merge-base --is-ancestor signals via exit code: cellGit → "" on exit 0
+    // (ancestor), null on exit 1 (not) / error. shallow clone / force-push → null.
+    if (cellGit(cellRoot, ["merge-base", "--is-ancestor", sha, head]) == null) return "unknown";
+    const names = cellGit(cellRoot, [
+      "diff", "--name-only", "--no-ext-diff", "--no-textconv", "--no-renames", sha, head,
+    ]);
+    if (names == null) return "unknown";
+    const drifted = names
+      .split("\n")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0 && s !== CELL_RECEIPT_REL);
+    return drifted.length === 0 ? "fresh" : "stale";
+  };
+
+  return { eventsPin, proofReceipts, buildingHeadSha: head, checkReceiptFreshness };
 }
 
 /**
@@ -309,33 +489,84 @@ export const doctor = async (opts: DoctorOptions = {}): Promise<DoctorReport> =>
   const push = (f: DoctorFinding) => findings.push(f);
 
   for (const [slug, entry] of Object.entries(registry.modules)) {
-    // 1. Resolve beacon. FAGAN iter-2 (gpt): --remote must NOT silently fall back
-    // to a fixture — a caller asking for live remote evidence gets beacon_unreachable
-    // (real fetch is SC-6, a follow-up), never fixture-substituted data.
-    if (opts.remote) {
+    const cellRoot = opts.cellsDir ? resolveCellRoot(opts.cellsDir, slug) : null;
+    // committed HEAD of the cell clone — ALL cell evidence (beacon, receipt,
+    // eventsPin, sealed schemas, freshness diff) is read AT this sha, so a
+    // working-tree mutation cannot influence the verdict (FAGAN opus, committed-only).
+    const cellHead = cellRoot ? resolveCellHead(cellRoot) : null;
+
+    // cellsDir requested but THIS cell's clone is absent/unresolvable: refuse to
+    // fall through to the in-repo fixture path (FAGAN composer). Cluster-side
+    // evidence MUST be the cell's own committed state — a substituted fixture
+    // would produce findings that look like a cell audit but are not. Surface it
+    // as unreachable (the per-cell clone step must run first), never silent.
+    if (opts.cellsDir && !cellRoot) {
+      push({
+        slug, check: "beacon_unreachable", severity: "warn",
+        message: `--cells-dir set but no clone at cell-${slug}/ — cell evidence unavailable; refusing fixture substitution (run the per-cell clone step first)`,
+      });
+      continue;
+    }
+
+    // 1. Resolve beacon. cellsDir (a per-cell clone) is the authoritative
+    // cluster-side source and takes precedence (sprint-400 step 3) — the beacon is
+    // read from the COMMITTED HEAD (git show), NOT the working tree, so a mutated
+    // working-tree beacon.yaml cannot add/relax invariants under doctor (FAGAN opus).
+    // Else FAGAN iter-2 (gpt): --remote must NOT silently fall back to a fixture — a
+    // caller asking for live remote evidence gets beacon_unreachable (SC-6), never
+    // fixture-substituted data; no fixture → deferred.
+    let resolved: ReturnType<typeof loadBeacon>;
+    let moduleRoot: string; // root for sealed-schema / per-cell reads
+    if (cellRoot) {
+      moduleRoot = cellRoot;
+      if (cellHead == null) {
+        push({
+          slug, check: "beacon_invalid", severity: "error",
+          message: `cell clone ${slug}: cannot resolve a committed HEAD (not a git checkout / shallow) — cannot audit committed state`,
+        });
+        continue;
+      }
+      const beaconText = cellShow(cellRoot, cellHead, CELL_BEACON_REL);
+      if (beaconText == null) {
+        push({
+          slug, check: "beacon_deferred", severity: "warn",
+          message: `cell clone ${slug}: no committed ${CELL_BEACON_REL} at HEAD — beacon audit deferred`,
+        });
+        continue;
+      }
+      resolved = loadBeaconFromText(beaconText);
+      if (resolved.kind === "error") {
+        push({
+          slug, check: "beacon_invalid", severity: "error",
+          message: `cell clone ${slug} (${CELL_BEACON_REL}@HEAD): ${resolved.error}`,
+        });
+        continue;
+      }
+    } else if (opts.remote) {
       push({
         slug, check: "beacon_unreachable", severity: "warn",
         message: `--remote fetch of ${entry.beacon_url} not implemented this build (SC-6); fixture substitution refused — omit --remote to audit the in-repo fixture`,
       });
       continue;
-    }
-    if (!entry.beacon_fixture) {
+    } else if (!entry.beacon_fixture) {
       push({
         slug, check: "beacon_deferred", severity: "warn",
-        message: `no beacon_fixture for '${slug}' — beacon audit deferred (add beacon_fixture, or --remote when fetch lands)`,
+        message: `no beacon_fixture for '${slug}' — beacon audit deferred (add beacon_fixture, --cells-dir, or --remote when fetch lands)`,
       });
       continue;
-    }
-    if (entry.visibility === "internal") {
-      push({
-        slug, check: "beacon_auth_required", severity: "warn",
-        message: `'${slug}' is internal — auth-gated fetch not implemented (SC-2); fixture audited if present`,
-      });
-    }
-    const resolved = loadBeacon(entry, registryRoot);
-    if (resolved.kind === "error") {
-      push({ slug, check: "beacon_invalid", severity: "error", message: resolved.error });
-      continue;
+    } else {
+      if (entry.visibility === "internal") {
+        push({
+          slug, check: "beacon_auth_required", severity: "warn",
+          message: `'${slug}' is internal — auth-gated fetch not implemented (SC-2); fixture audited if present`,
+        });
+      }
+      moduleRoot = registryRoot ?? repoRoot;
+      resolved = loadBeacon(entry, registryRoot);
+      if (resolved.kind === "error") {
+        push({ slug, check: "beacon_invalid", severity: "error", message: resolved.error });
+        continue;
+      }
     }
     if (resolved.kind === "legacy") {
       const nextReview = (resolved.beacon as { cycle_state?: { next_review?: string } }).cycle_state?.next_review;
@@ -361,41 +592,58 @@ export const doctor = async (opts: DoctorOptions = {}): Promise<DoctorReport> =>
     if (!opts.acvpOnly) {
       for (const f of checkCycleState(slug, beacon, now)) push(f);
       for (const f of checkComposesWith(slug, beacon, registry)) push(f);
+      // sealed-schema files: from the COMMITTED HEAD in cellsDir mode (committed-
+      // only, FAGAN opus — git rejects out-of-tree `..` paths), else the local
+      // working tree (in-repo fixture / same-repo self-audit).
       const resolveSchemaText = (relPath: string): string | null => {
-        if (!registryRoot) return null;
-        const p = safeResolve(registryRoot, relPath);
+        if (cellRoot && cellHead) return cellShow(cellRoot, cellHead, relPath);
+        const p = safeResolve(moduleRoot, relPath);
         return p ? readFileSync(p, "utf-8") : null;
       };
       for (const f of checkSealedSchemas(slug, beacon, resolveSchemaText)) push(f);
     }
 
     // 6. ACVP binding sub-check (folds AcvpBindingFinding → DoctorFinding).
-    // FAGAN iter-2 (critical): per-cell ACVP inputs (cluster.eventsPin, proof
-    // receipts) live in EACH building's OWN repo, which is NOT checked out
-    // cluster-side this build — we hold the registry + fixtures, not the cells.
-    // Reading them from the shared registry root would (a) read the REGISTRY
-    // package's own package.json as if it were a building's and (b) let one shared
-    // receipt file vouch for every slug. So they are null here: every declared
-    // binding is therefore un-backed (default-FAIL) or aspirational-allowlisted —
-    // the correct cluster-side posture. Per-cell resolution lands with the Tier-A
-    // receipts (T5a/T5b) once the cells are locally present.
-    const moduleRoot = registryRoot ?? repoRoot;
-    const eventsPin = null;
-    const proofReceipts = null;
-    const acvp = validateAcvpBindings({
-      slug, beacon, moduleRoot,
-      fileExists: (rel) => safeResolve(moduleRoot, rel) !== null,
-      eventsPin,
-      resolvePinSchemaVersion,
-      proofReceipts,
-      buildingHeadSha: null, // unknown cluster-side this build (SC)
-      aspirationalAllowlist: allowlist,
-      now,
-    });
-    for (const af of acvp.findings) {
+    // Per-cell inputs come from the cell clone when --cells-dir resolved one
+    // (sprint-400 step 3). Otherwise they stay null — the safe cluster-side
+    // posture FAGAN iter-2 established: reading cluster.eventsPin / proof
+    // receipts from the shared registry root would (a) read the REGISTRY
+    // package's own package.json as a building's and (b) let one shared receipt
+    // vouch for every slug. Null → every binding un-backed (default-FAIL) or
+    // aspirational-allowlisted. A resolved cell supplies a real checkout, so the
+    // receipt is consumed + git-freshness-checked (a committed receipt → bound).
+    try {
+      const cellInputs = cellRoot && cellHead ? resolveCellAcvpInputs(cellRoot, cellHead) : NULL_CELL_INPUTS;
+      const acvp = validateAcvpBindings({
+        slug, beacon, moduleRoot,
+        // Cluster-side (cellsDir): evidence is the COMMITTED, freshness-checked
+        // receipt — NOT mere file-presence in the clone working tree. Letting a
+        // present-but-unattested proof file vouch would re-introduce the weak
+        // file-presence signal (the α path the operator rejected; FAGAN opus's
+        // fail-open concern). So fileExists is false here: a cell is bound only
+        // via a fresh receipt. The local-file path stays for same-repo / Tier-A
+        // self-audit (no cellsDir), where the building IS the source.
+        fileExists: cellRoot ? () => false : (rel) => safeResolve(moduleRoot, rel) !== null,
+        eventsPin: cellInputs.eventsPin,
+        resolvePinSchemaVersion,
+        proofReceipts: cellInputs.proofReceipts,
+        buildingHeadSha: cellInputs.buildingHeadSha,
+        checkReceiptFreshness: cellInputs.checkReceiptFreshness,
+        aspirationalAllowlist: allowlist,
+        now,
+      });
+      for (const af of acvp.findings) {
+        push({
+          slug, check: af.check as DoctorCheck, severity: af.severity,
+          message: `[acvp:${af.invariant_id}] ${af.message}`,
+        });
+      }
+    } catch (err) {
+      // defense-in-depth (FAGAN opus): a single cell's unexpected throw must
+      // never abort the whole audit (DoS) — surface it as that slug's error.
       push({
-        slug, check: af.check as DoctorCheck, severity: af.severity,
-        message: `[acvp:${af.invariant_id}] ${af.message}`,
+        slug, check: "beacon_invalid", severity: "error",
+        message: `ACVP sub-check aborted for ${slug}: ${err instanceof Error ? err.message : String(err)}`,
       });
     }
   }

--- a/packages/freeside-cli/src/verbs/doctor.ts
+++ b/packages/freeside-cli/src/verbs/doctor.ts
@@ -294,7 +294,10 @@ function resolveCellRoot(cellsDir: string, slug: string): string | null {
 }
 
 /** Soft read: fn()'s value, or `fallback` if it throws — keeps the "never throw
- *  into the audit loop" contract in one place (FAGAN composer cleanup). */
+ *  into the audit loop" contract in one place (FAGAN composer cleanup). SCOPE
+ *  (BR-3 bridgebuilder): use ONLY for I/O + parse over UNTRUSTED bytes (git /
+ *  JSON from a cell clone) — the broad catch deliberately also swallows
+ *  programmer errors (TypeError &c.), so never wrap general application logic. */
 function softRead<T>(fn: () => T, fallback: T): T {
   try {
     return fn();

--- a/packages/freeside-cli/tests/doctor.test.ts
+++ b/packages/freeside-cli/tests/doctor.test.ts
@@ -8,7 +8,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -214,4 +214,260 @@ test("CLI · doctor --registry <bad> → exit 1 (sealed_schema_hash_drift)", () 
     exitCode = (e as { status?: number }).status ?? -1;
   }
   assert.equal(exitCode, 1, "expected exit 1 when a module has an error finding");
+});
+
+// ─── --cells-dir per-cell resolution + FL-B0 git-freshness (sprint-400 step 3) ──
+// Builds a real git cell clone at <tmp>/cell-test-api: commit the proof+beacon
+// (c1), publish a receipt recording c1, then COMMIT the receipt (c2 — HEAD now
+// past c1). Exact-HEAD match cannot accept this, but the git-freshness resolver
+// (proof unchanged between c1 and HEAD) marks it fresh → bound. The mutate
+// variant changes the proof after the receipt → stale → warn.
+
+const CELL_BEACON_YAML = [
+  'schema_version: "3"',
+  'slug: "test-api"',
+  'publisher: "0xHoneyJar"',
+  "is:",
+  '  one_liner: "Test cell for per-cell resolution"',
+  "  scope:",
+  '    - "decode round-trips"',
+  '    - "totality holds"',
+  "is_not:",
+  '  - "Does NOT do real work"',
+  '  - "Will NOT ship breaking changes"',
+  "acvp_invariants:",
+  "  - id: schema_enforcement",
+  '    scope: "decode round-trips identically"',
+  '    proof_artifact: "tests/proof.test.ts"',
+  "cycle_state:",
+  "  status: candidate",
+  '  since: "2026-05-18"',
+  '  next_review: "2026-08-18"',
+  "",
+].join("\n");
+
+function initCellRepo(
+  opts: { mutateProofAfterReceipt?: boolean; uncommittedReceipt?: boolean; mutateWorkingTreeBeacon?: boolean } = {},
+): {
+  cellsDir: string;
+  cleanup: () => void;
+} {
+  const cellsDir = mkdtempSync(join(tmpdir(), "doctor-cells-"));
+  const cell = join(cellsDir, "cell-test-api");
+  const w = (rel: string, body: string) => {
+    const p = join(cell, rel);
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, body);
+  };
+  const git = (...a: string[]) => execFileSync("git", ["-C", cell, ...a], { stdio: "ignore" });
+
+  w("packages/protocol/beacon.yaml", CELL_BEACON_YAML);
+  w("package.json", JSON.stringify({ name: "test-api", version: "0.0.0" }) + "\n");
+  w("tests/proof.test.ts", "// proof v1\n");
+  execFileSync("git", ["init", "-q", cell], { stdio: "ignore" });
+  git("config", "user.email", "t@example.com");
+  git("config", "user.name", "t");
+  git("config", "commit.gpgsign", "false");
+  git("add", "-A");
+  git("commit", "-q", "-m", "c1: cell + proof");
+  const c1 = execFileSync("git", ["-C", cell, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
+
+  // publish the receipt recording c1, then COMMIT it → HEAD advances past c1
+  w(
+    "app/.well-known/acvp-proof-receipt.json",
+    JSON.stringify(
+      [
+        {
+          slug: "test-api",
+          invariant_id: "schema_enforcement",
+          proof_artifact: "tests/proof.test.ts",
+          test_runner: "bun",
+          passed_at: "2026-05-30T00:00:00Z",
+          commit_sha: c1,
+        },
+      ],
+      null,
+      2,
+    ) + "\n",
+  );
+  if (opts.uncommittedReceipt) {
+    // leave the receipt in the WORKING TREE only — never committed. doctor reads
+    // evidence from the audited commit (git show HEAD:…), so this must NOT count.
+  } else {
+    git("add", "-A");
+    git("commit", "-q", "-m", "c2: receipt");
+
+    if (opts.mutateProofAfterReceipt) {
+      w("tests/proof.test.ts", "// proof v2 — CHANGED after the receipt was issued\n");
+      git("add", "-A");
+      git("commit", "-q", "-m", "c3: proof changed");
+    }
+  }
+
+  if (opts.mutateWorkingTreeBeacon) {
+    // overwrite beacon.yaml in the WORKING TREE only (NOT committed) — inject an
+    // envelope-bound invariant that would surface a runtime error if doctor read
+    // the working tree instead of the committed HEAD.
+    w(
+      "packages/protocol/beacon.yaml",
+      CELL_BEACON_YAML.replace(
+        "acvp_invariants:\n",
+        [
+          "acvp_invariants:",
+          "  - id: hash_chain",
+          '    scope: "injected via the working tree — must be invisible to doctor"',
+          '    proof_artifact: "tests/hash_chain.test.ts"',
+          "",
+        ].join("\n"),
+      ),
+    );
+  }
+
+  // registry points test-api at the clone (beacon resolved FROM the clone, no fixture)
+  writeFileSync(
+    join(cellsDir, "registry.yaml"),
+    [
+      "version: 1",
+      "modules:",
+      "  test-api:",
+      "    git_url: https://example.com/test-api.git",
+      '    beacon_url: ""',
+      "    visibility: public",
+      "    owner: o",
+      '    added: "2026-05-30"',
+      "",
+    ].join("\n"),
+  );
+
+  return { cellsDir, cleanup: () => rmSync(cellsDir, { recursive: true, force: true }) };
+}
+
+test("doctor() · --cells-dir → resolves beacon+receipt from clone; committed receipt fresh → acvp_proof ok, no error (FL-B0 bridge)", async () => {
+  const { cellsDir, cleanup } = initCellRepo();
+  try {
+    const report = await doctor({
+      registryPath: join(cellsDir, "registry.yaml"),
+      cellsDir,
+      acvpOnly: true,
+      now: NOW,
+    });
+    assert.ok(
+      report.findings.some(
+        (f) => f.slug === "test-api" && f.check === "acvp_proof:schema_enforcement" && f.severity === "ok",
+      ),
+      "committed receipt with unchanged proof must resolve fresh → acvp_proof ok",
+    );
+    assert.ok(
+      !report.findings.some((f) => f.slug === "test-api" && f.severity === "error"),
+      "a receipt-backed cell must produce no error",
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("doctor() · --cells-dir → UNCOMMITTED receipt does NOT fabricate bound (committed-evidence only; no file-presence fallback — FAGAN gpt/opus)", async () => {
+  const { cellsDir, cleanup } = initCellRepo({ uncommittedReceipt: true });
+  try {
+    const report = await doctor({
+      registryPath: join(cellsDir, "registry.yaml"),
+      cellsDir,
+      acvpOnly: true,
+      now: NOW,
+    });
+    // receipt is in the working tree but NOT in the audited commit, and cellsDir
+    // mode does not trust file-presence → un-backed → error (default-FAIL)
+    assert.ok(
+      report.findings.some(
+        (f) => f.slug === "test-api" && f.check === "acvp_proof:schema_enforcement" && f.severity === "error",
+      ),
+      "uncommitted receipt + present proof file must NOT yield ok — un-backed error",
+    );
+    assert.ok(
+      !report.findings.some(
+        (f) => f.slug === "test-api" && f.check === "acvp_proof:schema_enforcement" && f.severity === "ok",
+      ),
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("doctor() · --cells-dir set but cell clone ABSENT → beacon_unreachable warn, NO fixture substitution (FAGAN composer)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "doctor-nocell-"));
+  try {
+    // registry references test-api AND gives it a beacon_fixture — but there is
+    // no cell-test-api/ clone. cells-dir mode must refuse to audit the fixture.
+    writeFileSync(
+      join(dir, "registry.yaml"),
+      [
+        "version: 1",
+        "modules:",
+        "  test-api:",
+        "    git_url: https://example.com/test-api.git",
+        '    beacon_url: ""',
+        "    beacon_fixture: some-fixture.yaml",
+        "    visibility: public",
+        "    owner: o",
+        '    added: "2026-05-30"',
+        "",
+      ].join("\n"),
+    );
+    const report = await doctor({ registryPath: join(dir, "registry.yaml"), cellsDir: dir, acvpOnly: true, now: NOW });
+    assert.ok(
+      report.findings.some((f) => f.slug === "test-api" && f.check === "beacon_unreachable" && f.severity === "warn"),
+      "missing clone in cells-dir mode must surface as beacon_unreachable",
+    );
+    // and it must NOT have substituted/audited the in-repo fixture
+    assert.ok(!report.findings.some((f) => f.slug === "test-api" && f.check === "beacon_valid"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("doctor() · --cells-dir → WORKING-TREE beacon mutation is INVISIBLE (committed beacon audited — FAGAN opus)", async () => {
+  const { cellsDir, cleanup } = initCellRepo({ mutateWorkingTreeBeacon: true });
+  try {
+    const report = await doctor({
+      registryPath: join(cellsDir, "registry.yaml"),
+      cellsDir,
+      acvpOnly: true,
+      now: NOW,
+    });
+    // the injected hash_chain invariant exists ONLY in the working tree → it must
+    // NOT appear in any finding (doctor read the committed beacon at HEAD)
+    assert.ok(
+      !report.findings.some((f) => f.slug === "test-api" && /hash_chain/.test(f.check)),
+      "working-tree-injected invariant must be invisible — committed beacon is the audited authority",
+    );
+    // committed schema_enforcement + fresh committed receipt → still ok
+    assert.ok(
+      report.findings.some(
+        (f) => f.slug === "test-api" && f.check === "acvp_proof:schema_enforcement" && f.severity === "ok",
+      ),
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("doctor() · --cells-dir → proof CHANGED after the receipt → stale warn, no error", async () => {
+  const { cellsDir, cleanup } = initCellRepo({ mutateProofAfterReceipt: true });
+  try {
+    const report = await doctor({
+      registryPath: join(cellsDir, "registry.yaml"),
+      cellsDir,
+      acvpOnly: true,
+      now: NOW,
+    });
+    assert.ok(
+      report.findings.some(
+        (f) => f.slug === "test-api" && f.check === "acvp_proof:schema_enforcement" && f.severity === "warn",
+      ),
+      "proof changed since the receipt → stale → acvp_proof warn",
+    );
+    assert.ok(!report.findings.some((f) => f.slug === "test-api" && f.severity === "error"));
+  } finally {
+    cleanup();
+  }
 });

--- a/packages/freeside-cli/tests/doctor.test.ts
+++ b/packages/freeside-cli/tests/doctor.test.ts
@@ -425,6 +425,40 @@ test("doctor() · --cells-dir set but cell clone ABSENT → beacon_unreachable w
   }
 });
 
+test("doctor() · --cells-dir → cell clone with NO committed HEAD (git init, no commit) → beacon_invalid, no fixture [BR-2]", async () => {
+  const cellsDir = mkdtempSync(join(tmpdir(), "doctor-nohead-"));
+  try {
+    const cell = join(cellsDir, "cell-test-api");
+    mkdirSync(cell, { recursive: true });
+    execFileSync("git", ["init", "-q", cell], { stdio: "ignore" }); // repo with no commits → HEAD unresolvable
+    writeFileSync(
+      join(cellsDir, "registry.yaml"),
+      [
+        "version: 1",
+        "modules:",
+        "  test-api:",
+        "    git_url: https://example.com/test-api.git",
+        '    beacon_url: ""',
+        "    visibility: public",
+        "    owner: o",
+        '    added: "2026-05-30"',
+        "",
+      ].join("\n"),
+    );
+    const report = await doctor({ registryPath: join(cellsDir, "registry.yaml"), cellsDir, acvpOnly: true, now: NOW });
+    assert.ok(
+      report.findings.some(
+        (f) =>
+          f.slug === "test-api" && f.check === "beacon_invalid" && f.severity === "error" && /committed HEAD/.test(f.message),
+      ),
+      "no committed HEAD → beacon_invalid (cannot audit committed state)",
+    );
+    assert.ok(!report.findings.some((f) => f.slug === "test-api" && f.check === "beacon_valid"));
+  } finally {
+    rmSync(cellsDir, { recursive: true, force: true });
+  }
+});
+
 test("doctor() · --cells-dir → WORKING-TREE beacon mutation is INVISIBLE (committed beacon audited — FAGAN opus)", async () => {
   const { cellsDir, cleanup } = initCellRepo({ mutateWorkingTreeBeacon: true });
   try {

--- a/packages/freeside-registry/src/beacon-loader.ts
+++ b/packages/freeside-registry/src/beacon-loader.ts
@@ -78,6 +78,26 @@ export const classifyBeacon = (parsed: unknown): BeaconResolution => {
 };
 
 /**
+ * Classify a beacon from its raw YAML/JSON TEXT — for committed-only audits where
+ * the caller has already fetched the authoritative bytes (e.g.
+ * `git show <sha>:packages/protocol/beacon.yaml`, so a working-tree mutation of
+ * the beacon cannot influence the verdict). Never throws: a parse failure is
+ * `{ kind: "error" }`. Reuses the same try-V3-then-V2 `classifyBeacon`.
+ */
+export const loadBeaconFromText = (text: string): BeaconResolution => {
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(text);
+  } catch (err) {
+    return {
+      kind: "error",
+      error: `beacon parse failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  return classifyBeacon(parsed);
+};
+
+/**
  * Resolve one module's beacon. Prefers `beacon_fixture` (in-repo) over
  * `beacon_url` (remote, not fetched — SC-6). Never throws — every failure is a
  * `{ kind: "error" }` so callers (doctor / manifest builder) skip-not-crash.

--- a/packages/freeside-registry/src/index.ts
+++ b/packages/freeside-registry/src/index.ts
@@ -14,6 +14,7 @@ export {
 
 export {
   loadBeacon,
+  loadBeaconFromText,
   resolveFixturePath,
   classifyBeacon,
   type BeaconResolution,


### PR DESCRIPTION
## doctor-acvp step 3 — the receipts-actually-consumed bridge

`freeside-cli doctor --cells-dir` now resolves each building's beacon + `cluster.eventsPin` + proof receipts + HEAD from a per-cell clone — **all read from the committed HEAD** (`git show`), so a working-tree mutation can't influence the verdict. The validator gains an additive `checkReceiptFreshness` resolver (FL-B0 restored): a committed receipt is **fresh** iff nothing changed between the receipt commit and HEAD *except the receipt file itself* — so a real in-repo receipt resolves to `contract_status: bound` (exact-HEAD match alone never could, since publishing the receipt advances HEAD past the `commit_sha` it records).

- 🔒 committed-only evidence — beacon · receipt · eventsPin · sealed schemas · freshness diff
- 🚫 cells-dir mode is pure-β: a missing clone → `beacon_unreachable` (never fixture substitution); no file-presence fallback
- ✅ tests: beacon-schema 54 · freeside-registry 7 · freeside-cli 27 — all green

**FAGAN-converged over 4 multi-model iterations** — TOCTOU, abbreviated-SHA, null-head core gate, committed-vs-working-tree evidence, untrusted-receipt shape-guard, fail-open freshness, working-tree beacon, fixture fallthrough, git-hang timeout (all fixed + regression-tested).

⚠️ **Held by design:** unsigned receipts are forgeable by a first-party *committed* act (fine for a drift-detection threat model; Ed25519 signing tracked in `arrakis-nngt`). The cluster gate stays **report-only** — the T8 fail-block flip is deferred.

Bead: `arrakis-1ha3` · cycle `doctor-acvp-network-plane`. Pairs with mediums `acvp:verify`+receipt (→ `bound`) and sonar `status:aspirational` (→ aspirational).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
