### PR TITLE
test(platform/sietch): fix stale integration tests (routing + payout addresses) — unblock CI

### DIFF
--- a/themes/sietch/tests/integration/billing-e2e-launch.test.ts
+++ b/themes/sietch/tests/integration/billing-e2e-launch.test.ts
@@ -217,7 +217,7 @@ describe('Task 13.1: E2E Scenarios', () => {
       const payoutResult = payoutService.requestPayout({
         accountId: 'referrer-alice',
         amountMicro: earningAmount, // $10 payout
-        payoutAddress: '0xAlicePayoutAddress',
+        payoutAddress: '0x1111111111111111111111111111111111111111', // valid EIP-55 (all-lowercase); requestPayout validates the address
       });
 
       expect(payoutResult.success).toBe(true);
@@ -257,7 +257,7 @@ describe('Task 13.1: E2E Scenarios', () => {
       const result = payoutService.requestPayout({
         accountId: 'fail-referrer',
         amountMicro: 5_000_000,
-        payoutAddress: '0xFailAddr',
+        payoutAddress: '0x2222222222222222222222222222222222222222', // valid EIP-55 (all-lowercase)
       });
       expect(result.success).toBe(true);
 
@@ -284,7 +284,7 @@ describe('Task 13.1: E2E Scenarios', () => {
       const result = payoutService.requestPayout({
         accountId: 'cancel-referrer',
         amountMicro: 3_000_000,
-        payoutAddress: '0xCancelAddr',
+        payoutAddress: '0x3333333333333333333333333333333333333333', // valid EIP-55 (all-lowercase)
       });
 
       const stateMachine = new PayoutStateMachine(db);
@@ -587,7 +587,7 @@ describe('Task 13.2: Treasury Invariant Stress Test', () => {
       const result = payoutService.requestPayout({
         accountId: 'stress-referrer',
         amountMicro: payoutAmount,
-        payoutAddress: `0xStressAddr${i}`,
+        payoutAddress: `0x${String(i).padStart(40, '0')}`, // valid EIP-55 (all-lowercase hex)
       });
 
       // First payout should succeed, subsequent may be rate-limited

--- a/themes/sietch/tests/integration/gateway-loafinn.test.ts
+++ b/themes/sietch/tests/integration/gateway-loafinn.test.ts
@@ -170,7 +170,7 @@ describe('Full pipeline integration — S2S JWT → JWS → validate → store',
     expect(VALID_POOL_IDS.has(freeTier.poolId)).toBe(true)
 
     const enterpriseTier = resolvePoolId('native', 'enterprise')
-    expect(enterpriseTier.poolId).toBe('architect')
+    expect(enterpriseTier.poolId).toBe('reviewer') // hounfour canonical default (was 'architect' pre-ADR-006)
     expect(VALID_POOL_IDS.has(enterpriseTier.poolId)).toBe(true)
 
     // All allowed pools must be valid
@@ -423,9 +423,9 @@ describe('Pool routing integration', () => {
   })
 
   it('resolvePoolId + JWT signing produces valid pool claims', () => {
-    // Enterprise with native → architect
+    // Enterprise with native → reviewer (hounfour canonical default; architect is access-allowed, not the default — ADR-006)
     const result = resolvePoolId('native', 'enterprise')
-    expect(result.poolId).toBe('architect')
+    expect(result.poolId).toBe('reviewer')
     expect(result.allowedPools).toContain('architect')
     expect(result.allowedPools).toContain('cheap')
   })


### PR DESCRIPTION
## 🟢 layer-2 of the red CI — two stale tests, verified + fixed

After #289 fixed the config-validation layer, the integration job revealed 5 real failures. Dug each against the code (you chose "dig + fix honestly") — **both are stale test data, not regressions.** The code is correct; the tests predate intentional changes.

**`gateway-loafinn`** (2 failed) — `resolvePoolId('native','enterprise')` returns `'reviewer'` (hounfour canonical default; `architect` intentionally excluded from default routing per ADR-006, access-allowed only). The 4-month-old test still asserted `'architect'`. Updated to the verified runtime value; kept the access-control assertions (enterprise *can use* architect).

**`billing-e2e`** (3 failed) — `requestPayout` validates the address via `validateEIP55Checksum` (correct). The test used non-hex placeholders → `success:false` → cascaded to the treasury-invariant `expected 0 > 0`. Replaced with valid all-lowercase 40-hex addresses.

**Verified locally:** both files green — **58/58 pass**.

This + #289 should green the Integration Tests required check → unblock the estate's merge flow (`arrakis-yp7q`). Letting CI confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)