### PR TITLE
recover: worker-schema-drift guard + InteractionHistory port (stranded local-only work)

### DIFF
--- a/.github/workflows/worker-schema-drift-check.yml
+++ b/.github/workflows/worker-schema-drift-check.yml
@@ -1,0 +1,42 @@
+# =============================================================================
+# Worker Schema Drift Check
+# Coherence finding F5 / arrakis-pcpc — make worker↔sietch Drizzle drift LOUD.
+# =============================================================================
+#
+# apps/worker/src/data/schema.ts holds verbatim COPIES of three Drizzle tables
+# (communities, profiles, badges) canonically defined in
+# themes/sietch/src/packages/adapters/storage/schema.ts. The copy is intentional
+# (worker runs its own drizzle instance) but silent divergence was an unguarded
+# risk. This gate FAILS when the shared table definitions drift apart.
+#
+# Fail-block (teeth): a drift is a red check, not a warning — the worker copy must
+# mirror the sietch canonical until the shared schema package is extracted
+# (deferred to the worlds-api cycle; see tools/check-worker-schema-drift.sh).
+
+name: Worker Schema Drift Check
+
+on:
+  pull_request:
+    paths:
+      - 'apps/worker/src/data/schema.ts'
+      - 'themes/sietch/src/packages/adapters/storage/schema.ts'
+      - 'tools/check-worker-schema-drift.sh'
+      - '.github/workflows/worker-schema-drift-check.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/worker/src/data/schema.ts'
+      - 'themes/sietch/src/packages/adapters/storage/schema.ts'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  schema-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check worker↔sietch Drizzle schema drift
+        shell: bash
+        run: bash tools/check-worker-schema-drift.sh

--- a/packages/adapters/storage/audit-query-service.ts
+++ b/packages/adapters/storage/audit-query-service.ts
@@ -11,7 +11,7 @@
 
 import type { Pool } from 'pg';
 import type { Logger } from 'pino';
-import type { InteractionHistoryProvider, InteractionRecord } from '../../../themes/sietch/src/packages/core/protocol/capability-mesh.js';
+import type { InteractionHistoryProvider, InteractionRecord } from '@freeside/core/ports';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 

--- a/packages/core/ports/index.ts
+++ b/packages/core/ports/index.ts
@@ -76,3 +76,6 @@ export * from './migration.js';
 
 // Agent Gateway Interface (Hounfour Phase 4 — Spice Gate)
 export * from './agent-gateway.js';
+
+// Interaction History Port (relocated from themes/sietch — coherence F4 / arrakis-shqm)
+export * from './interaction-history.js';

--- a/packages/core/ports/interaction-history.ts
+++ b/packages/core/ports/interaction-history.ts
@@ -1,0 +1,29 @@
+/**
+ * Interaction History Port
+ *
+ * The InteractionHistoryProvider contract decouples capability/mesh resolution
+ * from the persistent audit query layer (dependency injection). It lives in core
+ * (the platform substrate) so that BOTH the theme that produces interaction
+ * records and the storage adapter that backs them depend on core — never on each
+ * other.
+ *
+ * Originally declared inside themes/sietch (capability-mesh.ts, cycle-043);
+ * relocated here to restore the belt direction platform-core <- theme and remove
+ * the platform->theme reach-in import (coherence finding F4 / arrakis-shqm).
+ */
+
+/** Record of interaction between two models */
+export interface InteractionRecord {
+  model_pair: [string, string];
+  quality_score: number;
+  observation_count: number;
+}
+
+/** Provider interface for interaction history — decoupled from storage layer */
+export interface InteractionHistoryProvider {
+  /**
+   * Get interaction records between two models.
+   * Returns empty array if no interactions found.
+   */
+  getInteractions(modelA: string, modelB: string): Promise<InteractionRecord[]>;
+}

--- a/themes/sietch/src/packages/core/protocol/capability-mesh.ts
+++ b/themes/sietch/src/packages/core/protocol/capability-mesh.ts
@@ -16,24 +16,15 @@ import type {
   CapabilitySet,
   ResolutionContext,
 } from './capability-catalog.js';
+// InteractionRecord + InteractionHistoryProvider now live in @freeside/core/ports
+// (single source of truth, platform-core <- theme belt — coherence F4 / arrakis-shqm).
+// Imported for local use by InMemoryInteractionHistoryProvider below.
+import type { InteractionRecord, InteractionHistoryProvider } from '@freeside/core/ports';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
-/** Record of interaction between two models */
-export interface InteractionRecord {
-  model_pair: [string, string];
-  quality_score: number;
-  observation_count: number;
-}
-
-/** Provider interface for interaction history — decoupled from storage layer */
-export interface InteractionHistoryProvider {
-  /**
-   * Get interaction records between two models.
-   * Returns empty array if no interactions found.
-   */
-  getInteractions(modelA: string, modelB: string): Promise<InteractionRecord[]>;
-}
+// Re-exported for any existing importers of these names from this module.
+export type { InteractionRecord, InteractionHistoryProvider };
 
 /** Threshold configuration for ensemble capability unlocking */
 export interface MeshThresholdConfig {

--- a/tools/check-worker-schema-drift.sh
+++ b/tools/check-worker-schema-drift.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# check-worker-schema-drift.sh — make worker↔sietch Drizzle-schema drift LOUD.
+#
+# apps/worker/src/data/schema.ts holds verbatim COPIES of three Drizzle tables
+# (communities, profiles, badges) that are canonically defined in
+# themes/sietch/src/packages/adapters/storage/schema.ts. The worker needs its own
+# table objects (its own drizzle instance), so the copy is intentional — but a column
+# change in sietch silently NOT propagating to the worker copy was an unguarded drift
+# risk (coherence finding F5 / arrakis-pcpc). This check fails CI when the shared table
+# definitions diverge, so the drift can never again be silent.
+#
+# Scope: the 3 SHARED tables only. agentThreads is worker's own (no sietch Drizzle
+# equivalent — only raw migrations 063/066), so it is NOT a drift target.
+#
+# This is a TEXT comparison, NOT an import — a worker test importing sietch's schema
+# would be a platform->theme membrane reach-in. Comparing source text avoids that.
+#
+# The durable fix (extract a shared schema package consumed by both) is deferred to the
+# worlds-api extraction cycle: the 3 tables are deeply FK-coupled into sietch's 21-table
+# schema, so extraction belongs with that larger refactor. Until then, this guard holds.
+#
+# Exit 0 = in sync · Exit 1 = drift detected.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKER="$REPO_ROOT/apps/worker/src/data/schema.ts"
+SIETCH="$REPO_ROOT/themes/sietch/src/packages/adapters/storage/schema.ts"
+TABLES=(communities profiles badges)
+
+for f in "$WORKER" "$SIETCH"; do
+  [ -f "$f" ] || { echo "::error::check-worker-schema-drift: missing schema file: $f"; exit 1; }
+done
+
+# extract the `export const <name> = pgTable( ... );` block, then normalize:
+# strip // line-comments, trim leading/trailing whitespace, drop blank lines.
+extract_normalized() {
+  local file="$1" name="$2"
+  awk -v t="export const ${name} = pgTable(" '
+    index($0, t) == 1 { inblk = 1 }
+    inblk { print }
+    inblk && /^\);/ { exit }
+  ' "$file" \
+    | sed -E 's://.*$::' \
+    | sed -E 's/[[:space:]]+$//; s/^[[:space:]]+//' \
+    | grep -v '^$'
+}
+
+drift=0
+for t in "${TABLES[@]}"; do
+  w="$(extract_normalized "$WORKER" "$t")"
+  s="$(extract_normalized "$SIETCH" "$t")"
+  if [ -z "$w" ]; then echo "::error::table '$t' not found in worker schema ($WORKER)"; drift=1; continue; fi
+  if [ -z "$s" ]; then echo "::error::table '$t' not found in sietch schema ($SIETCH)"; drift=1; continue; fi
+  if [ "$w" != "$s" ]; then
+    echo "::error::SCHEMA DRIFT — table '$t' differs between worker copy and sietch canonical:"
+    diff <(printf '%s\n' "$s") <(printf '%s\n' "$w") | sed 's/^/    /' || true
+    echo "    → reconcile apps/worker/src/data/schema.ts ($t) with themes/sietch/.../storage/schema.ts, or extract the shared schema package (arrakis-pcpc)."
+    drift=1
+  else
+    echo "  ✓ $t in sync (worker copy matches sietch canonical)"
+  fi
+done
+
+if [ "$drift" -ne 0 ]; then
+  echo "::error::worker↔sietch Drizzle schema has drifted. The worker copy must mirror the sietch canonical."
+  exit 1
+fi
+echo "✓ worker↔sietch schema in sync across: ${TABLES[*]}"


### PR DESCRIPTION
## What this is

Two finished pieces of work that were committed on a local-only branch and **never reached GitHub** (surfaced by a content-diff reconciliation of the local clone against this repo's main). Recovered here, grafted clean onto current main, both verified.

## C-1: worker/sietch Drizzle schema drift-guard (arrakis-pcpc / F5B)

`tools/check-worker-schema-drift.sh` + a CI job. The three shared Drizzle tables (`communities`, `profiles`, `badges`) are copied verbatim into `apps/worker`; this fails CI if the copy drifts from the `themes/sietch` canonical. Verified green on HEAD (all three in sync). This is the mirror that `tools/check-platform-membrane.sh` (PR #264) names.

## C-2: relocate InteractionHistory port to @freeside/core (arrakis-shqm, Coherence F4)

`InteractionRecord` + `InteractionHistoryProvider` were declared in `themes/sietch` and imported by a platform adapter via a 4-level relative path, inverting the belt direction (platform depending on a theme). Moved both (byte-identical) to `@freeside/core/ports`; `capability-mesh.ts` re-exports them; `audit-query-service.ts` repoints to the port. Result: the platform to sietch reach-in is closed. Pure type relocation, no runtime change. `packages/core` typechecks with the port added.

This is the fix that *made* the membrane clean, so it pairs naturally with the C1 guard in #264 that codifies that cleanliness.

## Domain

platform + shared, zero network paths. The cross-domain firewall passes (classifies as platform).

## Provenance

Recovered via `~/bonfire/reconcile-landed.mjs` (content-diff vs the remote default branch), part of a local to GitHub legibility pass. These were genuinely stranded (only on local disk), not WIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
