### PR TITLE
fix(cheval-verdict): a degenerate chain cannot report "consensus"

### DIFF
--- a/.claude/adapters/loa_cheval/verdict/consensus.py
+++ b/.claude/adapters/loa_cheval/verdict/consensus.py
@@ -114,6 +114,14 @@ def classify_consensus(
       location from another voice.
     """
     voices_succeeded = int(envelope.get("voices_succeeded") or 0)
+    # arrakis-verdict-consensus-lie-qzo4: a chain where NO voice succeeded
+    # reached no agreement at all — calling that "consensus" is a lie. The
+    # honest in-vocabulary value is "impossible" (compute_verdict_status maps
+    # it to FAILED, which a 0-voice chain already is). Distinct from the
+    # single-voice case below, which IS honest (degenerate) consensus: one
+    # voice cannot contradict itself.
+    if voices_succeeded == 0:
+        return _OUTCOME_IMPOSSIBLE
     if voices_succeeded < 2:
         return _OUTCOME_CONSENSUS
 

--- a/.claude/adapters/loa_cheval/verdict/consensus.py
+++ b/.claude/adapters/loa_cheval/verdict/consensus.py
@@ -20,8 +20,15 @@ Inputs:
                         comparison.
 
 Algorithm:
-  1. Trivial cases: voices_succeeded < 2 → "consensus" (cannot have
-     contradiction with fewer than 2 voices).
+  1. Degenerate / trivial cases:
+       voices_succeeded == 0 → "impossible" — NO voice produced a verdict, so
+         no agreement exists (arrakis-verdict-consensus-lie-qzo4). "impossible"
+         here denotes "no consensus was reachable", which compute_verdict_status
+         maps to FAILED — the same status a 0-voice chain already carries. This
+         broadens "impossible" beyond the cross-voice-contradiction sense in
+         step 3 to also cover the no-agreement-possible (empty/exhausted) case.
+       voices_succeeded == 1 → "consensus" — a single voice cannot contradict
+         itself; that is honest (degenerate) consensus.
   2. Per-finding cross-voice comparison: for each BLOCKER-severity finding
      emitted by any voice, check whether at least one other voice's
      findings cover the same (file_path, line_number) location AND

--- a/.claude/adapters/loa_cheval/verdict/quality.py
+++ b/.claude/adapters/loa_cheval/verdict/quality.py
@@ -206,14 +206,46 @@ def compute_verdict_status(envelope: Dict[str, Any]) -> str:
     return _STATUS_DEGRADED
 
 
+def _reconcile_degenerate_consensus(envelope: Dict[str, Any]) -> None:
+    """arrakis-verdict-consensus-lie-qzo4 — a degenerate chain reached no
+    agreement, so it MUST NOT carry ``consensus_outcome == "consensus"``.
+
+    Every producer flows through ``emit_envelope_with_status``, but only the
+    aggregate path calls ``classify_consensus``; the single-voice producer
+    (``cheval.cmd_invoke``) and the aggregate placeholder both hardcode
+    ``"consensus"``. That is how a 0-voice / exhausted chain ended up stamped
+    ``consensus_outcome="consensus"`` while ``status="FAILED"`` (observed live
+    in ``.run/model-invoke.jsonl``) — a lie that fools any consumer keying off
+    consensus rather than status (e.g. Flatline HIGH_CONSENSUS auto-integrate).
+
+    Reconcile at this single chokepoint: when no voice succeeded OR the chain
+    exhausted, the honest in-vocabulary value is ``"impossible"``. Both of
+    those states already auto-promote to FAILED in ``compute_verdict_status``,
+    so this is status-preserving — it only removes the false consensus claim.
+    A single succeeded voice is left untouched: 1/1 is honest consensus.
+    """
+    voices_succeeded = int(envelope.get("voices_succeeded") or 0)
+    chain_health = envelope.get("chain_health", _CHAIN_HEALTH_OK)
+    degenerate = (
+        voices_succeeded == 0 or chain_health == _CHAIN_HEALTH_EXHAUSTED
+    )
+    if degenerate and (
+        envelope.get("consensus_outcome") == _CONSENSUS_OUTCOME_CONSENSUS
+    ):
+        envelope["consensus_outcome"] = _CONSENSUS_OUTCOME_IMPOSSIBLE
+
+
 def emit_envelope_with_status(envelope: Dict[str, Any]) -> Dict[str, Any]:
     """Single producer entry-point per v5 SKP-003 closure.
 
     Pipeline:
       1. ``validate_invariants`` — raises ``EnvelopeInvariantViolation``
          on malformed input. Producer MUST NOT emit an unvalidated envelope.
-      2. ``compute_verdict_status`` — writes the canonical status field.
-      3. Return the mutated envelope (the input dict is mutated in-place
+      2. ``_reconcile_degenerate_consensus`` — a no-voice / exhausted chain
+         cannot carry ``consensus_outcome="consensus"`` (the verdict-honesty
+         invariant; arrakis-verdict-consensus-lie-qzo4).
+      3. ``compute_verdict_status`` — writes the canonical status field.
+      4. Return the mutated envelope (the input dict is mutated in-place
          AND returned; callers can rely on either reference).
 
     Error paths (SDD §6.2) flow through this same function with the same
@@ -222,6 +254,7 @@ def emit_envelope_with_status(envelope: Dict[str, Any]) -> Dict[str, Any]:
     paths that bypass this helper.
     """
     validate_invariants(envelope)
+    _reconcile_degenerate_consensus(envelope)
     envelope["status"] = compute_verdict_status(envelope)
     return envelope
 

--- a/.claude/adapters/tests/test_classify_consensus.py
+++ b/.claude/adapters/tests/test_classify_consensus.py
@@ -52,12 +52,19 @@ def _finding(severity: str, file_path: str = "src/app.py",
 # ---------------------------------------------------------------------------
 
 
-def test_zero_succeeded_returns_consensus():
-    """voices_succeeded=0: no findings to compare — trivially 'consensus'."""
+def test_zero_succeeded_returns_impossible():
+    """voices_succeeded=0: NO voice produced a verdict, so there is no
+    agreement to report. arrakis-verdict-consensus-lie-qzo4 — the earlier
+    "no findings to compare → trivially consensus" reading produced a
+    downstream lie (consensus_outcome="consensus" stamped on 0-voice/FAILED
+    chains, observed live in .run/model-invoke.jsonl). The honest
+    in-vocabulary value is "impossible" (→ compute_verdict_status → FAILED,
+    which a 0-voice chain already is). One-voice success below is distinct
+    and remains honest consensus."""
     from loa_cheval.verdict.consensus import classify_consensus
 
     env = _envelope_for(voices_succeeded=0)
-    assert classify_consensus(env, []) == "consensus"
+    assert classify_consensus(env, []) == "impossible"
 
 
 def test_one_succeeded_returns_consensus():

--- a/.claude/adapters/tests/test_verdict_quality_classifier.py
+++ b/.claude/adapters/tests/test_verdict_quality_classifier.py
@@ -414,3 +414,108 @@ class TestEmitEnvelopeWithStatus:
         assert out["rationale"] == "custom rationale text"
         assert out["voices_planned"] == 3
         assert out["consensus_outcome"] == "consensus"
+
+
+# ---------------------------------------------------------------------------
+# Consensus honesty — a degenerate chain cannot have reached "consensus"
+# (arrakis-verdict-consensus-lie-qzo4). The verdict emitter was stamping
+# consensus_outcome="consensus" on 0-voice / exhausted chains, observed live
+# in .run/model-invoke.jsonl: {voices_succeeded:0, chain_health:"exhausted",
+# status:"FAILED", consensus_outcome:"consensus"}. status was honest but the
+# consensus field lied — dangerous for any consumer that keys off consensus
+# (e.g. Flatline HIGH_CONSENSUS auto-integrate) rather than status.
+# ---------------------------------------------------------------------------
+
+
+def _degenerate_envelope(**overrides):
+    """A zero-voice / exhausted single-voice envelope mirroring the live
+    MODELINV failure shape. INV-6: len(voices_dropped) == planned - succeeded."""
+    env = {
+        "consensus_outcome": "consensus",
+        "truncation_waiver_applied": False,
+        "voices_planned": 1,
+        "voices_succeeded": 0,
+        "voices_succeeded_ids": [],
+        "voices_dropped": [
+            _dropped("claude-headless", reason="RetriesExhausted",
+                     exit_code=1, blocker_risk="unknown"),
+        ],
+        "chain_health": "exhausted",
+        "confidence_floor": "low",
+        "rationale": "single-voice cheval invoke; chain exhausted after 1/1",
+    }
+    env.update(overrides)
+    return env
+
+
+class TestConsensusHonesty:
+    def test_zero_voices_is_not_consensus(self):
+        """The live-MODELINV lie: 0 voices succeeded but consensus stamped."""
+        from loa_cheval.verdict.quality import emit_envelope_with_status
+        out = emit_envelope_with_status(_degenerate_envelope())
+        assert out["status"] == "FAILED"
+        assert out["consensus_outcome"] == "impossible", (
+            "a 0-voice/exhausted chain reached no consensus; the honest "
+            "in-vocabulary value is 'impossible' (→ FAILED), not 'consensus'"
+        )
+
+    def test_exhausted_multi_voice_is_not_consensus(self):
+        """All 3 voices dropped → exhausted → consensus is a lie."""
+        from loa_cheval.verdict.quality import emit_envelope_with_status
+        env = _degenerate_envelope(
+            voices_planned=3,
+            voices_dropped=[
+                _dropped("opus", reason="RetriesExhausted"),
+                _dropped("gpt-5.5-pro", reason="RetriesExhausted"),
+                _dropped("gemini-3.1-pro", reason="RetriesExhausted"),
+            ],
+        )
+        out = emit_envelope_with_status(env)
+        assert out["status"] == "FAILED"
+        assert out["consensus_outcome"] == "impossible"
+
+    def test_single_voice_success_stays_consensus(self):
+        """Guard against over-correction: 1/1 success is honest consensus."""
+        from loa_cheval.verdict.quality import emit_envelope_with_status
+        env = {
+            "consensus_outcome": "consensus",
+            "truncation_waiver_applied": False,
+            "voices_planned": 1,
+            "voices_succeeded": 1,
+            "voices_succeeded_ids": ["claude-headless"],
+            "voices_dropped": [],
+            "chain_health": "ok",
+            "confidence_floor": "high",
+            "rationale": "single-voice success",
+        }
+        out = emit_envelope_with_status(env)
+        assert out["status"] == "APPROVED"
+        assert out["consensus_outcome"] == "consensus"
+
+    def test_partial_success_keeps_consensus(self):
+        """2/3 succeeded (degraded but real) keeps consensus semantics."""
+        from loa_cheval.verdict.quality import emit_envelope_with_status
+        env = _baseline_envelope(
+            voices_succeeded=2,
+            voices_succeeded_ids=["opus", "gemini-3.1-pro"],
+            voices_dropped=[_dropped("gpt-5.5-pro")],
+            chain_health="degraded",
+            confidence_floor="med",
+        )
+        out = emit_envelope_with_status(env)
+        assert out["status"] == "DEGRADED"
+        assert out["consensus_outcome"] == "consensus"
+
+
+class TestClassifyConsensusZeroVoices:
+    def test_zero_voices_classifies_impossible(self):
+        """The pure classifier must not call a no-voice chain 'consensus'."""
+        from loa_cheval.verdict.consensus import classify_consensus
+        assert classify_consensus({"voices_succeeded": 0}, []) == "impossible"
+
+    def test_single_voice_classifies_consensus(self):
+        from loa_cheval.verdict.consensus import classify_consensus
+        out = classify_consensus(
+            {"voices_succeeded": 1}, [[{"severity": "HIGH"}]]
+        )
+        assert out == "consensus"


### PR DESCRIPTION
## What

Closes the verdict-honesty bug `arrakis-verdict-consensus-lie-qzo4` (P1): the cheval verdict emitter stamped `consensus_outcome: "consensus"` on chains where **zero voices succeeded**.

Observed live in `.run/model-invoke.jsonl`:
```
{voices_succeeded:0, chain_health:"exhausted", status:"FAILED", consensus_outcome:"consensus"}
```
`status` was honest (FAILED) — but the consensus field lied: it claimed the models agreed when zero models produced anything. Any consumer keying off consensus rather than status (e.g. Flatline `HIGH_CONSENSUS` auto-integrate) could be fooled into integrating a failed review.

## Root cause

Two stamping sites conflate "0 voices (nothing happened)" with "1 voice (nothing to contradict)":
- `consensus.py` `classify_consensus()`: `voices_succeeded < 2 -> "consensus"` includes 0.
- the single-voice producer + aggregate placeholder hardcode `"consensus"`.

## Fix (status-preserving)

- `consensus.py`: `voices_succeeded == 0 -> "impossible"` (1 stays consensus).
- `quality.py`: reconcile at `emit_envelope_with_status` — the single chokepoint every producer flows through — so no emission can carry `"consensus"` while `voices_succeeded==0` / `chain_health=="exhausted"`. `"impossible"` is the honest in-vocabulary value (schema enum `consensus|impossible`), and both states already auto-promote to FAILED → **no status regression**.

## Tests

Test-first. `TestConsensusHonesty` + `TestClassifyConsensusZeroVoices` reproduce the live MODELINV shape (fail-before), with guards that 1/1 and partial success **stay** consensus (no over-correction). Updated the one pre-existing test that codified the lie. cycle-109 conformance fixtures left intact — they deliberately pair a misleading consensus with an exhausted chain to prove `compute_status` returns FAILED independently (complementary defense-in-depth at the compute layer; this fix closes the lie at the emit layer).

- verdict/consensus suite: **77 pass** · conformance bats **16/16**
- the 36 unrelated failures in the full adapters suite are pre-existing env/version drift (cursor-CLI error classification, opus-4-7→4-8 model bump, mock-mode) — none import the changed modules.

> cheval routing is operator-gated — **review + merge is yours**, not auto. Repo main also carries the known-numb Unit Tests gate (#304); CI red here is not a per-PR signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)