### PR TITLE
test(platform/sietch): remediation batch 1 — billing addresses + flaky code (15 failures)

### DIFF
--- a/themes/sietch/tests/integration/billing-creator-payout.test.ts
+++ b/themes/sietch/tests/integration/billing-creator-payout.test.ts
@@ -62,7 +62,7 @@ function createSettledEarnings(accountDb: Database.Database, accountId: string, 
   accountDb.prepare(`
     INSERT INTO referral_codes (id, account_id, code, status, created_at)
     VALUES (?, ?, ?, 'active', datetime('now'))
-  `).run(codeId, accountId, `CODE${Date.now()}`);
+  `).run(codeId, accountId, `CODE${accountId}${Date.now()}`); // namespace by account → unique across same-ms calls (UNIQUE constraint)
 
   accountDb.prepare(`
     INSERT INTO referral_registrations
@@ -106,7 +106,7 @@ describe('Task 9.1: CreatorPayoutService', () => {
     const result = service.requestPayout({
       accountId: 'alice',
       amountMicro: 5_000_000, // $5
-      payoutAddress: '0xAliceWallet',
+      payoutAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaac',
     });
 
     expect(result.success).toBe(true);
@@ -120,7 +120,7 @@ describe('Task 9.1: CreatorPayoutService', () => {
     const result = service.requestPayout({
       accountId: 'alice',
       amountMicro: 500_000, // $0.50
-      payoutAddress: '0xAlice',
+      payoutAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     });
 
     expect(result.success).toBe(false);
@@ -134,7 +134,7 @@ describe('Task 9.1: CreatorPayoutService', () => {
     const result = service.requestPayout({
       accountId: 'alice',
       amountMicro: 5_000_000, // $5
-      payoutAddress: '0xAlice',
+      payoutAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     });
 
     expect(result.success).toBe(false);
@@ -149,14 +149,14 @@ describe('Task 9.1: CreatorPayoutService', () => {
     const result1 = service.requestPayout({
       accountId: 'alice',
       amountMicro: 5_000_000,
-      payoutAddress: '0xAlice',
+      payoutAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     });
     expect(result1.success).toBe(true);
 
     const result2 = service.requestPayout({
       accountId: 'alice',
       amountMicro: 5_000_000,
-      payoutAddress: '0xAlice',
+      payoutAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     });
     expect(result2.success).toBe(false);
     expect(result2.error).toContain('Rate limit');
@@ -170,7 +170,7 @@ describe('Task 9.1: CreatorPayoutService', () => {
       const result = service.requestPayout({
         accountId: 'alice',
         amountMicro: 50_000_000, // $50
-        payoutAddress: '0xAlice',
+        payoutAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       });
 
       expect(result.success).toBe(true);
@@ -183,7 +183,7 @@ describe('Task 9.1: CreatorPayoutService', () => {
       const result = service.requestPayout({
         accountId: 'alice',
         amountMicro: 150_000_000, // $150 → total > $100
-        payoutAddress: '0xAlice',
+        payoutAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       });
 
       expect(result.success).toBe(false);
@@ -199,7 +199,7 @@ describe('Task 9.1: CreatorPayoutService', () => {
       const result = service.requestPayout({
         accountId: 'alice',
         amountMicro: 150_000_000,
-        payoutAddress: '0xAlice',
+        payoutAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       });
 
       expect(result.success).toBe(true);
@@ -214,7 +214,7 @@ describe('Task 9.1: CreatorPayoutService', () => {
       const result = service.requestPayout({
         accountId: 'alice',
         amountMicro: 700_000_000, // $700 → total > $600
-        payoutAddress: '0xAlice',
+        payoutAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       });
 
       expect(result.success).toBe(false);
@@ -230,7 +230,7 @@ describe('Task 9.1: CreatorPayoutService', () => {
       const result = service.requestPayout({
         accountId: 'alice',
         amountMicro: 1_000_000_000, // $1000
-        payoutAddress: '0xAlice',
+        payoutAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       });
 
       expect(result.success).toBe(true);
@@ -271,7 +271,7 @@ describe('Task 9.3: getWithdrawableBalance', () => {
     service.requestPayout({
       accountId: 'alice',
       amountMicro: 3_000_000,
-      payoutAddress: '0xAlice',
+      payoutAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     });
 
     const balance = service.getWithdrawableBalance('alice');
@@ -335,7 +335,7 @@ describe('e2e-payout-service', () => {
     const result = service.requestPayout({
       accountId: 'alice',
       amountMicro: 10_000_000, // $10
-      payoutAddress: '0xAliceWallet',
+      payoutAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaac',
       currency: 'usdc',
     });
     expect(result.success).toBe(true);
@@ -361,7 +361,7 @@ describe('e2e-payout-service', () => {
     const result1 = service.requestPayout({
       accountId: 'alice',
       amountMicro: 5_000_000,
-      payoutAddress: '0xAlice',
+      payoutAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     });
     expect(result1.success).toBe(true);
 
@@ -369,7 +369,7 @@ describe('e2e-payout-service', () => {
     const result2 = service.requestPayout({
       accountId: 'alice',
       amountMicro: 5_000_000,
-      payoutAddress: '0xAlice',
+      payoutAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     });
     expect(result2.success).toBe(false);
     expect(result2.error).toContain('Rate limit');
@@ -379,7 +379,7 @@ describe('e2e-payout-service', () => {
     const result3 = service.requestPayout({
       accountId: 'bob',
       amountMicro: 5_000_000,
-      payoutAddress: '0xBob',
+      payoutAddress: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
     });
     expect(result3.success).toBe(true);
   });

--- a/themes/sietch/tests/integration/billing-payout-reconciliation.test.ts
+++ b/themes/sietch/tests/integration/billing-payout-reconciliation.test.ts
@@ -159,7 +159,7 @@ describe('Task 10.1: Webhook handler', () => {
     const sm = new PayoutStateMachine(db);
 
     // Create and approve payout
-    const { payoutId } = sm.createRequest('alice', 10_000_000, 0, '0xAlice');
+    const { payoutId } = sm.createRequest('alice', 10_000_000, 0, '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
     sm.approve(payoutId);
     sm.markProcessing(payoutId, 'provider-payout-123');
 
@@ -182,7 +182,7 @@ describe('Task 10.1: Webhook handler', () => {
     createSettledEarnings(db, 'alice', 20_000_000);
     const sm = new PayoutStateMachine(db);
 
-    const { payoutId } = sm.createRequest('alice', 10_000_000, 0, '0xAlice');
+    const { payoutId } = sm.createRequest('alice', 10_000_000, 0, '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
     sm.approve(payoutId);
     sm.markProcessing(payoutId, 'provider-payout-456');
 
@@ -204,7 +204,7 @@ describe('Task 10.1: Webhook handler', () => {
     createSettledEarnings(db, 'alice', 20_000_000);
     const sm = new PayoutStateMachine(db);
 
-    const { payoutId } = sm.createRequest('alice', 10_000_000, 0, '0xAlice');
+    const { payoutId } = sm.createRequest('alice', 10_000_000, 0, '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
     sm.approve(payoutId);
     sm.markProcessing(payoutId, 'provider-payout-789');
 
@@ -238,7 +238,7 @@ describe('Task 10.2: Reconciliation cron', () => {
     createSettledEarnings(db, 'alice', 50_000_000);
     const sm = new PayoutStateMachine(db);
 
-    const { payoutId } = sm.createRequest('alice', 10_000_000, 0, '0xAlice');
+    const { payoutId } = sm.createRequest('alice', 10_000_000, 0, '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
     sm.approve(payoutId);
     sm.markProcessing(payoutId, 'provider-stalled-1');
 
@@ -262,7 +262,7 @@ describe('Task 10.2: Reconciliation cron', () => {
     createSettledEarnings(db, 'alice', 50_000_000);
     const sm = new PayoutStateMachine(db);
 
-    const { payoutId } = sm.createRequest('alice', 10_000_000, 0, '0xAlice');
+    const { payoutId } = sm.createRequest('alice', 10_000_000, 0, '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
     sm.approve(payoutId);
 
     // Force to processing without provider ID
@@ -294,7 +294,7 @@ describe('Task 10.3: Payout cancellation', () => {
     createSettledEarnings(db, 'alice', 20_000_000);
     const sm = new PayoutStateMachine(db);
 
-    const { payoutId } = sm.createRequest('alice', 5_000_000, 0, '0xAlice');
+    const { payoutId } = sm.createRequest('alice', 5_000_000, 0, '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
     const result = sm.cancel(payoutId);
 
     expect(result.success).toBe(true);
@@ -306,7 +306,7 @@ describe('Task 10.3: Payout cancellation', () => {
     const sm = new PayoutStateMachine(db);
     const service = new CreatorPayoutService(db);
 
-    const { payoutId } = sm.createRequest('alice', 5_000_000, 0, '0xAlice');
+    const { payoutId } = sm.createRequest('alice', 5_000_000, 0, '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
     sm.approve(payoutId);
 
     // Escrow should exist
@@ -325,7 +325,7 @@ describe('Task 10.3: Payout cancellation', () => {
     createSettledEarnings(db, 'alice', 20_000_000);
     const sm = new PayoutStateMachine(db);
 
-    const { payoutId } = sm.createRequest('alice', 5_000_000, 0, '0xAlice');
+    const { payoutId } = sm.createRequest('alice', 5_000_000, 0, '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
     sm.approve(payoutId);
     sm.markProcessing(payoutId, 'provider-123');
 
@@ -338,7 +338,7 @@ describe('Task 10.3: Payout cancellation', () => {
     createSettledEarnings(db, 'alice', 20_000_000);
     const sm = new PayoutStateMachine(db);
 
-    const { payoutId } = sm.createRequest('alice', 5_000_000, 0, '0xAlice');
+    const { payoutId } = sm.createRequest('alice', 5_000_000, 0, '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
     sm.approve(payoutId);
     sm.markProcessing(payoutId, 'provider-123');
     sm.complete(payoutId);
@@ -405,7 +405,7 @@ describe('Task 10.4: Idempotency matrix', () => {
     createSettledEarnings(db, 'alice', 20_000_000);
     const sm = new PayoutStateMachine(db);
 
-    const { payoutId } = sm.createRequest('alice', 5_000_000, 0, '0xAlice');
+    const { payoutId } = sm.createRequest('alice', 5_000_000, 0, '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
 
     // First approve creates escrow
     const result1 = sm.approve(payoutId);
@@ -427,7 +427,7 @@ describe('Task 10.4: Idempotency matrix', () => {
     createSettledEarnings(db, 'alice', 20_000_000);
     const sm = new PayoutStateMachine(db);
 
-    const { payoutId } = sm.createRequest('alice', 5_000_000, 0, '0xAlice');
+    const { payoutId } = sm.createRequest('alice', 5_000_000, 0, '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
     sm.approve(payoutId);
     sm.markProcessing(payoutId, 'provider-123');
 
@@ -468,7 +468,7 @@ describe('Task 10.4: Idempotency matrix', () => {
     const result1 = service.requestPayout({
       accountId: 'alice',
       amountMicro: 5_000_000,
-      payoutAddress: '0xAlice',
+      payoutAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     });
     expect(result1.success).toBe(true);
 
@@ -492,7 +492,7 @@ describe('Task 10.5: E2E payout lifecycle', () => {
     const result = service.requestPayout({
       accountId: 'alice',
       amountMicro: 10_000_000,
-      payoutAddress: '0xAlice',
+      payoutAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       currency: 'usdc',
     });
     expect(result.success).toBe(true);
@@ -536,7 +536,7 @@ describe('Task 10.5: E2E payout lifecycle', () => {
     const result = service.requestPayout({
       accountId: 'alice',
       amountMicro: 10_000_000,
-      payoutAddress: '0xAlice',
+      payoutAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     });
     expect(result.success).toBe(true);
     const payoutId = result.payoutId!;
@@ -572,7 +572,7 @@ describe('Task 10.5: E2E payout lifecycle', () => {
     const result = service.requestPayout({
       accountId: 'alice',
       amountMicro: 10_000_000,
-      payoutAddress: '0xAlice',
+      payoutAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     });
     expect(result.success).toBe(true);
     const payoutId = result.payoutId!;


### PR DESCRIPTION
## 🧹 CI remediation — batch 1 (verified mechanical class)

Continuing the dig+fix sprint. **Batch 1 = the EIP-55 payout-address class** (same root cause as #290's billing-e2e).

- `billing-creator-payout` (11) + `billing-payout-reconciliation` (4) used non-hex placeholders (`'0xAlice'`, `'0xAliceWallet'`, `'0xBob'`) → `requestPayout` correctly rejects (`validateEIP55Checksum`) → `expected false to be true`. Replaced with valid 40-hex.
- Surfaced 1 pre-existing flaky test (`CODE${Date.now()}` referral-code collision in same-ms calls) → namespaced by accountId.

**Verified locally** (docker Redis + seeded env): both files green — **38/38** (was 15 failed). Code is correct; only test data/setup changed.

Full remediation roadmap (~96 failures / ~17 files / ~6 classes, confidence-ordered, domain-gated ones flagged) is in `grimoires/loa/context/2026-06-21-test-suite-remediation-plan.md` (local — that dir is gitignored). Relates `arrakis-yp7q`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)