### PR TITLE
freeside-decomposition: contracts-first de-risking (C1 membrane guard + C3 ledger/payment map)

### DIFF
--- a/.github/workflows/path-domain-check.yml
+++ b/.github/workflows/path-domain-check.yml
@@ -93,3 +93,20 @@ jobs:
         run: |
           echo "Bootstrap PR — path-domain-check intentionally skipped."
           echo "See workflow header for bypass policy."
+
+  # Platform↔world membrane guard (C1 / FR-7 / SKP-004, freeside-decomposition cycle).
+  # Codifies the one-directional membrane the decomposition relies on:
+  #   A) platform (apps/{gateway,worker,ingestor}, packages/{core,adapters,sandbox})
+  #      must NOT value-import themes/sietch (the world).
+  #   B) themes/sietch/src must NOT add NEW value-imports of @freeside/adapters/agent
+  #      (the C2 ports-only contract; existing reach-ins are baseline-allowlisted in the script).
+  # NOT bootstrap-bypassable: a membrane breach is a correctness regression regardless of the
+  # cross-domain exception. Runs an in-repo regex guard (madge unavailable in CI/workspace, NG-3;
+  # documented bypass classes live in the script header — transitive + alias reach-ins out of scope v1).
+  membrane:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Platform↔world membrane guard
+        run: bash tools/check-platform-membrane.sh

--- a/tools/check-platform-membrane.sh
+++ b/tools/check-platform-membrane.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# check-platform-membrane.sh — enforce the freeside platform↔world membranes (C1, FR-7/SKP-004).
+#
+# The whole decomposition relies on a one-directional membrane: the PLATFORM substrate
+# (apps/{gateway,worker,ingestor}, packages/{core,adapters,sandbox}) must NEVER value-import
+# the WORLD (themes/sietch) at runtime. The map confirmed this holds today (0 value-imports);
+# this guard CODIFIES the clean state so it can never silently regress (it has regressed +
+# been repaired before — coherence F4/F5). Same "declared → enforced" shape as
+# tools/check-worker-schema-drift.sh.
+#
+# Two boundaries:
+#   A) platform  ↛  themes/sietch            (the platform membrane — FAIL on any new value-import)
+#   B) themes/sietch/src ↛ @freeside/adapters/agent  (the C2 ports-only contract; existing reach-ins
+#      are baseline-allowlisted — teeth on NEW reach-ins; tests exempt)
+#
+# RULE: `import type … from '…'` AND inline `import { type Foo } from '…'` are PERMITTED across a
+#       membrane (they erase at compile). VALUE imports (static `import {…}`/`import x`/`import *`/
+#       side-effect, dynamic `import()`, CJS `require()`) are FORBIDDEN.
+#
+# SCANNER: an awk pass that reconstructs MULTI-LINE import statements before classifying (a line-by-line
+# grep mis-handles `import type {\n …\n} from '…'`). It matches the specifier as a SUBSTRING (no quote
+# escaping) and excludes whole-statement `import type` + all-inline-`type` brace clauses.
+#
+# TOOLING NOTE (honest, like block-destructive-bash's accepted-bypass list): madge is unavailable
+# (no local node_modules linkage, NG-3), so this is a text scan, NOT a resolved import graph.
+# DOCUMENTED BYPASS CLASSES — OUT OF SCOPE for v1, NOT claimed as covered:
+#   - TS path-alias imports of the world (e.g. a hypothetical `@sietch/*` alias) — only the literal
+#     `themes/sietch` / `@freeside/adapters/agent` specifier SUBSTRING is matched. No such alias today.
+#   - Transitive reach-in (platform A → platform B → world): only DIRECT edges are scanned (1-hop).
+#   - the specifier substring appearing inside a non-import string literal on an import-looking line.
+# Upgrading to madge/ts-morph would only find MORE reach-ins, never fewer.
+#
+# Exit 0 = membranes intact · Exit 1 = violation (with ::error::file:line for CI annotation).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+PLATFORM_DIRS=(apps/gateway apps/worker apps/ingestor packages/core packages/adapters packages/sandbox)
+WORLD_SPECIFIER="themes/sietch"
+WORLD_SRC="themes/sietch/src"
+ADAPTER_SPECIFIER="@freeside/adapters/agent"
+
+# Boundary B baseline-allowlist (C1.2): sietch SRC files that VALUE-import the agent adapter TODAY.
+# Teeth on NEW reach-ins immediately; these are the C2 burndown list — DELETE each line as C2 relocates
+# that file's seam to @freeside/core/ports. Empty list ⇒ boundary B fully enforced. TESTS EXEMPT.
+# byok.routes.ts is NOT here: it is type-only.
+BOUNDARY_B_ALLOWLIST=(
+  "themes/sietch/src/api/server.ts"
+  "themes/sietch/src/api/routes/agents.routes.ts"
+  "themes/sietch/src/discord/commands/agent.ts"
+  "themes/sietch/src/telegram/commands/agent.ts"
+)
+
+violations=0
+flag() { echo "::error::membrane: $1"; violations=$((violations + 1)); }
+
+# find_value_imports <file> <specifier-substring>
+# Prints the start line number of each VALUE import of the specifier (multi-line aware; type-only excluded).
+find_value_imports() {
+  local file="$1" spec="$2"
+  awk -v spec="$spec" '
+    function emit_if_value(stmt, ln,    clause, n, i, p, anyType, allType, parts) {
+      if (index(stmt, spec) == 0) return
+      if (stmt ~ /^[ \t]*(import|export)[ \t]+type[ \t]/) return        # whole import type-only → allowed
+      if (stmt ~ /\{/) {                                                # all-inline-type brace → allowed
+        clause = stmt; sub(/^[^{]*\{/, "", clause); sub(/\}.*/, "", clause)
+        n = split(clause, parts, ","); anyType = 0; allType = 1
+        for (i = 1; i <= n; i++) { p = parts[i]; gsub(/^[ \t]+|[ \t]+$/, "", p); if (p == "") continue; anyType = 1; if (p !~ /^type[ \t]/) allType = 0 }
+        if (anyType && allType) return
+      }
+      print ln
+    }
+    BEGIN { inblk = 0; buf = ""; start = 0 }
+    {
+      if (inblk) {                                                       # inside a multi-line brace import
+        buf = buf " " $0
+        # close on the module clause (from ...) or statement end — NOT on } alone:
+        # a brace import may put } and `from '...'` on separate lines, and the specifier
+        # lives in the from-clause, so closing on } would drop it (false negative).
+        if ($0 ~ /(^|[ \t])from([ \t]|$)/ || $0 ~ /;[ \t]*$/) { emit_if_value(buf, start); inblk = 0; buf = "" }
+        next
+      }
+      if ($0 ~ /^[ \t]*(import|export)([ \t]|\(|$)/) {
+        if ($0 ~ /\{/ && $0 !~ /\}/) { inblk = 1; buf = $0; start = NR }  # opens multi-line brace
+        else { emit_if_value($0, NR) }                                   # single-line / default / side-effect / dynamic-at-start
+      } else if ($0 ~ /(import|require)[ \t]*\(/ && index($0, spec) > 0) {
+        print NR                                                         # dynamic import()/require() mid-line
+      }
+    }
+  ' "$file" 2>/dev/null | sort -un
+}
+
+scan_boundary_a() {
+  echo "── Boundary A: platform ↛ ${WORLD_SPECIFIER} (value-imports forbidden; import type allowed) ──"
+  local found=0
+  while IFS= read -r -d '' file; do
+    while IFS= read -r ln; do
+      [ -n "${ln:-}" ] || continue
+      flag "$file:$ln value-imports the world ($WORLD_SPECIFIER)"
+      found=1
+    done < <(find_value_imports "$file" "$WORLD_SPECIFIER")
+  done < <(
+    for d in "${PLATFORM_DIRS[@]}"; do
+      [ -d "$d" ] && find "$d" -type f -name '*.ts' -not -name '*.d.ts' -print0
+    done
+  )
+  [ "$found" -eq 0 ] && echo "  ✓ clean — no platform→world value-imports"
+}
+
+in_allowlist() { local f="$1"; for a in "${BOUNDARY_B_ALLOWLIST[@]}"; do [ "$f" = "$a" ] && return 0; done; return 1; }
+
+scan_boundary_b() {
+  echo "── Boundary B: ${WORLD_SRC} ↛ ${ADAPTER_SPECIFIER} (value-imports; baseline-allowlisted, tests exempt) ──"
+  [ -d "$WORLD_SRC" ] || { echo "  (skip: $WORLD_SRC absent)"; return; }
+  local grandfathered=0 fresh=0
+  while IFS= read -r -d '' file; do
+    local hits; hits="$(find_value_imports "$file" "$ADAPTER_SPECIFIER")"
+    [ -n "$hits" ] || continue
+    if in_allowlist "$file"; then
+      echo "  ~ grandfathered (C2 burndown): $file"
+      grandfathered=$((grandfathered + 1))
+    else
+      flag "$file value-imports $ADAPTER_SPECIFIER but is NOT in the C1.2 baseline-allowlist (a NEW reach-in)"
+      fresh=$((fresh + 1))
+    fi
+  done < <(find "$WORLD_SRC" -type f -name '*.ts' -not -name '*.test.ts' -not -name '*.d.ts' -print0)
+  echo "  → $grandfathered grandfathered (pending C2), $fresh new reach-in(s)"
+}
+
+scan_boundary_a
+echo ""
+scan_boundary_b
+
+if [ "$violations" -ne 0 ]; then
+  echo ""
+  echo "::error::membrane breached — $violations violation(s)."
+  echo "  Boundary A: platform must not import the world at runtime — use a port + inject at the"
+  echo "  composition root, or convert to 'import type'."
+  echo "  Boundary B: new sietch→adapters/agent value-imports are forbidden — depend on"
+  echo "  @freeside/core/ports instead (the C2 contract). Existing reach-ins are allowlisted; do not add."
+  exit 1
+fi
+echo "✓ membranes intact (boundary A + boundary B baseline clean)"

--- a/tools/ledger-payment-callgraph.mjs
+++ b/tools/ledger-payment-callgraph.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+/**
+ * ledger-payment-callgraph.mjs — C3 (FR-8 / SKP-003) of the freeside-decomposition cycle.
+ *
+ * READ-ONLY analysis. Determines whether the credits-ledger (`credit-lot-service`
+ * and friends in packages/services) is cleanly separable from the payment on-ramp
+ * (NG-1 wall) or entangled — gating any future ledger-api extraction.
+ *
+ * Three indirection vectors are checked (flatline FL-B1 hardening):
+ *   1. static    — direct ESM import + call of a ledger-write symbol from a payment file
+ *   2. event     — a payment surface publishes an event a ledger writer consumes (bus/outbox)
+ *   3. shared-db — a payment surface writes a table a ledger writer reads/polls
+ *
+ * NG-1 fail-safe (IMP-010): any UNRESOLVED payment→ledger indirection → verdict
+ * defaults to `payment-entangled → defer`. "cleanly-separable" requires clean on ALL three.
+ *
+ * Tooling note: `madge` is unavailable in this workspace (no local node_modules linkage,
+ * NG-3). This uses a zero-dependency text scan with MULTI-LINE-AWARE import extraction.
+ * DOCUMENTED BYPASS CLASSES (same honesty discipline as block-destructive-bash) — NOT claimed
+ * as covered: dynamic `import()` target resolution beyond the literal specifier, transitive
+ * chains >1 hop, DI-injected call sites (ledger fn passed as a value), and ORM/query-builder
+ * table access (e.g. Drizzle `db.insert(creditLots)`) — the shared-db vector matches RAW SQL
+ * table names only. These are flagged `unresolved` / out-of-scope, never assumed clean.
+ *
+ * Usage: node tools/ledger-payment-callgraph.mjs [--json]
+ * Exit:  0 = analysis complete (read VERDICT in output). Non-zero = tool error.
+ */
+import { readFileSync, readdirSync, existsSync, lstatSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const JSON_OUT = process.argv.includes('--json');
+
+// --- The boundary definitions (grounded 2026-06-06) ---------------------------
+
+const PAYMENT_SURFACES = [
+  'packages/services/nowpayments-handler.ts',
+  'packages/services/x402-settlement.ts',
+];
+// The world (themes/sietch) vendors its OWN billing stack — a second payment surface.
+const PAYMENT_SURFACE_GLOBS = [
+  'themes/sietch/src/packages/adapters/billing',
+  'themes/sietch/src/packages/adapters/payment',
+];
+
+const LEDGER_WRITERS = {
+  'credit-lot-service': ['mintCreditLot', 'debitLots', 'expireLots'],
+  'event-sourcing-service': ['appendEvent', 'recordMutation', 'foldBalance'],
+  'debit-rollup-job': ['rollupDebits'],
+  'lot-expiry-sweep': ['sweepExpiredLots'],
+};
+const LEDGER_TABLES = ['credit_lots', 'usage_events', 'economic_policies', 'agent_usage', 'ledger_account', 'ledger_reservation', 'lot_entries'];
+const PAYMENT_TABLES = ['webhook_events', 'payment_intents', 'nowpayments_events', 'x402_settlements', 'crypto_payments'];
+const ALL_WRITER_SYMBOLS = new Set(Object.values(LEDGER_WRITERS).flat());
+
+// --- Robust import extraction (multi-line aware; F5/F6/F8 review fixes) --------
+
+function lineNoAt(text, idx) { return text.slice(0, idx).split('\n').length; }
+
+/** Extract every import/require from full file text, handling multi-line + aliases + per-symbol type. */
+function extractImports(text) {
+  const out = [];
+  // static: import [type] <clause> from '<spec>'   — [^;] spans newlines (F5 multi-line) but
+  // stops at a statement boundary so a preceding no-`from` import can't be swallowed (correct lineno).
+  const re = /import\s+(type\s+)?([^;]*?)\s+from\s*['"]([^'"]+)['"]/g;
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    const isTypeImport = !!m[1];
+    const clause = m[2];
+    const spec = m[3];
+    const lineno = lineNoAt(text, m.index);
+    const brace = clause.match(/\{([\s\S]*?)\}/);
+    let symbols = [];
+    if (brace) {
+      symbols = brace[1].split(',').map((s) => s.trim()).filter(Boolean).map((s) => ({
+        isType: /^type\s+/.test(s),                                   // F2: inline per-symbol type
+        name: s.replace(/^type\s+/, '').replace(/\s+as\s+\S+$/, '').trim(), // F6: strip alias
+      }));
+    }
+    out.push({ lineno, isTypeImport, spec, symbols });
+  }
+  // side-effect: import '<spec>'
+  const sideRe = /import\s*['"]([^'"]+)['"]/g;
+  while ((m = sideRe.exec(text)) !== null) out.push({ lineno: lineNoAt(text, m.index), isTypeImport: false, spec: m[1], symbols: [] });
+  // dynamic + CJS: import('<spec>') / require('<spec>')
+  const dynRe = /(?:import|require)\s*\(\s*['"]([^'"]+)['"]/g;
+  while ((m = dynRe.exec(text)) !== null) out.push({ lineno: lineNoAt(text, m.index), isTypeImport: false, spec: m[1], symbols: [], dynamic: true });
+  return out;
+}
+
+function readText(rel) {
+  const abs = join(ROOT, rel);
+  if (!existsSync(abs)) return null;
+  return readFileSync(abs, 'utf8');
+}
+
+function walkTs(relDir) {
+  const abs = join(ROOT, relDir);
+  if (!existsSync(abs)) return [];
+  const out = [];
+  for (const ent of readdirSync(abs)) {
+    const full = join(abs, ent);
+    let st;
+    try { st = lstatSync(full); } catch { continue; }   // F10: tolerate broken symlinks
+    if (!st.isDirectory() && !st.isFile()) continue;
+    const rel = join(relDir, ent);
+    if (st.isDirectory()) out.push(...walkTs(rel));
+    else if (ent.endsWith('.ts') && !ent.endsWith('.test.ts')) out.push(rel);
+  }
+  return out;
+}
+
+// --- Scanners -----------------------------------------------------------------
+
+const edges = [];
+const missingFiles = [];
+function addEdge(writer, source, reachesPayment, evidence, resolution) {
+  edges.push({ writer, source, reaches_payment: reachesPayment, evidence, resolution });
+}
+
+// Vector 1: static — payment file value-imports a ledger-write symbol
+function scanStatic(paymentFile) {
+  const text = readText(paymentFile);
+  if (text === null) { missingFiles.push(paymentFile); return; }
+  for (const imp of extractImports(text)) {
+    if (!/(credit-lot-service|event-sourcing-service|debit-rollup-job|lot-expiry-sweep)/.test(imp.spec)) continue;
+    if (imp.isTypeImport) continue;                                   // F8: whole import type-only → no runtime edge
+    const sink = imp.spec.split('/').pop().replace(/\.js$/, '');
+    for (const s of imp.symbols) {
+      if (s.isType) continue;                                         // F2: per-symbol type → no runtime edge
+      if (ALL_WRITER_SYMBOLS.has(s.name)) addEdge(paymentFile, `${sink}.${s.name}`, true, `${paymentFile}:${imp.lineno}`, 'static');
+    }
+  }
+}
+
+// Vector 3: shared-db — RAW SQL table references (ORM access is a documented blind spot)
+function scanSharedDb(paymentFile) {
+  const text = readText(paymentFile);
+  if (text === null) return;
+  text.split('\n').forEach((line, i) => {
+    if (/^\s*(\/\/|\*)/.test(line)) return;
+    for (const t of [...PAYMENT_TABLES, ...LEDGER_TABLES]) {
+      if (new RegExp(`(INSERT INTO|UPDATE|DELETE FROM|SELECT[^;]*FROM)\\s+${t}\\b`, 'i').test(line)) {
+        addEdge(paymentFile, `db:${t}`, LEDGER_TABLES.includes(t), `${paymentFile}:${i + 1}`, 'shared-db');
+      }
+    }
+  });
+}
+
+// Vector 2: event — payment publishes / ledger subscribes (bus/outbox) → cannot statically confirm → unresolved
+function scanEvents(files) {
+  let found = false;
+  for (const f of files) {
+    const text = readText(f);
+    if (text === null) continue;
+    text.split('\n').forEach((line, i) => {
+      if (/^\s*(\/\/|\*)/.test(line)) return;
+      if (/\b(publish|emit|enqueue|outbox)\s*\(/.test(line) && /(credit|ledger|lot|payment|settle)/i.test(line)) {
+        addEdge(f, 'event-bus', null, `${f}:${i + 1}`, 'unresolved');
+        found = true;
+      }
+    });
+  }
+  return found;
+}
+
+// --- Run (F7: scan ALL payment files incl. globs, not just the 2 hardcoded) ---
+
+const globFiles = PAYMENT_SURFACE_GLOBS.flatMap((g) => walkTs(g));
+const paymentFiles = [...PAYMENT_SURFACES, ...globFiles];
+
+for (const pf of paymentFiles) { scanStatic(pf); scanSharedDb(pf); }
+const eventFound = scanEvents([...paymentFiles, ...Object.keys(LEDGER_WRITERS).map((k) => `packages/services/${k}.ts`)]);
+
+const staticEdges = edges.filter((e) => e.resolution === 'static' && e.reaches_payment);
+const dbEdges = edges.filter((e) => e.resolution === 'shared-db' && e.reaches_payment);
+const unresolved = edges.filter((e) => e.resolution === 'unresolved');
+
+let verdict, reason;
+if (staticEdges.length > 0) {
+  verdict = 'payment-entangled → defer';
+  reason = `${staticEdges.length} DIRECT static payment→ledger-write call edge(s). Extracting the ledger would sever payment calls = NG-1 violation.`;
+} else if (dbEdges.length > 0) {
+  verdict = 'payment-entangled → defer';
+  reason = `${dbEdges.length} shared-database coupling edge(s) between payment surfaces and ledger tables.`;
+} else if (unresolved.length > 0) {
+  verdict = 'payment-entangled → defer';
+  reason = `${unresolved.length} UNRESOLVED indirection edge(s) (NG-1 fail-safe: unresolved → defer).`;
+} else if (missingFiles.length === PAYMENT_SURFACES.length) {
+  verdict = 'INCONCLUSIVE → defer';                                   // F11: scanned nothing ≠ clean
+  reason = `All hardcoded payment surfaces are MISSING (${missingFiles.join(', ')}) — scanned nothing; cannot assert separable.`;
+} else {
+  verdict = 'cleanly-separable';
+  reason = 'No payment→ledger edge found on any of the 3 vectors (static, shared-db, event).';
+}
+
+const result = {
+  generated: 'C3 / FR-8 / SKP-003 — freeside-decomposition',
+  tool_limitations: 'text scan (madge unavailable, NG-3). Multi-line imports + aliases + per-symbol type ARE handled. Misses: dynamic import() target resolution, >1-hop transitive, DI-injected call sites, and ORM/query-builder table access (shared-db matches RAW SQL only). Flagged unresolved / out-of-scope, never assumed clean.',
+  payment_surfaces_scanned: paymentFiles.length,
+  missing_payment_surfaces: missingFiles,
+  ledger_writers: LEDGER_WRITERS,
+  edges,
+  summary: { static: staticEdges.length, shared_db: dbEdges.length, unresolved: unresolved.length, event_bus_found: eventFound },
+  verdict,
+  reason,
+};
+
+if (JSON_OUT) {
+  console.log(JSON.stringify(result, null, 2));
+} else {
+  console.log(`\n=== C3 LEDGER↔PAYMENT CALL-GRAPH ===`);
+  console.log(`payment files scanned: ${paymentFiles.length}${missingFiles.length ? ` (MISSING: ${missingFiles.join(', ')})` : ''}`);
+  console.log(`\nEDGES (writer → sink | reaches-payment | resolution | evidence):`);
+  for (const e of edges) console.log(`  ${e.writer}\n     → ${e.source} | reaches=${e.reaches_payment} | ${e.resolution} | ${e.evidence}`);
+  console.log(`\nsummary: static=${staticEdges.length} shared-db=${dbEdges.length} unresolved=${unresolved.length}`);
+  console.log(`\nVERDICT: ${verdict}`);
+  console.log(`  ${reason}\n`);
+}


### PR DESCRIPTION
## What this is

Two payment-free, contracts-first de-risking artifacts from the freeside-decomposition cycle. No building lift (strangler-fig: contracts before lifts). Everything still compiles in the monorepo. Payments are out of scope (NG-1).

## C1: platform/world membrane CI guard (FR-7)

`tools/check-platform-membrane.sh`, wired as a non-bypassable job in `path-domain-check.yml`, enforces two boundaries:

- **Boundary A**: the platform (`apps/{gateway,worker,ingestor}`, `packages/{core,adapters,sandbox}`) must not value-import `themes/sietch`. Baseline is 0; green on HEAD.
- **Boundary B**: `themes/sietch/src` must not add NEW value-imports of `@freeside/adapters/agent` (the ports-only contract). The 4 existing reach-ins are baseline-allowlisted (the burndown list); test files are exempt.

`import type` and inline `{ type X }` are permitted (they erase at compile). madge is unavailable in this workspace (no local node_modules linkage), so the guard is a multi-line-aware awk text scan with documented bypass classes (alias and transitive reach-in are out of scope for v1). 14 guard tests pass, covering multi-line imports, inline type modifiers, and brace-then-from on separate lines (hardened by adversarial review).

## C3: ledger/payment call-graph map (FR-8), verdict DEFER

`tools/ledger-payment-callgraph.mjs` is a read-only NG-1 gate. It maps payment to ledger coupling across three vectors (static import, shared database table, event bus), with a fail-safe: any unresolved edge defaults to defer.

**Verdict: `payment-entangled -> defer`.** Both payment surfaces (`nowpayments-handler.ts:22`, `x402-settlement.ts:20`) call `credit-lot-service` directly (`mintCreditLot`, `debitLots`). 3 static edges plus 11 shared-database edges. The credits-ledger cannot be extracted cleanly without severing those payment callsites, which would touch payment code (out of scope). The verdict was cross-validated independently by a deeper run that reached the same conclusion with more coupling.

## NG-1

Zero edits to any payment or runtime file (nowpayments, x402, Paddle, settlement, pricing, fiat on-ramp). Audited. The committable diff is 3 shared-domain files; no platform or network paths are touched, so the cross-domain firewall passes.

## Deferred (with reasons), not in this PR

- **C2 burndown** (relocate the seam to ports plus the DI rewire): `themes/sietch` cannot typecheck `@freeside/*` on HEAD (171 baseline errors; the modules resolve at runtime via bun, not under tsc). The refactor is therefore not locally verifiable, and it touches auth and JWT wiring, so it waits. The contract stays enforced by Boundary B meanwhile.
- The decision artifacts (full C3 edge map, C2 seam enumeration) live under `grimoires/loa/cycles/freeside-decomposition/` (gitignored by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
