### PR TITLE
feat(events): chain-agnostic NftActivity family (EVM+SVM canonical contract)

### DIFF
--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -42,6 +42,10 @@
       "types": "./dist/src/schemas/nft-mint-detected.d.ts",
       "import": "./dist/src/schemas/nft-mint-detected.js"
     },
+    "./schemas/nft-activity": {
+      "types": "./dist/src/schemas/nft-activity.d.ts",
+      "import": "./dist/src/schemas/nft-activity.js"
+    },
     "./registry": {
       "types": "./dist/src/registry.d.ts",
       "import": "./dist/src/registry.js"

--- a/packages/events/scripts/rebuild-events-dist.sh
+++ b/packages/events/scripts/rebuild-events-dist.sh
@@ -22,7 +22,7 @@
 #   - pnpm install --ignore-scripts (no post-install from transitive deps)
 #   - SOURCE_DATE_EPOCH=0 for reproducible timestamps
 #   - dist/src/SOURCE_SHA provenance file
-#   - All 8 export specifiers verified (per packages/events/package.json)
+#   - All 9 export specifiers verified (per packages/events/package.json)
 #   - Stale-detection via SCHEMA_VERSION literal + SOURCE_SHA match
 #
 # Called automatically via "postinstall" in the consuming repo's
@@ -231,7 +231,7 @@ echo "$TAG Embedded SOURCE_SHA: $ACTUAL_SHA"
 # =============================================================================
 
 echo "$TAG Verifying export specifiers..."
-SPECIFIERS=("" "/envelope" "/jcs" "/signer" "/topics" "/publisher" "/subscriber" "/schemas/nft-mint-detected")
+SPECIFIERS=("" "/envelope" "/jcs" "/signer" "/topics" "/publisher" "/subscriber" "/schemas/nft-mint-detected" "/schemas/nft-activity")
 for specifier in "${SPECIFIERS[@]}"; do
   if [[ -z "$specifier" ]]; then
     ENTRY_FILE="dist/src/index.js"

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -22,6 +22,8 @@ export {
 export {
   nftMintDetectedTopic,
   NFT_MINT_DETECTED_WILDCARD,
+  nftActivityTopic,
+  NFT_ACTIVITY_WILDCARD,
   buildTopic,
   type TopicSegments,
 } from "./topics.js";
@@ -48,6 +50,16 @@ export {
   type NftMintDetected,
 } from "./schemas/nft-mint-detected.js";
 
+export {
+  NftActivitySchema,
+  EvmActivityMetadataSchema,
+  SvmActivityMetadataSchema,
+  EVM_TX_HASH_RX,
+  type NftActivity,
+  type EvmActivityMetadata,
+  type SvmActivityMetadata,
+} from "./schemas/nft-activity.js";
+
 // --- cycle-112 schema-emission floor -----------------------------------------
 
 // The event_type -> payload-schema registry (the keystone). Cells reference
@@ -56,6 +68,7 @@ export {
   schemaId,
   lookupSchema,
   NftMintDetectedId,
+  NftActivityId,
   ParallelModeEnabledId,
   REGISTRY_ENTRIES,
   REVIEWED_TRANSFORMS,

--- a/packages/events/src/registry.ts
+++ b/packages/events/src/registry.ts
@@ -1,7 +1,8 @@
 import { Schema as S } from "@effect/schema";
 import { NftMintDetectedSchema } from "./schemas/nft-mint-detected.js";
+import { NftActivitySchema } from "./schemas/nft-activity.js";
 import { ParallelModeEnabledSchema } from "./schemas/parallel-mode-enabled.js";
-import { nftMintDetectedTopic, parallelModeEnabledTopic } from "./topics.js";
+import { nftMintDetectedTopic, nftActivityTopic, parallelModeEnabledTopic } from "./topics.js";
 
 /**
  * The `event_type -> payload-schema` registry — the keystone of the
@@ -95,6 +96,13 @@ export const NftMintDetectedId: SchemaId<S.Schema.Type<typeof NftMintDetectedSch
   NftMintDetectedSchema,
 );
 
+/** The chain-agnostic NFT-activity family (mint/transfer/sale/burn for EVM+SVM) —
+ *  the canonical contract producers normalize into so consumers never branch on chain. */
+export const NftActivityId: SchemaId<S.Schema.Type<typeof NftActivitySchema>> = schemaId(
+  "nft.activity.recorded.v1",
+  NftActivitySchema,
+);
+
 // Each id is constructed WITH its schema (via `schemaId`), so `SchemaId<P>`'s
 // phantom `P` is pinned to the schema's inferred Type. New entries are appended
 // here (and exported), typically via `freeside events:new-schema` (cycle-112 S3).
@@ -103,6 +111,11 @@ const ENTRIES = [
     id: NftMintDetectedId,
     schema: NftMintDetectedSchema,
     buildSubject: (specifier?: string) => nftMintDetectedTopic({ collectionSlug: specifier }),
+  },
+  {
+    id: NftActivityId,
+    schema: NftActivitySchema,
+    buildSubject: (specifier?: string) => nftActivityTopic({ collectionSlug: specifier }),
   },
   {
     id: ParallelModeEnabledId,

--- a/packages/events/src/schemas/nft-activity.ts
+++ b/packages/events/src/schemas/nft-activity.ts
@@ -1,0 +1,114 @@
+import { Schema as S } from "@effect/schema";
+
+/**
+ * Payload schema for `nft.activity.recorded.*.v1` events — the CHAIN-AGNOSTIC
+ * NFT ownership-activity family.
+ *
+ * Where `nft.mint.detected.*` is EVM-specific (0x addresses, chain_id, token_id),
+ * this family is the canonical verb stream BOTH EVM and SVM producers normalize
+ * into, so a consumer (the Score API) reads ONE shape and never branches on chain.
+ * Producer-side normalization lives in `sonar-api/src/canonical`; this is the
+ * shared contract it emits.
+ *
+ * Design (cycle canonical-event-normalization, FAGAN-hardened ×2):
+ *  - `verb` carries the activity (mint/transfer/sale/burn) IN the payload, so the
+ *    subject family stays single (`nft.activity.recorded.<slug>.v1`).
+ *  - Addresses are OPAQUE strings (0x-hex for EVM, base58 for SVM) — equality/dedup
+ *    is chain-agnostic; a consumer that must PARSE an id reads the typed `metadata`.
+ *  - `value` is a DECIMAL STRING of the raw smallest-unit integer (wei / lamports),
+ *    NOT a float — uint256 wei exceeds 2^53 and the SVM price column is bigint.
+ *    `decimals` lets the consumer compute the human amount exactly, and is REQUIRED
+ *    whenever `value` is set (cross-field filter below).
+ *  - `metadata` is a TYPED discriminated union (`EvmMetadata | SvmMetadata` on `chain`).
+ *    The top-level `chain` MUST equal `metadata.chain` (cross-field filter) so the two
+ *    can never diverge.
+ *  - `collection_key` charset matches the topic SEGMENT grammar (`/^[a-z][a-z0-9-]*$/`)
+ *    so a validating key is ALWAYS a sendable subject specifier (no validate-but-fail-at-emit
+ *    skew — the assumed-schema class the cluster has antibodies for).
+ *
+ * NOTE: `tx` / `asset_ref` are opaque by design — the schema does NOT enforce an
+ * EVM tx-hash shape (a producer may validate independently via {@link EVM_TX_HASH_RX},
+ * which is a helper, NOT applied here). SVM signatures/mints aren't 0x-hex.
+ *
+ * Effect.Schema per cluster memory `freeside-effect-transition` (cross-cell wire =
+ * protocol layer). Validation-only (no transform): `emit()` signs the original payload
+ * (registry SKP-004). Non-additive change → publish under `*.v2` with a ≥30d overlap.
+ */
+
+const OneOrMoreDigits = /^\d+$/;
+const Iso8601Utc = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/;
+const EvmAddress = /^0x[0-9a-f]{40}$/;
+const EvmTxHash = /^0x[0-9a-f]{64}$/;
+const CollectionKey = /^[a-z][a-z0-9-]*$/; // matches topics.ts SEGMENT_RX → a valid key is a valid subject specifier
+
+/** EVM-specific enrichment (typed) — present when `chain === "evm"`. */
+export const EvmActivityMetadataSchema = S.Struct({
+  chain: S.Literal("evm"),
+  chain_id: S.Number.pipe(S.int(), S.positive()),
+  contract: S.String.pipe(S.pattern(EvmAddress, { message: () => "evm contract: lowercase 0x + 40 hex" })),
+  token_id: S.String.pipe(S.pattern(OneOrMoreDigits, { message: () => "token_id: non-negative decimal string" })),
+  log_index: S.Number.pipe(S.int(), S.nonNegative()),
+  block_number: S.Number.pipe(S.int(), S.nonNegative()),
+});
+
+/** SVM-specific enrichment (typed) — present when `chain === "svm"`. */
+export const SvmActivityMetadataSchema = S.Struct({
+  chain: S.Literal("svm"),
+  collection_mint: S.String,
+  nft_mint: S.String,
+  instruction_index: S.Number.pipe(S.int(), S.nonNegative()),
+  slot: S.Number.pipe(S.int(), S.nonNegative()),
+  marketplace: S.optional(S.String),
+  delegate: S.optional(S.NullOr(S.String)),
+});
+
+export const NftActivitySchema = S.Struct({
+  /** The activity (in the payload so the subject family stays single). */
+  verb: S.Literal("mint", "transfer", "sale", "burn"),
+
+  /** Opaque chain discriminator — MUST equal metadata.chain (filter below). */
+  chain: S.Literal("evm", "svm"),
+
+  /** Generic collection key — same charset as a topic segment (sendable as a specifier). */
+  collection_key: S.String.pipe(S.pattern(CollectionKey, { message: () => "collection_key must match /^[a-z][a-z0-9-]*$/ (topic-segment grammar)" })),
+
+  /** The NFT identity — tokenId (EVM) or nft_mint (SVM). Opaque for equality/dedup. */
+  asset_ref: S.String.pipe(S.minLength(1)),
+
+  /** Owner-level sender — null for `mint`; resolved seller for `sale`. */
+  from: S.NullOr(S.String.pipe(S.minLength(1))),
+
+  /** Owner-level recipient — null for `burn`; resolved buyer for `sale`. */
+  to: S.NullOr(S.String.pipe(S.minLength(1))),
+
+  /** Raw smallest-unit value as a DECIMAL STRING (wei | lamports) — null when n/a. No float precision loss. */
+  value: S.NullOr(S.String.pipe(S.pattern(OneOrMoreDigits, { message: () => "value: non-negative decimal string of smallest units" }))),
+
+  /** Decimals for `value` (18 EVM wei, 9 SOL lamports) — required when `value` is set (filter below). */
+  decimals: S.NullOr(S.Number.pipe(S.int(), S.nonNegative())),
+
+  /** The transaction — txHash (EVM, 0x) or signature (SVM, base58). Opaque (see NOTE). */
+  tx: S.String.pipe(S.minLength(1)),
+
+  /** On-chain block time as ISO-8601 UTC (envelope-consistent). */
+  timestamp: S.String.pipe(S.pattern(Iso8601Utc, { message: () => "ISO-8601 UTC with trailing Z" })),
+
+  /** Typed chain-specific richness (discriminated on `chain`). */
+  metadata: S.Union(EvmActivityMetadataSchema, SvmActivityMetadataSchema),
+}).pipe(
+  // top-level chain must match the typed metadata discriminant (no divergence).
+  S.filter((a) => a.chain === a.metadata.chain, {
+    message: () => "top-level `chain` must equal metadata.chain",
+  }),
+  // a value without decimals can't be turned into a human amount — require both or neither.
+  S.filter((a) => a.value === null || a.decimals !== null, {
+    message: () => "`decimals` is required when `value` is set",
+  }),
+);
+
+export type NftActivity = S.Schema.Type<typeof NftActivitySchema>;
+export type EvmActivityMetadata = S.Schema.Type<typeof EvmActivityMetadataSchema>;
+export type SvmActivityMetadata = S.Schema.Type<typeof SvmActivityMetadataSchema>;
+
+/** EVM tx-hash pattern — a producer-side helper. NOT applied by NftActivitySchema (tx is opaque). */
+export const EVM_TX_HASH_RX = EvmTxHash;

--- a/packages/events/src/topics.ts
+++ b/packages/events/src/topics.ts
@@ -94,3 +94,28 @@ export function parallelModeEnabledTopic(opts: { specifier?: string } = {}): str
     version: 1,
   });
 }
+
+// --- nft.activity.recorded.v1 (chain-agnostic NFT activity — canonical-event-normalization) ---
+
+/**
+ * Wildcard subject for subscribing to ALL chain-agnostic NFT activity across all
+ * collections (`nft.activity.recorded.>`). Subscribe-only — never publish to a wildcard.
+ */
+export const NFT_ACTIVITY_WILDCARD = "nft.activity.recorded.>";
+
+/**
+ * Build the publish subject for a chain-agnostic NFT-activity event.
+ *   nftActivityTopic({collectionSlug: "pythians"}) → "nft.activity.recorded.pythians.v1"
+ *   nftActivityTopic()                             → "nft.activity.recorded.v1"  (base; no discriminator)
+ * The `verb` (mint/transfer/sale/burn) lives in the PAYLOAD, not the subject, so this is one stream a
+ * consumer reads. 3-segment grammar: aggregate=nft, noun=activity, verb=recorded.
+ */
+export function nftActivityTopic(opts: { collectionSlug?: string; version?: number } = {}): string {
+  return buildTopic({
+    aggregate: "nft",
+    noun: "activity",
+    verb: "recorded",
+    specifier: opts.collectionSlug,
+    version: opts.version ?? 1,
+  });
+}

--- a/packages/events/tests/nft-activity.test.ts
+++ b/packages/events/tests/nft-activity.test.ts
@@ -1,0 +1,94 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Schema as S } from "@effect/schema";
+import { NftActivitySchema } from "../src/schemas/nft-activity.js";
+import { nftActivityTopic, NFT_ACTIVITY_WILDCARD } from "../src/topics.js";
+import { NftActivityId, lookupSchema } from "../src/registry.js";
+
+const decode = S.decodeUnknownSync(NftActivitySchema);
+
+const evmMint = {
+  verb: "mint", chain: "evm", collection_key: "mibera", asset_ref: "123",
+  from: null, to: "0x000000000000000000000000000000000000dead", value: null, decimals: null,
+  tx: "0x" + "a".repeat(64), timestamp: "2025-01-01T00:00:00Z",
+  metadata: { chain: "evm", chain_id: 80094, contract: "0x" + "b".repeat(40), token_id: "123", log_index: 0, block_number: 100 },
+};
+
+const svmSale = {
+  verb: "sale", chain: "svm", collection_key: "pythians", asset_ref: "JE8VKG6sUqQgz",
+  from: "5xJewztrSeller", to: "2Y1uiDUpBuyer", value: "3087000000", decimals: 9,
+  tx: "65SgkNWqSig", timestamp: "2025-02-02T19:47:00Z",
+  metadata: { chain: "svm", collection_mint: "pyTh2UtBKfuDW6KCdT3swospYeoLmmKaGujWA91Moru", nft_mint: "JE8VKG6sUqQgz", instruction_index: 0, slot: 314801673, marketplace: "MAGIC_EDEN" },
+};
+
+describe("NftActivitySchema", () => {
+  it("accepts a valid EVM mint activity", () => {
+    const v = decode(evmMint);
+    assert.equal(v.verb, "mint");
+    assert.equal(v.from, null);
+    assert.equal(v.metadata.chain, "evm");
+  });
+
+  it("accepts a valid SVM sale activity (resolved buyer/seller + decimal-string value)", () => {
+    const v = decode(svmSale);
+    assert.equal(v.verb, "sale");
+    assert.equal(v.value, "3087000000"); // decimal string — no float precision loss
+    assert.equal(v.decimals, 9);
+    assert.equal(v.metadata.chain, "svm");
+    if (v.metadata.chain === "svm") assert.equal(v.metadata.marketplace, "MAGIC_EDEN");
+  });
+
+  it("rejects a non-decimal value (float / scientific would lose precision)", () => {
+    assert.throws(() => decode({ ...svmSale, value: "3.087" }));
+  });
+
+  it("rejects an unknown verb", () => {
+    assert.throws(() => decode({ ...evmMint, verb: "stake" }));
+  });
+
+  it("rejects metadata whose chain discriminant doesn't match a union member", () => {
+    assert.throws(() => decode({ ...evmMint, metadata: { chain: "aptos", foo: 1 } }));
+  });
+
+  it("rejects an empty asset_ref / tx", () => {
+    assert.throws(() => decode({ ...evmMint, asset_ref: "" }));
+    assert.throws(() => decode({ ...evmMint, tx: "" }));
+  });
+
+  // --- FAGAN-hardening invariants ---
+  it("MED-2: rejects a collection_key that validates loosely but can't be a topic segment (underscore / leading digit)", () => {
+    assert.throws(() => decode({ ...svmSale, collection_key: "genesis_stones" }));
+    assert.throws(() => decode({ ...svmSale, collection_key: "7pixies" }));
+  });
+  it("LOW-1: rejects top-level chain diverging from metadata.chain", () => {
+    assert.throws(() => decode({ ...evmMint, chain: "svm" })); // metadata still evm
+  });
+  it("LOW-5: rejects a value without decimals", () => {
+    assert.throws(() => decode({ ...svmSale, decimals: null })); // value set, decimals null
+  });
+  it("LOW-2: rejects empty-string from/to (null is fine for mint/burn)", () => {
+    assert.throws(() => decode({ ...svmSale, from: "" }));
+    assert.doesNotThrow(() => decode({ ...evmMint })); // from:null on a mint is valid
+  });
+});
+
+describe("nftActivityTopic", () => {
+  it("builds the 3-segment versioned subject with a collection specifier", () => {
+    assert.equal(nftActivityTopic({ collectionSlug: "pythians" }), "nft.activity.recorded.pythians.v1");
+  });
+  it("builds the base subject with no specifier", () => {
+    assert.equal(nftActivityTopic(), "nft.activity.recorded.v1");
+  });
+  it("exposes the wildcard for subscribers", () => {
+    assert.equal(NFT_ACTIVITY_WILDCARD, "nft.activity.recorded.>");
+  });
+});
+
+describe("registry binding", () => {
+  it("NftActivityId resolves to the schema + builds the subject", () => {
+    const entry = lookupSchema(NftActivityId);
+    assert.ok(entry, "NftActivityId must be registered");
+    assert.equal(NftActivityId as unknown as string, "nft.activity.recorded.v1");
+    assert.equal(entry!.buildSubject("pythians"), "nft.activity.recorded.pythians.v1");
+  });
+});


### PR DESCRIPTION
## What
Additive to `@0xhoneyjar/events`: a **chain-agnostic `NftActivity`** family (verb-tagged mint/transfer/sale/burn) that both EVM and SVM producers normalize into, so consumers (Score API) read ONE shape and never branch on chain. The producer-side Effect normalizer lives in sonar (cycle `canonical-event-normalization`); this is the shared contract it emits.

## Changes (all additive)
- `schemas/nft-activity.ts` — `NftActivitySchema` (Effect Schema): opaque addresses, **decimal-STRING `value`** (+`decimals`; uint256 wei > 2^53), **typed `EvmMeta|SvmMeta` discriminated union**, cross-field filters (`chain==metadata.chain`; `value⇒decimals`), `collection_key` charset == topic SEGMENT grammar.
- `topics.ts` — `nftActivityTopic()` + `NFT_ACTIVITY_WILDCARD` (`nft.activity.recorded.<slug>.v1`).
- `registry.ts` — `NftActivityId` + ENTRIES (validation-only → `emit()` signs original).
- `index.ts` exports · `package.json` `./schemas/nft-activity` subpath · rebuild SPECIFIERS.

## Non-breaking
`nft.activity.*` ≠ `nft.mint.detected.>` (dash/characters untouched) · envelope `SCHEMA_VERSION` `acvp-l1-v2` unchanged (payload schema) · registry id unique · the eventsPin/rebuild gates resolve the envelope version, unaffected.

## Review
**FAGAN: APPROVED** (0 blockers). MED-2 (collection_key↔topic-grammar skew) + 6 LOW folded; **MED-1** (per-publisher hash-chain interleave) is handled in the sonar normalizer (distinct `sonar-canonical` publisher identity — it does NOT share the `nft.mint.detected` chain). **109/109 unit tests, tsc clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)