### PR TITLE
hivemind: reusable label-setup + deterministic autolabel prior-fixes

### DIFF
--- a/tools/hivemind/autolabel.mjs
+++ b/tools/hivemind/autolabel.mjs
@@ -15,12 +15,13 @@
  */
 const title = process.env.ISSUE_TITLE || process.argv[2] || '';
 const body  = process.env.ISSUE_BODY  || process.argv[3] || '';
-const hay = `${title}\n${body}`.toLowerCase();
+// strip markdown heading lines (e.g. "## Scope") — section labels, not work-type signal
+const hay = `${title}\n${body}`.replace(/^[ \t]*#{1,6}[ \t].*$/gm, '').toLowerCase();
 const RX = (s) => new RegExp(s, 'i');
 
 // workstream enum: discovery · delivery · experimentation · tech-debt · sorry-for-ur-loss
 const WS = [
-  ['sorry-for-ur-loss', RX('\\b(outage|hotfix|incident|on.?fire|sev[012]|p0|rollback|(is|went|going|service|site|prod|production) down|down for|broke (the )?(build|prod|production))\\b')], // M1: drop bare down/broke (over-matched "scroll down", "broke into subtasks")
+  ['sorry-for-ur-loss', RX('\\b(outage|hotfix|on.?fire|sev[012]|p0|active incident|(is|went|going|service|site|prod|production) down|down for|broke (the )?(build|prod|production))\\b')], // drop bare incident/rollback (fired on background mentions, eval 3/3 false); LLM layer catches real incidents
   ['experimentation',   RX('\\b(experiment|spike|prototype|hypothesis|canary|rlhf|poc|playtest)\\b')],
   ['tech-debt',         RX('\\b(refactor|upgrade|migrat|deprecat|clean.?up|tech.?debt|chore|lint|rename|bump)\\b')],
   ['discovery',         RX('\\b(research|discover|explore|investigat|scope|understand|unknown)\\b')],
@@ -29,7 +30,7 @@ const WS = [
 // artifact_type enum (11) — first match wins, specific → general
 const ART = [
   ['incident-postmortem',        RX('\\b(postmortem|post.?mortem)\\b')],
-  ['bug-report',                 RX('\\b(bug|broken|crash|fails?|regression|doesn.?t work|error)\\b')],
+  ['bug-report',                 RX('(stack ?trace|traceback|\\bexception\\b|\\bthrows?\\b|crashes? (on|when|at|after)|fails? to |does(n.?t| not) work|not working|\\b[45]\\d\\d\\b|reproduc)')], // require a failure SYMPTOM not a bare bug/error mention (eval: 8/8 false on design docs); LLM layer catches the rest
   ['technical-rfc',              RX('\\b(rfc|design doc|architecture|sdd|adr)\\b')],
   ['experiment-design',          RX('\\b(experiment design|hypothesis|a/b test)\\b')],
   ['launch-plan',                RX('\\b(launch|release plan|go.?to.?market|gtm|rollout)\\b')],

--- a/tools/hivemind/label-setup.sh
+++ b/tools/hivemind/label-setup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# label-setup.sh <org/repo> — create/recolor the canonical hivemind colon-labels in a repo.
+# Idempotent (gh label create --force upserts name+color). Reusable across repos (multi-repo).
+# Colors: priority = severity gradient; workstream/artifact/learning-status = distinguishable hues.
+set -uo pipefail
+REPO="${1:?usage: label-setup.sh <org/repo>}"
+# name|color (6-hex, no #)
+LABELS='
+workstream:delivery|1d76db
+workstream:discovery|5319e7
+workstream:experimentation|0e8a16
+workstream:tech-debt|5a5a5a
+workstream:sorry-for-ur-loss|b60205
+artifact-type:bug-report|d73a4a
+artifact-type:incident-postmortem|b60205
+artifact-type:technical-rfc|1d76db
+artifact-type:product-spec|0052cc
+artifact-type:experiment-design|8250df
+artifact-type:atomic-learning|0e8a16
+artifact-type:user-truth-canvas|fbca04
+artifact-type:user-interview-synthesis|fef2c0
+artifact-type:competitor-analysis|c5def5
+artifact-type:launch-plan|d4c5f9
+artifact-type:meeting-notes|cfd3d7
+priority:urgent|b60205
+priority:high|d93f0b
+priority:medium|fbca04
+priority:low|0e8a16
+learning-status:strongly-validated|0e8a16
+learning-status:directionally-correct|fbca04
+learning-status:hypothesis-failed|d93f0b
+learning-status:smol-evidence|e4e669
+learning-status:cant-make-a-conclusion|cfd3d7
+source:team-internal|5a5a5a
+source:dm-to-team-member|1d76db
+source:analytics-anomaly|5319e7
+source:discord-support-or-feedback|8250df
+triage:bug-queued|d73a4a
+triage:operator-review|fbca04
+'
+n=0
+while IFS='|' read -r name color; do
+  [ -z "$name" ] && continue
+  gh label create "$name" -R "$REPO" --color "$color" --description "hivemind taxonomy" --force >/dev/null 2>&1 && n=$((n+1)) || echo "  ! failed: $name" >&2
+done <<< "$LABELS"
+echo "$REPO: ensured $n canonical colored labels"


### PR DESCRIPTION
Reusable `label-setup.sh` (colored canonical labels, multi-repo seeding) + autolabel prior-fixes from the classification eval (strip `## Scope` headings; tighten bug-report to failure-symptoms — eval found 8/8 false on design docs; drop bare incident/rollback). The routine's LLM enrichment layer handles residual. Tooling-only; chronic-red required checks are unrelated (no app code). 🤖 Generated with [Claude Code](https://claude.com/claude-code)