### PR TITLE
fix(events): close publishEnvelope bypass — structural un-export fence + lint backstop (#255)

### DIFF
--- a/grimoires/loa/cycles/cycle-112-schema-emission-floor/sdd.md
+++ b/grimoires/loa/cycles/cycle-112-schema-emission-floor/sdd.md
@@ -464,6 +464,10 @@ The rule flags, outside `packages/events/**`:
    composition root, or
 4. (IMP-005) a dataflow where a raw NATS client is aliased to a variable and then
    `.publish`-ed — not just the direct call form.
+5. (events #255) an import of `publishEnvelope` from `"@0xhoneyjar/events"` as a
+   value (not `import type`) — the capability that bypasses schema validation.
+   Kind: `publishEnvelope-bypass`. Allowlist: `publishEnvelope_allowlist` section
+   of `raw-nats-allowlist.yaml`.
 
 …unless the site is in the allowlist (§5.2). `emitRaw` call sites are checked
 against the separate `emitRaw-allowlist` (§3.3/§5.2).

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -19,23 +19,44 @@ pnpm add nats  # peer dep — consumers bring their own connection
 
 ## Quick start (publisher)
 
+Emit through the sanctioned `emit()` facade. `makeEmitter(...)` closes over the
+per-cell constants (transport, signer, chain store) so the call site collapses to
+`emit(SchemaId, payload, specifier?)`. It validates the payload against its
+registry schema, signs the original bytes, advances the per-cell hash chain, and
+publishes — returning a typed `Either`, never throwing.
+
+> The raw `publishEnvelope` function is INTERNAL — `emit()` uses it under the hood
+> after validating. It skips schema validation, so it is NOT a public entrypoint:
+> it is unexported from the package index and the `./publisher` subpath is omitted
+> from the exports map (events #255, FR-7/SKP-002). Reach for `emit()`.
+
 ```typescript
 import { connect } from "nats";
 import {
-  publishEnvelope,
+  makeEmitter,
+  createNatsTransport,
   LocalEd25519Signer,
   InMemoryPrevHashStore,
-  nftMintDetectedTopic,
+  NftMintDetectedId,
 } from "@0xhoneyjar/events";
+import { Either } from "effect";
 
 const nats = await connect({ servers: process.env.NATS_URL });
 const signer = await LocalEd25519Signer.fromSeedHex(process.env.SIGNING_SEED_HEX!, "sonar-api-1");
-const prevHashStore = new InMemoryPrevHashStore();
 
-await publishEnvelope({
-  nats,
-  subject: nftMintDetectedTopic({ collectionSlug: "mibera-shadow" }),  // "nft.mint.detected.mibera-shadow.v1"
-  payload: {
+const emitter = makeEmitter({
+  cell: "sonar-api",
+  transport: createNatsTransport(nats),
+  signer,
+  prevHashStore: new InMemoryPrevHashStore(),
+});
+
+// The specifier ("mibera-shadow") builds the subject from the registry topic:
+// "nft.mint.detected.mibera-shadow.v1". A schema mismatch is an Either.Left —
+// it never reaches the bus and never forks the chain.
+const result = await emitter.emit(
+  NftMintDetectedId,
+  {
     chain_id: 80094,
     contract: "0x048327A187b944ddac61c6e202BfccD20d17c008",
     token_id: "234",
@@ -44,10 +65,12 @@ await publishEnvelope({
     transaction_hash: "0xdef...",
     timestamp: new Date().toISOString(),
   },
-  emittedBy: "sonar-api",
-  signer,
-  prevHashStore,
-});
+  "mibera-shadow",
+);
+
+if (Either.isLeft(result)) {
+  // handle SchemaEmitError | TransportEmitError | … — never a silent drop
+}
 ```
 
 ## Quick start (subscriber)
@@ -89,7 +112,7 @@ await subscribeEnvelope({
 | JCS | RFC 8785 canonicalization (byte-deterministic JSON) | `src/jcs.ts` |
 | Signer | Ed25519 sign/verify via @noble/curves; JWKS lookup | `src/signer.ts` |
 | Topics | Hounfour 3-segment topic builders (`{aggregate}.{noun}.{verb}.v{N}`) | `src/topics.ts` |
-| Publisher | publishEnvelope: canonicalize → hash → sign → publish → store prev_hash | `src/publisher.ts` |
+| Publisher (INTERNAL) | publishEnvelope: canonicalize → hash → sign → publish → store prev_hash. Used only by `emit()` internally — not a public entrypoint (skips schema validation; unexported, events #255). Consumers use `emit()`. | `src/publisher.ts` |
 | Subscriber | subscribeEnvelope: parse → schema → subject-bind → hash → sig → chain → payload-schema → advance → handler | `src/subscriber.ts` |
 | Schemas | Per-event Effect.Schema definitions (start: NftMintDetected) | `src/schemas/` |
 

--- a/packages/events/bin/events-lint.mjs
+++ b/packages/events/bin/events-lint.mjs
@@ -18,6 +18,10 @@
 //   3. An ignored `emit()` / `emitRaw()` result — a bare call statement whose
 //      Either is never consumed (fire-and-forget = silent dropped event;
 //      SKP-001 #1 / T2.7).
+//   4. `publishEnvelope` imported as a value from `@0xhoneyjar/events` in any
+//      file outside the events package — the capability that bypasses schema
+//      validation (FR-1 / events #255). Must go through emit() or be explicitly
+//      allowlisted in publishEnvelope_allowlist.
 //
 // Teaching output (FR-ADOPT-6): each finding names the file:line, says whether
 // it is NEW (un-allowlisted → a regression) or allowlisted (informational),
@@ -107,6 +111,11 @@ function isAllowlisted(relPath, subject) {
 
 const SUBJECT_LITERAL = /\.(?:nats|jetstream)\.publish\s*\(\s*["']([^"']+)["']/;
 
+// publishEnvelope-bypass detection (FR-1 / events #255)
+const PE_IMPORT = /\bpublishEnvelope\b/;
+const EVENTS_PKG_FROM = /from\s+["']@0xhoneyjar\/events["']/;
+const TYPE_ONLY_IMPORT = /^\s*import\s+type\b/;
+
 // Discriminate NATS from Redis/Rabbit/notifier by RECEIVER NAME, not imports:
 // every NATS emit in this codebase publishes via `.nats.publish(` or
 // `.jetstream.publish(`, while every carve-out uses `.client.` / `.redis.` /
@@ -154,6 +163,20 @@ for (const file of walk(ROOT)) {
     if (EMIT_CALL.test(line) && !CONSUMED.test(line) && !/function|interface|type\s|=>/.test(line)) {
       findings.push({ file: rel, line: i + 1, kind: "unhandled-emit-either", allowlisted: false, text: trimmed });
     }
+    // publishEnvelope-bypass: direct value import from @0xhoneyjar/events (FR-1 / events #255).
+    if (
+      PE_IMPORT.test(line) &&
+      EVENTS_PKG_FROM.test(line) &&
+      !TYPE_ONLY_IMPORT.test(line)
+    ) {
+      findings.push({
+        file: rel,
+        line: i + 1,
+        kind: "publishEnvelope-bypass",
+        allowlisted: isAllowlisted(rel, "publishEnvelope"),
+        text: trimmed,
+      });
+    }
   }
 }
 
@@ -170,6 +193,10 @@ if (JSON_OUT) {
       "raw NATS .publish bypasses the schema floor. Use emit(SchemaId, payload). New event? `freeside events:new-schema <name>`.",
     "unhandled-emit-either":
       "the emit()/emitRaw() result is a typed Either — handle it (branch on Either.isLeft). An ignored Left is a silent dropped event.",
+    "publishEnvelope-bypass":
+      "publishEnvelope skips schema validation. Use the cell's emit() (makeEmitter) — it " +
+      "validates before signing. If a raw path is genuinely required, add an explicit " +
+      "entry to publishEnvelope_allowlist in raw-nats-allowlist.yaml.",
   };
   if (findings.length === 0) {
     console.log("[events-lint] OK — no raw NATS emits, no capability leaks, no unhandled emit Eithers.");

--- a/packages/events/bin/events-lint.mjs
+++ b/packages/events/bin/events-lint.mjs
@@ -236,8 +236,12 @@ const lineAtOffset = (s, off) => {
 // in that charset, the clause cannot span a prior statement's `from "…"` (so a
 // `publishEnvelope` binding from a DIFFERENT package is never mis-attributed) NOR
 // an adjacent interface/object body whose member happens to be `publishEnvelope`
-// (FAGAN NF1). It is statement-isolation expressed as a charset.
-const EVENTS_IMPORT = /\b(import|export)\b([\w\s{},*]*?)\bfrom\s*["']@0xhoneyjar\/events["']/g;
+// (FAGAN NF1). The inner `(?!\b(?:import|export)\b)` lookahead additionally stops
+// the clause at a SECOND statement keyword, so a local `export { publishEnvelope }`
+// (no `from`, no `;` — ASI) immediately before an `@events` import is not swept in
+// on a no-semicolon codebase (FAGAN NF6). It is statement-isolation expressed as a
+// charset + a keyword barrier.
+const EVENTS_IMPORT = /\b(import|export)\b((?:(?!\b(?:import|export)\b)[\w\s{},*])*?)\bfrom\s*["']@0xhoneyjar\/events["']/g;
 
 // Returns { line } for the first reachable publishEnvelope VALUE, or null.
 function detectPublishEnvelopeBypass(stripped) {

--- a/packages/events/bin/events-lint.mjs
+++ b/packages/events/bin/events-lint.mjs
@@ -127,41 +127,96 @@ const SUBJECT_LITERAL = /\.(?:nats|jetstream)\.publish\s*\(\s*["']([^"']+)["']/;
 // `@0xhoneyjar/events`: a named value import (NOT `import type`, `export type`,
 // or an inline `{ type publishEnvelope }`), OR a namespace import whose alias is
 // then member-accessed as `.publishEnvelope`. Comments are stripped first so
-// mentions inside `//…` / `/* … */` never match (and string contents are
-// preserved, so a literal containing `//` is not mistaken for a comment).
+// mentions inside `//…` / `/* … */` never match (and string + regex literals are
+// preserved, so neither a `//` inside a string nor a quote inside a regex like
+// `/["']/` desyncs the stripper — FAGAN NF2).
+//
+// The match is bounded to a SINGLE import/export STATEMENT (FAGAN NF1): the
+// binding clause between the keyword and `from` is constrained to the import-
+// specifier grammar (identifiers / `{ } , *` / `as` / `type` / whitespace). A
+// `:`, `(`, `=`, or `"` ends the clause, so an `export interface Foo {
+// publishEnvelope: … }` or `export const cfg = { publishEnvelope: true }` sitting
+// next to a real `@0xhoneyjar/events` import is NOT swept into the binding and
+// never false-positives.
+//
+// **Load-bearing control is the STRUCTURAL fence, not this scanner.** events #255
+// is fenced by un-exporting `publishEnvelope` from the package index AND omitting
+// the `./publisher` subpath from package.json `exports` — so the raw capability
+// is unreachable from any consumer regardless of how they spell the import. This
+// scanner is the in-monorepo backstop (catches a relative-path reach inside the
+// repo before it ships); the un-export is the wall. Because of that wall, these
+// detector blind spots are ACCEPTED, not chased (the evasion cannot obtain the
+// capability from the public API anyway):
+//   • destructure-from-namespace: `const { publishEnvelope } = events;` after a
+//     `* as events` import (no `.publishEnvelope` member token).
+//   • fully-computed member access: `events["publish" + "Envelope"](…)`.
+//   • prefix-substring line attribution: a binding whose name merely STARTS with
+//     `publishEnvelope` (e.g. `publishEnvelopeRaw`) is attributed to the literal
+//     token line; cosmetic only.
 // =============================================================================
 
 // Strip line + block comments while PRESERVING byte offsets and newlines, so a
 // char offset into the stripped text maps to the same line as the original.
-// String-aware (single/double/template) so `//` or `/*` inside a string literal
-// is NOT treated as a comment opener.
+// String-AND-regex-aware: `//` or `/*` inside a string ('/"/`) OR inside a regex
+// literal (`/…/`) is NOT treated as a comment opener, and a quote inside a regex
+// does not desync the stripper into string state (FAGAN NF2). `/` is read as a
+// regex literal (not division) when the previous significant token is an
+// expression-start char OR a regex-preceding keyword (`return`, `typeof`, …).
 function stripComments(src) {
   let out = "";
   const n = src.length;
-  let state = "code"; // code | line | block | sq | dq | tpl
+  let state = "code"; // code | line | block | sq | dq | tpl | regex
+  let prevSig = "";   // last significant (non-ws) char emitted in code state
+  let curWord = "";   // current identifier run
+  let lastWord = "";  // most recent completed identifier (keyword-before-regex)
+  let inClass = false; // inside a [...] char class within a regex literal
+  const REGEX_BEFORE = new Set(["", "(", ",", "=", ":", "[", "!", "&", "|", "?", "{", "}", ";", "<", ">", "+", "-", "*", "/", "%", "^", "~", "\n"]);
+  const REGEX_KEYWORDS = new Set(["return", "typeof", "instanceof", "in", "of", "new", "delete", "void", "do", "else", "yield", "await", "case"]);
+  const isWord = (ch) =>
+    (ch >= "a" && ch <= "z") || (ch >= "A" && ch <= "Z") || (ch >= "0" && ch <= "9") || ch === "_" || ch === "$";
+
   for (let i = 0; i < n; i++) {
     const c = src[i];
     const d = i + 1 < n ? src[i + 1] : "";
     if (state === "code") {
-      if (c === "/" && d === "/") { state = "line"; out += "  "; i++; continue; }
-      if (c === "/" && d === "*") { state = "block"; out += "  "; i++; continue; }
-      if (c === "'") { state = "sq"; out += c; continue; }
-      if (c === '"') { state = "dq"; out += c; continue; }
-      if (c === "`") { state = "tpl"; out += c; continue; }
-      out += c; continue;
+      if (c === "/" && d === "/") { state = "line"; out += "  "; i++; prevSig = ""; curWord = ""; continue; }
+      if (c === "/" && d === "*") { state = "block"; out += "  "; i++; prevSig = ""; curWord = ""; continue; }
+      if (c === "/") {
+        const regexOk = REGEX_BEFORE.has(prevSig) || REGEX_KEYWORDS.has(lastWord);
+        out += c; prevSig = "/"; if (curWord) lastWord = curWord; curWord = "";
+        if (regexOk) { state = "regex"; inClass = false; }
+        continue;
+      }
+      if (c === "'" || c === '"' || c === "`") {
+        state = c === "'" ? "sq" : c === '"' ? "dq" : "tpl";
+        out += c; prevSig = c; if (curWord) lastWord = curWord; curWord = "";
+        continue;
+      }
+      out += c;
+      if (!/\s/.test(c)) prevSig = c;
+      if (isWord(c)) { curWord += c; } else { if (curWord) lastWord = curWord; curWord = ""; }
+      continue;
     }
     if (state === "line") {
-      if (c === "\n") { state = "code"; out += c; continue; }
+      if (c === "\n") { state = "code"; out += c; prevSig = "\n"; continue; }
       out += " "; continue;
     }
     if (state === "block") {
-      if (c === "*" && d === "/") { state = "code"; out += "  "; i++; continue; }
+      if (c === "*" && d === "/") { state = "code"; out += "  "; i++; prevSig = ""; continue; }
       out += c === "\n" ? "\n" : " "; continue;
     }
-    // string states: copy verbatim, honor escapes, exit on the matching quote
+    if (state === "regex") {
+      if (c === "\\") { out += c + (d || ""); i++; continue; }
+      if (c === "\n") { state = "code"; out += c; prevSig = "\n"; continue; } // defensive: regex can't span lines
+      if (c === "[") { inClass = true; out += c; continue; }
+      if (c === "]") { inClass = false; out += c; continue; }
+      if (c === "/" && !inClass) { state = "code"; out += c; prevSig = "/"; continue; }
+      out += c; continue;
+    }
+    // string states (sq/dq/tpl): copy verbatim, honor escapes, exit on matching quote
     if (c === "\\") { out += c + (d || ""); i++; continue; }
     if ((state === "sq" && c === "'") || (state === "dq" && c === '"') || (state === "tpl" && c === "`")) {
-      state = "code";
+      state = "code"; prevSig = c;
     }
     out += c;
   }
@@ -174,12 +229,15 @@ const lineAtOffset = (s, off) => {
   return line;
 };
 
-// Matches an `import`/`export … from "@0xhoneyjar/events"` statement. The clause
-// (group 2) is everything between the keyword and `from`; the inner negative
-// lookahead `(?!\bfrom\b)` stops a non-greedy clause from spanning a PRIOR
-// import's `from`, so a `publishEnvelope` binding from a DIFFERENT package can
-// never be mis-attributed to the events import.
-const EVENTS_IMPORT = /\b(import|export)\b((?:(?!\bfrom\b)[\s\S])*?)\bfrom\s*["']@0xhoneyjar\/events["']/g;
+// Matches a SINGLE `import`/`export … from "@0xhoneyjar/events"` statement. The
+// clause (group 2) is constrained to the import-specifier grammar `[\w\s{},*]` —
+// identifiers, `{ } , *`, and the word-keywords `as`/`type`, plus whitespace.
+// Because a string literal (`"`, `@`, `/`), a `;`, a `:`, a `(`, or an `=` is NOT
+// in that charset, the clause cannot span a prior statement's `from "…"` (so a
+// `publishEnvelope` binding from a DIFFERENT package is never mis-attributed) NOR
+// an adjacent interface/object body whose member happens to be `publishEnvelope`
+// (FAGAN NF1). It is statement-isolation expressed as a charset.
+const EVENTS_IMPORT = /\b(import|export)\b([\w\s{},*]*?)\bfrom\s*["']@0xhoneyjar\/events["']/g;
 
 // Returns { line } for the first reachable publishEnvelope VALUE, or null.
 function detectPublishEnvelopeBypass(stripped) {
@@ -202,7 +260,9 @@ function detectPublishEnvelopeBypass(stripped) {
 
     // Named bindings: `{ a, publishEnvelope, … }`. A `type ` prefix on the
     // specifier (inline type modifier) means the binding is NOT a runnable value.
-    const brace = clause.match(/\{([\s\S]*)\}/);
+    // `[^}]*` is safe because import braces never nest (the NF1 charset already
+    // forbids object/type bodies inside the clause).
+    const brace = clause.match(/\{([^}]*)\}/);
     if (brace) {
       for (const spec of brace[1].split(",")) {
         const s = spec.trim();

--- a/packages/events/bin/events-lint.mjs
+++ b/packages/events/bin/events-lint.mjs
@@ -111,10 +111,111 @@ function isAllowlisted(relPath, subject) {
 
 const SUBJECT_LITERAL = /\.(?:nats|jetstream)\.publish\s*\(\s*["']([^"']+)["']/;
 
-// publishEnvelope-bypass detection (FR-1 / events #255)
-const PE_IMPORT = /\bpublishEnvelope\b/;
-const EVENTS_PKG_FROM = /from\s+["']@0xhoneyjar\/events["']/;
-const TYPE_ONLY_IMPORT = /^\s*import\s+type\b/;
+// =============================================================================
+// publishEnvelope-bypass detection (FR-1 / events #255) — WHOLE-FILE, two-pass.
+//
+// The old detector matched `publishEnvelope` AND `from "@0xhoneyjar/events"` on
+// the SAME line. FAGAN proved that trivially evaded: a multi-line (Prettier)
+// import (F1) and a `import * as events` + `events.publishEnvelope()` member
+// access (F2) both split the two tokens across lines → total miss. Its
+// comment-skip was also insufficient → false positives on mentions inside
+// comments and on type-only forms (F3). This rule alone moves to whole-file
+// matching; the internalPublish / raw-nats-publish / unhandled-emit rules stay
+// line-based below.
+//
+// A file is flagged IFF it imports a runnable `publishEnvelope` VALUE from
+// `@0xhoneyjar/events`: a named value import (NOT `import type`, `export type`,
+// or an inline `{ type publishEnvelope }`), OR a namespace import whose alias is
+// then member-accessed as `.publishEnvelope`. Comments are stripped first so
+// mentions inside `//…` / `/* … */` never match (and string contents are
+// preserved, so a literal containing `//` is not mistaken for a comment).
+// =============================================================================
+
+// Strip line + block comments while PRESERVING byte offsets and newlines, so a
+// char offset into the stripped text maps to the same line as the original.
+// String-aware (single/double/template) so `//` or `/*` inside a string literal
+// is NOT treated as a comment opener.
+function stripComments(src) {
+  let out = "";
+  const n = src.length;
+  let state = "code"; // code | line | block | sq | dq | tpl
+  for (let i = 0; i < n; i++) {
+    const c = src[i];
+    const d = i + 1 < n ? src[i + 1] : "";
+    if (state === "code") {
+      if (c === "/" && d === "/") { state = "line"; out += "  "; i++; continue; }
+      if (c === "/" && d === "*") { state = "block"; out += "  "; i++; continue; }
+      if (c === "'") { state = "sq"; out += c; continue; }
+      if (c === '"') { state = "dq"; out += c; continue; }
+      if (c === "`") { state = "tpl"; out += c; continue; }
+      out += c; continue;
+    }
+    if (state === "line") {
+      if (c === "\n") { state = "code"; out += c; continue; }
+      out += " "; continue;
+    }
+    if (state === "block") {
+      if (c === "*" && d === "/") { state = "code"; out += "  "; i++; continue; }
+      out += c === "\n" ? "\n" : " "; continue;
+    }
+    // string states: copy verbatim, honor escapes, exit on the matching quote
+    if (c === "\\") { out += c + (d || ""); i++; continue; }
+    if ((state === "sq" && c === "'") || (state === "dq" && c === '"') || (state === "tpl" && c === "`")) {
+      state = "code";
+    }
+    out += c;
+  }
+  return out;
+}
+
+const lineAtOffset = (s, off) => {
+  let line = 1;
+  for (let k = 0; k < off && k < s.length; k++) if (s[k] === "\n") line++;
+  return line;
+};
+
+// Matches an `import`/`export … from "@0xhoneyjar/events"` statement. The clause
+// (group 2) is everything between the keyword and `from`; the inner negative
+// lookahead `(?!\bfrom\b)` stops a non-greedy clause from spanning a PRIOR
+// import's `from`, so a `publishEnvelope` binding from a DIFFERENT package can
+// never be mis-attributed to the events import.
+const EVENTS_IMPORT = /\b(import|export)\b((?:(?!\bfrom\b)[\s\S])*?)\bfrom\s*["']@0xhoneyjar\/events["']/g;
+
+// Returns { line } for the first reachable publishEnvelope VALUE, or null.
+function detectPublishEnvelopeBypass(stripped) {
+  EVENTS_IMPORT.lastIndex = 0;
+  let m;
+  while ((m = EVENTS_IMPORT.exec(stripped)) !== null) {
+    const full = m[0];
+    const clause = m[2];
+    // Statement-level type-only (`import type …` / `export type …`): no value.
+    if (/^\s*type\b/.test(clause)) continue;
+
+    // Namespace import: `* as ns` → reachable only if `ns.publishEnvelope` is used.
+    const ns = clause.match(/\*\s+as\s+(\w+)/);
+    if (ns) {
+      const member = new RegExp(`\\b${ns[1]}\\s*\\.\\s*publishEnvelope\\b`);
+      const mm = member.exec(stripped);
+      if (mm) return { line: lineAtOffset(stripped, mm.index) };
+      continue;
+    }
+
+    // Named bindings: `{ a, publishEnvelope, … }`. A `type ` prefix on the
+    // specifier (inline type modifier) means the binding is NOT a runnable value.
+    const brace = clause.match(/\{([\s\S]*)\}/);
+    if (brace) {
+      for (const spec of brace[1].split(",")) {
+        const s = spec.trim();
+        if (!s || /^type\b/.test(s)) continue;
+        if (/^publishEnvelope\b/.test(s)) {
+          const off = m.index + Math.max(0, full.indexOf("publishEnvelope"));
+          return { line: lineAtOffset(stripped, off) };
+        }
+      }
+    }
+  }
+  return null;
+}
 
 // Discriminate NATS from Redis/Rabbit/notifier by RECEIVER NAME, not imports:
 // every NATS emit in this codebase publishes via `.nats.publish(` or
@@ -163,20 +264,20 @@ for (const file of walk(ROOT)) {
     if (EMIT_CALL.test(line) && !CONSUMED.test(line) && !/function|interface|type\s|=>/.test(line)) {
       findings.push({ file: rel, line: i + 1, kind: "unhandled-emit-either", allowlisted: false, text: trimmed });
     }
-    // publishEnvelope-bypass: direct value import from @0xhoneyjar/events (FR-1 / events #255).
-    if (
-      PE_IMPORT.test(line) &&
-      EVENTS_PKG_FROM.test(line) &&
-      !TYPE_ONLY_IMPORT.test(line)
-    ) {
-      findings.push({
-        file: rel,
-        line: i + 1,
-        kind: "publishEnvelope-bypass",
-        allowlisted: isAllowlisted(rel, "publishEnvelope"),
-        text: trimmed,
-      });
-    }
+  }
+
+  // publishEnvelope-bypass (FR-1 / events #255): whole-file, comment-stripped,
+  // two-pass — catches multi-line imports (F1) and namespace member access (F2)
+  // the old line matcher missed, without the comment false-positives (F3).
+  const pe = detectPublishEnvelopeBypass(stripComments(text));
+  if (pe) {
+    findings.push({
+      file: rel,
+      line: pe.line,
+      kind: "publishEnvelope-bypass",
+      allowlisted: isAllowlisted(rel, "publishEnvelope"),
+      text: (lines[pe.line - 1] ?? "").trim(),
+    });
   }
 }
 

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -30,10 +30,6 @@
       "types": "./dist/src/topics.d.ts",
       "import": "./dist/src/topics.js"
     },
-    "./publisher": {
-      "types": "./dist/src/publisher.d.ts",
-      "import": "./dist/src/publisher.js"
-    },
     "./subscriber": {
       "types": "./dist/src/subscriber.d.ts",
       "import": "./dist/src/subscriber.js"
@@ -59,7 +55,7 @@
       "import": "./dist/src/mutex.js"
     }
   },
-  "//exports-note": "cycle-112: ./transport is DELIBERATELY omitted. The internalPublish capability (raw NATS publish) must be unreachable from outside the package; emit.ts/publisher.ts import ./transport.js via relative path. The exports map gates all subpaths, so neither @0xhoneyjar/events/transport nor /dist/src/transport.js resolves for a consumer (FR-7, SKP-002).",
+  "//exports-note": "cycle-112: ./transport AND ./publisher are DELIBERATELY omitted (events #255). The internalPublish capability (raw NATS publish, ./transport) and the raw publishEnvelope capability (schema-validation bypass, ./publisher) must both be unreachable from outside the package; emit.ts imports them via relative paths (./transport.js, ./publisher.js). The exports map gates all subpaths, so none of @0xhoneyjar/events/transport, @0xhoneyjar/events/publisher, nor their /dist/src/*.js forms resolve for a consumer. The sanctioned external path is makeEmitter()/emit(), which validates before signing (FR-7, SKP-002).",
   "files": [
     "dist",
     "src",

--- a/packages/events/raw-nats-allowlist.yaml
+++ b/packages/events/raw-nats-allowlist.yaml
@@ -45,3 +45,10 @@ entries:
 
 # Populated by S3 when the computed-subject sites convert from raw to emitRaw.
 emitRaw_allowlist: []
+
+# Populated only if a legitimate publishEnvelope bypass is identified during
+# implementation. Empty by default (zero external callers today — Assumption 1).
+# Entries use the same id format as `entries`:
+#   "<file-fragment>::publishEnvelope"
+# The shrink gate (tools/check-nats-allowlist-shrinks.sh) covers this section.
+publishEnvelope_allowlist: []

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -28,12 +28,17 @@ export {
   type TopicSegments,
 } from "./topics.js";
 
+// `publishEnvelope` (+ its `PublishOptions`/`PublishResult` raw-publish types) is
+// DELIBERATELY NOT re-exported (events #255). It is the raw, schema-validation-
+// bypassing capability; emit.ts imports it internally via the relative
+// "./publisher.js" path. The sanctioned external path is makeEmitter()/emit(),
+// which validates before signing. The package.json exports map also omits the
+// "./publisher" subpath, so the capability is unreachable from any consumer
+// (FR-7, SKP-002). InMemoryPrevHashStore + PrevHashStore stay public — emit()
+// consumers need them.
 export {
-  publishEnvelope,
   InMemoryPrevHashStore,
   type PrevHashStore,
-  type PublishOptions,
-  type PublishResult,
 } from "./publisher.js";
 
 export {

--- a/packages/events/tests/events-lint.publish-envelope.test.ts
+++ b/packages/events/tests/events-lint.publish-envelope.test.ts
@@ -174,4 +174,18 @@ describe("events-lint — publishEnvelope-bypass detection (T-1 TEETH TEST)", ()
       ].join("\n") + "\n",
     );
   });
+
+  // ── NF6 (keyword barrier): a no-semicolon local `export { publishEnvelope }`
+  //    (ASI, no `from`) immediately before a @events import must NOT be swept
+  //    into the import clause on a no-semicolon codebase.
+  it("does NOT flag a no-semicolon local `export { publishEnvelope }` next to a @events import (NF6)", () => {
+    assertClean(
+      "no-semi-local-export.ts",
+      [
+        `export { publishEnvelope }`,
+        `import { makeEmitter } from "@0xhoneyjar/events"`,
+        `export const e = makeEmitter`,
+      ].join("\n") + "\n",
+    );
+  });
 });

--- a/packages/events/tests/events-lint.publish-envelope.test.ts
+++ b/packages/events/tests/events-lint.publish-envelope.test.ts
@@ -137,4 +137,41 @@ describe("events-lint — publishEnvelope-bypass detection (T-1 TEETH TEST)", ()
       `import type { publishEnvelope } from "@0xhoneyjar/events";\n// type-only import — no capability, no bypass\n`,
     );
   });
+
+  // ── NF1 (statement-isolation): an interface/object member named publishEnvelope
+  //    sitting next to a @events import must NOT be swept into the import clause.
+  it("does NOT flag an interface member `publishEnvelope` next to a @events import (NF1)", () => {
+    assertClean(
+      "iface-member.ts",
+      [
+        `export interface Foo { publishEnvelope: () => void }`,
+        `import { makeEmitter } from "@0xhoneyjar/events";`,
+        `export const e = makeEmitter;`,
+      ].join("\n") + "\n",
+    );
+  });
+
+  it("does NOT flag an object key `publishEnvelope` next to a @events re-export (NF1)", () => {
+    assertClean(
+      "object-key.ts",
+      [
+        `export const cfg = { publishEnvelope: true };`,
+        `export { makeEmitter } from "@0xhoneyjar/events";`,
+      ].join("\n") + "\n",
+    );
+  });
+
+  // ── NF2 (regex-literal state): a quote-bearing regex must not desync the
+  //    comment-stripper and leave a commented-out import un-stripped → flagged.
+  it("does NOT flag a commented-out import after a quote-bearing regex literal (NF2)", () => {
+    assertClean(
+      "regex-then-comment.ts",
+      [
+        // a regex containing both quote chars — exactly the desync trigger
+        "const RX = /[\"']@0xhoneyjar\\/events[\"']/;",
+        '// import { publishEnvelope } from "@0xhoneyjar/events";',
+        "export const y = RX;",
+      ].join("\n") + "\n",
+    );
+  });
 });

--- a/packages/events/tests/events-lint.publish-envelope.test.ts
+++ b/packages/events/tests/events-lint.publish-envelope.test.ts
@@ -1,0 +1,97 @@
+// TEETH TEST — must be RED on the unpatched lint (base commit 59656d5a).
+// This test FAILS before the detection pattern is added (exit code is NOT 1,
+// or output does NOT contain "publishEnvelope-bypass"). The RED→GREEN transition
+// is the falsification proof that the bypass hole was real (G-3).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+
+// Resolve the binary path relative to this file — always points to the one true
+// binary at packages/events/bin/events-lint.mjs (G-2: no reimplementation).
+const BIN = fileURLToPath(new URL("../bin/events-lint.mjs", import.meta.url));
+
+describe("events-lint — publishEnvelope-bypass detection (T-1 TEETH TEST)", () => {
+  it("exits 1 and emits publishEnvelope-bypass when a file outside the events package imports publishEnvelope", () => {
+    assert.ok(existsSync(BIN), `Binary not found: ${BIN}`);
+
+    const tmpDir = mkdtempSync(join(tmpdir(), "events-lint-pe-"));
+    try {
+      const fixtureDir = join(tmpDir, "bypass-fixture");
+      mkdirSync(fixtureDir);
+
+      // Fixture: a direct publishEnvelope import — the bypass that skips schema
+      // validation. Must NOT be inside packages/events/src (which is exempt).
+      writeFileSync(
+        join(fixtureDir, "bypass.ts"),
+        [
+          `import { publishEnvelope } from "@0xhoneyjar/events";`,
+          `// direct bypass — no schema validation`,
+          `publishEnvelope({ nats: {} as any, subject: "test", payload: {},`,
+          `                  emittedBy: "test", signer: {} as any,`,
+          `                  prevHashStore: {} as any });`,
+        ].join("\n"),
+        "utf8",
+      );
+
+      const result = spawnSync(process.execPath, [BIN, "--root", fixtureDir, "--enforce"], {
+        encoding: "utf8",
+        timeout: 15_000,
+      });
+
+      const output = (result.stdout ?? "") + (result.stderr ?? "");
+
+      assert.strictEqual(
+        result.status,
+        1,
+        `Expected exit code 1 (detection fired), got ${result.status}.\nOutput:\n${output}`,
+      );
+      assert.ok(
+        output.includes("publishEnvelope-bypass"),
+        `Expected output to contain "publishEnvelope-bypass".\nOutput:\n${output}`,
+      );
+    } finally {
+      // AC-8 (test isolation): temp dir removed on pass OR fail.
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does NOT flag import type { publishEnvelope } (type-only import guard)", () => {
+    assert.ok(existsSync(BIN), `Binary not found: ${BIN}`);
+
+    const tmpDir = mkdtempSync(join(tmpdir(), "events-lint-pe-type-"));
+    try {
+      const fixtureDir = join(tmpDir, "bypass-fixture");
+      mkdirSync(fixtureDir);
+
+      writeFileSync(
+        join(fixtureDir, "type-only.ts"),
+        `import type { publishEnvelope } from "@0xhoneyjar/events";\n// type-only import — no capability, no bypass\n`,
+        "utf8",
+      );
+
+      const result = spawnSync(process.execPath, [BIN, "--root", fixtureDir, "--enforce"], {
+        encoding: "utf8",
+        timeout: 15_000,
+      });
+
+      const output = (result.stdout ?? "") + (result.stderr ?? "");
+
+      assert.strictEqual(
+        result.status,
+        0,
+        `Expected exit code 0 for type-only import, got ${result.status}.\nOutput:\n${output}`,
+      );
+      assert.ok(
+        !output.includes("publishEnvelope-bypass"),
+        `Expected no publishEnvelope-bypass finding for type-only import.\nOutput:\n${output}`,
+      );
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/events/tests/events-lint.publish-envelope.test.ts
+++ b/packages/events/tests/events-lint.publish-envelope.test.ts
@@ -2,6 +2,11 @@
 // This test FAILS before the detection pattern is added (exit code is NOT 1,
 // or output does NOT contain "publishEnvelope-bypass"). The RED→GREEN transition
 // is the falsification proof that the bypass hole was real (G-3).
+//
+// FAGAN-hardened (events #255 F1–F3): the line-by-line matcher was trivially
+// evaded by multi-line imports (F1) and namespace member access (F2), and its
+// comment-skip was insufficient (F3). These cases shell the REAL binary against
+// fixtures the test writes at runtime — never a mock.
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
@@ -15,83 +20,121 @@ import { tmpdir } from "node:os";
 // binary at packages/events/bin/events-lint.mjs (G-2: no reimplementation).
 const BIN = fileURLToPath(new URL("../bin/events-lint.mjs", import.meta.url));
 
+// Write a single fixture file into a fresh tmp dir and run the REAL binary with
+// --enforce against it. Returns { status, output } and removes the dir.
+function runFixture(filename: string, contents: string): { status: number | null; output: string } {
+  assert.ok(existsSync(BIN), `Binary not found: ${BIN}`);
+  const tmpDir = mkdtempSync(join(tmpdir(), "events-lint-pe-"));
+  try {
+    const fixtureDir = join(tmpDir, "bypass-fixture");
+    mkdirSync(fixtureDir);
+    writeFileSync(join(fixtureDir, filename), contents, "utf8");
+    const result = spawnSync(process.execPath, [BIN, "--root", fixtureDir, "--enforce"], {
+      encoding: "utf8",
+      timeout: 15_000,
+    });
+    return { status: result.status, output: (result.stdout ?? "") + (result.stderr ?? "") };
+  } finally {
+    // AC-8 (test isolation): temp dir removed on pass OR fail.
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function assertFlagged(filename: string, contents: string) {
+  const { status, output } = runFixture(filename, contents);
+  assert.strictEqual(status, 1, `Expected exit 1 (detection fired) for ${filename}, got ${status}.\nOutput:\n${output}`);
+  assert.ok(
+    output.includes("publishEnvelope-bypass"),
+    `Expected output to contain "publishEnvelope-bypass" for ${filename}.\nOutput:\n${output}`,
+  );
+}
+
+function assertClean(filename: string, contents: string) {
+  const { status, output } = runFixture(filename, contents);
+  assert.strictEqual(status, 0, `Expected exit 0 (no finding) for ${filename}, got ${status}.\nOutput:\n${output}`);
+  assert.ok(
+    !output.includes("publishEnvelope-bypass"),
+    `Expected NO publishEnvelope-bypass finding for ${filename}.\nOutput:\n${output}`,
+  );
+}
+
 describe("events-lint — publishEnvelope-bypass detection (T-1 TEETH TEST)", () => {
-  it("exits 1 and emits publishEnvelope-bypass when a file outside the events package imports publishEnvelope", () => {
-    assert.ok(existsSync(BIN), `Binary not found: ${BIN}`);
-
-    const tmpDir = mkdtempSync(join(tmpdir(), "events-lint-pe-"));
-    try {
-      const fixtureDir = join(tmpDir, "bypass-fixture");
-      mkdirSync(fixtureDir);
-
-      // Fixture: a direct publishEnvelope import — the bypass that skips schema
-      // validation. Must NOT be inside packages/events/src (which is exempt).
-      writeFileSync(
-        join(fixtureDir, "bypass.ts"),
-        [
-          `import { publishEnvelope } from "@0xhoneyjar/events";`,
-          `// direct bypass — no schema validation`,
-          `publishEnvelope({ nats: {} as any, subject: "test", payload: {},`,
-          `                  emittedBy: "test", signer: {} as any,`,
-          `                  prevHashStore: {} as any });`,
-        ].join("\n"),
-        "utf8",
-      );
-
-      const result = spawnSync(process.execPath, [BIN, "--root", fixtureDir, "--enforce"], {
-        encoding: "utf8",
-        timeout: 15_000,
-      });
-
-      const output = (result.stdout ?? "") + (result.stderr ?? "");
-
-      assert.strictEqual(
-        result.status,
-        1,
-        `Expected exit code 1 (detection fired), got ${result.status}.\nOutput:\n${output}`,
-      );
-      assert.ok(
-        output.includes("publishEnvelope-bypass"),
-        `Expected output to contain "publishEnvelope-bypass".\nOutput:\n${output}`,
-      );
-    } finally {
-      // AC-8 (test isolation): temp dir removed on pass OR fail.
-      rmSync(tmpDir, { recursive: true, force: true });
-    }
+  // ── POSITIVES (must flag → exit 1) ──────────────────────────────────────
+  it("flags a single-line value import of publishEnvelope", () => {
+    assertFlagged(
+      "bypass.ts",
+      [
+        `import { publishEnvelope } from "@0xhoneyjar/events";`,
+        `// direct bypass — no schema validation`,
+        `publishEnvelope({ nats: {} as any, subject: "test", payload: {},`,
+        `                  emittedBy: "test", signer: {} as any,`,
+        `                  prevHashStore: {} as any });`,
+      ].join("\n"),
+    );
   });
 
-  it("does NOT flag import type { publishEnvelope } (type-only import guard)", () => {
-    assert.ok(existsSync(BIN), `Binary not found: ${BIN}`);
+  it("flags a MULTI-LINE value import of publishEnvelope (F1 — was a total miss)", () => {
+    // Prettier's normal shape for multi-binding imports. publishEnvelope and the
+    // `from` clause land on different lines → the old same-line matcher missed it.
+    assertFlagged(
+      "multiline.ts",
+      [
+        `import {`,
+        `  someOther,`,
+        `  publishEnvelope,`,
+        `} from "@0xhoneyjar/events";`,
+        ``,
+        `publishEnvelope({} as any);`,
+      ].join("\n"),
+    );
+  });
 
-    const tmpDir = mkdtempSync(join(tmpdir(), "events-lint-pe-type-"));
-    try {
-      const fixtureDir = join(tmpDir, "bypass-fixture");
-      mkdirSync(fixtureDir);
+  it("flags a NAMESPACE import + member call (F2 — was a miss)", () => {
+    // Import line has `from` but not the token; call site has the token but not
+    // `from`. The old single-line AND-of-two-regexes never fired.
+    assertFlagged(
+      "namespace.ts",
+      [
+        `import * as events from "@0xhoneyjar/events";`,
+        ``,
+        `events.publishEnvelope({} as any);`,
+      ].join("\n"),
+    );
+  });
 
-      writeFileSync(
-        join(fixtureDir, "type-only.ts"),
-        `import type { publishEnvelope } from "@0xhoneyjar/events";\n// type-only import — no capability, no bypass\n`,
-        "utf8",
-      );
+  // ── NEGATIVES (must NOT flag → exit 0) ──────────────────────────────────
+  it("does NOT flag a mention inside an inline trailing comment (F3)", () => {
+    assertClean(
+      "inline-comment.ts",
+      `const x = 1; // never import publishEnvelope from "@0xhoneyjar/events"\nexport const y = x;\n`,
+    );
+  });
 
-      const result = spawnSync(process.execPath, [BIN, "--root", fixtureDir, "--enforce"], {
-        encoding: "utf8",
-        timeout: 15_000,
-      });
+  it("does NOT flag a mention inside a single-line block comment (F3)", () => {
+    assertClean(
+      "block-comment.ts",
+      `/* publishEnvelope from "@0xhoneyjar/events" forbidden */\nexport const z = 1;\n`,
+    );
+  });
 
-      const output = (result.stdout ?? "") + (result.stderr ?? "");
+  it("does NOT flag a type-only re-export: export type { publishEnvelope } (F3)", () => {
+    assertClean(
+      "export-type.ts",
+      `export type { publishEnvelope } from "@0xhoneyjar/events";\n`,
+    );
+  });
 
-      assert.strictEqual(
-        result.status,
-        0,
-        `Expected exit code 0 for type-only import, got ${result.status}.\nOutput:\n${output}`,
-      );
-      assert.ok(
-        !output.includes("publishEnvelope-bypass"),
-        `Expected no publishEnvelope-bypass finding for type-only import.\nOutput:\n${output}`,
-      );
-    } finally {
-      rmSync(tmpDir, { recursive: true, force: true });
-    }
+  it("does NOT flag an inline type modifier: import { type publishEnvelope } (F3)", () => {
+    assertClean(
+      "inline-type.ts",
+      `import { type publishEnvelope } from "@0xhoneyjar/events";\n// type-only binding — no runnable value\n`,
+    );
+  });
+
+  it("does NOT flag a statement-level type-only import: import type { publishEnvelope }", () => {
+    assertClean(
+      "type-only.ts",
+      `import type { publishEnvelope } from "@0xhoneyjar/events";\n// type-only import — no capability, no bypass\n`,
+    );
   });
 });

--- a/tools/check-nats-allowlist-shrinks.sh
+++ b/tools/check-nats-allowlist-shrinks.sh
@@ -122,4 +122,25 @@ if [ -n "$additions" ]; then
 fi
 
 echo "[nats-allowlist] OK — allowlist did not grow (additions: 0)."
+
+# publishEnvelope_allowlist: same shrink-only gate (OQ-2 / events #255).
+# The `// []` fallback makes this safe when the base branch predates the section.
+comm -13 \
+  <(printf '%s\n' "$base_blob" \
+    | yq -r '(.publishEnvelope_allowlist // []) | .[].id' 2>/dev/null | sort) \
+  <(yq -r '(.publishEnvelope_allowlist // []) | .[].id' \
+    "$ALLOWLIST" 2>/dev/null | sort) \
+  > /tmp/added_pe_ids
+if [ -s /tmp/added_pe_ids ]; then
+  echo "::error::publishEnvelope_allowlist gained id(s) — shrink-only gate:"
+  cat /tmp/added_pe_ids
+  echo "A genuinely-needed bypass must be documented as an operator decision first."
+  if [ "$ENFORCE" = "1" ]; then
+    exit 1
+  fi
+  echo "::notice::[nats-allowlist] REPORT-ONLY — not failing. Pass --enforce to fail-block."
+  exit 0
+fi
+
+echo "[nats-allowlist] OK — publishEnvelope_allowlist did not grow."
 exit 0

--- a/tools/check-nats-allowlist-shrinks.sh
+++ b/tools/check-nats-allowlist-shrinks.sh
@@ -49,6 +49,10 @@ ENFORCE=0
 [ "${1:-}" = "--enforce" ] && ENFORCE=1
 
 # Extract the union of `- id: "..."` values from a YAML stream on stdin.
+# Section-BLIND by design: it unions EVERY `- id:` line — `entries`,
+# `emitRaw_allowlist`, AND `publishEnvelope_allowlist` (events #255) alike. So the
+# shrink-only gate at the addition check below already covers a publishEnvelope
+# bypass addition; no separate, yq-dependent PE block is needed (FAGAN F4).
 extract_ids() {
   grep -E '^[[:space:]]*-[[:space:]]+id:' \
     | sed -E 's/^[[:space:]]*-[[:space:]]+id:[[:space:]]*//; s/^"//; s/"[[:space:]]*$//' \
@@ -122,25 +126,9 @@ if [ -n "$additions" ]; then
 fi
 
 echo "[nats-allowlist] OK — allowlist did not grow (additions: 0)."
-
-# publishEnvelope_allowlist: same shrink-only gate (OQ-2 / events #255).
-# The `// []` fallback makes this safe when the base branch predates the section.
-comm -13 \
-  <(printf '%s\n' "$base_blob" \
-    | yq -r '(.publishEnvelope_allowlist // []) | .[].id' 2>/dev/null | sort) \
-  <(yq -r '(.publishEnvelope_allowlist // []) | .[].id' \
-    "$ALLOWLIST" 2>/dev/null | sort) \
-  > /tmp/added_pe_ids
-if [ -s /tmp/added_pe_ids ]; then
-  echo "::error::publishEnvelope_allowlist gained id(s) — shrink-only gate:"
-  cat /tmp/added_pe_ids
-  echo "A genuinely-needed bypass must be documented as an operator decision first."
-  if [ "$ENFORCE" = "1" ]; then
-    exit 1
-  fi
-  echo "::notice::[nats-allowlist] REPORT-ONLY — not failing. Pass --enforce to fail-block."
-  exit 0
-fi
-
-echo "[nats-allowlist] OK — publishEnvelope_allowlist did not grow."
+# NOTE: publishEnvelope_allowlist (events #255) is covered by the SAME addition
+# check above — extract_ids unions its `- id:` lines too, so a PE-bypass addition
+# already trips "GAINED id(s)". The former yq-based PE block here was dead code
+# (it fired only after the union path already failed) and fails-open where yq is
+# absent; deleted per FAGAN F4. Smoke test #6 asserts the union catches it.
 exit 0

--- a/tools/check-nats-allowlist-shrinks.test.sh
+++ b/tools/check-nats-allowlist-shrinks.test.sh
@@ -35,6 +35,13 @@ check() { # name expected-rc actual-rc
     echo "FAIL: $1 — expected exit $2, got $3"; sed 's/^/    /' /tmp/nats-gate-smoke.out; fail=1
   fi
 }
+check_msg() { # name substring  (asserts last run's output contains it)
+  if grep -qF "$2" /tmp/nats-gate-smoke.out; then
+    echo "PASS: $1 (output contains '$2')"
+  else
+    echo "FAIL: $1 — expected output to contain '$2'"; sed 's/^/    /' /tmp/nats-gate-smoke.out; fail=1
+  fi
+}
 
 # 1) Count-preserving SWAP (remove b::y, add c::z) — the IMP-003 bypass — MUST fail.
 printf 'version: 1\nentries:\n  - id: "a::x"\n  - id: "c::z"\nemitRaw_allowlist: []\n' > "$AL"
@@ -56,10 +63,19 @@ check "unchanged stays GREEN" 0 "$(run)"
 printf 'version: 1\nentries:\n  - id: "a::x"\nemitRaw_allowlist:\n  - id: "b::y"\n' > "$AL"
 check "entries->emitRaw move stays GREEN" 0 "$(run)"
 
-# 6) publishEnvelope_allowlist ADDITION — MUST fail (events #255 shrink gate).
+# 6) publishEnvelope_allowlist ADDITION — MUST fail, caught by the GENERIC union
+#    path (events #255). extract_ids is section-blind: it unions the PE section's
+#    `- id:` lines too, so the addition trips the generic "GAINED id(s)" check.
+#    There is NO PE-specific gate block anymore (it was dead code — FAGAN F4).
+#    Asserting the message (not just exit 1) makes this a real regression test of
+#    the union covering the PE section — it goes RED if that coverage breaks,
+#    instead of passing whether or not the enforcing code exists.
 git show HEAD:"$AL" > "$AL"  # reset to base
 printf 'version: 1\nentries:\n  - id: "a::x"\n  - id: "b::y"\nemitRaw_allowlist: []\npublishEnvelope_allowlist:\n  - id: "src/foo.ts::publishEnvelope"\n' > "$AL"
-check "publishEnvelope_allowlist addition goes RED" 1 "$(run)"
+rc6="$(run)"
+check "publishEnvelope_allowlist addition goes RED" 1 "$rc6"
+check_msg "publishEnvelope addition is caught by the generic union path" "GAINED id(s)"
+check_msg "the offending PE id is named in the diff" "src/foo.ts::publishEnvelope"
 
 # 7) Empty publishEnvelope_allowlist — MUST pass.
 printf 'version: 1\nentries:\n  - id: "a::x"\n  - id: "b::y"\nemitRaw_allowlist: []\npublishEnvelope_allowlist: []\n' > "$AL"

--- a/tools/check-nats-allowlist-shrinks.test.sh
+++ b/tools/check-nats-allowlist-shrinks.test.sh
@@ -56,6 +56,22 @@ check "unchanged stays GREEN" 0 "$(run)"
 printf 'version: 1\nentries:\n  - id: "a::x"\nemitRaw_allowlist:\n  - id: "b::y"\n' > "$AL"
 check "entries->emitRaw move stays GREEN" 0 "$(run)"
 
+# 6) publishEnvelope_allowlist ADDITION — MUST fail (events #255 shrink gate).
+git show HEAD:"$AL" > "$AL"  # reset to base
+printf 'version: 1\nentries:\n  - id: "a::x"\n  - id: "b::y"\nemitRaw_allowlist: []\npublishEnvelope_allowlist:\n  - id: "src/foo.ts::publishEnvelope"\n' > "$AL"
+check "publishEnvelope_allowlist addition goes RED" 1 "$(run)"
+
+# 7) Empty publishEnvelope_allowlist — MUST pass.
+printf 'version: 1\nentries:\n  - id: "a::x"\n  - id: "b::y"\nemitRaw_allowlist: []\npublishEnvelope_allowlist: []\n' > "$AL"
+check "empty publishEnvelope_allowlist stays GREEN" 0 "$(run)"
+
+# 8) Base branch lacks publishEnvelope_allowlist section entirely — MUST pass (// [] fallback).
+# The base commit (HEAD) has no publishEnvelope_allowlist; head adds it empty.
+git show HEAD:"$AL" > "$AL"  # reset to base (has no publishEnvelope_allowlist)
+# Temporarily add the section empty to the working copy (simulates the new section landing):
+printf 'version: 1\nentries:\n  - id: "a::x"\n  - id: "b::y"\nemitRaw_allowlist: []\npublishEnvelope_allowlist: []\n' > "$AL"
+check "base-lacks-section with empty head stays GREEN" 0 "$(run)"
+
 if [ "$fail" = "0" ]; then
   echo "ALL SHRINK-GATE SMOKE TESTS PASS"
   exit 0


### PR DESCRIPTION
## Close the events #255 producer/consumer asymmetry — structural fence + lint backstop

Convergence-loop turn 1. The event protocol enforced its payload-schema contract **asymmetrically**: the consumer (`subscribeEnvelope`) mandatorily validates (`subscriber.ts:299-307`), the sanctioned producer path (`emit()`) validates before signing (`emit.ts:261-265`) — but raw `publishEnvelope` was publicly exported and signed-without-validating. A consumer could `import { publishEnvelope }` and ship a schema-divergent payload (GitHub #255, `learning-status:strongly-validated`).

### The close — deletion-over-denylist (primary), lint backstop (secondary)

**1. Structural fence (the real control).** `publishEnvelope` is **un-exported** — removed from the `index.ts` barrel and the `./publisher` subpath deleted from `package.json` `exports` (following the package's own `./transport` containment precedent, FR-7). The raw capability is now **unreachable from any consumer**; the only public publish path is the validating `emit()`. `InMemoryPrevHashStore`/`PrevHashStore` remain exported for `emit()` consumers.

**2. Lint backstop.** `events-lint.mjs` (already run `--enforce` by `schema-emission-floor.yml`) now also flags any in-monorepo relative deep-import of `publishEnvelope` — a defense-in-depth tripwire behind the fence.

### Proof — deterministic, against the REAL artifacts (no mock)

**Fence (Node v22 resolver, against the actual `exports` map):**
| consumer specifier | result |
|---|---|
| `@0xhoneyjar/events/publisher` | `ERR_PACKAGE_PATH_NOT_EXPORTED` |
| `@0xhoneyjar/events/dist/src/publisher.js` | `ERR_PACKAGE_PATH_NOT_EXPORTED` |
| `@0xhoneyjar/events/src/publisher.js` (despite `files` shipping `src`) | `ERR_PACKAGE_PATH_NOT_EXPORTED` |
| `@0xhoneyjar/events` (barrel) / `@0xhoneyjar/events/emit` | resolve; `publishEnvelope` **not** a named export |

Zero `export *` wildcards; the only non-comment `publishEnvelope` binding outside `publisher.ts` is `emit.ts`'s internal import (never re-exported); zero in-repo consumers of the removed symbols → compiles, breaks nothing.

**Lint backstop matrix (real binary `--enforce`):** single-line / multi-line / namespace import → **exit 1**; interface-member, object-key, inline/block comment, `export type`, inline `{type}`, no-semicolon local export, quote-bearing regex → **exit 0**; clean tree → **exit 0**.

### Provenance (honest)
Built via `spiral-harness.sh` (cycle-coherence-2); the harness died on budget in a post-implementation evidence loop (false-positive "missing artifact" paths), so its REVIEW/AUDIT phases didn't run. Compensated by **three independent FAGAN (cross-model) review rounds** that found and drove fixes for: F1 multi-line miss, F2 namespace miss, F3 comment FPs, F4 dead shrink-gate code, then NF1 span-FP, NF2 regex-desync FP, NF3 destructure FN (mooted by the fence), NF6 no-semicolon FP — each proven against the real binary. The branch was rebased onto clean `origin/main`; an out-of-scope System-Zone edit the run introduced was dropped. Full FAGAN trail in the review comment below.

Closes #255. Folds in the deferred un-export (was bead `arrakis-bs5n`). Convergence: EULER re-map 7 → 6 asymmetric edges.
