### PR TITLE
feat(shared/cheval): jam-reviewer-claude-headless council voice

### DIFF
--- a/.claude/defaults/model-config.yaml
+++ b/.claude/defaults/model-config.yaml
@@ -818,6 +818,16 @@ agents:
   jam-reviewer-cursor:
     model: cursor:cursor-headless
     temperature: 0.3
+  # FAGAN council Claude voice via the HEADLESS terminal (anthropic:claude-headless),
+  # NOT the native runtime. jam-reviewer-claude (above) is model:native +
+  # native_runtime:true, so the resolver refuses to dispatch it to a remote/headless
+  # model (NATIVE_RUNTIME_REQUIRED) and it cannot serve as a council voice. This
+  # additive sibling binds DIRECTLY to anthropic:claude-headless (subscription CLI
+  # auth, no API key) so the council gets a real Claude corpus as its 4th distinct
+  # family. The native voice (jam-reviewer-claude) stays intact for native jam geometry.
+  jam-reviewer-claude-headless:
+    model: anthropic:claude-headless
+    temperature: 0.3
   jam-synthesizer:
     model: cheap
     temperature: 0.3


### PR DESCRIPTION
## What

Adds `jam-reviewer-claude-headless`, the Claude voice for the FAGAN cross-model council, dispatched through the headless terminal.

## Why

The native `jam-reviewer-claude` (model: native, `requires.native_runtime: true`) cannot serve as a council voice. cheval's resolver raises `NATIVE_RUNTIME_REQUIRED` when a native-required agent is dispatched to a remote/headless model, so it always drops. This additive sibling binds directly to `anthropic:claude-headless` (subscription CLI auth, no API key), giving the council a real Claude corpus as its 4th distinct family. The native voice is unchanged.

## Verified live

Real dispatch: claude-sonnet-4-6 returned a valid verdict. MODELINV recorded `final_model_id: anthropic:claude-headless`, `transport: cli`, `models_failed: []`. Dry-run resolves to `anthropic:claude-headless` with no native_runtime error; the native `jam-reviewer-claude` still resolves as native (unchanged).

Refs beads `arrakis-7bhq` (epic `arrakis-dun2`). Pairs with construct-fagan's 4-voice council wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
