### PR TITLE
fix(network/freeside-registry): register billing-api + worlds-api (KRANZ drift sweep)

### DIFF
--- a/packages/freeside-registry/registry.yaml
+++ b/packages/freeside-registry/registry.yaml
@@ -84,6 +84,26 @@ modules:
       PR: activities-api #25 (Lane A read-plane LIVE + write path built behind
       GATE-SEC-1, merged 269ede35; PRs #21/#22/#23 superseded by the squash).
 
+  billing-api:
+    git_url: https://github.com/0xHoneyJar/billing-api.git
+    beacon_url: ~
+    deployment_url: ~
+    visibility: internal
+    owner: 0xHoneyJar
+    added: "2026-06-06"
+    runtime_state: scaffolded
+    notes: |
+      Billing building — credit ledger + S2S reserve/finalize. EXTRACTED from the
+      loa-freeside monolith (ADR-008); repo github.com/0xHoneyJar/billing-api is
+      PRIVATE (created 2026-06-06, thin-v1 #1 merged: credit ledger + S2S finalize;
+      last push 2026-06-21). NOT deployed — billing-api-production.up.railway.app/health
+      → 404 (probed 2026-06-25). beacon_url ~ (private cell, no public subdomain).
+      Registered 2026-06-25 to close the registry-vs-territory drift KRANZ flagged: the
+      ledger-api note below previously asserted "billing remains genuinely un-extracted
+      (no repo)" — FALSE; billing-api exists. Credit-lot logic MAY still dual-home in the
+      monolith (packages/services/credit-lot-service.ts) — verify cutover before treating
+      billing-api as the live billing authority. Bears on the revenue line (loa-finn#66).
+
   events-api:
     # In-repo LIBRARY building (@0xhoneyjar/events) — the ACVP event protocol
     # definer. The FIRST in-repo beacon (cycle-112 S5, closes arrakis-vl8f).
@@ -162,7 +182,8 @@ modules:
       cutover; do NOT assume ledger-api is the live balance authority yet. Registered
       2026-06-19 to close the registry-vs-territory drift the 2026-06-04 gecko census
       flagged (DRIFT-2: "freeside-ledger IS extracted; doctrine said it wasn't").
-      billing remains genuinely un-extracted (no repo).
+      billing IS NOW extracted too — see billing-api above (registered 2026-06-25); the
+      prior "un-extracted (no repo)" claim here was the same drift class, now corrected.
 
   mediums-api:
     # NOTE: GH repo still at freeside-mediums (only mediums of the 8 cells not yet
@@ -259,3 +280,22 @@ modules:
       GraphQL API at `/graphql`. Per memory, storage was named the
       "real blocker" for the Mibera inventory sovereignty arc — that
       framing predates the current deployment; verify status with operator.
+
+  worlds-api:
+    git_url: https://github.com/0xHoneyJar/worlds-api.git
+    beacon_url: ~
+    deployment_url: ~
+    visibility: public
+    owner: 0xHoneyJar
+    added: "2026-04-29"
+    runtime_state: scaffolded
+    notes: |
+      World manifest registry — sealed schemas + terraform generator (created
+      2026-04-29, public; last push 2026-06-06). Library/tool shape, NOT an HTTP
+      runtime: worlds-api-production.up.railway.app/health → 404 (probed 2026-06-25);
+      deployment_url ~ (no served runtime planned — it generates terraform the platform
+      consumes). Registered 2026-06-25 to close the registry-vs-territory drift KRANZ
+      flagged (worlds-api existed but was unrecorded). ⚠ Manifest-only: world RUNTIME
+      (guild/member lifecycle) still lives in themes/sietch — there is NO world-runtime
+      building, so runtime work (e.g. #292) must NOT route here. Verify intended runtime
+      shape with operator.


### PR DESCRIPTION
## What

Reconciles `registry.yaml` (L1 canonical SoT) against deployed truth, surfaced by KRANZ during loa-freeside backlog triage:

- **+ `billing-api`** — private, extracted from monolith 2026-06-06 (thin-v1 #1 merged: credit ledger + S2S finalize), `scaffolded` (/health 404). The registry had NO entry and line 165 asserted *'billing remains genuinely un-extracted (no repo)'* — false.
- **+ `worlds-api`** — public manifest registry + terraform generator (created 2026-04-29), `scaffolded` (no HTTP runtime). Was unrecorded.
- **Corrected** the stale line-165 claim.

## Why

`#232` (cluster-wide beacon-validation GHA) and `freeside-cli doctor` (`#231`) walk this registry. A validator pointed at a false map validates a fiction — same map↔territory drift class as the 2026-06-04 gecko census DRIFT-2 (freeside-ledger). Fix the map before the validator lands.

## Grounding

`gh repo view` confirms both repos exist; `/health` probed 404 (scaffolded, not deployed) 2026-06-25. Notes flag billing credit-lot dual-home + worlds runtime-shape ambiguity for operator verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)