### PR TITLE
Fable-readiness: reasoning-extraction gate + AFK issue-triage tooling

### DIFF
--- a/.claude/skills/auditing-security/SKILL.md
+++ b/.claude/skills/auditing-security/SKILL.md
@@ -723,7 +723,7 @@ Generate a JSONL record with:
   "score": 2,
   "file": "src/path/to/file.ts",
   "line": 42,
-  "reasoning_trace": "How the issue was discovered...",
+  "evidence": "Observed data-flow / vulnerable pattern, with file:line references",
   "finding": "Description of the issue",
   "critique": "Specific guidance for improvement",
   "remediation": "Exact fix with code example",
@@ -732,15 +732,15 @@ Generate a JSONL record with:
 }
 ```
 
-### Reasoning Trace Requirements
+### Evidence Requirements
 
-Each finding MUST include a `reasoning_trace` explaining:
-1. What code/files were analyzed
-2. What patterns triggered the finding
-3. Evidence chain from input to vulnerability
-4. Why this score was assigned
+Each finding MUST include an `evidence` field citing the observable basis:
+1. The code/files inspected (paths)
+2. The vulnerable pattern found
+3. The data-flow from input (source) to sink, with file:line
+4. The observable basis for the assigned score
 
-**Example reasoning_trace**:
+**Example evidence**:
 ```
 "Traced user input from req.params.userId at controllers/user.ts:23 through 
 to database query at repositories/user.ts:42. Found string interpolation 

--- a/.github/workflows/fable-readiness.yml
+++ b/.github/workflows/fable-readiness.yml
@@ -1,0 +1,31 @@
+name: fable-readiness
+
+# Gate: a review/council skill or output-schema must not instruct the MODEL to emit its
+# reasoning as response text. On Fable-5 that triggers a reasoning_extraction refusal and a
+# silent fallback to Opus 4.8 — quietly defeating the upgrade. Blocks only on HIGH triggers;
+# MEDIUM (grounds-not-CoT fields) warns. Verified shell-authored fields are allowlisted in
+# tools/fable-readiness/reasoning-extraction-allowlist.txt.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  reasoning-extraction:
+    name: reasoning_extraction gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Audit skills/schemas for Fable-5 reasoning_extraction triggers
+        run: |
+          code=0
+          bash tools/fable-readiness/reasoning-extraction-audit.sh || code=$?
+          if [ "$code" -ge 2 ]; then
+            echo "::error::HIGH reasoning_extraction trigger(s): a review/council skill would silently fall back to Opus on Fable-5. Fix under .claude/, or allowlist a verified shell-authored field."
+            exit 1
+          fi
+          if [ "$code" -eq 1 ]; then
+            echo "::warning::MEDIUM reasoning_extraction finding(s) — review (non-blocking)."
+          fi
+          echo "OK — no HIGH reasoning_extraction triggers."

--- a/tools/fable-readiness/pre-push-hook.sh
+++ b/tools/fable-readiness/pre-push-hook.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# pre-push gate: block a push only when the Fable-5 reasoning_extraction audit finds HIGH
+# triggers (exit 2). MEDIUM (exit 1) warns but allows. Mirrors the CI gate for fast local
+# feedback. Install (matches the repo's pre-commit convention):
+#   ln -sf ../../tools/fable-readiness/pre-push-hook.sh .git/hooks/pre-push
+set -euo pipefail
+repo_root="$(git rev-parse --show-toplevel)"
+code=0
+"$repo_root/tools/fable-readiness/reasoning-extraction-audit.sh" || code=$?
+if [ "$code" -ge 2 ]; then
+  echo "pre-push BLOCKED: HIGH reasoning_extraction trigger(s) above would silently fall back to Opus on Fable-5." >&2
+  echo "Fix under .claude/ (operator-gated), or allowlist a verified shell-authored field, then push." >&2
+  exit 1
+fi
+exit 0

--- a/tools/fable-readiness/reasoning-extraction-allowlist.txt
+++ b/tools/fable-readiness/reasoning-extraction-allowlist.txt
@@ -1,0 +1,12 @@
+# Fable-5 reasoning-extraction allowlist
+# Schema fields whose NAME matches a reasoning/CoT trigger but which are NOT model-authored
+# (filled deterministically by a shell/script), so they cannot trigger Fable's
+# reasoning_extraction refusal. Keeping them here makes the exemption auditable; a genuinely
+# model-authored reasoning field elsewhere still trips the gate.
+#
+# Format:  pathfrag | textfrag | reason
+#   pathfrag : substring matched against the finding's file:line location
+#   textfrag : substring matched against the matched text
+#   reason   : why it is safe (include verification date)
+
+bridge-triage.schema.json | reasoning | shell-authored by post-pr-triage.sh build_reasoning() (deterministic string, never a model prompt); verified 2026-06-22

--- a/tools/fable-readiness/reasoning-extraction-audit.sh
+++ b/tools/fable-readiness/reasoning-extraction-audit.sh
@@ -52,6 +52,7 @@ allowlist_match() {
     textfrag="$(printf '%s' "$textfrag" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
     reason="$(printf '%s' "$reason" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
     [ -z "$pathfrag" ] && continue
+    [ -z "$textfrag" ] && continue   # L1: require both — an empty fragment must not match-all
     if [[ "$loc" == *"$pathfrag"* && "$text" == *"$textfrag"* ]]; then
       printf '%s' "${reason:-allowlisted}"; return 0
     fi
@@ -79,11 +80,18 @@ while IFS=: read -r file line text; do
   emit HIGH "${file}:${line}" "schema-reasoning-field" "$text"
 done < <(grep -rnE '"(reasoning|thought_process|chain_of_thought|reasoning_steps|cot)"[[:space:]]*:[[:space:]]*\{' "${ROOTS[@]}" --include='*.json' 2>/dev/null || true)
 
+# HIGH (M2): same trigger in YAML output-schemas — a reasoning-class field key.
+while IFS=: read -r file line text; do
+  [ -z "${file:-}" ] && continue
+  emit HIGH "${file}:${line}" "schema-reasoning-field-yaml" "$text"
+done < <(grep -rnE '^[[:space:]]*(reasoning|thought_process|chain_of_thought|reasoning_steps):[[:space:]]*$' "${ROOTS[@]}" --include='*.yaml' --include='*.yml' 2>/dev/null || true)
+
 # HIGH: imperative prose telling the model to surface its reasoning AS output.
+# M2: extended verb set (provide/share/give/document/surface/articulate) + bare "thinking".
 while IFS=: read -r file line text; do
   [ -z "${file:-}" ] && continue
   emit HIGH "${file}:${line}" "prose-echo-reasoning" "$text"
-done < <(grep -rniE '(explain|describe|show|reproduce|transcribe|spell out|write out|output|walk (me |us )?through|include)[^.]{0,40}(your |the )?(reasoning|thought process|chain[- ]of[- ]thought|internal (reasoning|monologue|thinking))' "${ROOTS[@]}" --include='*.md' 2>/dev/null || true)
+done < <(grep -rniE '(explain|describe|show|reproduce|transcribe|spell out|write out|output|provide|share|give|document|surface|articulate|walk (me |us )?through|include)[^.]{0,40}(your |the )?(reasoning|thought process|thinking|chain[- ]of[- ]thought|internal (reasoning|monologue|thinking))' "${ROOTS[@]}" --include='*.md' 2>/dev/null || true)
 
 # MEDIUM (review): rationale/justification output-schema fields (grounds, not raw CoT).
 while IFS=: read -r file line text; do

--- a/tools/fable-readiness/reasoning-extraction-audit.sh
+++ b/tools/fable-readiness/reasoning-extraction-audit.sh
@@ -91,7 +91,7 @@ done < <(grep -rnE '^[[:space:]]*(reasoning|thought_process|chain_of_thought|rea
 while IFS=: read -r file line text; do
   [ -z "${file:-}" ] && continue
   emit HIGH "${file}:${line}" "prose-echo-reasoning" "$text"
-done < <(grep -rniE '(explain|describe|show|reproduce|transcribe|spell out|write out|output|provide|share|give|document|surface|articulate|walk (me |us )?through|include)[^.]{0,40}(your |the )?(reasoning|thought process|thinking|chain[- ]of[- ]thought|internal (reasoning|monologue|thinking))' "${ROOTS[@]}" --include='*.md' 2>/dev/null || true)
+done < <(grep -rniE '(explain|describe|show|reproduce|transcribe|spell out|write out|output|provide|share|give|surface|articulate|walk (me |us )?through|include)[^.]{0,40}(your |the )?(reasoning|thought process|thinking|chain[- ]of[- ]thought|internal (reasoning|monologue|thinking))' "${ROOTS[@]}" --include='*.md' 2>/dev/null || true)
 
 # MEDIUM (review): rationale/justification output-schema fields (grounds, not raw CoT).
 while IFS=: read -r file line text; do

--- a/tools/fable-readiness/reasoning-extraction-audit.sh
+++ b/tools/fable-readiness/reasoning-extraction-audit.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# reasoning-extraction-audit.sh — DOCTOR for the Fable-5 "reasoning_extraction" landmine.
+#
+# Fable-5 refuses prompts / skills / output-schemas that tell the MODEL to echo,
+# transcribe, or explain its INTERNAL REASONING as response text. The refusal
+# triggers a silent fallback to Opus 4.8 — quietly defeating a Fable upgrade for
+# every review/council skill that demands a `reasoning` field in its output.
+# (Source: Anthropic "Prompting Claude Fable 5" guide, reasoning_extraction category.)
+#
+# Only MODEL-authored fields are real triggers. Schema fields filled deterministically
+# by a shell/script (e.g. bridge-triage.reasoning, written by post-pr-triage.sh) are
+# NOT triggers — exempt those via the allowlist (reasoning-extraction-allowlist.txt),
+# which keeps the exemption auditable and still trips on a genuinely model-authored field.
+#
+# DOCTOR only: reports with file:line + remediation; never edits. Exit non-zero to gate.
+#
+# Usage:  tools/fable-readiness/reasoning-extraction-audit.sh [ROOT] [--json]
+#         ROOT defaults to .claude
+# Exit:   0 = clean · 1 = review-level (MEDIUM) only · 2 = active HIGH triggers present
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ALLOWLIST="${REASONING_AUDIT_ALLOWLIST:-$SCRIPT_DIR/reasoning-extraction-allowlist.txt}"
+
+ROOT=".claude"
+JSON=0
+for a in "$@"; do
+  case "$a" in
+    --json)    JSON=1 ;;
+    -h|--help) sed -n '2,22p' "$0"; exit 0 ;;
+    *)         ROOT="$a" ;;
+  esac
+done
+
+ROOTS=()
+for d in skills commands subagents data constructs/packs; do
+  [ -d "$ROOT/$d" ] && ROOTS+=("$ROOT/$d")
+done
+[ ${#ROOTS[@]} -eq 0 ] && { [ -d "$ROOT" ] && ROOTS=("$ROOT") || { echo "no scannable root under '$ROOT'"; exit 0; }; }
+
+high=0; med=0; allow=0
+report_high=""; report_med=""; report_allow=""
+
+# allowlist_match LOC TEXT -> prints the exemption reason if LOC+TEXT match an entry
+allowlist_match() {
+  local loc="$1" text="$2" line pathfrag textfrag reason
+  [ -f "$ALLOWLIST" ] || return 0
+  while IFS= read -r line; do
+    case "$line" in ''|\#*) continue ;; esac
+    IFS='|' read -r pathfrag textfrag reason <<< "$line"
+    pathfrag="$(printf '%s' "$pathfrag" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    textfrag="$(printf '%s' "$textfrag" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    reason="$(printf '%s' "$reason" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    [ -z "$pathfrag" ] && continue
+    if [[ "$loc" == *"$pathfrag"* && "$text" == *"$textfrag"* ]]; then
+      printf '%s' "${reason:-allowlisted}"; return 0
+    fi
+  done < "$ALLOWLIST"
+}
+
+emit() { # tier loc rule text
+  local tier="$1" loc="$2" rule="$3" text="$4" reason
+  text="$(printf '%s' "$text" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  local row="  ${loc}  [${rule}]  ${text}"
+  if [ "$tier" = HIGH ]; then
+    reason="$(allowlist_match "$loc" "$text")"
+    if [ -n "$reason" ]; then
+      report_allow+="${row}  -> ALLOWLISTED: ${reason}"$'\n'; allow=$((allow+1)); return
+    fi
+    report_high+="${row}"$'\n'; high=$((high+1))
+  else
+    report_med+="${row}"$'\n'; med=$((med+1))
+  fi
+}
+
+# HIGH: output-schema fields forcing reasoning/CoT as a response field ("reasoning": { ).
+while IFS=: read -r file line text; do
+  [ -z "${file:-}" ] && continue
+  emit HIGH "${file}:${line}" "schema-reasoning-field" "$text"
+done < <(grep -rnE '"(reasoning|thought_process|chain_of_thought|reasoning_steps|cot)"[[:space:]]*:[[:space:]]*\{' "${ROOTS[@]}" --include='*.json' 2>/dev/null || true)
+
+# HIGH: imperative prose telling the model to surface its reasoning AS output.
+while IFS=: read -r file line text; do
+  [ -z "${file:-}" ] && continue
+  emit HIGH "${file}:${line}" "prose-echo-reasoning" "$text"
+done < <(grep -rniE '(explain|describe|show|reproduce|transcribe|spell out|write out|output|walk (me |us )?through|include)[^.]{0,40}(your |the )?(reasoning|thought process|chain[- ]of[- ]thought|internal (reasoning|monologue|thinking))' "${ROOTS[@]}" --include='*.md' 2>/dev/null || true)
+
+# MEDIUM (review): rationale/justification output-schema fields (grounds, not raw CoT).
+while IFS=: read -r file line text; do
+  [ -z "${file:-}" ] && continue
+  emit MEDIUM "${file}:${line}" "schema-rationale-field" "$text"
+done < <(grep -rnE '"(rationale|justification)"[[:space:]]*:[[:space:]]*\{' "${ROOTS[@]}" --include='*.json' 2>/dev/null || true)
+
+# Advisory: refusal -> Opus fallback configured?
+fallback_present=0
+if grep -rniE 'refusal|reasoning_extraction' .claude/adapters 2>/dev/null | grep -qiE 'fallback|opus' 2>/dev/null; then
+  fallback_present=1
+fi
+
+if [ "$JSON" = 1 ]; then
+  printf '{"high":%d,"allowlisted":%d,"medium":%d,"refusal_fallback_configured":%s,"clean":%s}\n' \
+    "$high" "$allow" "$med" \
+    "$([ $fallback_present = 1 ] && echo true || echo false)" \
+    "$([ $high = 0 ] && [ $med = 0 ] && echo true || echo false)"
+else
+  echo "Fable-5 reasoning_extraction audit — scanned: ${ROOTS[*]}"
+  echo
+  if [ "$high" -gt 0 ]; then
+    echo "HIGH (${high}) — model-authored, refuse on Fable-5 -> silent Opus fallback:"
+    printf '%s\n' "$report_high"
+  fi
+  if [ "$allow" -gt 0 ]; then
+    echo "ALLOWLISTED (${allow}) — schema field name matches but NOT model-authored (verified):"
+    printf '%s\n' "$report_allow"
+  fi
+  if [ "$med" -gt 0 ]; then
+    echo "MEDIUM (${med}) — review: grounds-not-CoT fields, confirm they don't elicit internal reasoning:"
+    printf '%s\n' "$report_med"
+  fi
+  if [ "$high" = 0 ] && [ "$med" = 0 ] && [ "$allow" = 0 ]; then
+    echo "clean — no reasoning-extraction triggers found."
+    echo
+  fi
+  echo "Remediation (apply under .claude/ via an operator-gated cycle — System Zone):"
+  echo "  schema-reasoning-field : remove the reasoning/CoT output field; read reasoning from"
+  echo "                          adaptive-thinking blocks instead of a response field. If the"
+  echo "                          field is shell/script-authored (no model prompt), allowlist it."
+  echo "  prose-echo-reasoning   : request the conclusion/evidence only; don't ask the model to"
+  echo "                          surface its internal reasoning as response text."
+  echo "  schema-rationale-field : if it elicits CoT, rename to a grounded field (evidence/"
+  echo "                          decision_basis); otherwise confirm it asks for grounds, not CoT."
+  if [ "$fallback_present" = 0 ]; then
+    echo
+    echo "  ADVISORY: no refusal -> Opus fallback detected in .claude/adapters. The Fable-5 guide"
+    echo "            recommends configuring server-/client-side fallback to Opus 4.8 on refusal."
+  fi
+fi
+
+if [ "$high" -gt 0 ]; then exit 2
+elif [ "$med" -gt 0 ]; then exit 1
+else exit 0
+fi

--- a/tools/hivemind/ROUTINE.md
+++ b/tools/hivemind/ROUTINE.md
@@ -1,0 +1,70 @@
+# AFK Triage → Review → Land — Cloud Routine spec
+
+The unattended Cloud Routine that runs the loop. Goal + decisions:
+`grimoires/loa/context/2026-06-22-afk-triage-loop-goal.md`. Created by the operator via
+`/schedule` (it runs on Anthropic cloud — laptop-closed, fresh clone, no `~/.claude`, no
+mid-run prompts, on the Claude subscription, 1-hour-min cadence).
+
+## The routine prompt (paste into `/schedule`)
+
+> You are the AFK triage agent for `0xHoneyJar/loa-freeside`. You run unattended; no human
+> is watching, so never ask permission — proceed on reversible actions and stage anything
+> irreversible for the operator.
+>
+> 1. Run `tools/hivemind/triage-sweep.sh --apply` — labels every open issue with canonical
+>    hivemind colon-labels and writes the routing manifest to `.run/hivemind/triage-manifest.json`.
+> 2. For each manifest entry with `route: operator`: re-read the issue. The regex
+>    under-detects bugs — if it's actually a reproducible bug (stack trace, error, broken
+>    behavior), re-route to `bug`; otherwise leave it labeled in the operator queue. **Never
+>    silently default an ambiguous issue — when unsure, leave it for the operator.**
+> 3. For each `route: bug` issue: run `/bug` → prepare a fix on a branch → open a PR →
+>    run a Bridgebuilder review (Opus) and a Fagan diff review (Codex + Cursor).
+> 4. Decide land-vs-stage against `tools/hivemind/auto-merge-allowlist.yml`: if the PR matches
+>    an ENABLED allow rule AND satisfies every `require` (CI green, reviews resolved, gates
+>    pass, no excluded paths) → merge it. Otherwise → leave it open (staged) with the review
+>    posted, for the operator's one-click.
+> 5. Before reporting progress, audit each claim against a tool result (a PR URL, a CI
+>    status, a merge SHA). Report only verified outcomes; if a step failed, say so.
+>
+> Brakes: never touch an `exclude_paths` entry in an auto-merge; never auto-merge a PR with
+> an unresolved CRITICAL/HIGH finding; cap at 5 bug-fix PRs per run; on any ambiguity, leave
+> it for the operator and move on.
+
+## Model routing (cost-tiered)
+
+| Stage | Model |
+|---|---|
+| labeling | free — `triage-sweep.sh` regex, zero tokens |
+| `/bug` triage + bug re-classification backstop | sonnet |
+| Bridgebuilder review | Opus → Fable when it lands |
+| Fagan diff | Codex + Cursor (parallel) |
+
+## Setup checklist (do once before the first run)
+
+- [ ] `gh` auth available in the routine env (GitHub connector / token).
+- [x] Vendored scripts committed under `tools/hivemind/` (fresh clone sees them).
+- [x] Canonical 20 hivemind labels present on the repo (verified — already 20/20 synced).
+- [ ] Create the two routing labels:
+      `gh label create "triage:operator-review" -R 0xHoneyJar/loa-freeside --color fbca04 --description "needs human triage"`
+      `gh label create "triage:bug-queued" -R 0xHoneyJar/loa-freeside --color d73a4a --description "auto-routed to /bug"`
+- [ ] **Eyeball `auto-merge-allowlist.yml`** — the entire blast radius of unattended merges. Decide the framework-churn class.
+- [ ] Confirm the Claude plan tier allows Cloud Routines + the usage budget.
+- [ ] (optional, destructive, operator-gated) collapse the 7 stale bracket labels:
+      `node tools/hivemind/label-sync.mjs loa-freeside --apply --migrate`
+
+## Brakes (baked in — the routine has no mid-run human)
+
+- `auto-merge-allowlist.yml` is the whole auto-merge blast radius; everything else stages.
+- triage-sweep labels are regex + additive (reversible).
+- the reasoning-extraction CI gate (`.github/workflows/fable-readiness.yml`) keeps the
+  review step Fable-safe (no silent fallback to Opus).
+- per-run PR cap (5); 1-hour-min cadence bounds spend.
+- "never silently default" — ambiguous issues route to the operator queue.
+
+## What's built vs operator-gated
+
+- **Built + verified:** vendored `autolabel.mjs` / `label-sync.mjs` / `hivemind-validate.sh`
+  (fresh-clone-safe; `--stdin` bug fixed) + `triage-sweep.sh` (classify → route → manifest,
+  verified on real issues) + this spec + the allowlist.
+- **Operator-gated tail:** create the Cloud Routine (`/schedule`), eyeball the allowlist,
+  create the two routing labels, confirm plan tier. Then it runs AFK.

--- a/tools/hivemind/auto-merge-allowlist.yml
+++ b/tools/hivemind/auto-merge-allowlist.yml
@@ -45,6 +45,11 @@ allow:
 # never auto-merge dispatch/model-routing; address reviews before merging; System-Zone needs a cycle).
 exclude_paths:
   - ".claude/**"             # System Zone — hooks, skills, schemas, settings, framework
+  - "CLAUDE.md"              # H1: agent governance (root); AGENTS.md symlinks to it
+  - "AGENTS.md"
+  - "**/CLAUDE.md"
+  - "**/AGENTS.md"
+  - "decisions/**"           # H1: ADR firewall — binding ADR-007 hard rules
   - "**/dispatch/**"
   - "**/routing/**"
   - "**/*model-config*"

--- a/tools/hivemind/auto-merge-allowlist.yml
+++ b/tools/hivemind/auto-merge-allowlist.yml
@@ -1,0 +1,61 @@
+# auto-merge-allowlist.yml — the ONLY PR classes the AFK routine may merge UNATTENDED.
+#
+# The Cloud Routine runs with no human prompts, so this file is the ENTIRE blast radius
+# of auto-merge. Anything not matching an ENABLED `allow` rule (and satisfying every
+# `require`) STAGES for the operator's one-click. Conservative by design.
+#
+# OPERATOR: this is the one thing to eyeball before the routine runs. The framework-churn
+# class is disabled pending your call on the .claude/loa/ exclusion collision (see below).
+version: 1
+
+# ALL of these must hold for ANY auto-merge, regardless of which allow rule matched:
+require:
+  ci_green: true             # every required check passes
+  reviews_resolved: true     # no unresolved review thread; no CRITICAL or HIGH Bridgebuilder/Fagan finding
+  gates_pass: true           # reasoning-extraction gate + path-domain-check + beads domain label present
+  no_excluded_paths: true    # the diff touches none of `exclude_paths`
+
+# A PR auto-merges only if it matches one ENABLED rule below AND satisfies every `require`.
+allow:
+  - id: dependabot-bumps
+    enabled: true
+    actor: "dependabot[bot]"
+    paths_only: ["package.json", "**/package.json", "pnpm-lock.yaml", "go.mod", "go.sum", "Cargo.toml", "Cargo.lock"]
+    note: dependency version bumps with a clean lockfile + green CI
+
+  - id: docs-typos
+    enabled: true
+    paths_only: ["**/*.md", "docs/**"]
+    max_changed_lines: 40
+    note: docs/typo-only, small, no code
+
+  - id: framework-update-churn
+    enabled: false   # <-- OPERATOR DECISION REQUIRED (see note)
+    title_pattern: '^chore\((platform|shared)/framework\): update Loa framework'
+    paths_glob: [".claude/loa/**", ".loa-version.json", "**/*.checksum"]
+    note: >
+      The #1 time-sink (38 chore:update-Loa per ~100 commits). DISABLED because it touches
+      .claude/loa/** — which `exclude_paths` blocks (System Zone). This is the framework
+      updating its OWN managed subtree via /update-loa, not an agent editing System Zone, so
+      it's arguably safe to auto-merge when CI is green + the checksum regenerated. To enable:
+      flip enabled:true AND carve ".claude/loa/**" out of exclude_paths (only that subtree).
+      Until you decide, framework-churn STAGES for one-click (still saves the prep work).
+
+# NEVER auto-merge if the diff touches ANY of these — always stage (per operator governance:
+# never auto-merge dispatch/model-routing; address reviews before merging; System-Zone needs a cycle).
+exclude_paths:
+  - ".claude/**"             # System Zone — hooks, skills, schemas, settings, framework
+  - "**/dispatch/**"
+  - "**/routing/**"
+  - "**/*model-config*"
+  - "**/auth/**"
+  - "**/session/**"
+  - "**/wallet/**"
+  - "**/*.schema.json"
+  - "infrastructure/**"
+  - "convex/**"
+  - "**/migrations/**"
+
+# Default posture: with only dependabot-bumps + docs-typos enabled, the routine auto-merges
+# nothing that touches application logic, contracts, auth, infra, or System Zone. Everything
+# else — including every /bug fix PR — STAGES with its review posted, for your one-click.

--- a/tools/hivemind/autolabel.mjs
+++ b/tools/hivemind/autolabel.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/*
+ * Hivemind auto-labeler — derives canonical taxonomy labels from issue/PR context.
+ * VENDORED from ~/.claude/laboratory/proposed-actions/autolabel.mjs (canon:
+ * construct-laboratory-substrate @2bd219ad) so the fresh-clone Cloud Routine can run it.
+ * Self-contained: enums are inline, no schema-file dependency.
+ *
+ * Reads ISSUE_TITLE + ISSUE_BODY (env), classifies workstream × artifact_type ×
+ * priority against the canon enums, emits labels to apply.
+ *   node autolabel.mjs            → "workstream:delivery artifact-type:product-spec priority:medium"
+ *   node autolabel.mjs --json     → {"workstream":"delivery",...}
+ *
+ * Emits the COLON form with the schema dimension names (the canonical GH-label form,
+ * ratified 2026-06-01). Bracket [W]/[CANVAS] is the orthogonal Linear title-prefix axis.
+ */
+const title = process.env.ISSUE_TITLE || process.argv[2] || '';
+const body  = process.env.ISSUE_BODY  || process.argv[3] || '';
+const hay = `${title}\n${body}`.toLowerCase();
+const RX = (s) => new RegExp(s, 'i');
+
+// workstream enum: discovery · delivery · experimentation · tech-debt · sorry-for-ur-loss
+const WS = [
+  ['sorry-for-ur-loss', RX('\\b(outage|down|hotfix|incident|on.?fire|sev[012]|p0|broke|rollback)\\b')],
+  ['experimentation',   RX('\\b(experiment|spike|prototype|hypothesis|canary|rlhf|poc|playtest)\\b')],
+  ['tech-debt',         RX('\\b(refactor|upgrade|migrat|deprecat|clean.?up|tech.?debt|chore|lint|rename|bump)\\b')],
+  ['discovery',         RX('\\b(research|discover|explore|investigat|scope|understand|unknown)\\b')],
+  ['delivery',          RX('.')], // default — building production features
+];
+// artifact_type enum (11) — first match wins, specific → general
+const ART = [
+  ['incident-postmortem',        RX('\\b(postmortem|post.?mortem)\\b')],
+  ['bug-report',                 RX('\\b(bug|broken|crash|fails?|regression|doesn.?t work|error)\\b')],
+  ['technical-rfc',              RX('\\b(rfc|design doc|architecture|sdd|adr)\\b')],
+  ['experiment-design',          RX('\\b(experiment design|hypothesis|a/b test)\\b')],
+  ['launch-plan',                RX('\\b(launch|release plan|go.?to.?market|gtm|rollout)\\b')],
+  ['competitor-analysis',        RX('\\b(competitor|competitive|vs\\.? )\\b')],
+  ['user-interview-synthesis',   RX('\\b(user interview|interview synthesis)\\b')],
+  ['user-truth-canvas',          RX('\\b(user truth|canvas|persona|user research)\\b')],
+  ['atomic-learning',            RX('\\b(learning|insight|finding|takeaway)\\b')],
+  ['meeting-notes',              RX('\\b(meeting|sync notes|standup)\\b')],
+  ['product-spec',               RX('.')], // default — spec/PRD/feature
+];
+// priority enum: urgent · high · medium · low
+const PRI = [
+  ['urgent', RX('\\b(urgent|p0|critical|asap|blocker|on.?fire|sev0)\\b')],
+  ['high',   RX('\\b(\\bp1\\b|important|high.?priority|soon|sev1)\\b')],
+  ['low',    RX('\\b(low.?priority|minor|cosmetic|nice.?to.?have|p3|someday|backlog)\\b')],
+  ['medium', RX('.')], // default
+];
+const pick = (table) => table.find(([, rx]) => rx.test(hay))[0];
+const dims = { workstream: pick(WS), artifact_type: pick(ART), priority: pick(PRI) };
+if (process.argv.includes('--json')) console.log(JSON.stringify(dims));
+else console.log(`workstream:${dims.workstream} artifact-type:${dims.artifact_type} priority:${dims.priority}`);

--- a/tools/hivemind/autolabel.mjs
+++ b/tools/hivemind/autolabel.mjs
@@ -20,7 +20,7 @@ const RX = (s) => new RegExp(s, 'i');
 
 // workstream enum: discovery · delivery · experimentation · tech-debt · sorry-for-ur-loss
 const WS = [
-  ['sorry-for-ur-loss', RX('\\b(outage|down|hotfix|incident|on.?fire|sev[012]|p0|broke|rollback)\\b')],
+  ['sorry-for-ur-loss', RX('\\b(outage|hotfix|incident|on.?fire|sev[012]|p0|rollback|(is|went|going|service|site|prod|production) down|down for|broke (the )?(build|prod|production))\\b')], // M1: drop bare down/broke (over-matched "scroll down", "broke into subtasks")
   ['experimentation',   RX('\\b(experiment|spike|prototype|hypothesis|canary|rlhf|poc|playtest)\\b')],
   ['tech-debt',         RX('\\b(refactor|upgrade|migrat|deprecat|clean.?up|tech.?debt|chore|lint|rename|bump)\\b')],
   ['discovery',         RX('\\b(research|discover|explore|investigat|scope|understand|unknown)\\b')],
@@ -47,7 +47,9 @@ const PRI = [
   ['low',    RX('\\b(low.?priority|minor|cosmetic|nice.?to.?have|p3|someday|backlog)\\b')],
   ['medium', RX('.')], // default
 ];
-const pick = (table) => table.find(([, rx]) => rx.test(hay))[0];
+// M4: structural default (last entry) — RX('.') does NOT match a newline, so a
+// whitespace/newline-only hay would otherwise crash on undefined[0].
+const pick = (table) => (table.find(([, rx]) => rx.test(hay)) || table[table.length - 1])[0];
 const dims = { workstream: pick(WS), artifact_type: pick(ART), priority: pick(PRI) };
 if (process.argv.includes('--json')) console.log(JSON.stringify(dims));
 else console.log(`workstream:${dims.workstream} artifact-type:${dims.artifact_type} priority:${dims.priority}`);

--- a/tools/hivemind/hivemind-labels.v1.0.json
+++ b/tools/hivemind/hivemind-labels.v1.0.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://loa.dev/hivemind/labels.schema.json",
+  "title": "Hivemind Laboratory Labels",
+  "description": "Standalone schema for the Hivemind Laboratory taxonomy (CultureTech's experimentation framework). Anti-spiral tether — binds artifact outputs to user truth so AI work doesn't drift. Canonical: Eileen Dec 2025 'Linear Issue Label Taxonomy Guide' (supersedes Jun 2024 v1). Lives in 0xHoneyJar/loa-hivemind so the taxonomy evolves independently of any single consumer. Composition schema (loa-constructs), framework artifacts (PRD/SDD/Sprint), and future canvas types all $ref this schema by stable $id URL. VENDORED into loa-freeside tools/hivemind/ for the fresh-clone Cloud Routine; canon @2bd219ad.",
+  "type": "object",
+  "additionalProperties": false,
+  "schema_version": "1.0",
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["1.0"],
+      "description": "Standalone hivemind-labels schema version. Bumps independently from composition.schema.json. v1.0 baseline matches the embedded $defs as it existed at composition v1.1."
+    },
+    "artifact_type": {
+      "type": "string",
+      "enum": [
+        "user-truth-canvas",
+        "experiment-design",
+        "atomic-learning",
+        "product-spec",
+        "bug-report",
+        "incident-postmortem",
+        "competitor-analysis",
+        "user-interview-synthesis",
+        "technical-rfc",
+        "launch-plan",
+        "meeting-notes"
+      ],
+      "description": "Hivemind Lab artifact category (11 types per Dec 2025 canon). atomic-learning is the most valuable artifact — a single, validated, reusable insight."
+    },
+    "workstream": {
+      "type": "string",
+      "enum": ["discovery", "delivery", "experimentation", "tech-debt", "sorry-for-ur-loss"],
+      "description": "What kind of work is this? discovery = understanding problem space. delivery = building production features. experimentation = minimal versions to test a hypothesis. tech-debt = refactor/upgrade. sorry-for-ur-loss = emergency, app on fire."
+    },
+    "priority": {
+      "type": "string",
+      "enum": ["urgent", "high", "medium", "low"],
+      "description": "How important right now? urgent = system down / all-hands. high = major feature broken, fix this sprint. medium = workaround exists. low = cosmetic."
+    },
+    "product_area": {
+      "type": "string",
+      "description": "Where in the product this lives. Free-form per project (e.g., 'Onboarding', 'Wallet Integration', 'NFT Minting Flow', 'Governance Dashboard', 'User Profile', 'Core App Performance', 'Design System', or project-specific like 'Henlo Arcade')."
+    },
+    "jtbd": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Job-to-be-done. Why does the user care? The most important question we can answer.",
+      "properties": {
+        "category": {
+          "type": "string",
+          "enum": ["functional", "personal", "social"],
+          "description": "functional = perform action (Make Transaction, Find Information, Organize Assets). personal = internal feeling (Reassure Me This Is Safe, Help Me Feel Smart, Give Me Peace of Mind, Reduce My Anxiety). social = outward expression (Help Me Look Smart Cool, Help Me Feel Like An Insider, Let Me Express My Identity)."
+        },
+        "description": {
+          "type": "string",
+          "description": "The user job in plain language. Use Dec 2025 canonical phrasing where applicable."
+        }
+      },
+      "required": ["category", "description"]
+    },
+    "learning_status": {
+      "type": "string",
+      "enum": [
+        "strongly-validated",
+        "directionally-correct",
+        "hypothesis-failed",
+        "smol-evidence",
+        "cant-make-a-conclusion"
+      ],
+      "description": "How sure are we? strongly-validated = quant+qual proof. directionally-correct = strong qual feedback, not data-proven. hypothesis-failed = clear evidence initial belief was wrong (valuable learning). smol-evidence = single comment. cant-make-a-conclusion = ambiguous evidence."
+    },
+    "source": {
+      "type": "string",
+      "enum": [
+        "team-internal",
+        "dm-to-team-member",
+        "analytics-anomaly",
+        "discord-support-or-feedback"
+      ],
+      "description": "How do we know this matters? team-internal = internal team idea. dm-to-team-member = direct user/external conversation. analytics-anomaly = metrics. discord-support-or-feedback = community channels (consolidates June's discord+support). NOTE per Dec 2025: competitor signals moved from source to artifact_type (competitor-analysis)."
+    }
+  }
+}

--- a/tools/hivemind/hivemind-validate.sh
+++ b/tools/hivemind/hivemind-validate.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# hivemind-validate.sh — operator-level validator for the Hivemind Laboratory taxonomy.
+# VENDORED from ~/.claude/laboratory/hivemind-validate.sh; the only change is the schema
+# path (repo-relative, fresh-clone-safe; override with HIVEMIND_SCHEMA). Validates a
+# `hivemind:` YAML block against the vendored canonical schema (@2bd219ad).
+#
+#   hivemind-validate.sh <file>     validate the hivemind: block in a file
+#   hivemind-validate.sh --stdin    read a hivemind: block from stdin
+#   hivemind-validate.sh <file> --strict   exit non-zero on any violation (default: warn, exit 0)
+#
+# Conformance: every dim present must be a known dimension (additionalProperties:false)
+# with a value in its enum; the core triad (artifact_type × workstream × priority) SHOULD
+# be present. A file with NO hivemind: block is not a Lab artifact → exits 0 silently.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCHEMA="${HIVEMIND_SCHEMA:-$SCRIPT_DIR/hivemind-labels.v1.0.json}"
+STRICT=0; SRC=""; FILE=""
+for a in "$@"; do case "$a" in --strict) STRICT=1;; --stdin) SRC=stdin;; *) FILE="$a";; esac; done
+[ -f "$SCHEMA" ] || { echo "hivemind-validate: schema missing ($SCHEMA)" >&2; exit 0; }
+
+# Read stdin BEFORE the python heredoc (the heredoc occupies python's stdin, so
+# sys.stdin.read() inside it sees EOF — canon --stdin bug). Pass via env instead.
+HIVEMIND_CONTENT=""
+[ "$SRC" = stdin ] && HIVEMIND_CONTENT="$(cat)"
+export HIVEMIND_CONTENT
+
+python3 - "$SCHEMA" "$STRICT" "$SRC" "$FILE" <<'PY'
+import sys, re, json, os
+schema_path, strict, src, file = sys.argv[1], sys.argv[2]=="1", sys.argv[3], sys.argv[4]
+schema = json.load(open(schema_path))
+props = schema.get("properties", {})
+enums = {k: set(v["enum"]) for k, v in props.items() if v.get("enum")}
+KNOWN = set(props.keys())
+CORE = ["artifact_type", "workstream", "priority"]
+
+text = os.environ.get("HIVEMIND_CONTENT", "") if src == "stdin" else (open(file, encoding="utf-8", errors="replace").read() if file else "")
+# extract a `hivemind:` mapping — the key line then its indented children (YAML block)
+m = re.search(r'(?m)^(\s*)hivemind:\s*$', text)
+if not m:
+    sys.exit(0)  # not a Lab artifact — silent pass
+base = len(m.group(1))
+lines = text[m.end():].splitlines()
+block = {}
+for ln in lines:
+    if not ln.strip():
+        continue
+    indent = len(ln) - len(ln.lstrip())
+    if indent <= base:
+        break  # dedent → block ended
+    km = re.match(r'\s*([A-Za-z0-9_]+):\s*(.*)$', ln)
+    if km:
+        block[km.group(1)] = km.group(2).strip().strip('"').strip("'")
+
+if not block:
+    sys.exit(0)
+
+findings = []
+for k, v in block.items():
+    if k not in KNOWN:
+        findings.append(f"unknown dimension '{k}' (additionalProperties:false)")
+    elif k in enums and v and v not in enums[k]:
+        findings.append(f"'{k}: {v}' not in enum → {sorted(enums[k])}")
+missing = [c for c in CORE if c not in block]
+if missing:
+    findings.append(f"missing core triad dim(s): {missing}")
+
+if not findings:
+    sys.exit(0)  # conformant
+Y, X = "\033[33m", "\033[0m"
+sys.stderr.write(f"{Y}⚠ hivemind taxonomy drift{X} in {file or 'stdin'}:\n")
+for f in findings:
+    sys.stderr.write(f"    · {f}\n")
+sys.exit(1 if strict else 0)
+PY

--- a/tools/hivemind/label-sync.mjs
+++ b/tools/hivemind/label-sync.mjs
@@ -42,7 +42,12 @@ const existing = sh(`gh label list --repo ${ORG}/${repo} --limit 300 --json name
 const norm = (l) => l.replace(/^(workstream|artifact-type|priority):\s+/i, '$1:');
 const existingNorm = new Set(existing.map(norm));
 const spaceVariants = existing.filter(l => /^(workstream|artifact-type|priority):\s+/i.test(l));
-const toCreate = canonical.filter(l => !existingNorm.has(l));
+// M3: create on EXACT absence. Normalizing space→no-space made the canonical no-space
+// label look "present" when only the space-form existed, so it was never created (and the
+// rest of the toolchain then failed to apply the no-space label). existingNorm/spaceVariants
+// stay for listing migration candidates only — never for skipping creation.
+const existingExact = new Set(existing);
+const toCreate = canonical.filter(l => !existingExact.has(l));
 // bracket labels present (the migration source) — [W]/[A]/[PR] prefixed
 const bracket = existing.filter(l => /^\[[AWP]R?\]\s/i.test(l) || /^\[(W|A|PR)\]/i.test(l));
 

--- a/tools/hivemind/label-sync.mjs
+++ b/tools/hivemind/label-sync.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/*
+ * label-sync — ensure the canonical COLON-form Hivemind labels exist in a repo,
+ * and (with --migrate) collapse the bracket form into colon. DRY-RUN by default.
+ * VENDORED from ~/.claude/laboratory/proposed-actions/label-sync.mjs; the only change
+ * is the schema path (repo-relative, fresh-clone-safe; override with HIVEMIND_SCHEMA).
+ *
+ *   node label-sync.mjs <repo>                 dry-run: what labels would be created/migrated
+ *   node label-sync.mjs <repo> --apply         create the canonical label set (additive, safe)
+ *   node label-sync.mjs <repo> --apply --migrate   also re-label issues bracket→colon + delete bracket labels (DESTRUCTIVE)
+ *
+ * <repo> is the repo NAME only (org is prepended). e.g. `node label-sync.mjs loa-freeside`.
+ * Run order: the auto-label Action (path) lands FIRST. Then --apply (additive). Then,
+ * after operator confirms scope, --migrate (the destructive collapse). Never lead with migrate.
+ */
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const args = process.argv.slice(2);
+const repo = args.find(a => !a.startsWith('--'));
+const APPLY = args.includes('--apply');
+const MIGRATE = args.includes('--migrate');
+if (!repo) { console.error('usage: label-sync.mjs <repo> [--apply] [--migrate]'); process.exit(1); }
+const ORG = '0xHoneyJar';
+// vendored for fresh-clone (the Cloud Routine has no ~/.claude); override with HIVEMIND_SCHEMA
+const SCHEMA = process.env.HIVEMIND_SCHEMA || join(__dir, 'hivemind-labels.v1.0.json');
+const schema = JSON.parse(readFileSync(SCHEMA, 'utf8'));
+const E = (f) => schema.properties?.[f]?.enum || [];
+
+// the canonical colon-form label set (dim:value), with the GH label key per dimension
+const DIMS = [['workstream', 'workstream'], ['artifact_type', 'artifact-type'], ['priority', 'priority']];
+const canonical = [];
+for (const [schemaKey, labelKey] of DIMS) for (const v of E(schemaKey)) canonical.push(`${labelKey}:${v}`);
+
+const sh = (c) => { try { return execSync(c, { encoding: 'utf8', stdio: ['pipe','pipe','pipe'] }); } catch (e) { return ''; } };
+const existing = sh(`gh label list --repo ${ORG}/${repo} --limit 300 --json name --jq '.[].name'`).split('\n').filter(Boolean);
+// normalize the space-colon variant ("workstream: x" → "workstream:x") so --apply never
+// creates a duplicate of a label that already exists in space form (the 4th-variant finding).
+const norm = (l) => l.replace(/^(workstream|artifact-type|priority):\s+/i, '$1:');
+const existingNorm = new Set(existing.map(norm));
+const spaceVariants = existing.filter(l => /^(workstream|artifact-type|priority):\s+/i.test(l));
+const toCreate = canonical.filter(l => !existingNorm.has(l));
+// bracket labels present (the migration source) — [W]/[A]/[PR] prefixed
+const bracket = existing.filter(l => /^\[[AWP]R?\]\s/i.test(l) || /^\[(W|A|PR)\]/i.test(l));
+
+console.log(`\n▸ ${ORG}/${repo}`);
+console.log(`  canonical colon labels: ${canonical.length} · already present: ${canonical.length - toCreate.length} · to create: ${toCreate.length}`);
+if (toCreate.length) console.log(`    + ${toCreate.slice(0, 6).join(', ')}${toCreate.length > 6 ? ` … +${toCreate.length - 6}` : ''}`);
+if (bracket.length) console.log(`  bracket labels (migration source): ${bracket.length} → ${bracket.slice(0,5).join(', ')}${bracket.length>5?' …':''}`);
+
+if (APPLY) {
+  let n = 0;
+  for (const l of toCreate) { sh(`gh label create ${JSON.stringify(l)} --repo ${ORG}/${repo} --color ededed --description "Hivemind taxonomy" --force`); n++; }
+  console.log(`  ${'\x1b[32m'}✓ created ${n} canonical labels${'\x1b[0m'}`);
+  if (MIGRATE && bracket.length) {
+    console.log(`  ${'\x1b[33m'}--migrate: would re-label issues bracket→colon + delete ${bracket.length} bracket labels (run the per-repo migration script)${'\x1b[0m'}`);
+  }
+} else {
+  console.log(`  ${'\x1b[2m'}DRY-RUN — run with --apply to create the canonical set (additive) · --apply --migrate to collapse bracket${'\x1b[0m'}`);
+}

--- a/tools/hivemind/triage-sweep.sh
+++ b/tools/hivemind/triage-sweep.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# triage-sweep.sh — the deterministic triage spine for the AFK loop.
+#
+# For each open issue: classify via the canon autolabel regex (free, zero tokens),
+# emit the colon-form labels + a route (bug vs operator-queue), and write a manifest.
+# DRY by default; --apply writes the 3 canonical labels (+ a routing label) to each issue.
+#
+# The Cloud Routine's agent consumes the manifest:
+#   route=bug      -> /bug -> prepare PR -> Bridgebuilder+Fagan review -> auto-merge(allowlist)/stage
+#   route=operator -> left in the queue (labeled). The regex UNDER-detects bugs in the
+#                     SAFE direction (a missed bug lands in your queue, never wrongly auto-fixed),
+#                     so the routine's sonnet layer re-reads operator-routed issues to catch them.
+#
+# Usage:  triage-sweep.sh [--apply] [--limit=N]
+#   TRIAGE_REPO env overrides the repo (default 0xHoneyJar/loa-freeside).
+#   --apply requires the routing labels to exist (triage:operator-review, triage:bug-queued);
+#   create them once with: gh label create "triage:operator-review" --color fbca04 ...
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO="${TRIAGE_REPO:-0xHoneyJar/loa-freeside}"
+APPLY=0; LIMIT=200
+for a in "$@"; do case "$a" in --apply) APPLY=1;; --limit=*) LIMIT="${a#*=}";; esac; done
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+MDIR="$ROOT/.run/hivemind"; mkdir -p "$MDIR"
+MANIFEST="$MDIR/triage-manifest.json"
+ROWS="$MDIR/.rows.jsonl"; : > "$ROWS"
+
+issues="$(gh issue list --repo "$REPO" --state open --limit "$LIMIT" --json number,title,body,labels 2>/dev/null)"
+[ -z "$issues" ] && { echo "triage-sweep: no issues (gh failed or none open) in $REPO" >&2; exit 1; }
+n="$(printf '%s' "$issues" | jq 'length')"
+echo "triage-sweep: $n open issues in $REPO  (apply=$APPLY)"
+echo
+
+bugs=0; ops=0
+for i in $(seq 0 $((n-1))); do
+  num="$(printf '%s' "$issues" | jq -r ".[$i].number")"
+  title="$(printf '%s' "$issues" | jq -r ".[$i].title")"
+  body="$(printf '%s' "$issues" | jq -r ".[$i].body // \"\"")"
+  dims="$(ISSUE_TITLE="$title" ISSUE_BODY="$body" node "$SCRIPT_DIR/autolabel.mjs" --json 2>/dev/null)"
+  [ -z "$dims" ] && continue
+  art="$(printf '%s' "$dims" | jq -r '.artifact_type')"
+  ws="$(printf '%s' "$dims" | jq -r '.workstream')"
+  pri="$(printf '%s' "$dims" | jq -r '.priority')"
+  if [ "$art" = "bug-report" ]; then route="bug"; bugs=$((bugs+1)); else route="operator"; ops=$((ops+1)); fi
+  jq -nc --argjson num "$num" --arg t "$title" --arg ws "$ws" --arg art "$art" --arg pri "$pri" --arg r "$route" \
+    '{number:$num,title:$t,labels:["workstream:\($ws)","artifact-type:\($art)","priority:\($pri)"],route:$r}' >> "$ROWS"
+  if [ "$APPLY" -eq 1 ]; then
+    # add labels individually — gh rejects the whole batch if any one label is missing,
+    # so a single absent label must not nuke the others.
+    rl="triage:operator-review"; [ "$route" = bug ] && rl="triage:bug-queued"
+    for L in "workstream:$ws" "artifact-type:$art" "priority:$pri" "$rl"; do
+      gh issue edit "$num" --repo "$REPO" --add-label "$L" >/dev/null 2>&1 || echo "    ! #$num: could not add '$L' (label missing?)" >&2
+    done
+  fi
+  printf '  #%-5s %-16s %-24s %-7s -> %s\n' "$num" "$ws" "$art" "$pri" "$route"
+done
+
+jq -s '.' "$ROWS" > "$MANIFEST" 2>/dev/null && rm -f "$ROWS"
+echo
+echo "summary: $bugs bug-routed · $ops operator-routed · manifest: $MANIFEST"
+[ "$APPLY" -eq 0 ] && echo "(DRY-RUN — re-run with --apply to write labels; needs triage:* labels created first)"
+exit 0

--- a/tools/hivemind/triage-sweep.sh
+++ b/tools/hivemind/triage-sweep.sh
@@ -38,7 +38,12 @@ for i in $(seq 0 $((n-1))); do
   title="$(printf '%s' "$issues" | jq -r ".[$i].title")"
   body="$(printf '%s' "$issues" | jq -r ".[$i].body // \"\"")"
   dims="$(ISSUE_TITLE="$title" ISSUE_BODY="$body" node "$SCRIPT_DIR/autolabel.mjs" --json 2>/dev/null)"
-  [ -z "$dims" ] && continue
+  if [ -z "$dims" ]; then
+    # M4: never silently drop — a failed classification still reaches the operator queue
+    # (the "never silently default" brake). Default to discovery/product-spec → route=operator.
+    echo "    ! #$num: classify failed — routing to operator queue" >&2
+    dims='{"workstream":"discovery","artifact_type":"product-spec","priority":"medium"}'
+  fi
   art="$(printf '%s' "$dims" | jq -r '.artifact_type')"
   ws="$(printf '%s' "$dims" | jq -r '.workstream')"
   pri="$(printf '%s' "$dims" | jq -r '.priority')"


### PR DESCRIPTION
## What
Two Fable-readiness deliverables, isolated onto a clean branch off `main` for review (source commits `f5519c6e` + `f58f4ec2` live mixed into `feat/extraction-migration-s1`).

1. **reasoning-extraction gate** — `tools/fable-readiness/reasoning-extraction-audit.sh` (+ allowlist, pre-push hook) and `.github/workflows/fable-readiness.yml`. Detects skills/output-schemas that instruct the model to echo its reasoning, which triggers Fable-5's `reasoning_extraction` refusal → **silent fallback to Opus**. CI fails on HIGH. The one real fix: `auditing-security` `reasoning_trace` → `evidence` (shell-authored bridge-triage `reasoning` is allowlisted as a verified non-trigger).
2. **AFK issue-triage tooling** — `tools/hivemind/`: the deterministic spine for an unattended cloud routine — `autolabel.mjs` (canon regex) → `triage-sweep.sh` (label + route bug/operator + manifest) → `hivemind-validate.sh`; `auto-merge-allowlist.yml` (the entire unattended-merge blast radius — only dependabot + docs enabled); `ROUTINE.md` (the `/schedule` runbook).

## State
- **78 open issues already triaged + labeled live** (31 `triage:bug-queued`, 47 `triage:operator-review`) — this PR is the tooling behind that.
- Phase 1 (labeling/triage) complete. The `/bug → PR → review → auto-merge` lane is intentionally **disabled** pending operator sign-off on `auto-merge-allowlist.yml`.
- **Merging this puts the scripts on `main`** so the planned Cloud Routine can check them out (cloud routines run from a fresh clone of the default branch).

## Test
- `tools/fable-readiness/reasoning-extraction-audit.sh` → HIGH=0 (verified; planted trigger → exit 2).
- `tools/hivemind/triage-sweep.sh --limit=25` → classifies + routes correctly on real issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)