### PR TITLE
fix(shared/ci): unblock chronically-red CI (integration-tests config env)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,3 +258,22 @@ jobs:
         run: npm run test:integration
         env:
           REDIS_URL: redis://localhost:6379
+          # config.ts validates all env at import (Zod); the integration vitest project has no
+          # setupFiles, so unlike the unit project (tests/setup-unit.ts) these required vars are
+          # unset → "Configuration validation failed: triggerDev.secretKey". Test placeholders,
+          # mirroring tests/setup-unit.ts (NOT real secrets).
+          BERACHAIN_RPC_URLS: https://rpc.test.example.com
+          BGT_ADDRESS: '0x0000000000000000000000000000000000000001'
+          TRIGGER_PROJECT_ID: test-project-id
+          TRIGGER_SECRET_KEY: test-secret-key
+          DISCORD_BOT_TOKEN: test-bot-token
+          DISCORD_GUILD_ID: test-guild-id
+          DISCORD_CHANNEL_THE_DOOR: test-channel-the-door
+          DISCORD_CHANNEL_CENSUS: test-channel-census
+          DISCORD_ROLE_NAIB: test-role-naib
+          DISCORD_ROLE_FEDAYKIN: test-role-fedaykin
+          ADMIN_API_KEYS: 'test-key:test-admin'
+          API_KEY_PEPPER: test-pepper-value-for-unit-tests-32chars!
+          RATE_LIMIT_SALT: test-rate-limit-salt-value
+          NODE_ENV: test
+          LOG_LEVEL: error


### PR DESCRIPTION
## 🔓 the estate's merge-flow unblocker

`pr-validation` / `ci.yml` "Integration Tests" is a **required** check that's **red on every PR** (genome-evals, platform-stranded-chunks, sprint-bug-332, sietch-identity, …) — merge-blind, the root of the cross-system stall.

**Root cause:** `config.ts` validates all env at import (Zod). The integration vitest project (`vitest.workspace.ts`) has **no `setupFiles`**, so unlike the unit project (`tests/setup-unit.ts`, which seeds them) the required vars are unset → `Configuration validation failed: triggerDev.secretKey`. The integration job seeded only `REDIS_URL`.

**Fix:** add the same test placeholders (mirroring `setup-unit.ts`) to the integration job env. Test-only values, never real secrets — same pattern `pr-validation.yml` already uses.

**Verification:** this PR's own `ci.yml` run is the proof — watching the Integration Tests check go green.

Closes `arrakis-yp7q`. (Note: if a *separate* "Unit Tests" failure remains, that's a distinct root cause — this targets the confirmed config-validation failure.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)