### PR TITLE
fix(ci): un-numb 'Unit Tests' — pre-bundle opossum so vitest resolves ./lib/circuit

### DIFF
--- a/themes/sietch/vitest.config.ts
+++ b/themes/sietch/vitest.config.ts
@@ -29,6 +29,20 @@ export default defineConfig({
         moduleDirectories: ['node_modules', path.resolve(__dirname, 'node_modules')],
       },
     },
+    // opossum is CJS with no `main`/`exports` field, so Node defaults to its index.js,
+    // which does `require('./lib/circuit')`. moduleDirectories (above) resolves the bare
+    // `opossum` specifier, but Vite's SSR transform then fails on opossum's INTERNAL
+    // relative require ("Cannot find module './lib/circuit'") — the error that reds every
+    // unit file importing the @freeside/adapters chain. Pre-bundling opossum through
+    // esbuild resolves its internals at bundle time, sidestepping the runtime failure.
+    deps: {
+      optimizer: {
+        ssr: {
+          enabled: true,
+          include: ['opossum'],
+        },
+      },
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'json-summary', 'html', 'lcov'],


### PR DESCRIPTION
## Un-numb the `Unit Tests` gate — opossum `./lib/circuit` resolution under vitest

**The keystone freeze.** `Unit Tests` (a required check) is red on **27/27** open loa-freeside PRs — freezing the entire merge backlog. Every run fails identically:

```
Error: Cannot find module './lib/circuit'
```

### Root cause (grounded, not guessed)
- `./lib/circuit` is **opossum's own internal module** — `opossum/index.js` is literally `module.exports = require('./lib/circuit')`. opossum 9.0.0 ships no `main`/`exports` field, so Node falls back to `index.js`.
- opossum is imported transitively by the `@freeside/adapters` chain (`loa-finn-client.ts`, `sonar-client.ts`, chain providers…), which `vitest.config.ts` aliases to **packages/adapters TS source**. So every unit file that touches the adapters barrel errors at *load*, which is why ~10 files "fail" from one dependency.
- The existing `server.deps.moduleDirectories` hint resolves the *bare* `opossum` specifier, but Vite's SSR transform then fails on opossum's **internal relative** `require('./lib/circuit')`.

### The fix
Force opossum through esbuild's pre-bundler (`test.deps.optimizer.ssr.include: ['opossum']`), which resolves opossum's internals at bundle time. Scoped to opossum via the `include` list — no blast radius on other deps. (Confirmed *not* a version issue: opossum 8.x has the identical no-`main` + `index.js → ./lib/circuit` structure, so downgrade wouldn't help.)

### ⚠️ Honesty: needs CI to confirm
I **could not validate this locally** — `npm ci` dies on `sharp`'s native build on macOS, and CI runs on Linux. This is a high-confidence fix for *this error class*, but **CI is the validator** — hence draft. If `optimizer.ssr.include` doesn't catch it, the documented fallbacks (in bead `arrakis-0q6r`) are: `server.deps.external: ['opossum']`, or pointing the adapters alias at `dist/`. Governed FAGAN review attached as a comment.

**Impact if green:** un-freezes all 27 loa-freeside PRs (the `strict`-rebase tail then needs a rebase pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code) · IMMUNE NIGHT → morning thaw
