### PR TITLE
fix(cheval/cursor): pgkill dispatch + stdin prompt + sandbox — orphan-on-timeout + BB #966

### DIFF
--- a/.claude/adapters/loa_cheval/providers/cursor_headless_adapter.py
+++ b/.claude/adapters/loa_cheval/providers/cursor_headless_adapter.py
@@ -49,15 +49,19 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
+import tempfile
 import time
 from typing import Any, Dict, List, Optional
 
 from loa_cheval.providers.base import (
     ProviderAdapter,
+    SubprocessOutputCapExceeded,
     build_headless_subprocess_env,
     enforce_context_window,
+    run_subprocess_pgkill,
 )
 from loa_cheval.types import (
     CompletionRequest,
@@ -115,7 +119,7 @@ class CursorHeadlessAdapter(ProviderAdapter):
         enforce_context_window(request, model_config)
 
         prompt = self._build_prompt(request.messages)
-        cmd = self._build_command(request, model_config, prompt)
+        cmd = self._build_command(request, model_config)
         timeout_s = self._compute_timeout()
         # Cycle-110 sprint-2b2b1 BB iter-2 F-001 closure: read per-model
         # headless_concurrency_limit (cycle-110 ModelConfig field). Default 50
@@ -136,35 +140,59 @@ class CursorHeadlessAdapter(ProviderAdapter):
             acquire_slot as _acquire_slot,
         )
 
+        # #966 round-4 (HIGH_CONSENSUS) + #982: run cursor-agent in a FRESH empty
+        # workspace (defense-in-depth — `ask` mode is read-only, but an isolated
+        # cwd mirrors codex's `-C <workspace>` untrusted-prompt posture) and
+        # dispatch through the process-group-killing helper so a timeout reaps the
+        # WHOLE cursor-agent tree instead of orphaning it (the #982 fix codex got
+        # but this adapter missed). The prompt rides STDIN (input=prompt), never
+        # argv — cursor-agent reads stdin (verified), so a 200K-token prompt can't
+        # blow ARG_MAX or leak into the process command line.
+        workspace: Optional[str] = None
         start = time.monotonic()
         try:
+            try:
+                workspace = tempfile.mkdtemp(prefix="loa-cursor-ws-")
+            except OSError as exc:
+                raise ConfigError(
+                    f"cursor-headless: failed to create isolated workspace: {exc}"
+                ) from exc
             with _acquire_slot("cursor-headless", n_slots=n_slots):
                 try:
-                    proc = subprocess.run(
+                    proc = run_subprocess_pgkill(
                         cmd,
-                        capture_output=True,
-                        text=True,
+                        input=prompt,
                         timeout=timeout_s,
-                        check=False,
-                        # cursor-agent's `--print` flag consumes the prompt
-                        # argument directly. Keep stdin closed so the CLI never
-                        # blocks waiting for piped input in some shells.
-                        stdin=subprocess.DEVNULL,
                         # Symmetric with codex / gemini (#879 / #880): strip
                         # API-key auth vars so the CLI uses its own login
                         # session, not an ambient API key.
                         env=build_headless_subprocess_env(),
+                        cwd=workspace,
                     )
                 except subprocess.TimeoutExpired:
                     raise ProviderUnavailableError(
                         self.provider,
                         f"cursor-agent --print timed out after {timeout_s:.0f}s",
                     )
+                except SubprocessOutputCapExceeded as exc:
+                    # Truncated output must never masquerade as success — the cap
+                    # is a provider failure so the chain advances (codex parity).
+                    raise ProviderUnavailableError(
+                        self.provider, f"cursor-agent {exc}",
+                    ) from exc
                 except FileNotFoundError as exc:
                     raise ConfigError(
                         f"cursor-agent CLI not found on PATH (set CURSOR_HEADLESS_BIN "
                         f"to override). Install from https://cursor.com/cli. "
                         f"Original: {exc}"
+                    ) from exc
+                except OSError as exc:
+                    # A spawn-level OSError (permission, exec-format, ENOMEM) is a
+                    # provider availability problem, not a config error — let the
+                    # chain advance. FileNotFoundError (a missing binary, an
+                    # OSError subclass) is handled above as ConfigError.
+                    raise ProviderUnavailableError(
+                        self.provider, f"cursor-agent failed to spawn: {exc}",
                     ) from exc
         except _SemaphoreExhausted as exc:
             raise ProviderUnavailableError(
@@ -173,6 +201,9 @@ class CursorHeadlessAdapter(ProviderAdapter):
                 f"exhausted after {exc.waited_seconds:.1f}s "
                 f"(n_slots={exc.n_slots})",
             ) from exc
+        finally:
+            if workspace is not None:
+                shutil.rmtree(workspace, ignore_errors=True)
 
         latency_ms = int((time.monotonic() - start) * 1000)
 
@@ -183,25 +214,56 @@ class CursorHeadlessAdapter(ProviderAdapter):
         # when there is no parseable JSON result.
         parsed: Optional[Dict[str, Any]] = None
         if proc.stdout and proc.stdout.strip():
-            try:
-                parsed = json.loads(proc.stdout)
-            except json.JSONDecodeError:
-                parsed = None
+            # cursor-agent emits a SINGLE {"type":"result",...} envelope, but may
+            # PREPEND non-result log lines (e.g. {"level":"warn",...} or a node
+            # ExperimentalWarning). Scan for the RESULT line so a log line cannot
+            # shadow it; a stdout carrying ONLY log lines (no result) leaves
+            # parsed=None and is treated as a failure, never an empty success.
+            for line in proc.stdout.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(obj, dict) and obj.get("type") == "result":
+                    parsed = obj
+                    break
 
         if proc.returncode != 0 or (parsed and parsed.get("is_error")):
             self._raise_for_error(
                 returncode=proc.returncode,
                 stderr=proc.stderr or "",
                 parsed=parsed,
+                stdout=proc.stdout or "",
             )
 
         if parsed is None:
-            # Exit 0 but no JSON — the trust/model/auth diagnostics land here.
+            # Exit 0 but no result envelope — trust/model/auth diagnostics AND
+            # transport errors cursor writes to stdout (resource_exhausted) land
+            # here; the raw stdout is the diagnostic.
             self._raise_for_error(
                 returncode=proc.returncode,
                 stderr=proc.stderr or "",
                 parsed=None,
+                stdout=proc.stdout or "",
             )
+
+        # Transport-probe safety (the silencing-attack regression): a rate-limit
+        # / transport error on STDERR means the call was THROTTLED even if cursor
+        # still emitted a result envelope — back the chain off rather than accept
+        # a partial result. The result's own usage/metadata is NOT scanned (a
+        # token count like 4290 must never masquerade as a 429); only a standalone
+        # 429 status / explicit rate-limit phrasing on stderr counts.
+        stderr_l = (proc.stderr or "").lower()
+        if (
+            re.search(r"\b429\b", proc.stderr or "")
+            or "rate limit" in stderr_l
+            or "resource_exhausted" in stderr_l
+            or "too many requests" in stderr_l
+        ):
+            raise RateLimitError(self.provider)
 
         return self._parse_json_output(
             parsed=parsed,
@@ -259,9 +321,10 @@ class CursorHeadlessAdapter(ProviderAdapter):
         self,
         request: CompletionRequest,
         model_config,
-        prompt: str,
     ) -> List[str]:
-        """Build the cursor-agent argv. Headless, read-only ask-mode, trusted."""
+        """Build the cursor-agent argv (flags only — the prompt rides STDIN, not
+        argv, so a 200K-token prompt can't blow ARG_MAX or leak into the process
+        command line). Headless, read-only ask-mode, trusted."""
         # cycle-104 sprint-2 T2.11 amendment (mirrored): honor `extra.cli_model`
         # so a kind:cli alias (`cursor-headless`) translates to the real cursor
         # model id the CLI binary expects (the CLI doesn't recognize the Loa
@@ -273,11 +336,17 @@ class CursorHeadlessAdapter(ProviderAdapter):
             "--output-format",
             "json",
             "--mode",
-            "ask",                     # read-only Q&A; no edits, no shell exec
+            "plan",                    # read-only/planning: analyze + propose, no edits
+            "--sandbox",
+            "enabled",                 # sandboxed even under --trust (defense-in-depth,
+                                       # matching gemini --approval-mode plan / codex
+                                       # --sandbox read-only). Verified: the full flag
+                                       # set dispatches over stdin (2026-06-24).
             "--trust",                 # required: --print refuses untrusted workspaces
             "--model",
             cli_model,
-            prompt,                    # positional prompt (last arg)
+            # No positional prompt: cursor-agent reads it from STDIN (complete()
+            # passes input=prompt to run_subprocess_pgkill).
         ]
 
         # Forward additional cursor-agent flags an operator may need but we
@@ -286,15 +355,13 @@ class CursorHeadlessAdapter(ProviderAdapter):
         extra = (model_config.extra or {})
         extra_flags = extra.get("cursor_extra_flags")
         if isinstance(extra_flags, list):
-            # Insert before the positional prompt so flags stay flag-shaped.
-            insert_at = len(cmd) - 1
-            forwarded: List[str] = []
+            # Append the forwarded flags — there is no positional prompt to keep
+            # them ahead of (the prompt rides STDIN now).
             for entry in extra_flags:
                 if isinstance(entry, str):
-                    forwarded.append(entry)
+                    cmd.append(entry)
                 elif isinstance(entry, list):
-                    forwarded.extend(str(x) for x in entry)
-            cmd[insert_at:insert_at] = forwarded
+                    cmd.extend(str(x) for x in entry)
 
         return cmd
 
@@ -376,19 +443,28 @@ class CursorHeadlessAdapter(ProviderAdapter):
         session_id = parsed.get("session_id")
         content = (parsed.get("result") or "").strip("\n")
 
+        # Coerce usage fields defensively: cursor may emit a non-int (a string
+        # like "oops", or null) on a malformed/partial envelope — int() would
+        # crash, turning a recoverable parse into a hard failure.
+        def _int0(v: Any) -> int:
+            try:
+                return int(v)
+            except (TypeError, ValueError):
+                return 0
+
         usage_data = parsed.get("usage") or {}
         usage = Usage(
-            input_tokens=int(usage_data.get("inputTokens") or 0),
-            output_tokens=int(usage_data.get("outputTokens") or 0),
+            input_tokens=_int0(usage_data.get("inputTokens")),
+            output_tokens=_int0(usage_data.get("outputTokens")),
             # Cursor does not surface a separate reasoning-token field.
             reasoning_tokens=0,
             source="actual" if usage_data else "estimated",
         )
 
         metadata: Dict[str, Any] = {}
-        cached = usage_data.get("cacheReadTokens")
+        cached = _int0(usage_data.get("cacheReadTokens"))
         if cached:
-            metadata["cached_tokens"] = int(cached)
+            metadata["cached_tokens"] = cached
         request_id = parsed.get("request_id")
         if request_id:
             metadata["request_id"] = request_id
@@ -405,7 +481,7 @@ class CursorHeadlessAdapter(ProviderAdapter):
             tool_calls=None,
             thinking=None,
             usage=usage,
-            model=requested_model,
+            model=parsed.get("model") or requested_model,
             latency_ms=latency_ms,
             provider=self.provider,
             interaction_id=session_id,
@@ -421,10 +497,15 @@ class CursorHeadlessAdapter(ProviderAdapter):
         returncode: int,
         stderr: str,
         parsed: Optional[Dict[str, Any]],
+        stdout: str = "",
     ) -> None:
         """Map cursor failure (subprocess, stderr diagnostic, or is_error JSON) to typed cheval error."""
         # Prefer a structured JSON error message when present; otherwise the
-        # plain-text stderr diagnostic (trust / model / auth all land here).
+        # plain-text diagnostic. cursor-agent surfaces transport errors
+        # (ConnectError / [resource_exhausted]) on STDOUT with a ZERO exit code
+        # and a non-JSON body, so the diagnostic must include stdout — checking
+        # stderr alone misses them and mis-classifies a rate-limit as a generic
+        # failure (the chain then can't react correctly).
         if parsed and parsed.get("is_error"):
             full_diag = str(
                 parsed.get("result")
@@ -433,7 +514,10 @@ class CursorHeadlessAdapter(ProviderAdapter):
                 or "cursor-agent reported is_error"
             )
         else:
-            full_diag = stderr.strip() or f"exit code {returncode}"
+            full_diag = (
+                (stderr.strip() + " " + stdout.strip()).strip()
+                or f"exit code {returncode}"
+            )
 
         diag_lower = full_diag.lower()
 
@@ -448,10 +532,12 @@ class CursorHeadlessAdapter(ProviderAdapter):
                 f"(diagnostic: {full_diag[:300]})"
             )
 
-        # Rate-limit / quota
+        # Rate-limit / quota. Match 429 as a STANDALONE token (HTTP status), not
+        # a substring — "429ms" (a latency) and "4290" (a token count) must not
+        # masquerade as a rate limit (the transport-probe-safety regression).
         if (
             "rate limit" in diag_lower
-            or "429" in full_diag
+            or re.search(r"\b429\b", full_diag)
             or "quota" in diag_lower
             or "too many requests" in diag_lower
             or "resource_exhausted" in diag_lower
@@ -472,7 +558,22 @@ class CursorHeadlessAdapter(ProviderAdapter):
                 f"(Auth file: {_CURSOR_CONFIG_FILE}; diagnostic: {full_diag[:300]})"
             )
 
+        # Final fallback — nothing specific matched, but this is STILL a failure;
+        # the chain must advance, never a silent pass. Name the shape so the
+        # cause is legible (and so transport-probe-safety regressions stay
+        # distinguishable): an is_error envelope vs. no parseable result at all.
         snippet = full_diag[:500] or f"exit code {returncode}, no diagnostic"
+        if parsed is not None and parsed.get("is_error"):
+            raise ProviderUnavailableError(
+                self.provider,
+                f"cursor-agent reported is_error (exit {returncode}): {snippet}",
+            )
+        if parsed is None:
+            raise ProviderUnavailableError(
+                self.provider,
+                f"cursor-agent produced no parseable JSON result "
+                f"(exit {returncode}): {snippet}",
+            )
         raise ProviderUnavailableError(
             self.provider,
             f"cursor-agent --print failed (exit {returncode}): {snippet}",

--- a/.claude/adapters/loa_cheval/providers/cursor_headless_adapter.py
+++ b/.claude/adapters/loa_cheval/providers/cursor_headless_adapter.py
@@ -22,20 +22,24 @@ Design notes:
     role-prefixed sections. Sufficient for the single-pass review modes
     (review / skeptic / scorer / dissenter) that are this adapter's consumers.
   - Tools / tool_choice are NOT forwarded to the cursor agent. The agent runs in
-    read-only `ask` mode (Q&A / explanation, no edits, no shell), so it cannot
-    touch the operator's files — pure inference, matching the gemini-headless
-    `--approval-mode plan` / codex-headless `--sandbox read-only` posture.
+    read-only `plan` mode under `--sandbox enabled` (analyze / propose, no edits,
+    no shell), so it cannot touch the operator's files — pure inference, matching
+    the gemini-headless `--approval-mode plan` / codex-headless `--sandbox
+    read-only` posture. (Both cursor-agent `--mode` choices — plan and ask — are
+    read-only; plan + sandbox is the stronger, codex-aligned posture, verified to
+    dispatch live 2026-06-24.)
   - `--trust` is passed because `--print` (headless) refuses to run in an
     untrusted workspace; without it the CLI emits a "Workspace Trust Required"
-    prompt to stderr and exits before producing output. `ask` mode keeps the
-    grant read-only (no code execution / file writes regardless of trust).
+    prompt to stderr and exits before producing output. `plan` mode + the sandbox
+    keep the grant read-only (no code execution / file writes regardless of trust).
   - `--output-format json` produces a SINGLE JSON object (not a JSONL stream):
       {"type":"result","subtype":"success","is_error":false,"result":"<text>",
        "session_id":"...","request_id":"...",
        "usage":{"inputTokens":..,"outputTokens":..,"cacheReadTokens":..,
                 "cacheWriteTokens":..}}
-    so parsing mirrors gemini-headless (json.loads of the whole stdout), not
-    codex-headless (line-by-line JSONL).
+    Parsing scans stdout LINE-ORIENTED for the {"type":"result",...} envelope
+    (cursor may prepend log lines), with a whole-stdout json.loads fallback for a
+    pretty-printed object — not a blind json.loads of the whole stdout.
   - Token usage maps from cursor's usage shape:
       usage.inputTokens      → Usage.input_tokens
       usage.outputTokens     → Usage.output_tokens
@@ -154,8 +158,15 @@ class CursorHeadlessAdapter(ProviderAdapter):
             try:
                 workspace = tempfile.mkdtemp(prefix="loa-cursor-ws-")
             except OSError as exc:
-                raise ConfigError(
-                    f"cursor-headless: failed to create isolated workspace: {exc}"
+                # A workspace-creation failure (e.g. /tmp exhaustion) is a
+                # TRANSIENT availability problem, not a config error — raise
+                # ProviderUnavailableError so the fallback chain advances instead
+                # of aborting the whole invoke as INVALID_CONFIG (codex/grok
+                # parity, #1008 DISS-002).
+                raise ProviderUnavailableError(
+                    self.provider,
+                    f"cursor-headless: failed to create isolated workspace: "
+                    f"{type(exc).__name__}: {exc}",
                 ) from exc
             with _acquire_slot("cursor-headless", n_slots=n_slots):
                 try:
@@ -231,6 +242,21 @@ class CursorHeadlessAdapter(ProviderAdapter):
                     parsed = obj
                     break
 
+            if parsed is None:
+                # Fallback for a PRETTY-PRINTED (multi-line) result envelope: the
+                # per-line scan only matches a compact single-line result, so a
+                # multi-line JSON object would be misread as no-envelope. cursor's
+                # --output-format json is compact today, but a formatting change
+                # must not turn a real result into a spurious failure. A
+                # log-line-only stdout stays type!=result here, so it remains a
+                # failure (never a silent empty success).
+                try:
+                    whole = json.loads(proc.stdout.strip())
+                except json.JSONDecodeError:
+                    whole = None
+                if isinstance(whole, dict) and whole.get("type") == "result":
+                    parsed = whole
+
         if proc.returncode != 0 or (parsed and parsed.get("is_error")):
             self._raise_for_error(
                 returncode=proc.returncode,
@@ -257,12 +283,21 @@ class CursorHeadlessAdapter(ProviderAdapter):
         # token count like 4290 must never masquerade as a 429); only a standalone
         # 429 status / explicit rate-limit phrasing on stderr counts.
         stderr_l = (proc.stderr or "").lower()
-        if (
+        # Word-boundary tokens (so "429ms" / "4290" / benign substrings do not
+        # match), AND a negated form ("no rate limit", "not resource_exhausted")
+        # must NOT fire — it is the OPPOSITE signal (cross-model review, #309).
+        _signal = (
             re.search(r"\b429\b", proc.stderr or "")
-            or "rate limit" in stderr_l
-            or "resource_exhausted" in stderr_l
-            or "too many requests" in stderr_l
-        ):
+            or re.search(r"\brate[ _-]?limit(?:ed|s|ing)?\b", stderr_l)
+            or re.search(r"\bresource_exhausted\b", stderr_l)
+            or re.search(r"\btoo many requests\b", stderr_l)
+        )
+        _negated = re.search(
+            r"\b(?:no|not|never|without|non)\b[\s:=-]*"
+            r"(?:rate[ _-]?limit|resource_exhausted|429|too many requests)",
+            stderr_l,
+        )
+        if _signal and not _negated:
             raise RateLimitError(self.provider)
 
         return self._parse_json_output(

--- a/.claude/adapters/tests/test_cursor_headless_adapter.py
+++ b/.claude/adapters/tests/test_cursor_headless_adapter.py
@@ -272,6 +272,34 @@ class TestTransportProbeSafety:
             r = _adapter().complete(_req())
         assert r.content == '{"verdict":"APPROVED"}'
 
+    def test_negated_rate_limit_in_stderr_not_misclassified(self):
+        # Cross-model review (#309): a NEGATED transport phrase ("no rate limit")
+        # is the OPPOSITE signal — it must not rate-limit-classify a billed
+        # success (the naive substring check would false-positive here).
+        with patch(_PGKILL, return_value=_completed(_OK_ENVELOPE, stderr="health: no rate limit hit")):
+            r = _adapter().complete(_req())
+        assert r.content == '{"verdict":"APPROVED"}'
+
+    def test_pretty_printed_result_envelope_parses(self):
+        # Cross-model review (#309): a multi-line / pretty-printed result envelope
+        # must still parse — the line-oriented scan finds no single-line result,
+        # so the whole-stdout fallback recovers it (never a spurious failure).
+        import json as _json
+        pretty = _json.dumps(_json.loads(_OK_ENVELOPE), indent=2)
+        assert "\n" in pretty  # guard: genuinely multi-line
+        with patch(_PGKILL, return_value=_completed(pretty)):
+            r = _adapter().complete(_req())
+        assert r.content == '{"verdict":"APPROVED"}'
+
+    def test_mkdtemp_failure_is_provider_unavailable_not_config(self):
+        # Cross-model review (#309): a workspace-creation failure (/tmp exhaustion)
+        # is TRANSIENT — it must advance the fallback chain (ProviderUnavailableError),
+        # not abort the whole invoke as INVALID_CONFIG (codex/grok parity #1008).
+        _mkdtemp = "loa_cheval.providers.cursor_headless_adapter.tempfile.mkdtemp"
+        with patch(_mkdtemp, side_effect=OSError("No space left on device")):
+            with pytest.raises(ProviderUnavailableError, match="isolated workspace"):
+                _adapter().complete(_req())
+
 
 # ---------------------------------------------------------------------------
 # Error classification


### PR DESCRIPTION
## The cursor adapter diverged from its own (45-test) spec

`voice-utilization` (laplas #82) showed **cursor is the under-used subscription** (1.3%) — and auditing it (the council that PR #11 restored) found why it's unreliable: the adapter never caught up to its own test suite, which encodes a design (pgkill + stdin-prompt + isolated cwd + sandbox) the implementation lacked. Brought it into agreement, **test-first**, with cursor-agent's interface **verified live**.

| Fix | Why |
|-----|-----|
| **pgkill dispatch** (was plain `subprocess.run`) | the real bug: on timeout, cursor-agent grandchildren orphaned (consuming the subscription) and held pipes open, **hanging the fallback chain**. #982 fixed this on codex; never applied here. |
| **prompt via STDIN, not argv** (BB #966 round-4 HIGH_CONSENSUS) | a 200K-token prompt could blow ARG_MAX + leaked into the process list. Verified: `echo … \| cursor-agent -p` returns a result. |
| **isolated `loa-cursor-ws-*` cwd + `--mode plan --sandbox enabled`** | codex/gemini untrusted-prompt posture; both read-only, sandboxed (stronger than `--mode ask`). Full flag set verified live. |
| **classification hardening** | transport errors on STDOUT now classified; per-line envelope parse (a JSON log line can't shadow the result, log-line-only ≠ silent success); `\b429\b` standalone-token match (so `429ms`/`4290` aren't false rate-limits); stderr-429 rate-limits even with a result; malformed usage → 0; OSError fails closed; model from the envelope. |

**45/45** (was 17+ failing). **Verified end-to-end**: a real cursor review dispatched through cheval (`{"type":"result",...}`). cheval routing = operator merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)