### PR TITLE
feat(dune-meter): extract @freeside/dune-meter onto main (405 fix) — unblocks Corpus Engine MVP

### DIFF
--- a/packages/dune-meter/.gitignore
+++ b/packages/dune-meter/.gitignore
@@ -1,0 +1,3 @@
+# Local runtime state — the budget ledger + CostAtom JSONL the CLI writes.
+# These are per-environment mutable state, never committed.
+.run/

--- a/packages/dune-meter/README.md
+++ b/packages/dune-meter/README.md
@@ -1,0 +1,158 @@
+# @freeside/dune-meter
+
+> The EXP-002 scar, made into a guard.
+
+A cost-aware Dune adapter. Every on-chain Dune query goes **through** this, never
+around it: estimated, cost-capped, metered, and budget-checked — or it does not
+run. Zero-dependency core, Asson-graduatable CLI (`.mjs`, Node ESM, `node:test`).
+
+## Why this exists
+
+EXP-002 burned its datapoint budget on **two unbounded `evt_transfer` scans** that
+timed out — because **nothing estimated cost before executing.** dune-meter is the
+foundation the Score forensic-integrity vertical sits on: the metered pipe that
+makes on-chain provenance data cost-safe. Build the guard first.
+
+## The honest constraint
+
+Dune has **no native dry-run / EXPLAIN.** Billing is dynamic (compute time + data
+scanned) and is not previewable. So cost-awareness here is **DEFENSIVE, not
+predictive**:
+
+- `estimate` is a **probe-based heuristic** — labeled `heuristic: true`, **not** a
+  true cost preview, and it never executes the target:
+  - **SQL** → a cheap `COUNT(*)` / `LIMIT 1` probe on the SMALL engine to gauge
+    rows × cols (design-sanctioned).
+  - **query_id** → a **non-executing** read of the query's latest **cached** result
+    metadata (the results endpoint, zero rows fetched). A saved query is **never
+    executed just to estimate it** — that would reintroduce the exact EXP-002
+    failure (an unbounded scan run with nothing metering it). If the query has no
+    completed cached result, `estimate` errors (exit 2) and tells you to pass SQL
+    or `run` it once (cost-capped) first — it will not execute to fill the gap.
+- The **real teeth** are (1) Dune's per-query **Query Cost Cap** (a hard-abort that
+  kills a runaway scan at the source) and (2) the **budget-refuse** gate (this tool
+  refuses to launch a run whose estimate exceeds the remaining budget). Those two
+  paths are the EXP-002 fix and are the ones that are airtight + tested.
+
+Billing unit: **1 credit = 1,000 datapoints (rows × cols).** Free tier = 2,500
+credits (the default ceiling).
+
+## Commands
+
+```
+dune-meter estimate <sql|query_id>
+  → probe-based verdict, NEVER a full execution. SQL → cheap COUNT(*)/LIMIT-1 probe
+    on the small engine; query_id → non-executing read of the latest cached result
+    metadata (exit 2 if none cached — pass SQL or run it once first).
+    Computes estimated_datapoints (rows×cols) and estimated_credits
+    (ceil(datapoints/1000)), reads the budget ledger, prints:
+    { estimated_datapoints, estimated_credits, remaining_budget, verdict, heuristic, note }
+    verdict: OK | WARN (est > 25% of remaining) | REFUSE (est > remaining → exit 3)
+
+dune-meter run <sql|query_id> --cap <credits> [--force] [--engine small|medium|large]
+  → executes WITH a Dune cost-cap (small engine by default). Runs the pre-run
+    estimate first (non-executing for a query_id) and REFUSES (exit 3) if it
+    exceeds the remaining budget, unless --force. An un-estimatable target (e.g. a
+    never-run query_id with no cached metadata) needs --force to proceed on the
+    cost-cap alone (exit 2 otherwise) — it is never executed just to estimate.
+    Polls to completion, reads credits/datapoints consumed from the result
+    metadata, EMITS a CostAtom (hash-chained JSONL), and decrements the budget
+    ledger. Exit 4 if Dune aborts on the cap (or reported spend > --cap).
+
+dune-meter budget
+  → reads the ledger, prints { spent_credits, remaining_credits, ceiling,
+    atoms_count, chain_ok, recent_atoms: last 5 }.
+```
+
+### Exit codes
+
+| code | meaning |
+|------|---------|
+| `0`  | ok |
+| `2`  | caller error (bad args, missing `DUNE_API_KEY`, malformed target) |
+| `3`  | budget refuse (estimate exceeds remaining budget) |
+| `4`  | cap aborted (Dune cost-cap hard-abort, or reported spend over `--cap`) |
+
+### Environment
+
+| var | default | purpose |
+|-----|---------|---------|
+| `DUNE_API_KEY` | — | Dune Analytics API key (required for live calls) |
+| `DUNE_BUDGET_LEDGER` | `<pkg>/.run/dune-budget.json` | budget ledger path |
+| `DUNE_COST_ATOMS` | `<pkg>/.run/dune-cost-atoms.jsonl` | CostAtom ledger path |
+| `DUNE_BUDGET_CEILING` | `2500` | credit ceiling (free-tier default) |
+
+> **Set the account-level Query Cost Cap.** The `--cap` flag is the per-query
+> intent, and the API `performance` tier picks the engine — but the structural
+> hard-abort lives in the Dune dashboard's **Query Cost Cap** setting. Set it.
+> The 30-minute engine execution cap is a documented hard limit: queries are
+> expected to be **era-bound** (a block/time range), never an unbounded scan.
+> The unbounded scan is exactly the EXP-002 failure mode, closed by construction.
+
+## The CostAtom bridge
+
+dune-meter emits a `dune` call-class CostAtom per execution, **shape-compatible
+with loa-finn `src/cost/cost-atom.ts`** (same 3-ledger record —
+inference/infra/orchestration — integer units, canonical-JSON sha256, append-only
+JSONL). It is **shape-compatible, not wire-compatible**: the two ledgers are
+independently verifiable but NOT cross-validatable by finn's reader. Three honest
+deltas:
+
+1. **`dune` call class** — the finn original has `A_relay | B_enrich`; a dune atom
+   zeroes the model ledgers (no token spend) and books the credit cost on
+   dune-native fields (`query_id`, `datapoints_scanned`, `credits_consumed`,
+   `engine`) plus the orchestration gate record.
+2. **Numbers, not decimal-strings** — finn serializes its `*_micro` fields
+   (`cost_micro`/`total_micro`/`x402_quote_micro`) as **bigint → decimal STRINGS**;
+   dune-meter stores them as plain integer **numbers** (free-tier credit
+   magnitudes are safe integers, no bigint branch). The encodings differ.
+3. **A hash-chain over a wider envelope** — finn's envelope self-checksums the
+   **atom only**; dune-meter's envelope adds a `prev_hash` link and checksums over
+   `{schema_version, prev_hash, atom}`, so the ledger is a tamper-evident chain.
+   The genesis atom links to `GENESIS_PREV_HASH`. Consequence: finn's
+   `parseEnvelopeLine` would throw `checksum mismatch` on a dune envelope (and vice
+   versa) — the shapes match, the wire bytes do not.
+
+One meter, two sources: harness tokens (finn) + Dune credits (here) — readable by
+one readout that understands both encodings; not byte-cross-validated by either
+reader alone.
+
+## How it composes
+
+- **Cost meter** (loa-finn) — the CostAtom shape is shared; both ledgers can feed
+  one readout.
+- **Asson liveness watchdog** — the veve's `liveness.timeout_s` (300s) feeds finn's
+  sandbox CommandPolicy as the enrage timer; the watchdog governs runtime pace.
+- **GECKO `sense-runtime-fit`** — senses declared-vs-actual cost drift (the veve
+  declares the cost contract; GECKO senses when reality diverges).
+
+## Testing
+
+```
+npm test          # → node --test test/*.test.mjs  (run from packages/dune-meter/)
+```
+
+> The directory form `node --test packages/dune-meter/test/` is avoided: on the
+> Node 23 test-runner a trailing-slash path is treated as a single (failing) module
+> target. The `test/*.test.mjs` glob (what `npm test` wires) runs the whole suite.
+
+**No live Dune call ever runs in tests or build** — the whole point is cost-safety;
+don't spend credits to test the cost guard. The Dune client (and, for the probe
+tests, `fetch`) is mocked; tests run offline and deterministic. Coverage: estimate
+verdict thresholds (OK/WARN/REFUSE), the **non-executing** query_id probe (asserts
+no `/execute` call), budget-ledger atomic read/write, CostAtom hash-chain continuity
++ tamper detection, exit-code mapping (including `--force` past an un-estimatable
+target).
+
+## Asson ladder status (honest)
+
+This CLI claims **L2** in its veve (`ladder.level: 2`) — the level the
+[`asson.doctor`](../asson/src/asson.mjs) **earns** it from evidence (veve + 2
+evidence_runs + passing golden vectors + honest `attestable` determinism +
+liveness). It is **Asson-graduatable to L3**, not yet L3: L3 requires a
+**verifiable build attestation** (tree-hash + ed25519 signature whose key resolves
+in the asson keyring), produced by the CI key ceremony — a step that lives outside
+this package (`packages/asson/keyring/`). The doctor therefore still reports an
+`AS-1` "attestation absent" finding; that is the honest unattested state, not a
+misclassification. Claiming L3 before that ceremony would be exactly the
+declaration lie this construct exists to prevent (`claimed > earned` DRIFT).

--- a/packages/dune-meter/bin/dune-meter.mjs
+++ b/packages/dune-meter/bin/dune-meter.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+// dune-meter — cost-aware Dune adapter. The EXP-002 scar, made into a guard.
+//
+// Three subcommands, all cost-defensive:
+//   estimate <sql|query_id>            — the probe-based "dry-run" verdict (NEVER a full run;
+//                                        SQL → cheap COUNT/LIMIT-1; query_id → non-executing
+//                                        read of the latest cached result metadata)
+//   run <sql|query_id> --cap <credits> — execute WITH a Dune cost-cap, emit a CostAtom
+//   budget                             — show spent/remaining/ceiling + recent atoms
+//
+// Exit codes (also declared in veve.json):
+//   0  ok            2  caller error      3  budget refuse      4  cap aborted
+//
+// The estimate is an HONEST HEURISTIC — Dune has no native cost preview. The
+// real teeth are the per-query cost-cap (Dune hard-abort) + the budget-refuse
+// gate. NEVER does a full execution before the estimate clears the budget check
+// (unless --force). node stdlib only.
+
+import { argv, env, exit, stdout, stderr } from 'node:process';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createHash } from 'node:crypto';
+
+import { DuneClient, looksLikeQueryId, CostCapAbortError, DuneClientError, ENGINES } from '../src/dune-client.mjs';
+import { buildEstimate } from '../src/estimate.mjs';
+import {
+  readLedger, remaining, recordSpend,
+  DEFAULT_CEILING_CREDITS, DEFAULT_LEDGER_PATH,
+} from '../src/budget-ledger.mjs';
+import { makeDuneAtom, appendAtom, readAtoms, DEFAULT_ATOMS_PATH } from '../src/cost-atom.mjs';
+
+const PKG_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+const EXIT = { OK: 0, CALLER: 2, BUDGET_REFUSE: 3, CAP_ABORTED: 4 };
+
+// Command handlers are PURE w.r.t. process side effects: they return
+// { json?, text?, error?, exit }. main() does the actual stdout/stderr write +
+// process.exit. This keeps handlers fully testable in-process (no global stdout
+// monkeypatch, no real exit) — the node:test reporter's stdout stays untouched.
+function ok(json, code = EXIT.OK) { return { json, exit: code }; }
+function err(code, message) { return { error: message, exit: code }; }
+
+/** Resolve ledger/atoms paths: env override → package .run default (absolute). */
+function resolvePaths() {
+  return {
+    ledgerPath: env.DUNE_BUDGET_LEDGER
+      ? resolve(env.DUNE_BUDGET_LEDGER)
+      : join(PKG_ROOT, DEFAULT_LEDGER_PATH),
+    atomsPath: env.DUNE_COST_ATOMS
+      ? resolve(env.DUNE_COST_ATOMS)
+      : join(PKG_ROOT, DEFAULT_ATOMS_PATH),
+    ceiling: env.DUNE_BUDGET_CEILING ? Number.parseInt(env.DUNE_BUDGET_CEILING, 10) : DEFAULT_CEILING_CREDITS,
+  };
+}
+
+/** Minimal flag parser: --cap N, --force, --engine X, positional target. */
+function parseArgs(args) {
+  const flags = { force: false, engine: ENGINES.small, cap: null };
+  const positional = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--force') flags.force = true;
+    else if (a === '--cap') flags.cap = Number.parseInt(args[++i], 10);
+    else if (a === '--engine') flags.engine = args[++i];
+    else if (a.startsWith('--cap=')) flags.cap = Number.parseInt(a.slice(6), 10);
+    else if (a.startsWith('--engine=')) flags.engine = a.slice(9);
+    else positional.push(a);
+  }
+  return { flags, positional };
+}
+
+// ── estimate ─────────────────────────────────────────────────────────────────
+async function cmdEstimate(args, { client } = {}) {
+  const { positional } = parseArgs(args);
+  const target = positional[0];
+  if (!target) return err(EXIT.CALLER, 'estimate: missing <sql|query_id>');
+
+  const { ledgerPath, ceiling } = resolvePaths();
+  let ledger;
+  try { ledger = readLedger(ledgerPath, { ceiling }); }
+  catch (e) { return err(EXIT.CALLER, e.message); }
+  const rem = remaining(ledger);
+
+  const dune = client ?? new DuneClient();
+  let probe;
+  try {
+    probe = await dune.probe(target, { isQueryId: looksLikeQueryId(target) });
+  } catch (e) {
+    if (e instanceof DuneClientError) return err(EXIT.CALLER, e.message);
+    return err(EXIT.CALLER, `estimate probe failed: ${e.message}`);
+  }
+
+  const est = buildEstimate({ rows: probe.rows, cols: probe.cols, remainingCredits: rem });
+  return ok(est, est.verdict === 'REFUSE' ? EXIT.BUDGET_REFUSE : EXIT.OK);
+}
+
+// ── run ──────────────────────────────────────────────────────────────────────
+async function cmdRun(args, { client } = {}) {
+  const { flags, positional } = parseArgs(args);
+  const target = positional[0];
+  if (!target) return err(EXIT.CALLER, 'run: missing <sql|query_id>');
+  if (flags.cap === null || !Number.isInteger(flags.cap) || flags.cap <= 0) {
+    return err(EXIT.CALLER, 'run: --cap <credits> is required (a positive integer — the Dune cost-cap is mandatory)');
+  }
+
+  const { ledgerPath, atomsPath, ceiling } = resolvePaths();
+  let ledger;
+  try { ledger = readLedger(ledgerPath, { ceiling }); }
+  catch (e) { return err(EXIT.CALLER, e.message); }
+  const rem = remaining(ledger);
+
+  const dune = client ?? new DuneClient();
+  const isQueryId = looksLikeQueryId(target);
+
+  // 1) PRE-RUN estimate — refuse if it would overspend, unless --force. The probe
+  //    NEVER executes the target (SQL → cheap COUNT/LIMIT-1; query_id → a
+  //    non-executing read of cached result metadata). An un-estimatable target
+  //    (e.g. a never-run query_id with no cached metadata) needs --force to
+  //    proceed on the cost-cap alone — we never execute it just to estimate.
+  let est = null;
+  try {
+    const probe = await dune.probe(target, { isQueryId });
+    est = buildEstimate({ rows: probe.rows, cols: probe.cols, remainingCredits: rem });
+  } catch (e) {
+    if (e instanceof DuneClientError) {
+      if (!flags.force) {
+        return err(EXIT.CALLER, `${e.message} (or re-run with --force to proceed on the cost-cap alone)`);
+      }
+      // --force: proceed un-estimated; the per-query cost-cap is the backstop.
+    } else {
+      return err(EXIT.CALLER, `pre-run estimate failed: ${e.message}`);
+    }
+  }
+  if (est && est.verdict === 'REFUSE' && !flags.force) {
+    return ok({ refused: true, reason: 'estimate exceeds remaining budget', estimate: est }, EXIT.BUDGET_REFUSE);
+  }
+
+  // 2) EXECUTE with the cost-cap. The --cap is the per-query hard-abort; the
+  //    account-level Query Cost Cap is the structural backstop (see README).
+  const t0 = Date.now();
+  let executionId;
+  let metadata;
+  try {
+    const exec = isQueryId
+      ? await dune.executeQuery(target, { performance: flags.engine })
+      : await dune.executeSql(target, { performance: flags.engine });
+    executionId = exec.execution_id;
+    await dune.pollStatus(executionId);
+    metadata = await dune.resultMetadata(executionId);
+  } catch (e) {
+    if (e instanceof CostCapAbortError) {
+      return ok({ aborted: true, reason: 'Dune aborted execution on cost cap', execution_id: e.execution_id, cap: flags.cap }, EXIT.CAP_ABORTED);
+    }
+    if (e instanceof DuneClientError) return err(EXIT.CALLER, e.message);
+    return err(EXIT.CALLER, `execution failed: ${e.message}`);
+  }
+  const wallMs = Date.now() - t0;
+
+  // 3) Read consumed credits/datapoints; if Dune did not report credits, derive
+  //    from datapoints (1 credit = 1000 datapoints, rounded up) — the honest
+  //    fallback, flagged.
+  const datapoints = Number.isInteger(metadata.datapoints) ? metadata.datapoints : 0;
+  let credits = metadata.credits;
+  let credits_derived = false;
+  if (!Number.isInteger(credits)) {
+    credits = Math.ceil(datapoints / 1000);
+    credits_derived = true;
+  }
+
+  // Cap enforcement at our layer too (defense in depth): if reported spend
+  // exceeds the cap, treat as cap-aborted accounting.
+  const capExceeded = credits > flags.cap;
+
+  // 4) EMIT a CostAtom (hash-chained JSONL) + decrement the budget ledger.
+  const atom = makeDuneAtom({
+    query_id: isQueryId ? String(target) : `sql:${sqlHashShort(target)}`,
+    datapoints_scanned: datapoints,
+    credits_consumed: credits,
+    engine: flags.engine,
+    wall_ms: wallMs,
+  });
+  const envelope = appendAtom(atomsPath, atom);
+  const newLedger = recordSpend(ledgerPath, credits, { ceiling });
+
+  return ok({
+    executed: true,
+    execution_id: executionId,
+    engine: flags.engine,
+    cap: flags.cap,
+    cap_exceeded: capExceeded,
+    datapoints_scanned: datapoints,
+    credits_consumed: credits,
+    credits_derived,
+    wall_ms: wallMs,
+    pre_run_estimate: est,
+    atom_id: atom.atom_id,
+    atom_checksum: envelope.checksum,
+    budget: { spent_credits: newLedger.spent_credits, remaining_credits: remaining(newLedger), ceiling: newLedger.ceiling_credits },
+  }, capExceeded ? EXIT.CAP_ABORTED : EXIT.OK);
+}
+
+// ── budget ─────────────────────────────────────────────────────────────────
+function cmdBudget() {
+  const { ledgerPath, atomsPath, ceiling } = resolvePaths();
+  let ledger;
+  try { ledger = readLedger(ledgerPath, { ceiling }); }
+  catch (e) { return err(EXIT.CALLER, e.message); }
+  const { atoms, chain_ok, chain_break } = readAtoms(atomsPath);
+  const recent = atoms.slice(-5).map((a) => ({
+    atom_id: a.atom_id,
+    query_id: a.dune?.query_id ?? a.correlation_id,
+    credits_consumed: a.dune?.credits_consumed,
+    datapoints_scanned: a.dune?.datapoints_scanned,
+    engine: a.dune?.engine,
+    ts: a.ts,
+  }));
+  return ok({
+    spent_credits: ledger.spent_credits,
+    remaining_credits: remaining(ledger),
+    ceiling: ledger.ceiling_credits,
+    atoms_count: ledger.atoms_count,
+    chain_ok,
+    ...(chain_ok ? {} : { chain_break }),
+    recent_atoms: recent,
+  }, EXIT.OK);
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+function sqlHashShort(sql) {
+  return createHash('sha256').update(String(sql)).digest('hex').slice(0, 16);
+}
+
+const HELP = [
+  'dune-meter — cost-aware Dune adapter',
+  '',
+  '  dune-meter estimate <sql|query_id>            probe-based cost verdict (no full run)',
+  '  dune-meter run <sql|query_id> --cap <credits> execute with cost-cap, emit CostAtom',
+  '  dune-meter budget                             show spent/remaining/ceiling + recent',
+  '',
+  '  flags: --cap <n> (run, required)  --force (override budget-refuse)  --engine small|medium|large',
+  '  env:   DUNE_API_KEY  DUNE_BUDGET_LEDGER  DUNE_COST_ATOMS  DUNE_BUDGET_CEILING',
+  '  exit:  0 ok · 2 caller-error · 3 budget-refuse · 4 cap-aborted',
+  '',
+].join('\n');
+
+/** Dispatch a parsed command to its handler. Returns a result object. */
+async function dispatch(cmd, rest) {
+  switch (cmd) {
+    case 'estimate': return cmdEstimate(rest);
+    case 'run': return cmdRun(rest);
+    case 'budget': return cmdBudget();
+    case '--help': case '-h': return { text: HELP, exit: EXIT.OK };
+    case undefined: return { text: HELP, exit: EXIT.CALLER };
+    default: return err(EXIT.CALLER, `unknown command: ${cmd}`);
+  }
+}
+
+/** The process entrypoint: dispatch, then do the ONE write + exit. */
+async function main() {
+  const [cmd, ...rest] = argv.slice(2);
+  let result;
+  try {
+    result = await dispatch(cmd, rest);
+  } catch (e) {
+    result = err(EXIT.CALLER, e instanceof Error ? e.message : String(e));
+  }
+  if (result.error !== undefined) stderr.write(`dune-meter: ${result.error}\n`);
+  if (result.text !== undefined) stdout.write(result.text);
+  if (result.json !== undefined) stdout.write(JSON.stringify(result.json) + '\n');
+  exit(result.exit);
+}
+
+// Export the command handlers for in-process testing (no subprocess, no network).
+export { cmdEstimate, cmdRun, cmdBudget, dispatch, parseArgs };
+
+// Only run main() when invoked as a script, not when imported by tests.
+if (resolve(fileURLToPath(import.meta.url)) === resolve(argv[1] ?? '')) {
+  main();
+}

--- a/packages/dune-meter/package.json
+++ b/packages/dune-meter/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@freeside/dune-meter",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Cost-aware Dune adapter — estimate (probe heuristic) / run (cost-capped + CostAtom) / budget. The EXP-002 budget-blowout, made structurally impossible. Zero-dependency core; Asson-graduatable CLI.",
+  "bin": {
+    "dune-meter": "bin/dune-meter.mjs"
+  },
+  "exports": {
+    "./cost-atom": "./src/cost-atom.mjs",
+    "./budget-ledger": "./src/budget-ledger.mjs",
+    "./estimate": "./src/estimate.mjs",
+    "./dune-client": "./src/dune-client.mjs"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/packages/dune-meter/src/budget-ledger.mjs
+++ b/packages/dune-meter/src/budget-ledger.mjs
@@ -1,0 +1,86 @@
+// budget-ledger.mjs — the credit budget the cost-cap defends.
+//
+// {ceiling_credits, spent_credits, atoms_count, updated_at}. Integer credits.
+// Default ceiling 2500 (Dune free tier: 2,500 credits). Atomic write via
+// temp-file + rename so a crash mid-write never leaves a torn ledger — the rename
+// is the commit point (POSIX atomic on the same filesystem).
+//
+// node:fs only. The budget ledger is the SOFT guard (it informs estimate/run
+// verdicts); Dune's per-query Query Cost Cap is the HARD guard (it aborts a
+// runaway scan at the source). Both exist because EXP-002 had neither.
+
+import { writeFileSync, renameSync, readFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, basename, join } from 'node:path';
+
+/** Dune free-tier ceiling: 2,500 credits = 2,500,000 datapoints. */
+export const DEFAULT_CEILING_CREDITS = 2500;
+
+/** Default ledger path (the CLI passes an absolute path). */
+export const DEFAULT_LEDGER_PATH = '.run/dune-budget.json';
+
+/**
+ * Read the budget ledger. Returns a fresh ledger at the default ceiling if the
+ * file does not exist. Throws on a corrupt (unparseable) file — a corrupt budget
+ * ledger is a refuse-to-spend condition, not a silently-reset-to-full one.
+ */
+export function readLedger(path, { ceiling = DEFAULT_CEILING_CREDITS } = {}) {
+  if (!existsSync(path)) {
+    return {
+      ceiling_credits: ceiling,
+      spent_credits: 0,
+      atoms_count: 0,
+      updated_at: null,
+    };
+  }
+  const raw = readFileSync(path, 'utf8');
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`budget-ledger: corrupt ledger at ${path} (${err instanceof Error ? err.message : err}) — refusing to spend`);
+  }
+  for (const k of ['ceiling_credits', 'spent_credits', 'atoms_count']) {
+    if (!Number.isInteger(parsed[k]) || parsed[k] < 0) {
+      throw new Error(`budget-ledger: field ${k} is not a non-negative integer — refusing to spend`);
+    }
+  }
+  return parsed;
+}
+
+/** Remaining credits = ceiling − spent (clamped at 0, never negative). */
+export function remaining(ledger) {
+  return Math.max(0, ledger.ceiling_credits - ledger.spent_credits);
+}
+
+/**
+ * Atomically write the ledger: write a sibling temp file, then rename over the
+ * target. The temp file lives in the SAME directory so the rename is atomic
+ * (cross-device renames are not). updated_at is stamped to an ISO string.
+ */
+export function writeLedger(path, ledger) {
+  mkdirSync(dirname(path), { recursive: true });
+  const stamped = { ...ledger, updated_at: new Date().toISOString() };
+  const tmp = join(dirname(path), `.${basename(path)}.tmp-${process.pid}-${Date.now()}`);
+  writeFileSync(tmp, JSON.stringify(stamped, null, 2) + '\n', { encoding: 'utf8' });
+  renameSync(tmp, path); // atomic commit
+  return stamped;
+}
+
+/**
+ * Decrement the budget by `credits` (record a spend). Reads the current ledger,
+ * adds the spend + one atom, writes atomically. Returns the new ledger.
+ * `credits` must be a non-negative integer.
+ */
+export function recordSpend(path, credits, { ceiling = DEFAULT_CEILING_CREDITS } = {}) {
+  if (!Number.isInteger(credits) || credits < 0) {
+    throw new Error(`budget-ledger: spend must be a non-negative integer (got ${credits})`);
+  }
+  const ledger = readLedger(path, { ceiling });
+  const next = {
+    ceiling_credits: ledger.ceiling_credits,
+    spent_credits: ledger.spent_credits + credits,
+    atoms_count: ledger.atoms_count + 1,
+    updated_at: ledger.updated_at,
+  };
+  return writeLedger(path, next);
+}

--- a/packages/dune-meter/src/cost-atom.mjs
+++ b/packages/dune-meter/src/cost-atom.mjs
@@ -1,0 +1,225 @@
+// cost-atom.mjs — the dune-meter CostAtom emitter.
+//
+// COMPATIBLE with loa-finn src/cost/cost-atom.ts (CostAtom interface l.59,
+// CallClass l.28, the 3 ledgers InferenceLedger/InfraLedger/OrchestrationLedger,
+// canonical serialization + sha256 checksum, integer units, append-only JSONL).
+//
+// Two deliberate deltas from the finn original, both honest:
+//   1. call_class adds a 'dune' class (finn has only A_relay | B_enrich). A dune
+//      atom carries the inference/infra ledgers at zero and books the credit cost
+//      on the orchestration ledger's gate_inputs — there is no model token spend,
+//      the cost is Dune compute credits.
+//   2. A hash-CHAIN. The finn envelope self-checksums each atom; dune-meter adds a
+//      `prev_hash` link (the previous envelope's checksum) so the ledger is a
+//      tamper-evident chain, not just a bag of self-checksummed lines. The genesis
+//      atom links to GENESIS_PREV_HASH. This is the design-doc "hash-chain via
+//      prev_hash linkage" requirement.
+//
+// Units are integers. Dune bills 1 credit = 1000 datapoints (rows × cols). We
+// store credits_consumed and datapoints_scanned as plain integers (Number, all
+// safe-integer at free-tier magnitudes — credits cap at thousands). No floats in
+// any stored cost field.
+//
+// node:crypto + node:fs only — zero-dependency core, asson house style.
+
+import { createHash } from 'node:crypto';
+import { appendFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+/** The genesis link: the prev_hash of the first atom in any ledger. */
+export const GENESIS_PREV_HASH = 'sha256:' + '0'.repeat(64);
+
+/** Default ledger path (relative to package). The CLI passes an absolute path. */
+export const DEFAULT_ATOMS_PATH = '.run/dune-cost-atoms.jsonl';
+
+// ── canonical serialization (mirrors finn canonicalize/canonicalJson) ────────
+// Sort object keys recursively so the checksum is order-insensitive. dune-meter
+// stores integers, not bigints, so there is no bigint→string coercion step.
+
+export function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value !== null && typeof value === 'object') {
+    const out = {};
+    for (const key of Object.keys(value).sort()) out[key] = canonicalize(value[key]);
+    return out;
+  }
+  return value;
+}
+
+export function canonicalJson(value) {
+  return JSON.stringify(canonicalize(value));
+}
+
+/** sha256 hex of the canonical JSON of an atom, prefixed `sha256:`. */
+export function atomChecksum(atom) {
+  return 'sha256:' + createHash('sha256').update(canonicalJson(atom)).digest('hex');
+}
+
+// ── atom construction ────────────────────────────────────────────────────────
+
+/**
+ * Build a dune CostAtom. Integer units only.
+ *
+ * @param {object} p
+ * @param {string} p.atom_id          ULID-ish unique id (caller supplies; default time+rand)
+ * @param {string} p.query_id         the Dune query id (or a hash of the SQL)
+ * @param {number} p.datapoints_scanned  rows × cols actually scanned (integer)
+ * @param {number} p.credits_consumed    credits the execution cost (integer)
+ * @param {'small'|'medium'|'large'} p.engine  the Dune compute engine used
+ * @param {number} p.wall_ms          execution wall time in ms (integer)
+ * @param {number} [p.ts]             epoch ms (default Date.now())
+ */
+export function makeDuneAtom({
+  atom_id,
+  query_id,
+  datapoints_scanned,
+  credits_consumed,
+  engine,
+  wall_ms,
+  ts = Date.now(),
+}) {
+  for (const [name, v] of [
+    ['datapoints_scanned', datapoints_scanned],
+    ['credits_consumed', credits_consumed],
+    ['wall_ms', wall_ms],
+  ]) {
+    if (!Number.isInteger(v) || v < 0) {
+      throw new Error(`cost-atom: ${name} must be a non-negative integer (got ${v})`);
+    }
+  }
+  return {
+    atom_id: atom_id ?? `${ts.toString(36)}-${Math.random().toString(36).slice(2, 10)}`,
+    correlation_id: query_id,
+    ts,
+    call_class: 'dune',
+    // finn-shaped ledgers, zeroed where dune has no spend. The credit cost lives
+    // on the dune-native fields + the orchestration ledger's gate record.
+    inference: { model: null, input_tokens: 0, output_tokens: 0, cached_tokens: 0, cost_micro: 0 },
+    infra: { wall_ms, allocated_ppm: 0, egress_bytes: 0, rpc_calls: 1, cost_micro: 0 },
+    orchestration: {
+      steps: 1,
+      retries: 0,
+      cheval_spawn_ms: null,
+      gate_decision: 'DUNE_EXECUTED',
+      gate_inputs: { engine, credits_consumed },
+      cost_micro: 0,
+    },
+    // dune-native cost fields (the real bill, in Dune's billing unit):
+    dune: {
+      query_id,
+      datapoints_scanned,
+      credits_consumed,
+      engine,
+    },
+    total_micro: 0,
+    x402_quote_micro: 0,
+  };
+}
+
+// ── envelope (finn-shaped: schema_version + atom + checksum) + prev_hash chain ─
+
+/**
+ * Wrap an atom in its chain envelope.
+ * @param {object} atom
+ * @param {string} prevHash  the previous envelope's checksum (GENESIS_PREV_HASH for atom 0)
+ */
+export function makeEnvelope(atom, prevHash) {
+  const enveloped = {
+    schema_version: 1,
+    prev_hash: prevHash,
+    atom: canonicalize(atom),
+  };
+  // checksum covers schema_version + prev_hash + atom — so reordering or
+  // re-linking any line breaks the chain, not just the atom body.
+  enveloped.checksum = 'sha256:' + createHash('sha256')
+    .update(canonicalJson({ schema_version: enveloped.schema_version, prev_hash: enveloped.prev_hash, atom: enveloped.atom }))
+    .digest('hex');
+  return enveloped;
+}
+
+/** Serialize an envelope to a newline-terminated JSONL line. */
+export function envelopeLine(envelope) {
+  return JSON.stringify(envelope) + '\n';
+}
+
+/**
+ * Parse one JSONL line into an envelope, verifying its self-checksum.
+ * Chain linkage (prev_hash continuity) is verified separately by readAtoms.
+ */
+export function parseEnvelopeLine(line) {
+  const parsed = JSON.parse(line);
+  if (parsed.schema_version !== 1) {
+    throw new Error(`unknown cost-atom schema_version: ${parsed.schema_version}`);
+  }
+  const recomputed = 'sha256:' + createHash('sha256')
+    .update(canonicalJson({ schema_version: parsed.schema_version, prev_hash: parsed.prev_hash, atom: parsed.atom }))
+    .digest('hex');
+  if (recomputed !== parsed.checksum) {
+    throw new Error('cost-atom checksum mismatch');
+  }
+  return parsed;
+}
+
+// ── append-only writer with chain continuity ─────────────────────────────────
+
+/** Read the last envelope's checksum from a ledger file (the next prev_hash). */
+export function tailHash(path) {
+  if (!existsSync(path)) return GENESIS_PREV_HASH;
+  const raw = readFileSync(path, 'utf8');
+  const lines = raw.split('\n').filter((l) => l.trim());
+  if (lines.length === 0) return GENESIS_PREV_HASH;
+  const last = parseEnvelopeLine(lines[lines.length - 1]);
+  return last.checksum;
+}
+
+/**
+ * Append an atom to the JSONL ledger, linking it to the current tail.
+ * Synchronous (the CLI is a oneshot; one writer, no interleave). Returns the
+ * written envelope.
+ */
+export function appendAtom(path, atom) {
+  mkdirSync(dirname(path), { recursive: true });
+  const prevHash = tailHash(path);
+  const envelope = makeEnvelope(atom, prevHash);
+  appendFileSync(path, envelopeLine(envelope), { encoding: 'utf8' });
+  return envelope;
+}
+
+// ── reader: parse + verify checksums AND chain continuity ────────────────────
+
+/**
+ * Read a cost-atom ledger. Returns { atoms, envelopes, malformed, chain_ok,
+ * chain_break }. Malformed lines (bad JSON / failed self-checksum) are skipped
+ * with a reason. chain_ok=false with chain_break={line, expected, got} on the
+ * first prev_hash discontinuity.
+ */
+export function readAtoms(path) {
+  if (!existsSync(path)) return { atoms: [], envelopes: [], malformed: [], chain_ok: true, chain_break: null };
+  const raw = readFileSync(path, 'utf8');
+  const lines = raw.split('\n');
+  const atoms = [];
+  const envelopes = [];
+  const malformed = [];
+  let expectedPrev = GENESIS_PREV_HASH;
+  let chain_ok = true;
+  let chain_break = null;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    let env;
+    try {
+      env = parseEnvelopeLine(line);
+    } catch (err) {
+      malformed.push({ line: i + 1, reason: err instanceof Error ? err.message : String(err) });
+      continue;
+    }
+    if (chain_ok && env.prev_hash !== expectedPrev) {
+      chain_ok = false;
+      chain_break = { line: i + 1, expected: expectedPrev, got: env.prev_hash };
+    }
+    expectedPrev = env.checksum;
+    envelopes.push(env);
+    atoms.push(env.atom);
+  }
+  return { atoms, envelopes, malformed, chain_ok, chain_break };
+}

--- a/packages/dune-meter/src/dune-client.mjs
+++ b/packages/dune-meter/src/dune-client.mjs
@@ -1,0 +1,250 @@
+// dune-client.mjs — a thin Dune Analytics API client.
+//
+// Covers: submit a SQL/query execution on a chosen compute engine (small by
+// default), poll to completion, read the result metadata (datapoints scanned +
+// credits consumed), and run the cheap COUNT(*)/LIMIT-1 probe `estimate` uses.
+//
+// EXP-002 lessons baked in (the scar this whole package is the guard for):
+//   • jittered exponential backoff on 429 (rate limit) and 5xx (transient) —
+//     a runaway retry loop is its own budget hazard.
+//   • explicit per-request timeout (AbortController) — no unbounded waits.
+//   • the engine 30-minute execution cap is a DOCUMENTED HARD LIMIT; queries are
+//     expected to be era-bound (a block/time range), NEVER an unbounded scan.
+//     The unbounded `evt_transfer` scan is what burned EXP-002 — closed here by
+//     forcing the small engine, a per-query cost cap, and bounded polling.
+//   • the per-query Query Cost Cap must be set at the ACCOUNT level in the Dune
+//     dashboard — the API performance tier picks the engine, but the hard credit
+//     abort is the account cap. We surface a CAP_ABORTED signal when Dune reports
+//     an execution failed/cancelled by the cost cap.
+//
+// stdlib fetch (node 18+). API key from env DUNE_API_KEY. Zero dependencies.
+
+const DUNE_API_BASE = 'https://api.dune.com/api/v1';
+
+/** Engine → Dune `performance` tier. small is the prototyping default. */
+export const ENGINES = { small: 'small', medium: 'medium', large: 'large' };
+
+/** Hard documented cap: a single execution may not run past 30 minutes. */
+export const ENGINE_EXEC_CAP_MS = 30 * 60 * 1000;
+
+/** Thrown when Dune reports an execution aborted by the cost cap. */
+export class CostCapAbortError extends Error {
+  constructor(message, execution_id) {
+    super(message);
+    this.name = 'CostCapAbortError';
+    this.execution_id = execution_id;
+  }
+}
+
+/** Thrown for caller errors (bad args, missing key) — maps to exit 2. */
+export class DuneClientError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'DuneClientError';
+  }
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Jittered exponential backoff: base·2^attempt + up to base jitter, capped. */
+function backoffMs(attempt, base = 500, cap = 15_000) {
+  const exp = Math.min(cap, base * 2 ** attempt);
+  return exp + Math.floor(Math.random() * base);
+}
+
+/**
+ * The Dune client. Inject `fetchImpl` (defaults to global fetch) and `sleepImpl`
+ * so tests can run fully offline + deterministic — NO live Dune call ever runs
+ * in tests or build (the whole point is cost-safety: don't spend credits to
+ * build the cost guard).
+ */
+export class DuneClient {
+  constructor({
+    apiKey = process.env.DUNE_API_KEY,
+    base = DUNE_API_BASE,
+    fetchImpl,
+    sleepImpl = sleep,
+    maxRetries = 4,
+    requestTimeoutMs = 30_000,
+    pollIntervalMs = 2_000,
+    pollTimeoutMs = ENGINE_EXEC_CAP_MS,
+  } = {}) {
+    this.apiKey = apiKey;
+    this.base = base;
+    this.fetch = fetchImpl ?? globalThis.fetch;
+    this.sleep = sleepImpl;
+    this.maxRetries = maxRetries;
+    this.requestTimeoutMs = requestTimeoutMs;
+    this.pollIntervalMs = pollIntervalMs;
+    this.pollTimeoutMs = pollTimeoutMs;
+  }
+
+  _headers() {
+    if (!this.apiKey) throw new DuneClientError('DUNE_API_KEY not set');
+    return { 'X-Dune-Api-Key': this.apiKey, 'Content-Type': 'application/json' };
+  }
+
+  /** A single fetch with explicit timeout + jittered retry on 429/5xx. */
+  async _request(path, { method = 'GET', body } = {}) {
+    let lastErr;
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), this.requestTimeoutMs);
+      try {
+        const res = await this.fetch(`${this.base}${path}`, {
+          method,
+          headers: this._headers(),
+          body: body ? JSON.stringify(body) : undefined,
+          signal: controller.signal,
+        });
+        clearTimeout(timer);
+        if (res.status === 429 || res.status >= 500) {
+          lastErr = new Error(`Dune ${res.status} on ${path}`);
+          if (attempt < this.maxRetries) {
+            await this.sleep(backoffMs(attempt));
+            continue;
+          }
+          throw lastErr;
+        }
+        if (!res.ok) {
+          const text = await res.text().catch(() => '');
+          throw new DuneClientError(`Dune ${res.status} on ${path}: ${text.slice(0, 200)}`);
+        }
+        return await res.json();
+      } catch (err) {
+        clearTimeout(timer);
+        lastErr = err;
+        // AbortError / network error → retry with backoff (transient).
+        const transient = err?.name === 'AbortError' || err?.name === 'TypeError';
+        if (transient && attempt < this.maxRetries) {
+          await this.sleep(backoffMs(attempt));
+          continue;
+        }
+        throw err;
+      }
+    }
+    throw lastErr ?? new Error(`Dune request failed: ${path}`);
+  }
+
+  /** Execute a saved query id. performance picks the engine (small default). */
+  async executeQuery(queryId, { performance = ENGINES.small } = {}) {
+    return this._request(`/query/${queryId}/execute`, { method: 'POST', body: { performance } });
+  }
+
+  /** Execute raw SQL via Dune's first-party raw-SQL endpoint (POST
+   *  /api/v1/sql/execute → { execution_id, state }). small engine by default.
+   *  NB: the inline-SQL endpoint is /sql/execute with body { sql } — NOT
+   *  /query/execute (which is not a live Dune route → HTTP 405). */
+  async executeSql(sql, { performance = ENGINES.small } = {}) {
+    return this._request('/sql/execute', { method: 'POST', body: { sql, performance } });
+  }
+
+  /** Poll an execution's status until it terminates or the poll budget expires. */
+  async pollStatus(executionId) {
+    const deadline = Date.now() + this.pollTimeoutMs;
+    for (;;) {
+      const status = await this._request(`/execution/${executionId}/status`);
+      const state = status.state ?? status.execution_state;
+      if (state === 'QUERY_STATE_COMPLETED') return status;
+      if (state === 'QUERY_STATE_FAILED' || state === 'QUERY_STATE_CANCELLED') {
+        // A cost-cap abort surfaces as a FAILED/CANCELLED execution. Treat it as
+        // the hard signal the CLI maps to exit 4.
+        throw new CostCapAbortError(`execution ${executionId} terminated: ${state}`, executionId);
+      }
+      if (Date.now() > deadline) {
+        throw new Error(`execution ${executionId} exceeded poll budget (${this.pollTimeoutMs}ms) — engine cap`);
+      }
+      await this.sleep(this.pollIntervalMs);
+    }
+  }
+
+  /** Read result metadata: datapoints scanned + credits/resource consumed. */
+  async resultMetadata(executionId) {
+    const res = await this._request(`/execution/${executionId}/results?limit=0`);
+    const md = res.execution_result?.metadata ?? res.result?.metadata ?? res.metadata ?? {};
+    // Dune exposes datapoint_count + total credits via result metadata / the
+    // billing fields. We read defensively across the documented shapes.
+    const datapoints = md.datapoint_count ?? md.total_row_count ?? 0;
+    const credits = res.credits_used ?? md.total_credits_used ?? md.credits_used ?? null;
+    return { datapoints, credits, raw: md };
+  }
+
+  /**
+   * NON-EXECUTING read of a saved query's LATEST CACHED result metadata, via the
+   * results endpoint with limit=0 (zero rows fetched — metadata only, no scan, no
+   * new execution). This is how `estimate <query_id>` stays honest to the design
+   * doc's hard constraint ("No full execution"): we NEVER run a saved query just
+   * to estimate it. Returns {rows, cols} from the cached result's metadata.
+   *
+   * If the query has never completed an execution there is no cached metadata to
+   * read — we DO NOT execute to fill the gap; we raise a caller error (exit 2)
+   * telling the caller to pass SQL (the COUNT/LIMIT-1 probe path) or to run it
+   * once through `run` (cost-capped) before estimating.
+   */
+  async latestResultMetadata(queryId) {
+    let res;
+    try {
+      res = await this._request(`/query/${queryId}/results?limit=0`);
+    } catch (e) {
+      const why = e instanceof Error ? e.message : String(e);
+      throw new DuneClientError(
+        `estimate: no cached result for query ${queryId} (${why}) — estimate never executes a saved query; pass the SQL, or run it once (cost-capped) then estimate`,
+      );
+    }
+    const md = res.result?.metadata ?? res.execution_result?.metadata ?? res.metadata ?? {};
+    const finished = res.is_execution_finished === true
+      || res.state === 'QUERY_STATE_COMPLETED'
+      || md.total_row_count != null
+      || md.datapoint_count != null;
+    const rows = Number.isInteger(md.total_row_count)
+      ? md.total_row_count
+      : (Number.isInteger(md.row_count) ? md.row_count : 0);
+    const cols = Array.isArray(md.column_names) ? md.column_names.length : 0;
+    if (!finished || (rows === 0 && cols === 0)) {
+      throw new DuneClientError(
+        `estimate: query ${queryId} has no completed cached result — estimate never executes a saved query; pass the SQL, or run it once (cost-capped) then estimate`,
+      );
+    }
+    return { rows, cols };
+  }
+
+  /**
+   * The estimate PROBE → {rows, cols}, the heuristic input (labeled honestly
+   * upstream in estimate.mjs). NEVER does a full execution of the target:
+   *   • SQL      — a cheap COUNT(*) (rows) + LIMIT-1 (cols) probe on the small
+   *                engine (design-sanctioned: "a cheap COUNT(*) / LIMIT 1 probe").
+   *   • query_id — a NON-EXECUTING read of the latest cached result metadata
+   *                (latestResultMetadata). A saved query is never executed just
+   *                to estimate it (design doc: "No full execution" — the EXP-002
+   *                scar was an unbounded scan run with nothing metering it; the
+   *                estimate path must not reintroduce that).
+   */
+  async probe(target, { isQueryId }) {
+    if (isQueryId) {
+      return this.latestResultMetadata(target);
+    }
+    // Raw SQL probe: wrap in COUNT(*) to get rows cheaply, and a LIMIT 1 to read
+    // the column shape. We send the COUNT form (cheapest signal).
+    const countSql = `SELECT count(*) AS n FROM (${stripTrailingSemicolon(target)}) _probe`;
+    const exec = await this.executeSql(countSql, { performance: ENGINES.small });
+    const status = await this.pollStatus(exec.execution_id);
+    const rows = status.result?.rows?.[0]?.n ?? 0;
+    // column count of the ORIGINAL query: a LIMIT 1 read.
+    const sampleSql = `SELECT * FROM (${stripTrailingSemicolon(target)}) _probe LIMIT 1`;
+    const sampleExec = await this.executeSql(sampleSql, { performance: ENGINES.small });
+    const sampleStatus = await this.pollStatus(sampleExec.execution_id);
+    const cols = sampleStatus.result?.metadata?.column_names?.length
+      ?? (sampleStatus.result?.rows?.[0] ? Object.keys(sampleStatus.result.rows[0]).length : 1);
+    return { rows: Number(rows), cols, execution_id: exec.execution_id };
+  }
+}
+
+/** Strip a single trailing semicolon so SQL can be subquery-wrapped. */
+export function stripTrailingSemicolon(sql) {
+  return String(sql).trim().replace(/;\s*$/, '');
+}
+
+/** Cheap heuristic: a bare integer string is a query id; anything else is SQL. */
+export function looksLikeQueryId(target) {
+  return /^\d+$/.test(String(target).trim());
+}

--- a/packages/dune-meter/src/estimate.mjs
+++ b/packages/dune-meter/src/estimate.mjs
@@ -1,0 +1,67 @@
+// estimate.mjs — the verdict heuristic (pure, testable, no I/O).
+//
+// HONEST LABEL: Dune has NO native dry-run / EXPLAIN (design doc §"The honest
+// constraint"). Billing is dynamic (compute time + data scanned) and not
+// previewable. So `estimate` is a PROBE-BASED HEURISTIC, never a true cost
+// preview: a cheap COUNT(*) / LIMIT-1 probe on the SMALL engine gauges rows ×
+// cols, and we project from that. The verdict thresholds here are the budget
+// guard; the probe magnitude (in dune-client) is the input.
+//
+// Billing unit: 1 credit = 1,000 datapoints (rows × cols).
+
+/** datapoints → credits. Dune bills per 1,000 datapoints, rounded up. */
+export function creditsForDatapoints(datapoints) {
+  if (!Number.isInteger(datapoints) || datapoints < 0) {
+    throw new Error(`estimate: datapoints must be a non-negative integer (got ${datapoints})`);
+  }
+  return Math.ceil(datapoints / 1000);
+}
+
+/** estimated_datapoints = probed_rows × cols. Both integers. */
+export function estimateDatapoints(rows, cols) {
+  for (const [n, v] of [['rows', rows], ['cols', cols]]) {
+    if (!Number.isInteger(v) || v < 0) throw new Error(`estimate: ${n} must be a non-negative integer (got ${v})`);
+  }
+  return rows * cols;
+}
+
+/**
+ * The verdict, given an estimate and the remaining budget.
+ *   REFUSE  — estimated_credits > remaining        (would overspend; exit 3)
+ *   WARN    — estimated_credits > 25% of remaining  (large relative to budget)
+ *   OK      — otherwise
+ *
+ * 25% boundary is inclusive on OK: est == 25% of remaining is OK; strictly
+ * greater is WARN. Integer comparison (4·est vs remaining) avoids float drift.
+ */
+export function verdictFor(estimatedCredits, remainingCredits) {
+  if (!Number.isInteger(estimatedCredits) || estimatedCredits < 0) {
+    throw new Error(`estimate: estimatedCredits must be a non-negative integer (got ${estimatedCredits})`);
+  }
+  if (!Number.isInteger(remainingCredits) || remainingCredits < 0) {
+    throw new Error(`estimate: remainingCredits must be a non-negative integer (got ${remainingCredits})`);
+  }
+  if (estimatedCredits > remainingCredits) return 'REFUSE';
+  // WARN if est > 25% of remaining  ⇔  4·est > remaining
+  if (4 * estimatedCredits > remainingCredits) return 'WARN';
+  return 'OK';
+}
+
+/**
+ * Full estimate result from a probe (rows × cols) and the current ledger
+ * remaining. The honest-heuristic flag is always true — this is never a true
+ * preview.
+ */
+export function buildEstimate({ rows, cols, remainingCredits }) {
+  const estimated_datapoints = estimateDatapoints(rows, cols);
+  const estimated_credits = creditsForDatapoints(estimated_datapoints);
+  const verdict = verdictFor(estimated_credits, remainingCredits);
+  return {
+    estimated_datapoints,
+    estimated_credits,
+    remaining_budget: remainingCredits,
+    verdict,
+    heuristic: true,
+    note: 'probe-based heuristic — Dune has no native cost preview',
+  };
+}

--- a/packages/dune-meter/test/dune-meter.test.mjs
+++ b/packages/dune-meter/test/dune-meter.test.mjs
@@ -1,0 +1,503 @@
+// dune-meter.test.mjs — offline, deterministic unit tests.
+//
+// NO live Dune call ever runs here (the whole point of the package is cost-
+// safety — don't spend credits to test the cost guard). The Dune client is
+// mocked: each command takes an injected client with canned probe/execute/poll/
+// metadata responses. Tests cover:
+//   • estimate verdict logic — OK / WARN / REFUSE thresholds (the 25% + 100% boundaries)
+//   • budget-ledger atomic read/write + remaining + recordSpend
+//   • cost-atom hash-chain continuity (prev_hash linkage) + tamper detection
+//   • exit-code mapping (0 / 2 / 3 / 4) through the CLI command handlers
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { creditsForDatapoints, estimateDatapoints, verdictFor, buildEstimate } from '../src/estimate.mjs';
+import {
+  readLedger, writeLedger, remaining, recordSpend, DEFAULT_CEILING_CREDITS,
+} from '../src/budget-ledger.mjs';
+import {
+  makeDuneAtom, makeEnvelope, appendAtom, readAtoms, tailHash, GENESIS_PREV_HASH, atomChecksum,
+} from '../src/cost-atom.mjs';
+import { DuneClient, DuneClientError } from '../src/dune-client.mjs';
+import { cmdEstimate, cmdRun, cmdBudget } from '../bin/dune-meter.mjs';
+
+// ── test harness ──────────────────────────────────────────────────────────────
+// The command handlers are pure w.r.t. process side effects: they RETURN
+// { json?, text?, error?, exit }. No stdout monkeypatch, no real process.exit —
+// so the node:test reporter is never clobbered. We normalize to the shape the
+// assertions use: { out (stringified json), err (error string), exit }.
+async function runHandler(fn) {
+  const result = await fn();
+  return {
+    out: result.json !== undefined ? JSON.stringify(result.json) : (result.text ?? ''),
+    err: result.error ?? '',
+    exit: result.exit,
+  };
+}
+
+function tmpEnv() {
+  const dir = mkdtempSync(join(tmpdir(), 'dune-meter-'));
+  const prev = { L: process.env.DUNE_BUDGET_LEDGER, A: process.env.DUNE_COST_ATOMS, C: process.env.DUNE_BUDGET_CEILING };
+  process.env.DUNE_BUDGET_LEDGER = join(dir, 'budget.json');
+  process.env.DUNE_COST_ATOMS = join(dir, 'atoms.jsonl');
+  delete process.env.DUNE_BUDGET_CEILING;
+  return {
+    dir,
+    ledgerPath: process.env.DUNE_BUDGET_LEDGER,
+    atomsPath: process.env.DUNE_COST_ATOMS,
+    cleanup() {
+      process.env.DUNE_BUDGET_LEDGER = prev.L; process.env.DUNE_COST_ATOMS = prev.A; process.env.DUNE_BUDGET_CEILING = prev.C;
+      if (prev.L === undefined) delete process.env.DUNE_BUDGET_LEDGER;
+      if (prev.A === undefined) delete process.env.DUNE_COST_ATOMS;
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+// A mock Dune client: canned probe + execute + poll + metadata. No network.
+function mockClient({ rows = 100, cols = 4, datapoints, credits = null, throwOnExecute = null } = {}) {
+  return {
+    async probe() { return { rows, cols, execution_id: 'exec-probe' }; },
+    async executeQuery() { if (throwOnExecute) throw throwOnExecute; return { execution_id: 'exec-run' }; },
+    async executeSql() { if (throwOnExecute) throw throwOnExecute; return { execution_id: 'exec-run' }; },
+    async pollStatus() { if (throwOnExecute) throw throwOnExecute; return { state: 'QUERY_STATE_COMPLETED' }; },
+    async resultMetadata() {
+      return { datapoints: datapoints ?? rows * cols, credits, raw: {} };
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// estimate verdict logic
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('creditsForDatapoints rounds up per 1000', () => {
+  assert.equal(creditsForDatapoints(0), 0);
+  assert.equal(creditsForDatapoints(1), 1);
+  assert.equal(creditsForDatapoints(1000), 1);
+  assert.equal(creditsForDatapoints(1001), 2);
+  assert.equal(creditsForDatapoints(2500000), 2500);
+});
+
+test('estimateDatapoints = rows × cols', () => {
+  assert.equal(estimateDatapoints(100, 4), 400);
+  assert.equal(estimateDatapoints(0, 9), 0);
+});
+
+test('verdictFor: OK when est <= 25% of remaining', () => {
+  // remaining 2500, 25% = 625. est 625 → OK (inclusive boundary), 626 → WARN.
+  assert.equal(verdictFor(625, 2500), 'OK');
+  assert.equal(verdictFor(626, 2500), 'WARN');
+  assert.equal(verdictFor(0, 2500), 'OK');
+});
+
+test('verdictFor: WARN when est > 25% but <= remaining', () => {
+  assert.equal(verdictFor(1000, 2500), 'WARN');
+  assert.equal(verdictFor(2500, 2500), 'WARN'); // exactly remaining → still affordable → WARN, not REFUSE
+});
+
+test('verdictFor: REFUSE when est > remaining', () => {
+  assert.equal(verdictFor(2501, 2500), 'REFUSE');
+  assert.equal(verdictFor(1, 0), 'REFUSE');
+});
+
+test('buildEstimate flags heuristic honestly', () => {
+  const est = buildEstimate({ rows: 1000, cols: 5, remainingCredits: 2500 });
+  assert.equal(est.estimated_datapoints, 5000);
+  assert.equal(est.estimated_credits, 5);
+  assert.equal(est.verdict, 'OK');
+  assert.equal(est.heuristic, true);
+  assert.match(est.note, /no native cost preview/);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// budget-ledger atomic read/write
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('readLedger returns fresh default when absent', () => {
+  const e = tmpEnv();
+  try {
+    const led = readLedger(e.ledgerPath);
+    assert.equal(led.ceiling_credits, DEFAULT_CEILING_CREDITS);
+    assert.equal(led.spent_credits, 0);
+    assert.equal(led.atoms_count, 0);
+    assert.equal(remaining(led), 2500);
+  } finally { e.cleanup(); }
+});
+
+test('writeLedger then readLedger round-trips + stamps updated_at', () => {
+  const e = tmpEnv();
+  try {
+    writeLedger(e.ledgerPath, { ceiling_credits: 2500, spent_credits: 100, atoms_count: 2, updated_at: null });
+    const led = readLedger(e.ledgerPath);
+    assert.equal(led.spent_credits, 100);
+    assert.equal(led.atoms_count, 2);
+    assert.equal(remaining(led), 2400);
+    assert.ok(typeof led.updated_at === 'string' && led.updated_at.length > 0);
+    // atomic write leaves no temp file behind
+    const files = readFileSync(e.ledgerPath, 'utf8');
+    assert.match(files, /"spent_credits": 100/);
+  } finally { e.cleanup(); }
+});
+
+test('recordSpend accumulates spend + atom count', () => {
+  const e = tmpEnv();
+  try {
+    recordSpend(e.ledgerPath, 50);
+    recordSpend(e.ledgerPath, 75);
+    const led = readLedger(e.ledgerPath);
+    assert.equal(led.spent_credits, 125);
+    assert.equal(led.atoms_count, 2);
+    assert.equal(remaining(led), 2375);
+  } finally { e.cleanup(); }
+});
+
+test('readLedger throws on corrupt ledger (refuse-to-spend, not reset)', () => {
+  const e = tmpEnv();
+  try {
+    writeFileSync(e.ledgerPath, '{ this is not json');
+    assert.throws(() => readLedger(e.ledgerPath), /corrupt ledger/);
+  } finally { e.cleanup(); }
+});
+
+test('recordSpend rejects non-integer / negative credits', () => {
+  const e = tmpEnv();
+  try {
+    assert.throws(() => recordSpend(e.ledgerPath, -1), /non-negative integer/);
+    assert.throws(() => recordSpend(e.ledgerPath, 1.5), /non-negative integer/);
+  } finally { e.cleanup(); }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// cost-atom hash-chain continuity
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('first atom links to GENESIS_PREV_HASH', () => {
+  const e = tmpEnv();
+  try {
+    assert.equal(tailHash(e.atomsPath), GENESIS_PREV_HASH);
+    const atom = makeDuneAtom({ query_id: '123', datapoints_scanned: 4000, credits_consumed: 4, engine: 'small', wall_ms: 1200, ts: 1000 });
+    const env = appendAtom(e.atomsPath, atom);
+    assert.equal(env.prev_hash, GENESIS_PREV_HASH);
+    assert.match(env.checksum, /^sha256:[0-9a-f]{64}$/);
+  } finally { e.cleanup(); }
+});
+
+test('chain links each atom to the previous checksum', () => {
+  const e = tmpEnv();
+  try {
+    const a1 = appendAtom(e.atomsPath, makeDuneAtom({ query_id: '1', datapoints_scanned: 1000, credits_consumed: 1, engine: 'small', wall_ms: 10, ts: 1 }));
+    const a2 = appendAtom(e.atomsPath, makeDuneAtom({ query_id: '2', datapoints_scanned: 2000, credits_consumed: 2, engine: 'small', wall_ms: 20, ts: 2 }));
+    const a3 = appendAtom(e.atomsPath, makeDuneAtom({ query_id: '3', datapoints_scanned: 3000, credits_consumed: 3, engine: 'small', wall_ms: 30, ts: 3 }));
+    assert.equal(a2.prev_hash, a1.checksum);
+    assert.equal(a3.prev_hash, a2.checksum);
+    const read = readAtoms(e.atomsPath);
+    assert.equal(read.atoms.length, 3);
+    assert.equal(read.chain_ok, true);
+    assert.equal(read.chain_break, null);
+    // the dune-native cost fields survive the round-trip
+    assert.equal(read.atoms[2].dune.credits_consumed, 3);
+    assert.equal(read.atoms[2].call_class, 'dune');
+  } finally { e.cleanup(); }
+});
+
+test('readAtoms detects a broken chain (tampered prev_hash)', () => {
+  const e = tmpEnv();
+  try {
+    appendAtom(e.atomsPath, makeDuneAtom({ query_id: '1', datapoints_scanned: 1000, credits_consumed: 1, engine: 'small', wall_ms: 10, ts: 1 }));
+    appendAtom(e.atomsPath, makeDuneAtom({ query_id: '2', datapoints_scanned: 2000, credits_consumed: 2, engine: 'small', wall_ms: 20, ts: 2 }));
+    // Tamper: rewrite line 2 with a re-checksummed envelope whose prev_hash is wrong.
+    const lines = readFileSync(e.atomsPath, 'utf8').split('\n').filter(Boolean);
+    const atom2 = makeDuneAtom({ query_id: '2', datapoints_scanned: 2000, credits_consumed: 2, engine: 'small', wall_ms: 20, ts: 2 });
+    const forged = makeEnvelope(atom2, GENESIS_PREV_HASH); // wrong link, but self-consistent
+    writeFileSync(e.atomsPath, lines[0] + '\n' + JSON.stringify(forged) + '\n');
+    const read = readAtoms(e.atomsPath);
+    assert.equal(read.chain_ok, false);
+    assert.equal(read.chain_break.line, 2);
+  } finally { e.cleanup(); }
+});
+
+test('readAtoms flags a self-checksum mismatch as malformed', () => {
+  const e = tmpEnv();
+  try {
+    const atom = makeDuneAtom({ query_id: '1', datapoints_scanned: 1000, credits_consumed: 1, engine: 'small', wall_ms: 10, ts: 1 });
+    const env = makeEnvelope(atom, GENESIS_PREV_HASH);
+    env.atom.dune.credits_consumed = 999; // mutate body after checksum
+    writeFileSync(e.atomsPath, JSON.stringify(env) + '\n');
+    const read = readAtoms(e.atomsPath);
+    assert.equal(read.atoms.length, 0);
+    assert.equal(read.malformed.length, 1);
+    assert.match(read.malformed[0].reason, /checksum mismatch/);
+  } finally { e.cleanup(); }
+});
+
+test('makeDuneAtom rejects non-integer cost fields', () => {
+  assert.throws(() => makeDuneAtom({ query_id: '1', datapoints_scanned: 1.5, credits_consumed: 1, engine: 'small', wall_ms: 10 }), /non-negative integer/);
+  assert.throws(() => makeDuneAtom({ query_id: '1', datapoints_scanned: 1000, credits_consumed: -1, engine: 'small', wall_ms: 10 }), /non-negative integer/);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DuneClient.probe — the estimate input MUST NOT full-execute a saved query
+// (the design-doc constraint "No full execution"). Fetch is mocked; no network.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// A mock fetch recording every call. Each route returns a canned JSON response.
+function mockFetch(routes) {
+  const calls = [];
+  const fetchImpl = async (url, opts = {}) => {
+    calls.push({ url, method: opts.method ?? 'GET' });
+    for (const [match, make] of routes) {
+      if (url.includes(match)) {
+        const { status = 200, json = {} } = make(url, opts);
+        return { ok: status >= 200 && status < 300, status, async json() { return json; }, async text() { return JSON.stringify(json); } };
+      }
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+  return { fetchImpl, calls };
+}
+
+test('probe(query_id) reads cached metadata via results endpoint — NEVER executes', async () => {
+  const { fetchImpl, calls } = mockFetch([
+    ['/results', () => ({ json: { is_execution_finished: true, result: { metadata: { total_row_count: 500, column_names: ['a', 'b', 'c'] } } } })],
+  ]);
+  const client = new DuneClient({ apiKey: 'k', fetchImpl, sleepImpl: async () => {} });
+  const { rows, cols } = await client.probe('12345', { isQueryId: true });
+  assert.equal(rows, 500);
+  assert.equal(cols, 3);
+  // The whole point: no POST /execute, no /status poll — estimate must not run it.
+  assert.equal(calls.some((c) => c.url.includes('/execute')), false, 'estimate must NOT execute a saved query');
+  assert.equal(calls.some((c) => c.url.includes('/status')), false, 'estimate must NOT poll an execution');
+  assert.ok(calls.every((c) => c.method === 'GET'), 'estimate reads (GET) only — no mutating POST');
+  assert.ok(calls.some((c) => c.url.includes('/query/12345/results')), 'reads the cached-results endpoint');
+});
+
+test('probe(query_id) raises caller-error (never executes) when no cached result exists', async () => {
+  const { fetchImpl, calls } = mockFetch([
+    ['/results', () => ({ json: { is_execution_finished: false } })],
+  ]);
+  const client = new DuneClient({ apiKey: 'k', fetchImpl, sleepImpl: async () => {} });
+  await assert.rejects(
+    () => client.probe('12345', { isQueryId: true }),
+    (e) => e instanceof DuneClientError && /no completed cached result|no cached result/.test(e.message),
+  );
+  assert.equal(calls.some((c) => c.url.includes('/execute')), false, 'must not execute to fill a missing cache');
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// exit-code mapping through the CLI command handlers (mocked client)
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('estimate exit 0 on OK verdict', async () => {
+  const e = tmpEnv();
+  try {
+    const r = await runHandler(() => cmdEstimate(['12345'], { client: mockClient({ rows: 100, cols: 4 }) }));
+    assert.equal(r.exit, 0);
+    const j = JSON.parse(r.out);
+    assert.equal(j.verdict, 'OK');
+    assert.equal(j.estimated_datapoints, 400);
+  } finally { e.cleanup(); }
+});
+
+test('estimate exit 3 on REFUSE verdict (est > remaining)', async () => {
+  const e = tmpEnv();
+  try {
+    // remaining 2500 → 2,500,001 datapoints = 2501 credits > 2500 → REFUSE
+    const r = await runHandler(() => cmdEstimate(['12345'], { client: mockClient({ rows: 2500001, cols: 1 }) }));
+    assert.equal(r.exit, 3);
+    assert.equal(JSON.parse(r.out).verdict, 'REFUSE');
+  } finally { e.cleanup(); }
+});
+
+test('estimate exit 2 on missing target', async () => {
+  const e = tmpEnv();
+  try {
+    const r = await runHandler(() => cmdEstimate([], { client: mockClient() }));
+    assert.equal(r.exit, 2);
+    assert.match(r.err, /missing/);
+  } finally { e.cleanup(); }
+});
+
+test('run exit 2 without required --cap', async () => {
+  const e = tmpEnv();
+  try {
+    const r = await runHandler(() => cmdRun(['12345'], { client: mockClient() }));
+    assert.equal(r.exit, 2);
+    assert.match(r.err, /--cap/);
+  } finally { e.cleanup(); }
+});
+
+test('run exit 3 when pre-run estimate refuses (no --force)', async () => {
+  const e = tmpEnv();
+  try {
+    const r = await runHandler(() => cmdRun(['12345', '--cap', '10'], { client: mockClient({ rows: 2500001, cols: 1 }) }));
+    assert.equal(r.exit, 3);
+    assert.equal(JSON.parse(r.out).refused, true);
+    // budget ledger untouched — nothing spent on a refused run
+    const led = readLedger(e.ledgerPath);
+    assert.equal(led.spent_credits, 0);
+  } finally { e.cleanup(); }
+});
+
+test('run requires --force when the target cannot be estimated (never-run query_id)', async () => {
+  const e = tmpEnv();
+  try {
+    const client = mockClient({ rows: 1000, cols: 4, datapoints: 4000, credits: 4 });
+    client.probe = async () => { throw new DuneClientError('estimate: query 9 has no completed cached result'); };
+    const r = await runHandler(() => cmdRun(['9', '--cap', '100'], { client }));
+    assert.equal(r.exit, 2);
+    assert.match(r.err, /--force/);
+    // nothing executed → ledger untouched
+    assert.equal(readLedger(e.ledgerPath).spent_credits, 0);
+  } finally { e.cleanup(); }
+});
+
+test('run --force proceeds past an un-estimatable target (cost-cap is the backstop)', async () => {
+  const e = tmpEnv();
+  try {
+    const client = mockClient({ rows: 1000, cols: 4, datapoints: 4000, credits: 4 });
+    client.probe = async () => { throw new DuneClientError('estimate: query 9 has no completed cached result'); };
+    const r = await runHandler(() => cmdRun(['9', '--cap', '100', '--force'], { client }));
+    assert.equal(r.exit, 0);
+    const j = JSON.parse(r.out);
+    assert.equal(j.executed, true);
+    assert.equal(j.pre_run_estimate, null); // un-estimated; proceeded on the cap alone
+    assert.equal(j.credits_consumed, 4);
+  } finally { e.cleanup(); }
+});
+
+test('run executes, emits a CostAtom, decrements budget (happy path)', async () => {
+  const e = tmpEnv();
+  try {
+    const client = mockClient({ rows: 1000, cols: 4, datapoints: 4000, credits: 4 });
+    const r = await runHandler(() => cmdRun(['12345', '--cap', '100'], { client }));
+    assert.equal(r.exit, 0);
+    const j = JSON.parse(r.out);
+    assert.equal(j.executed, true);
+    assert.equal(j.credits_consumed, 4);
+    assert.equal(j.datapoints_scanned, 4000);
+    assert.equal(j.budget.spent_credits, 4);
+    assert.equal(j.budget.remaining_credits, 2496);
+    // atom was written + chains from genesis
+    const read = readAtoms(e.atomsPath);
+    assert.equal(read.atoms.length, 1);
+    assert.equal(read.chain_ok, true);
+    assert.equal(read.atoms[0].dune.credits_consumed, 4);
+  } finally { e.cleanup(); }
+});
+
+test('run exit 4 when reported spend exceeds --cap (cap-aborted accounting)', async () => {
+  const e = tmpEnv();
+  try {
+    const client = mockClient({ rows: 50000, cols: 4, datapoints: 200000, credits: 200 });
+    const r = await runHandler(() => cmdRun(['12345', '--cap', '10', '--force'], { client }));
+    assert.equal(r.exit, 4);
+    assert.equal(JSON.parse(r.out).cap_exceeded, true);
+  } finally { e.cleanup(); }
+});
+
+test('run exit 4 when Dune aborts on cost cap (CostCapAbortError)', async () => {
+  const e = tmpEnv();
+  try {
+    const { CostCapAbortError } = await import('../src/dune-client.mjs');
+    const client = mockClient({ throwOnExecute: new CostCapAbortError('aborted', 'exec-x') });
+    // probe still works; execute throws the cap abort
+    client.probe = async () => ({ rows: 10, cols: 2, execution_id: 'p' });
+    const r = await runHandler(() => cmdRun(['12345', '--cap', '100'], { client }));
+    assert.equal(r.exit, 4);
+    assert.equal(JSON.parse(r.out).aborted, true);
+  } finally { e.cleanup(); }
+});
+
+test('run derives credits from datapoints when Dune reports none', async () => {
+  const e = tmpEnv();
+  try {
+    const client = mockClient({ rows: 1000, cols: 3, datapoints: 3001, credits: null });
+    const r = await runHandler(() => cmdRun(['12345', '--cap', '100'], { client }));
+    const j = JSON.parse(r.out);
+    assert.equal(j.credits_derived, true);
+    assert.equal(j.credits_consumed, 4); // ceil(3001/1000)
+  } finally { e.cleanup(); }
+});
+
+test('budget reports spent/remaining/ceiling + recent atoms + chain status', async () => {
+  const e = tmpEnv();
+  try {
+    appendAtom(e.atomsPath, makeDuneAtom({ query_id: '7', datapoints_scanned: 5000, credits_consumed: 5, engine: 'small', wall_ms: 100, ts: 1 }));
+    recordSpend(e.ledgerPath, 5);
+    const r = await runHandler(() => cmdBudget());
+    assert.equal(r.exit, 0);
+    const j = JSON.parse(r.out);
+    assert.equal(j.spent_credits, 5);
+    assert.equal(j.remaining_credits, 2495);
+    assert.equal(j.ceiling, 2500);
+    assert.equal(j.chain_ok, true);
+    assert.equal(j.recent_atoms.length, 1);
+    assert.equal(j.recent_atoms[0].credits_consumed, 5);
+  } finally { e.cleanup(); }
+});
+
+test('budget recent_atoms caps at last 5', async () => {
+  const e = tmpEnv();
+  try {
+    for (let i = 1; i <= 7; i++) {
+      appendAtom(e.atomsPath, makeDuneAtom({ query_id: String(i), datapoints_scanned: 1000 * i, credits_consumed: i, engine: 'small', wall_ms: 10, ts: i }));
+    }
+    const r = await runHandler(() => cmdBudget());
+    const j = JSON.parse(r.out);
+    assert.equal(j.recent_atoms.length, 5);
+    assert.equal(j.recent_atoms[0].query_id, '3'); // atoms 3..7
+    assert.equal(j.recent_atoms[4].query_id, '7');
+  } finally { e.cleanup(); }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// bd-qbts / sprint-bug-170 — defect A (raw-SQL execute endpoint → Dune 405) +
+// defect B (bin not executable). FETCH-LEVEL through the real DuneClient — NOT the
+// client-level mockClient above, whose canned `executeSql` masked the dead HTTP
+// path (the coverage gap that let this ship). Offline, deterministic, no Dune spend.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Records url + method + parsed body of every fetch; responds canned to any URL.
+function recordingFetch(responder = () => ({ json: {} })) {
+  const calls = [];
+  const fetchImpl = async (url, opts = {}) => {
+    const body = opts.body ? JSON.parse(opts.body) : undefined;
+    calls.push({ url, method: opts.method ?? 'GET', body });
+    const { status = 200, json = {} } = responder(url, opts) ?? {};
+    return { ok: status >= 200 && status < 300, status, async json() { return json; }, async text() { return JSON.stringify(json); } };
+  };
+  return { fetchImpl, calls };
+}
+
+test('executeSql routes raw SQL to the first-party /sql/execute endpoint with {sql, performance} (defect A — the 405 fix)', async () => {
+  const { fetchImpl, calls } = recordingFetch(() => ({ json: { execution_id: 'exec-sql-1', state: 'QUERY_STATE_PENDING' } }));
+  const client = new DuneClient({ apiKey: 'k', fetchImpl, sleepImpl: async () => {} });
+  const res = await client.executeSql('SELECT 1');
+  const post = calls.find((c) => c.method === 'POST');
+  assert.ok(post, 'executeSql issues a POST');
+  assert.ok(post.url.endsWith('/api/v1/sql/execute'), `POST goes to /api/v1/sql/execute (got ${post.url})`);
+  assert.deepEqual(post.body, { sql: 'SELECT 1', performance: 'small' }, 'body uses {sql} (not the dead {query_sql})');
+  assert.equal(res.execution_id, 'exec-sql-1');
+});
+
+test('executeSql NEVER POSTs the dead /query/execute endpoint (defect A regression — locks out the Dune 405)', async () => {
+  const { fetchImpl, calls } = recordingFetch(() => ({ json: { execution_id: 'exec-sql-2' } }));
+  const client = new DuneClient({ apiKey: 'k', fetchImpl, sleepImpl: async () => {} });
+  await client.executeSql('SELECT 1');
+  assert.equal(calls.some((c) => c.url.includes('/query/execute')), false, 'must not hit /query/execute (Dune: HTTP method not allowed)');
+});
+
+test('bin/dune-meter.mjs is executable and spawns directly (defect B — DUNE_METER_BIN consumers child_process.spawn it)', () => {
+  const bin = fileURLToPath(new URL('../bin/dune-meter.mjs', import.meta.url));
+  assert.notEqual(statSync(bin).mode & 0o111, 0, 'bin must carry an executable bit');
+  const r = spawnSync(bin, ['--help'], { encoding: 'utf8' });
+  assert.equal(r.status, 0, `spawned --help exits 0 (status=${r.status}, stderr=${r.stderr})`);
+  assert.match(r.stdout, /dune-meter/, '--help prints usage');
+});

--- a/packages/dune-meter/veve.json
+++ b/packages/dune-meter/veve.json
@@ -1,0 +1,78 @@
+{
+  "veve_version": "0.2.0",
+  "name": "dune-meter",
+  "version": "0.1.0",
+  "summary": "Cost-aware Dune adapter: estimate (probe heuristic) / run (cost-capped + CostAtom) / budget. The EXP-002 budget-blowout made structurally impossible.",
+  "binary": {
+    "entry": "bin/dune-meter.mjs",
+    "runtime": "node",
+    "subcommands": [
+      "estimate",
+      "run",
+      "budget"
+    ]
+  },
+  "determinism": {
+    "class": "attestable",
+    "declared_by": "author",
+    "ambient": [
+      "network",
+      "clock",
+      "randomness"
+    ]
+  },
+  "rel_required": "casual",
+  "liveness": {
+    "timeout_s": 300,
+    "expected_p95_s": 30,
+    "mode": "oneshot"
+  },
+  "io": {
+    "input": "argv",
+    "output": "stdout_json",
+    "exit_codes": {
+      "0": "ok",
+      "2": "caller error (bad args, missing key, malformed target)",
+      "3": "budget refuse (estimate exceeds remaining budget)",
+      "4": "cap aborted (Dune cost-cap hard-abort, or reported spend over --cap)"
+    }
+  },
+  "vectors": [
+    {
+      "name": "help-usage (ambient-free: static usage text; no network/clock/env/ledger touched — replays byte-stable on any host)",
+      "argv": [
+        "--help"
+      ],
+      "stdin": null,
+      "expect_output_hash": "sha256:1de550dd2ceccd9398c9fb3e3c292e2f54b155108ba162b9592f1985cdf6f4e7",
+      "expect_exit": 0
+    },
+    {
+      "name": "run-requires-cap (ambient-free: the cost-cap mandate — `run` errors exit 2 before any ledger/network I/O; empty stdout, deterministic)",
+      "argv": [
+        "run",
+        "12345"
+      ],
+      "stdin": null,
+      "expect_output_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "expect_exit": 2
+    }
+  ],
+  "ladder": {
+    "level": 2,
+    "promoted_from": "grimoires/loa/context/dune-meter-cost-aware-adapter.md",
+    "evidence_runs": [
+      "run:exp-002-budget-blowout:postmortem",
+      "run:dune-meter-0612a:build"
+    ]
+  },
+  "attestation": {
+    "tree_hash": "sha256:667e52ef6fee98307a2bfc2b72e845e499edf30caae82e9b5d3d02fbc38e4d1d",
+    "git_commit": "771e5fcb8bc312bd5f559a85b7b65b3311c47c7b",
+    "signed_by_key_id": "436c1bd81f70aefa6739230657cafadd4b9181c9ea0517cb77124ae4ad270871",
+    "signature_type": "dev_signature",
+    "ts": "2026-06-12T20:38:27.762Z",
+    "signature": "GY7ccXg+3FjpM2M0B8RYkW2Q0irEkQQ13wrtW5hS1ENHro0Ox8Sg6bP6sD0AkmL4OrnKMn63u5KXEX95Bud6Bw==",
+    "public_key": {}
+  }
+}


### PR DESCRIPTION
## Extract `@freeside/dune-meter` onto main — unblock the Corpus Engine MVP without the stale behemoth

The Corpus Engine MVP's **blocking-dependency #1** (`loa-finn/grimoires/loa/prd.md:68,124`) is the governed headless Dune path — the `dune-meter` package. Its **Dune-405 fix already exists** (`8b8c0142`, "raw-SQL execute endpoint") but is **trapped in #282**: 45 commits behind main, 418 files, +76k lines, open since 2026-06-12. So "merge the fix" has actually meant "rebase + merge a 10-day-stale behemoth" — and it sat, blocking the MVP.

`packages/dune-meter` is **fully self-contained** — `dependencies: {}`, tests via `node --test` (no install), no workspace siblings, and **not on main**. This PR lifts *just that package* onto current main:

- The **405 fix**, regression-locked: `executeSql NEVER POSTs the dead /query/execute endpoint` ✓
- Cost-cap accounting (`--cap`, exit 4 on blowout) + the executable `bin/dune-meter.mjs` (for `DUNE_METER_BIN` consumers) ✓
- **34 tests pass standalone** (verified: `node --test test/*.test.mjs`).

**Effect:** the Corpus Engine can wire `DUNE_METER_BIN` against main *now*, instead of waiting on #282's rebase. Found via the loa-finn MVP re-point (2026-06-23) — the re-point surfaced this as the singular unblock, and grounding revealed the fix was extractable.

> If you'd rather land **#282** whole, just close this — it's an *unblock option*, not a replacement. The package here is byte-identical to #282's version; no divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
