### PR TITLE
fix(ci): secret-scanning full-scan on push/schedule (un-numb the gate)

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -27,8 +27,10 @@ jobs:
         continue-on-error: true
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          # Diff-scan on PRs; full-tree scan on push/schedule (empty base+head ->
+          # TruffleHog full-scan mode, avoiding the BASE==HEAD error that failed every push).
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
+          head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
           extra_args: --only-verified --no-update
 
       - name: Run GitLeaks


### PR DESCRIPTION
TruffleHog `base==head` on push/schedule made Secret Scanning red on every commit (effectively OFF). Fix: diff-scan on PRs, full-tree scan on push/schedule. Proven in 0xHoneyJar/loa-constructs#267 (merged; main secret-scan now green). Estate-wide pattern — ~27 repos affected.