### PR TITLE
docs(shared): point agents at `loa` for ecosystem navigation (arrakis-yemk)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,10 +138,10 @@ Every goal in the PRD must have a `G-N` identifier for traceability.
 
 ```bash
 # CORRECT - reach for loa first when you need to know what is live or reachable
-loa doctor              # health + discovery probe across registered buildings
-loa caps                # capabilities reachable under the current grant (discovery == permission)
-loa where <dest>        # cheapest invocation to reach a destination (the `cd` of the ecosystem)
-loa census --graph      # the living building graph (nodes/edges + pinned topology_digest)
+loa doctor              # live · health + discovery probe across registered buildings
+loa caps                # live · capabilities reachable under the current grant (discovery == permission)
+loa where <dest>        # live · cheapest invocation to reach a destination (the `cd` of the ecosystem)
+loa census --graph      # live · the living building graph — set LOA_WORKSPACE=<cluster-root> first
 
 # WRONG - do not hand-probe what loa already covers
 grep -r "deployment_url" packages/freeside-registry/registry.yaml  # stale hand-authored field
@@ -154,10 +154,10 @@ building liveness, reachable capabilities, or the belt-DAG — instead of greppi
 hand-reading `registry.yaml`. This is the consumption-gradient floor ADR-011 §D-5 mandates:
 the verified path must be the path of least resistance.
 
-> `loa doctor` / `loa caps` are live today with no setup. `loa census --graph` reads the live
-> cluster (4 registries → buildings + constructs + worlds + zones) once `loa-cli#6` lands, and
-> needs `LOA_WORKSPACE=<cluster-root>` set — `loa` reads only approved veve roots, never an
-> arbitrary cwd: `LOA_WORKSPACE=~/Documents/GitHub loa census --graph`.
+> All four are live today (`census --graph` since loa-cli#6 merged). `census --graph` needs
+> `LOA_WORKSPACE=<cluster-root>` set first — `loa` reads only approved veve roots, never an
+> arbitrary cwd: `LOA_WORKSPACE=~/Documents/GitHub loa census --graph` (reads 4 registries →
+> buildings + constructs + worlds + zones). `ADR-011 §D-5` is the cited floor.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,8 +154,10 @@ building liveness, reachable capabilities, or the belt-DAG — instead of greppi
 hand-reading `registry.yaml`. This is the consumption-gradient floor ADR-011 §D-5 mandates:
 the verified path must be the path of least resistance.
 
-> `loa census --graph` reads the live cluster (4 registries → buildings + constructs + worlds +
-> zones) once `loa-cli#6` lands; `loa doctor` / `loa caps` are live today.
+> `loa doctor` / `loa caps` are live today with no setup. `loa census --graph` reads the live
+> cluster (4 registries → buildings + constructs + worlds + zones) once `loa-cli#6` lands, and
+> needs `LOA_WORKSPACE=<cluster-root>` set — `loa` reads only approved veve roots, never an
+> arbitrary cwd: `LOA_WORKSPACE=~/Documents/GitHub loa census --graph`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,29 @@ rg "pattern" src/       # DEPRECATED - use ck instead
 
 Every goal in the PRD must have a `G-N` identifier for traceability.
 
+### 4. Ecosystem Navigation: Use `loa` (NOT raw grep / registry.yaml reads)
+
+```bash
+# CORRECT - reach for loa first when you need to know what is live or reachable
+loa doctor              # health + discovery probe across registered buildings
+loa caps                # capabilities reachable under the current grant (discovery == permission)
+loa where <dest>        # cheapest invocation to reach a destination (the `cd` of the ecosystem)
+loa census --graph      # the living building graph (nodes/edges + pinned topology_digest)
+
+# WRONG - do not hand-probe what loa already covers
+grep -r "deployment_url" packages/freeside-registry/registry.yaml  # stale hand-authored field
+gh api repos/.../contents/registry.yaml                            # reconstructing the map by hand
+```
+
+`loa` is the ecosystem launcher (npm-linked globally → `loa-cli/bin/loa.mjs`): grant-gated,
+metacharacter-safe (Finn-sandbox safe), proof-of-run. Reach for it FIRST when navigating
+building liveness, reachable capabilities, or the belt-DAG — instead of grepping packages or
+hand-reading `registry.yaml`. This is the consumption-gradient floor ADR-011 §D-5 mandates:
+the verified path must be the path of least resistance.
+
+> `loa census --graph` reads the live cluster (4 registries → buildings + constructs + worlds +
+> zones) once `loa-cli#6` lands; `loa doctor` / `loa caps` are live today.
+
 ---
 
 ## Chain Provider Architecture (Sprint 14-16)


### PR DESCRIPTION
## 🚪 close the consumption-gradient slip at the harness

`loa` (the ecosystem launcher) is npm-linked globally and all 7 verbs run — yet `CLAUDE.md` + `CLAUDE.loa.md` reference it **zero** times. So agents default to `grep` / `gh api` / hand-reading `registry.yaml`. That's exactly the slip [ADR-011 §D-5](decisions/011-loa-launcher-the-front-door.md) was built to close: *the verified path must be the path of least resistance.*

This adds **rule 4** to "CRITICAL: Tool Enforcement Rules", mirroring the existing `br` / `ck` CORRECT-vs-WRONG pattern:

```bash
loa doctor / loa caps / loa where <dest> / loa census --graph   # reach for these first
# not: grep -r registry.yaml ; gh api .../contents/registry.yaml
```

Doc-only, additive, highest-precedence file (not System Zone). Honestly notes that `census --graph` reads the live cluster once **loa-cli#6** lands (the parser keystone) — `doctor`/`caps` are live today.

Closes arrakis-yemk. Companion to the scan brief `grimoires/loa/context/2026-06-20-loa-cli-consumption-gradient-scan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)