### PR TITLE
fix(shadow-audit): correct sonar adapter query to the live belt-gateway schema (was 400ing)

### DIFF
--- a/packages/adapters/sonar/__tests__/sonar-client.test.ts
+++ b/packages/adapters/sonar/__tests__/sonar-client.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { SonarClient, type TransferPageFetcher } from '../sonar-client.js';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { SonarClient, defaultTransferPageFetcher, type TransferPageFetcher } from '../sonar-client.js';
 import { ReconstructionError, ZERO_ADDRESS, type TransferEvent } from '../types.js';
 
 const A = '0x' + 'a'.repeat(40);
@@ -67,5 +67,72 @@ describe('SonarClient.holderDiff', () => {
     });
     expect(diff.soldLapsed).toEqual([A]); // held at snapshot, burned by compare block
     expect(diff.newlyEligible).toEqual([]);
+  });
+});
+
+describe('defaultTransferPageFetcher — live belt-gateway wire-mapping (regression for the schema-assumption 400)', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  // The live Transfer row shape (verified 2026-06-23): id=`<txHash>_<logIndex>`,
+  // blockNumber as a STRING, `transactionHash` (not txHash), no logIndex/value.
+  const liveRow = (id: string, blockNumber: string, from: string, to: string, tokenId: string) => ({
+    id,
+    blockNumber,
+    transactionHash: id.slice(0, id.lastIndexOf('_')),
+    from,
+    to,
+    tokenId,
+  });
+
+  it('maps the LIVE shape → TransferEvent (derives logIndex from id, renames transactionHash, coerces string blockNumber) and queries only real fields', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        data: {
+          Transfer: [
+            liveRow('0xaaa_80', '4928204', '0x' + 'b'.repeat(40), A, '7241'),
+            liveRow('0xbbb_0', '12689978', ZERO_ADDRESS, A, '2839'),
+          ],
+        },
+      }),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const out = await defaultTransferPageFetcher({
+      endpoint: 'https://belt-gateway.test/v1/graphql',
+      collection: 'HoneyJar3',
+      lteBlock: 99_999_999,
+      limit: 1000,
+      offset: 0,
+      timeoutMs: 5000,
+    });
+
+    // the query must target the REAL live schema, not the phantom fields that 400'd
+    const sent = JSON.parse((fetchMock.mock.calls[0][1] as { body: string }).body);
+    expect(sent.query).toContain('$lte: numeric!');
+    expect(sent.query).toContain('transactionHash');
+    expect(sent.query).not.toMatch(/\blogIndex\b/);
+    expect(sent.query).not.toMatch(/\bvalue\b/);
+    expect(sent.query).not.toMatch(/\btxHash\b/);
+
+    expect(out).toEqual([
+      { blockNumber: 4928204, logIndex: 80, txHash: '0xaaa', from: '0x' + 'b'.repeat(40), to: A, tokenId: '7241' },
+      { blockNumber: 12689978, logIndex: 0, txHash: '0xbbb', from: ZERO_ADDRESS, to: A, tokenId: '2839' },
+    ]);
+  });
+
+  it('refuses loudly (throws) when a row id cannot yield a logIndex — schema drift must not silently mis-map', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          data: { Transfer: [{ id: 'no-suffix', blockNumber: '1', transactionHash: '0x1', from: A, to: B, tokenId: '1' }] },
+        }),
+      })),
+    );
+    await expect(
+      defaultTransferPageFetcher({ endpoint: 'x', collection: 'c', lteBlock: 1, limit: 1, offset: 0, timeoutMs: 5000 }),
+    ).rejects.toBeTruthy();
   });
 });

--- a/packages/adapters/sonar/__tests__/sonar-client.test.ts
+++ b/packages/adapters/sonar/__tests__/sonar-client.test.ts
@@ -135,4 +135,24 @@ describe('defaultTransferPageFetcher — live belt-gateway wire-mapping (regress
       defaultTransferPageFetcher({ endpoint: 'x', collection: 'c', lteBlock: 1, limit: 1, offset: 0, timeoutMs: 5000 }),
     ).rejects.toBeTruthy();
   });
+
+  // The Number() trap (FAGAN review): an id suffix that is a hex address parses to a
+  // huge integer that passes Number.isInteger — it MUST be refused, not silently
+  // mis-derived. crayons writes `${txHash}_crayons_factory_${address}` ids today.
+  it.each([
+    ['address suffix (crayons_factory)', '0xabc_crayons_factory_0x' + 'd'.repeat(40)],
+    ['empty suffix', '0xabc_'],
+    ['scientific suffix', '0xabc_1e3'],
+  ])('refuses an id with a non-decimal logIndex suffix: %s', async (_label, id) => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ data: { Transfer: [{ id, blockNumber: '1', transactionHash: '0xabc', from: A, to: B, tokenId: '1' }] } }),
+      })),
+    );
+    await expect(
+      defaultTransferPageFetcher({ endpoint: 'x', collection: 'c', lteBlock: 1, limit: 1, offset: 0, timeoutMs: 5000 }),
+    ).rejects.toBeTruthy();
+  });
 });

--- a/packages/adapters/sonar/sonar-client.ts
+++ b/packages/adapters/sonar/sonar-client.ts
@@ -78,14 +78,30 @@ const TransferRowSchema = z
     tokenId: z.union([z.string(), z.number()]),
   })
   .transform((r, ctx): TransferEvent => {
-    const blockNumber = Number(r.blockNumber);
-    if (!Number.isInteger(blockNumber) || blockNumber < 0) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: `belt-gateway: non-integer blockNumber '${r.blockNumber}'` });
+    // Validate the RAW decimal string before Number() — Number() silently parses
+    // hex (`0x…` addresses → a huge integer that passes Number.isInteger), empty
+    // (`''`→0), scientific (`1e3`), binary/octal, and whitespace. The live Transfer
+    // table already contains non-`_<decimal>` ids (e.g. crayons writes
+    // `${txHash}_crayons_factory_${address}`), so a lax guard would mis-derive a
+    // garbage logIndex instead of the advertised LOUD refusal.
+    const blockStr = String(r.blockNumber);
+    if (!/^\d+$/.test(blockStr)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: `belt-gateway: non-decimal blockNumber '${r.blockNumber}'` });
       return z.NEVER;
     }
-    const logIndex = Number(r.id.slice(r.id.lastIndexOf('_') + 1));
-    if (!Number.isInteger(logIndex) || logIndex < 0) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: `belt-gateway: cannot derive logIndex from Transfer id '${r.id}'` });
+    const blockNumber = Number(blockStr);
+    if (!Number.isSafeInteger(blockNumber)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: `belt-gateway: blockNumber out of safe-integer range '${r.blockNumber}'` });
+      return z.NEVER;
+    }
+    const logIndexStr = r.id.slice(r.id.lastIndexOf('_') + 1);
+    if (!/^\d+$/.test(logIndexStr)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: `belt-gateway: Transfer id '${r.id}' does not end in _<decimal logIndex> — cannot derive logIndex` });
+      return z.NEVER;
+    }
+    const logIndex = Number(logIndexStr);
+    if (!Number.isSafeInteger(logIndex)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: `belt-gateway: derived logIndex out of safe-integer range from id '${r.id}'` });
       return z.NEVER;
     }
     return {
@@ -146,7 +162,7 @@ export const defaultTransferPageFetcher: TransferPageFetcher = async ({
   }
   const envelope = z
     .object({
-      data: z.object({ Transfer: z.array(z.unknown()) }).optional(),
+      data: z.object({ Transfer: z.array(z.unknown()) }).nullish(),
       errors: z.array(z.unknown()).optional(),
     })
     .parse(body);

--- a/packages/adapters/sonar/sonar-client.ts
+++ b/packages/adapters/sonar/sonar-client.ts
@@ -53,24 +53,51 @@ export interface TransferPageArgs {
 export type TransferPageFetcher = (args: TransferPageArgs) => Promise<TransferEvent[]>;
 
 /**
- * Wire row → TransferEvent. The belt-gateway field names below match the
- * [OBSERVED] Transfer entity {blockNumber, collection, from, to, tokenId};
- * `logIndex`, `txHash` and `value` are [ASSUMPTION] pending live-schema
- * confirmation. Row validation makes a schema drift a LOUD failure (the audit
- * refuses) rather than a silent mis-map.
+ * Wire row → TransferEvent, VERIFIED against the live belt-gateway 2026-06-23
+ * (GraphQL introspection + sample rows). The served Transfer type is
+ * { id, blockNumber, chainId, collection, from, timestamp, to, tokenId,
+ *   transactionHash }. Three corrections vs the prior [ASSUMPTION] mapping
+ * (which 400'd against live — `field 'logIndex' not found in type 'Transfer'`):
+ *   - the tx hash is exposed as `transactionHash`, not `txHash`;
+ *   - there is NO `logIndex` column — it is recoverable from the row id, which
+ *     is `<transactionHash>_<logIndex>` (e.g. `0xabc…_80`);
+ *   - there is NO `value` column. ERC-721 needs none; ERC-1155 reconstruction
+ *     refuses loudly on missing value (fold1155), which is correct until sonar
+ *     exposes a per-transfer amount.
+ * Hasura also serializes the `numeric` blockNumber as a STRING. Row validation
+ * makes a schema drift a LOUD failure (the audit refuses) rather than a silent
+ * mis-map.
  */
-const TransferRowSchema = z.object({
-  blockNumber: z.number().int().nonnegative(),
-  logIndex: z.number().int().nonnegative(),
-  txHash: z.string().min(1),
-  from: z.string(),
-  to: z.string(),
-  tokenId: z.union([z.string(), z.number()]).transform(String),
-  value: z
-    .union([z.string(), z.number()])
-    .nullish()
-    .transform((v) => (v == null ? undefined : String(v))),
-});
+const TransferRowSchema = z
+  .object({
+    id: z.string().min(1),
+    blockNumber: z.union([z.string(), z.number()]),
+    transactionHash: z.string().min(1),
+    from: z.string(),
+    to: z.string(),
+    tokenId: z.union([z.string(), z.number()]),
+  })
+  .transform((r, ctx): TransferEvent => {
+    const blockNumber = Number(r.blockNumber);
+    if (!Number.isInteger(blockNumber) || blockNumber < 0) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: `belt-gateway: non-integer blockNumber '${r.blockNumber}'` });
+      return z.NEVER;
+    }
+    const logIndex = Number(r.id.slice(r.id.lastIndexOf('_') + 1));
+    if (!Number.isInteger(logIndex) || logIndex < 0) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: `belt-gateway: cannot derive logIndex from Transfer id '${r.id}'` });
+      return z.NEVER;
+    }
+    return {
+      blockNumber,
+      logIndex,
+      txHash: r.transactionHash,
+      from: r.from,
+      to: r.to,
+      tokenId: String(r.tokenId),
+      // value omitted — belt-gateway Transfer has no per-transfer amount (see header).
+    };
+  });
 
 export const defaultTransferPageFetcher: TransferPageFetcher = async ({
   endpoint,
@@ -80,20 +107,24 @@ export const defaultTransferPageFetcher: TransferPageFetcher = async ({
   offset,
   timeoutMs,
 }) => {
-  const query = `query Transfers($c: String!, $lte: Int!, $limit: Int!, $offset: Int!) {
+  // $lte is `numeric!` (NOT Int!) — blockNumber is a Hasura numeric column and a
+  // numeric `_lte` argument rejects an Int! variable. order_by uses `id` (stable,
+  // exists) rather than the absent `logIndex`; reconstructOwnership re-sorts by
+  // numeric (blockNumber, logIndex, tokenId) internally, so the wire order only
+  // needs to be deterministic for offset pagination.
+  const query = `query Transfers($c: String!, $lte: numeric!, $limit: Int!, $offset: Int!) {
   Transfer(
     where: { collection: { _eq: $c }, blockNumber: { _lte: $lte } }
-    order_by: { blockNumber: asc, logIndex: asc }
+    order_by: { blockNumber: asc, id: asc }
     limit: $limit
     offset: $offset
   ) {
+    id
     blockNumber
-    logIndex
-    txHash
+    transactionHash
     from
     to
     tokenId
-    value
   }
 }`;
   const controller = new AbortController();


### PR DESCRIPTION
## The Shadow-Audit MVP did not work against live sonar — it 400'd on the first page fetch

`packages/adapters/sonar/sonar-client.ts` `defaultTransferPageFetcher` queries the belt-gateway for fields the **live** `Transfer` type does not expose. I verified this on **2026-06-23** by GraphQL-introspecting `https://belt-gateway-production.up.railway.app/v1/graphql` and running live sample rows. The production query returns:

```
400: field 'logIndex' not found in type: 'Transfer'
```

So no real audit run could fetch a single page. It's **invisible in CI** because every test injects a *mock* `TransferPageFetcher` — only the default production fetcher touches the wire. The code even flagged it: `logIndex, txHash and value are [ASSUMPTION] pending live-schema confirmation` (`sonar-client.ts:58`). The verification was never run; doing it now, the assumptions fail.

### Live `Transfer` type (introspected)
`id, blockNumber, chainId, collection, from, timestamp, to, tokenId, transactionHash` — no `logIndex`, no `value`; `transactionHash` not `txHash`; `blockNumber` serialized as a **string**.

### Four corrections (each verified against the live endpoint)
| was | now | why |
|---|---|---|
| `$lte: Int!` | `$lte: numeric!` | `blockNumber` is a Hasura `numeric` column; a `numeric` `_lte` rejects an `Int!` variable (`variable 'lte' is declared as 'Int!', but used where 'numeric' is expected`) |
| select `txHash` | select `transactionHash` | real field name |
| select + `order_by` `logIndex` | derive `logIndex` from `id` | `id = "<transactionHash>_<logIndex>"` (e.g. `0xabc…_80`). `reconstructOwnership` re-sorts by numeric `(blockNumber, logIndex, tokenId)` **internally** (`reconstruct.ts:88-93`), so `order_by: {blockNumber, id}` (stable, exists) is sufficient for offset pagination |
| select `value` | drop it | belt-gateway has no per-transfer amount. ERC-721 needs none; ERC-1155 `fold1155` **already refuses loudly** on missing `value` — correct until sonar exposes a per-transfer amount |

Plus: coerce the string `blockNumber`.

### Proof
```
# broken (shipped):   field 'logIndex' not found in type: 'Transfer'   → 400
# corrected query:    3 rows ≤ block 18090868, logIndex derived 80/85/135   → ✓
```
Mapping verified: live-shape → `TransferEvent` (logIndex derived, `transactionHash`→`txHash`, string `blockNumber` coerced); schema drift (id without `_logIndex`) throws loudly.

### Tests
Adds `defaultTransferPageFetcher` wire-mapping regression (mock fetch + live-shaped rows) — asserts the mapping **and** that the query no longer references `logIndex`/`txHash`/`value` (the test that would have caught this). Existing tests unchanged (they inject mocks, bypassing the wire).

> CI runs the full vitest suite. I verified the corrected query against the live endpoint + the mapping logic + the loud-failure path directly (the pnpm worktree fought local `vitest` resolution); the regression test is in this PR for CI.

### Scope note
ERC-1155 collections will now correctly *refuse* (no `value` from sonar) rather than mis-reconstruct — acceptable for the dogfood-NFT (ERC-721) magnet. Full ERC-1155 support needs sonar to expose a per-transfer amount (separate enhancement).

Tracked: loa-freeside bead `arrakis-tup6`. Found by sonar-side contract verification (sonar = the upstream `Transfer` provider). **Review before merge** — this changes the production reconstruction input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
