### PR TITLE
feat(shared/immune): meta-immune doctor — detect lying health instruments (campaign M0 / G-IMMUNE)

### DIFF
--- a/tools/instrument-truth-sensor.mjs
+++ b/tools/instrument-truth-sensor.mjs
@@ -38,7 +38,7 @@
  *   node tools/instrument-truth-sensor.mjs --log=PATH      # point at a specific audit log
  *   node tools/instrument-truth-sensor.mjs --probe-table=FILE.json   # override the declared probe
  *   node tools/instrument-truth-sensor.mjs --freshness-days=N        # active window (default 3)
- *   node tools/instrument-truth-sensor.mjs --now=ISO                 # freshness anchor (default: newest record)
+ *   node tools/instrument-truth-sensor.mjs --now=ISO                 # freshness anchor (default: WALL-CLOCK)
  *
  * Exit code is the verdict (so it can gate):
  *   0 = TRUTHFUL  (every instrument's declaration matches ground truth)
@@ -51,7 +51,11 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 export const DAY_MS = 86_400_000;
 export const DEFAULT_FRESHNESS_MS = 3 * DAY_MS; // a voice is ACTIVE if it produced a final in this window
-const MAX_RECORDS = 20_000; // bounded tail — read the recent window, never unbounded
+// Bounds how many lines are PARSED (the recent tail). The file READ itself is NOT bounded by this:
+// readRecords() reads the whole file via readFileSync, then keeps only the last MAX_RECORDS lines to
+// parse. Fine for the small audit log today; if this is ever pointed at a full audit stream, switch
+// readRecords to an EOF-seeking byte-capped tail so the memory envelope matches this intent.
+const MAX_RECORDS = 20_000;
 
 // provider prefix (left of the first ':') -> canonical cheval voice. anthropic-via-bedrock is claude.
 export const PROVIDER_VOICE = {
@@ -64,19 +68,33 @@ export const PROVIDER_VOICE = {
 };
 
 /**
- * The STATIC cheval doctor's DECLARED report — the *declaration* side this sensor checks against
+ * AS-OF date of STATIC_DOCTOR_PROBE. Surfaced in every render so the declaration's STATIC nature is
+ * first-class: this is a frozen snapshot, NOT a live read of doctor.py. A frozen baseline measures
+ * the age of the baseline as much as the thing — so we make that age visible (and offer
+ * --probe-table=FILE.json to re-ground) rather than letting the constant silently drift.
+ */
+export const STATIC_DOCTOR_PROBE_AS_OF = '2026-06-26';
+
+/**
+ * The STATIC cheval doctor's DECLARED coverage — the *declaration* side this sensor checks against
  * ground truth. This is a CONFIG constant (the probe's known coverage + verdicts as observed
- * 2026-06-26, GECKO-derived in grimoires/loa/context/morning-leverage-ideation-2026-06-26.md), NOT
- * a live probe — invoking doctor.py here would hang. Override with --probe-table=FILE.json to
- * re-ground. `cursor` is deliberately ABSENT: it is invisible to the static probe table (that
- * invisibility is exactly the lie this sensor surfaces).
+ * 2026-06-26, GECKO-derived), NOT a live probe — invoking doctor.py here would hang. Override with
+ * --probe-table=FILE.json to re-ground.
+ *
+ * The keys MIRROR doctor.py's contract-pinned `_PROBE_TABLE` — exactly {claude, codex, gemini}
+ * (test_doctor.py::TestProbeTableContract). The new-company headless adapters (`cursor`, `grok`) are
+ * deliberately ABSENT here BECAUSE they are absent from doctor.py's probe table — each ships its own
+ * adapter-level health_check() instead. That invisibility is exactly the lie this sensor surfaces:
+ * if such a voice produces fresh finals, it reads as INVISIBLE (a live-but-unlisted lie of omission);
+ * if it is silent, it reads as DARK (nothing claimed, nothing done). Declaring `grok: 'up'` here
+ * would instead MANUFACTURE a FALSE_HEALTHY whenever grok is idle — a self-inflicted false positive
+ * about the constant, not a real lying instrument.
  */
 export const STATIC_DOCTOR_PROBE = Object.freeze({
   claude: 'unknown', // probe artifact — reports unknown despite a live workhorse
   codex: 'up',
   gemini: 'down', // genuinely dead — the probe is correct here
-  grok: 'up',
-  // cursor: (absent — invisible to the probe)
+  // cursor, grok: (absent — not in doctor.py's contract-pinned probe table)
 });
 
 const CLAIMS_HEALTHY = new Set(['up', 'healthy', 'ok']);
@@ -212,22 +230,54 @@ export function readRecords(logPath) {
   return out;
 }
 
-function loadProbeTable() {
-  const file = argVal('probe-table') || process.env.LOA_DOCTOR_PROBE_TABLE;
-  if (!file) return STATIC_DOCTOR_PROBE;
-  return JSON.parse(readFileSync(file, 'utf8'));
-}
-
 function die(msg, code = 1) {
   console.error(`instrument-truth: ${msg}`);
   process.exit(code);
 }
 
+/**
+ * Resolve the declared probe table. Same fail-closed discipline as the log read: a missing/malformed
+ * --probe-table (or a parse that succeeds but yields a non-object, e.g. a JSON array — the
+ * `typeof [] === 'object'` footgun) routes through die(... INSUFFICIENT), never a raw stack trace and
+ * never a silently-wrong classification. Returns { probeTable, source, asOf }.
+ */
+function loadProbeTable() {
+  const file = argVal('probe-table') || process.env.LOA_DOCTOR_PROBE_TABLE;
+  if (!file) return { probeTable: STATIC_DOCTOR_PROBE, source: 'static', asOf: STATIC_DOCTOR_PROBE_AS_OF };
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(file, 'utf8'));
+  } catch (e) {
+    die(`cannot read/parse probe table ${file} (${e.code || e.message}) — INSUFFICIENT, refusing to assert "truthful" without evidence`);
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    die(`probe table ${file} is not a JSON object (expected a voice -> status map) — INSUFFICIENT, refusing to assert "truthful" without evidence`);
+  }
+  return { probeTable: parsed, source: file, asOf: null };
+}
+
 function main() {
   const logPath = argVal('log') || process.env.LOA_MODELINV_LOG || defaultLogPath();
-  const freshDays = argVal('freshness-days') ? Number(argVal('freshness-days')) : 3;
+
+  // Validate numeric/date args at the boundary BEFORE any work. NaN comparisons silently return false,
+  // which for a fail-closed sensor flips a typo from "guard" to "all clear" (e.g. --freshness-days=abc
+  // -> every voice stale -> divergences collapse -> a false TRUTHFUL). Fail toward INSUFFICIENT instead.
+  const freshDaysRaw = argVal('freshness-days');
+  const freshDays = freshDaysRaw === undefined ? 3 : Number(freshDaysRaw);
+  if (!Number.isFinite(freshDays) || freshDays < 0) {
+    die(`--freshness-days=${freshDaysRaw} is not a non-negative number — INSUFFICIENT, refusing to assert "truthful" without evidence`);
+  }
   const freshnessMs = freshDays * DAY_MS;
-  const now = argVal('now');
+
+  const nowArg = argVal('now');
+  if (nowArg !== undefined && Number.isNaN(Date.parse(nowArg))) {
+    die(`--now=${nowArg} is not a parseable date — INSUFFICIENT, refusing to assert "truthful" without evidence`);
+  }
+  // Freshness is anchored to WALL-CLOCK by default, NOT the log's own newest record. Anchoring to the
+  // newest record makes a frozen dispatch stream (the ultimate numb instrument) undetectable: the most
+  // recent voice always reads age-0 against a clock that froze with it. Wall-clock is the external,
+  // monotonic reference a watchdog needs. --now overrides it for deterministic tests.
+  const now = nowArg || new Date().toISOString();
 
   let records;
   try {
@@ -239,10 +289,23 @@ function main() {
     die(`no MODELINV records in ${logPath} — INSUFFICIENT, refusing to assert "truthful" without evidence`);
   }
 
-  const probeTable = loadProbeTable();
+  const { probeTable, source: probeSource, asOf: probeAsOf } = loadProbeTable();
   const result = analyzeVoiceTruth({ records, probeTable, now, freshnessMs });
   result.logPath = logPath;
   result.recordCount = records.length;
+  result.probeSource = probeSource;
+  result.probeAsOf = probeAsOf;
+
+  // First-class log-staleness signal: if the whole log's newest record predates the active window
+  // (measured against the same wall-clock anchor), the dispatch stream itself may have stopped. Surface
+  // it; the verdict is still driven by lying instruments (a frozen log surfaces declared-up voices as
+  // FALSE_HEALTHY, which is the actionable, gateable signal).
+  const newest = newestTs(records);
+  const newestMs = newest ? Date.parse(newest) : NaN;
+  const logAgeMs = Number.isFinite(newestMs) ? Date.parse(now) - newestMs : Infinity;
+  result.newestRecordTs = newest;
+  result.logAgeDays = Number.isFinite(logAgeMs) ? Math.round((logAgeMs / DAY_MS) * 10) / 10 : null;
+  result.logStale = Number.isFinite(logAgeMs) ? logAgeMs > freshnessMs : true;
 
   if (MODE === 'json') console.log(JSON.stringify(result, null, 2));
   else if (MODE === 'probe') console.log(renderProbe(result));
@@ -269,18 +332,26 @@ const WHY = {
 
 function renderProbe(r) {
   const tag = r.verdict === 'LYING' ? '⚠ instrument-truth' : '✓ instrument-truth';
+  const stale = r.logStale ? ` · ⚠ log stale (newest ${r.logAgeDays}d old — dispatch may have stopped)` : '';
   if (r.verdict === 'TRUTHFUL') {
-    return `${tag} · ${r.voices.length} voices · all declarations match ground truth (${r.recordCount} records)`;
+    return `${tag} · ${r.voices.length} voices · all declarations match ground truth (${r.recordCount} records)${stale}`;
   }
   const names = r.lyingInstruments.map((v) => `${v.voice}:${v.classification}`).join(', ');
-  return `${tag} · LYING: ${r.lyingInstruments.length}/${r.voices.length} instrument(s) diverge — ${names}`;
+  return `${tag} · LYING: ${r.lyingInstruments.length}/${r.voices.length} instrument(s) diverge — ${names}${stale}`;
 }
 
 function renderBoard(r) {
   const L = [];
   L.push(`  ∴ instrument-truth · cheval voice health · re-derived from ${r.recordCount} MODELINV records`);
   L.push(`    ground-source: ${r.logPath}`);
+  const decl = r.probeSource === 'static'
+    ? `static snapshot as of ${r.probeAsOf} (NOT a live doctor.py read — re-ground with --probe-table)`
+    : r.probeSource;
+  L.push(`    declaration:   ${decl}`);
   L.push(`    reference(now): ${r.reference}   active-window: ${Math.round(r.freshnessMs / DAY_MS)}d`);
+  if (r.logStale) {
+    L.push(`    ⚠ log itself is STALE — newest record is ${r.logAgeDays}d old (> ${Math.round(r.freshnessMs / DAY_MS)}d window); the dispatch stream may have stopped.`);
+  }
   L.push('');
   L.push(`    voice     finals  last-final   age   declared   verdict`);
   for (const v of r.voices) {

--- a/tools/instrument-truth-sensor.mjs
+++ b/tools/instrument-truth-sensor.mjs
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+/**
+ * instrument-truth-sensor.mjs — the meta-immune DOCTOR (read-only).
+ *
+ * Campaign: Estate Immune System · M0 / G-IMMUNE ("every verdict/health/goal/sensor re-derives
+ * from a ground source; 0 lying instruments"). Bead: arrakis-estate-immune-epic-4xw6.1.
+ * Pattern hoisted from ~/bonfire/gate-freeze.mjs — PURE testable core + thin I/O wrapper,
+ * exit-code-IS-the-verdict, board/json/probe renderers, false-positive guard documented in-code.
+ *
+ * WHAT IT DETECTS — lying instruments. A health/verdict instrument whose DECLARED state diverges
+ * from GROUND TRUTH. The verified first instance: cheval voice health. The static cheval doctor
+ * (doctor.py) MISREPORTS the council — it calls `claude` "unknown" (a `--max-budget-usd 0.001`
+ * probe artifact) while `.run/model-invoke.jsonl` shows ~500 successful finals, and it is BLIND to
+ * `cursor` (45 fresh finals, the real idle capacity) which never appears in its probe table at all.
+ * This sensor re-derives each voice's REAL health from the audit log (the ground source) and flags
+ * any voice the static doctor would misreport.
+ *
+ * Operationalizes the operator's standing immune doctrine:
+ *   - declaration != ground-truth, and the machine trusts the declaration  ([[map-territory-drift-unifying-failure]])
+ *   - a gate's verdict is a number you read, not a vibe                     ([[gate-output-never-piped]])
+ *   - exists != wired != runs != enforces                                  ([[verification-ladder-exists-to-verified]])
+ *   - a check is INSUFFICIENT, not "clean", when it has no evidence        (absence of evidence != proof)
+ *
+ * THE FALSE-POSITIVE GUARD (the honest core): a voice that is legitimately DOWN is NOT a lying
+ * instrument. Only a DIVERGENCE between what the probe declares and what the ground truth shows is
+ * a lie. `gemini` is genuinely dead (Google retired the CLI; ~9 days since its last final) and the
+ * probe correctly calls it "down" → CONSISTENT, NOT flagged. We flag the divergence, never the
+ * outage. The inverse lie (probe says "up" but the voice has gone silent → FALSE_HEALTHY) is just
+ * as dishonest and is also flagged.
+ *
+ * Read-only. Reads ONLY `.run/model-invoke.jsonl` — never invokes doctor.py or any slow/hanging
+ * external command. Born from the morning-leverage ground-truth (2026-06-26).
+ *
+ * Usage:
+ *   node tools/instrument-truth-sensor.mjs                 # human board (default log + static probe)
+ *   node tools/instrument-truth-sensor.mjs --json          # machine
+ *   node tools/instrument-truth-sensor.mjs --probe         # one-line STATUS tile (banner-style)
+ *   node tools/instrument-truth-sensor.mjs --log=PATH      # point at a specific audit log
+ *   node tools/instrument-truth-sensor.mjs --probe-table=FILE.json   # override the declared probe
+ *   node tools/instrument-truth-sensor.mjs --freshness-days=N        # active window (default 3)
+ *   node tools/instrument-truth-sensor.mjs --now=ISO                 # freshness anchor (default: newest record)
+ *
+ * Exit code is the verdict (so it can gate):
+ *   0 = TRUTHFUL  (every instrument's declaration matches ground truth)
+ *   2 = LYING     (>=1 instrument's declaration diverges from ground truth)
+ *   1 = INSUFFICIENT / operational error (no ground-truth records, unreadable log) — never asserts
+ *       "truthful" without evidence (that would be the very numbness this sensor exists to catch).
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+export const DAY_MS = 86_400_000;
+export const DEFAULT_FRESHNESS_MS = 3 * DAY_MS; // a voice is ACTIVE if it produced a final in this window
+const MAX_RECORDS = 20_000; // bounded tail — read the recent window, never unbounded
+
+// provider prefix (left of the first ':') -> canonical cheval voice. anthropic-via-bedrock is claude.
+export const PROVIDER_VOICE = {
+  anthropic: 'claude',
+  bedrock: 'claude',
+  openai: 'codex',
+  google: 'gemini',
+  cursor: 'cursor',
+  xai: 'grok',
+};
+
+/**
+ * The STATIC cheval doctor's DECLARED report — the *declaration* side this sensor checks against
+ * ground truth. This is a CONFIG constant (the probe's known coverage + verdicts as observed
+ * 2026-06-26, GECKO-derived in grimoires/loa/context/morning-leverage-ideation-2026-06-26.md), NOT
+ * a live probe — invoking doctor.py here would hang. Override with --probe-table=FILE.json to
+ * re-ground. `cursor` is deliberately ABSENT: it is invisible to the static probe table (that
+ * invisibility is exactly the lie this sensor surfaces).
+ */
+export const STATIC_DOCTOR_PROBE = Object.freeze({
+  claude: 'unknown', // probe artifact — reports unknown despite a live workhorse
+  codex: 'up',
+  gemini: 'down', // genuinely dead — the probe is correct here
+  grok: 'up',
+  // cursor: (absent — invisible to the probe)
+});
+
+const CLAIMS_HEALTHY = new Set(['up', 'healthy', 'ok']);
+
+/** canonical voice for a MODELINV final_model_id, or null if unmappable/absent. */
+export function voiceOf(modelId) {
+  if (!modelId || typeof modelId !== 'string') return null;
+  const prov = modelId.split(':', 1)[0];
+  return PROVIDER_VOICE[prov] || null;
+}
+
+/**
+ * Re-derive each voice's REAL health from already-parsed MODELINV records (the ground source).
+ * Only a record carrying payload.final_model_id counts as a successful final.
+ * @returns Map<voice, { finals, lastSuccessTs, lastSuccessMs }>
+ */
+export function deriveGroundTruth(records) {
+  const truth = new Map();
+  for (const r of records) {
+    const fm = r?.payload?.final_model_id;
+    const voice = voiceOf(fm);
+    if (!voice) continue; // no successful final / unmappable
+    const ts = r?.ts_utc || '';
+    const ms = ts ? Date.parse(ts) : NaN;
+    const cur = truth.get(voice) || { finals: 0, lastSuccessTs: null, lastSuccessMs: -Infinity };
+    cur.finals += 1;
+    if (Number.isFinite(ms) && ms > cur.lastSuccessMs) {
+      cur.lastSuccessMs = ms;
+      cur.lastSuccessTs = ts;
+    }
+    truth.set(voice, cur);
+  }
+  return truth;
+}
+
+/** newest ts_utc across records (the log's "present"), or null. */
+export function newestTs(records) {
+  let max = '';
+  for (const r of records) {
+    const ts = r?.ts_utc || '';
+    if (ts > max) max = ts;
+  }
+  return max || null;
+}
+
+/**
+ * THE PURE CORE. Compare the declared probe table against re-derived ground truth; classify each
+ * voice; return the divergence verdict. No I/O — feed it fixture records in tests.
+ *
+ * @param {object[]} records   parsed MODELINV records
+ * @param {Record<string,string>} probeTable  declared voice -> status ('up'|'down'|'unknown'|...).
+ *        A voice ABSENT from the table is "invisible to the probe".
+ * @param {string} [now]       ISO anchor for freshness; defaults to the newest record ts.
+ * @param {number} [freshnessMs]  active window; defaults to DEFAULT_FRESHNESS_MS (3d).
+ */
+export function analyzeVoiceTruth({ records = [], probeTable = STATIC_DOCTOR_PROBE, now, freshnessMs = DEFAULT_FRESHNESS_MS } = {}) {
+  const reference = now || newestTs(records);
+  const refMs = reference ? Date.parse(reference) : NaN;
+  const truth = deriveGroundTruth(records);
+
+  // union of voices SEEN in the ground truth and voices DECLARED by the probe (so a declared-up
+  // voice that never produced a final is still examined → FALSE_HEALTHY).
+  const voiceNames = new Set([...truth.keys(), ...Object.keys(probeTable)]);
+
+  const voices = [...voiceNames].map((voice) => {
+    const g = truth.get(voice) || { finals: 0, lastSuccessTs: null, lastSuccessMs: -Infinity };
+    const declaredRaw = Object.prototype.hasOwnProperty.call(probeTable, voice) ? probeTable[voice] : undefined;
+    const declared = declaredRaw === undefined ? 'ABSENT' : declaredRaw;
+    const ageMs = Number.isFinite(g.lastSuccessMs) && Number.isFinite(refMs) ? refMs - g.lastSuccessMs : Infinity;
+    // fresh = produced a final within the active window of the reference. A final newer than the
+    // reference (negative age) is trivially fresh; a never-seen voice (Infinity) is not.
+    const fresh = g.lastSuccessTs != null && ageMs <= freshnessMs;
+
+    let classification;
+    if (declaredRaw === undefined) {
+      // probe doesn't list this voice at all
+      classification = fresh ? 'INVISIBLE' : 'DARK'; // live+unlisted = lie of omission; dead+unlisted = nothing claimed, nothing done
+    } else if (CLAIMS_HEALTHY.has(String(declaredRaw).toLowerCase())) {
+      classification = fresh ? 'CONSISTENT' : 'FALSE_HEALTHY'; // declared up: lie iff actually silent
+    } else {
+      // declared down/unknown/degraded: lie iff actually alive
+      classification = fresh ? 'DIVERGENT' : 'CONSISTENT'; // the GUARD: genuinely-down stays CONSISTENT
+    }
+    const lying = classification === 'INVISIBLE' || classification === 'DIVERGENT' || classification === 'FALSE_HEALTHY';
+
+    return {
+      voice,
+      finals: g.finals,
+      lastSuccessTs: g.lastSuccessTs,
+      ageDays: Number.isFinite(ageMs) ? Math.round((ageMs / DAY_MS) * 10) / 10 : null,
+      fresh,
+      declared,
+      classification,
+      lying,
+    };
+  }).sort((a, b) => b.finals - a.finals || a.voice.localeCompare(b.voice));
+
+  const lyingInstruments = voices.filter((v) => v.lying);
+  const verdict = lyingInstruments.length ? 'LYING' : 'TRUTHFUL';
+  return {
+    reference,
+    freshnessMs,
+    voices,
+    lyingInstruments,
+    verdict,
+    exitCode: lyingInstruments.length ? 2 : 0,
+  };
+}
+
+// ── I/O wrapper (the thin shell) ────────────────────────────────────────────
+
+const ARGS = process.argv.slice(2);
+const argVal = (k) => {
+  const hit = ARGS.find((a) => a.startsWith(`--${k}=`));
+  return hit ? hit.slice(k.length + 3) : undefined;
+};
+const MODE = ARGS.includes('--json') ? 'json' : ARGS.includes('--probe') ? 'probe' : 'board';
+
+function defaultLogPath() {
+  // tools/ -> repo-root/.run/model-invoke.jsonl
+  return fileURLToPath(new URL('../.run/model-invoke.jsonl', import.meta.url));
+}
+
+/** read + parse a bounded tail of the MODELINV jsonl. throws only on unreadable file. */
+export function readRecords(logPath) {
+  const text = readFileSync(logPath, 'utf8');
+  const lines = text.split('\n').filter((l) => l.trim());
+  const tail = lines.length > MAX_RECORDS ? lines.slice(-MAX_RECORDS) : lines;
+  const out = [];
+  for (const line of tail) {
+    try { out.push(JSON.parse(line)); } catch { /* skip a malformed line — robustness, never crash */ }
+  }
+  return out;
+}
+
+function loadProbeTable() {
+  const file = argVal('probe-table') || process.env.LOA_DOCTOR_PROBE_TABLE;
+  if (!file) return STATIC_DOCTOR_PROBE;
+  return JSON.parse(readFileSync(file, 'utf8'));
+}
+
+function die(msg, code = 1) {
+  console.error(`instrument-truth: ${msg}`);
+  process.exit(code);
+}
+
+function main() {
+  const logPath = argVal('log') || process.env.LOA_MODELINV_LOG || defaultLogPath();
+  const freshDays = argVal('freshness-days') ? Number(argVal('freshness-days')) : 3;
+  const freshnessMs = freshDays * DAY_MS;
+  const now = argVal('now');
+
+  let records;
+  try {
+    records = readRecords(logPath);
+  } catch (e) {
+    die(`cannot read ground-truth log ${logPath} (${e.code || e.message}) — INSUFFICIENT, refusing to assert "truthful" without evidence`);
+  }
+  if (!records.length) {
+    die(`no MODELINV records in ${logPath} — INSUFFICIENT, refusing to assert "truthful" without evidence`);
+  }
+
+  const probeTable = loadProbeTable();
+  const result = analyzeVoiceTruth({ records, probeTable, now, freshnessMs });
+  result.logPath = logPath;
+  result.recordCount = records.length;
+
+  if (MODE === 'json') console.log(JSON.stringify(result, null, 2));
+  else if (MODE === 'probe') console.log(renderProbe(result));
+  else console.log(renderBoard(result));
+  process.exit(result.exitCode);
+}
+
+// ── renderers ───────────────────────────────────────────────────────────────
+
+const GLYPH = {
+  CONSISTENT: '✓',
+  DARK: '·',
+  INVISIBLE: '⚠',
+  DIVERGENT: '⚠',
+  FALSE_HEALTHY: '⚠',
+};
+const WHY = {
+  INVISIBLE: 'live but absent from the probe table (lie of omission)',
+  DIVERGENT: 'probe declares it down/unknown but it has fresh successful finals',
+  FALSE_HEALTHY: 'probe declares it up but it has gone silent',
+  CONSISTENT: 'declaration matches ground truth',
+  DARK: 'absent from the probe and inactive — nothing claimed, nothing done',
+};
+
+function renderProbe(r) {
+  const tag = r.verdict === 'LYING' ? '⚠ instrument-truth' : '✓ instrument-truth';
+  if (r.verdict === 'TRUTHFUL') {
+    return `${tag} · ${r.voices.length} voices · all declarations match ground truth (${r.recordCount} records)`;
+  }
+  const names = r.lyingInstruments.map((v) => `${v.voice}:${v.classification}`).join(', ');
+  return `${tag} · LYING: ${r.lyingInstruments.length}/${r.voices.length} instrument(s) diverge — ${names}`;
+}
+
+function renderBoard(r) {
+  const L = [];
+  L.push(`  ∴ instrument-truth · cheval voice health · re-derived from ${r.recordCount} MODELINV records`);
+  L.push(`    ground-source: ${r.logPath}`);
+  L.push(`    reference(now): ${r.reference}   active-window: ${Math.round(r.freshnessMs / DAY_MS)}d`);
+  L.push('');
+  L.push(`    voice     finals  last-final   age   declared   verdict`);
+  for (const v of r.voices) {
+    const age = v.ageDays == null ? '   —' : `${String(v.ageDays).padStart(4)}d`;
+    const last = (v.lastSuccessTs || '—').slice(0, 10).padEnd(10);
+    L.push(`    ${GLYPH[v.classification]} ${v.voice.padEnd(8)} ${String(v.finals).padStart(5)}  ${last}  ${age}  ${String(v.declared).padEnd(8)}  ${v.classification}`);
+  }
+  L.push('');
+  if (r.verdict === 'TRUTHFUL') {
+    L.push(`    ✓ TRUTHFUL — every instrument's declaration matches ground truth.`);
+  } else {
+    L.push(`    ⚠ LYING — ${r.lyingInstruments.length} instrument(s) misreport reality:`);
+    for (const v of r.lyingInstruments) {
+      L.push(`      · ${v.voice} (${v.classification}): ${WHY[v.classification]} — ${v.finals} finals, last ${v.lastSuccessTs || 'never'}`);
+    }
+    L.push('');
+    L.push(`    note: a voice that is genuinely DOWN is CONSISTENT, not a lie — only the DIVERGENCE`);
+    L.push(`          between declared and real health is flagged. (exit 2 = >=1 lying instrument.)`);
+  }
+  return L.join('\n');
+}
+
+// main-guard: importing the module (tests) must NOT read files or exit.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/tools/instrument-truth-sensor.test.mjs
+++ b/tools/instrument-truth-sensor.test.mjs
@@ -12,6 +12,11 @@
 // Run: node tools/instrument-truth-sensor.test.mjs   (or: node --test tools/instrument-truth-sensor.test.mjs)
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   voiceOf,
   analyzeVoiceTruth,
@@ -173,3 +178,100 @@ test('freshnessMs default is 3 days and is honored', () => {
   const narrow = analyzeVoiceTruth({ records, probeTable: { claude: 'unknown', codex: 'up' }, now: NOW });
   assert.equal(narrow.voices.find((v) => v.voice === 'claude').classification, 'CONSISTENT');
 });
+
+// ── I/O shell: exit-code-IS-the-verdict contract (the seam where the tool meets the OS) ──
+// "exit-code-is-the-verdict" means the thin shell IS the contract. These spawn the real script and
+// pin the fail-closed input contract: nothing that fails to parse may EVER produce a clean verdict.
+// All bad-input paths must route through the same die(... INSUFFICIENT)/exit-1 the log path honors.
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'instrument-truth-sensor.mjs');
+const LINE = (voice, tsUtc) => JSON.stringify(rec(voice, tsUtc));
+const runScript = (args) => spawnSync(process.execPath, [SCRIPT, ...args], { encoding: 'utf8' });
+const withFixtures = (fn) => {
+  const dir = mkdtempSync(join(tmpdir(), 'instrument-truth-'));
+  try { return fn(dir); } finally { rmSync(dir, { recursive: true, force: true }); }
+};
+const writeLog = (dir, lines) => {
+  const p = join(dir, 'log.jsonl');
+  writeFileSync(p, lines.join('\n') + '\n');
+  return p;
+};
+const writeProbe = (dir, value) => {
+  const p = join(dir, 'probe.json');
+  writeFileSync(p, typeof value === 'string' ? value : JSON.stringify(value));
+  return p;
+};
+
+test('[shell] a consistent log + probe-table -> exit 0 TRUTHFUL', () => withFixtures((dir) => {
+  const log = writeLog(dir, [LINE('codex', ago(0.5))]);
+  const probe = writeProbe(dir, { codex: 'up' });
+  const r = runScript([`--log=${log}`, `--probe-table=${probe}`, `--now=${NOW}`, '--json']);
+  assert.equal(r.status, 0, r.stderr);
+}));
+
+test('[shell] a divergent log + probe-table -> exit 2 LYING', () => withFixtures((dir) => {
+  const log = writeLog(dir, [LINE('claude', ago(0.5))]);
+  const probe = writeProbe(dir, { claude: 'unknown' }); // declared unknown, but fresh finals -> DIVERGENT
+  const r = runScript([`--log=${log}`, `--probe-table=${probe}`, `--now=${NOW}`, '--probe']);
+  assert.equal(r.status, 2, r.stderr);
+  assert.match(r.stdout, /LYING/);
+}));
+
+test('[shell] missing log file -> exit 1 INSUFFICIENT', () => withFixtures((dir) => {
+  const r = runScript([`--log=${join(dir, 'does-not-exist.jsonl')}`, `--now=${NOW}`]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /INSUFFICIENT/);
+}));
+
+test('[shell] empty log (no records) -> exit 1 INSUFFICIENT', () => withFixtures((dir) => {
+  const log = join(dir, 'empty.jsonl');
+  writeFileSync(log, '');
+  const r = runScript([`--log=${log}`, `--now=${NOW}`]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /INSUFFICIENT/);
+}));
+
+test('[shell] malformed --probe-table JSON -> exit 1 INSUFFICIENT (not a raw stack trace)', () => withFixtures((dir) => {
+  const log = writeLog(dir, [LINE('codex', ago(0.5))]);
+  const probe = writeProbe(dir, '{ not valid json');
+  const r = runScript([`--log=${log}`, `--probe-table=${probe}`, `--now=${NOW}`]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /INSUFFICIENT/);
+}));
+
+test('[shell] --probe-table that parses to a JSON ARRAY -> exit 1 INSUFFICIENT (shape guard)', () => withFixtures((dir) => {
+  const log = writeLog(dir, [LINE('codex', ago(0.5))]);
+  const probe = writeProbe(dir, ['codex', 'up']); // typeof [] === 'object' footgun
+  const r = runScript([`--log=${log}`, `--probe-table=${probe}`, `--now=${NOW}`]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /INSUFFICIENT/);
+}));
+
+test('[shell] missing --probe-table file -> exit 1 INSUFFICIENT', () => withFixtures((dir) => {
+  const log = writeLog(dir, [LINE('codex', ago(0.5))]);
+  const r = runScript([`--log=${log}`, `--probe-table=${join(dir, 'nope.json')}`, `--now=${NOW}`]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /INSUFFICIENT/);
+}));
+
+test('[shell] --freshness-days=abc (NaN) -> exit 1 INSUFFICIENT, never a false clean verdict', () => withFixtures((dir) => {
+  const log = writeLog(dir, [LINE('codex', ago(0.5))]);
+  const r = runScript([`--log=${log}`, '--freshness-days=abc', `--now=${NOW}`]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /INSUFFICIENT/);
+}));
+
+test('[shell] --now=garbage (unparseable date) -> exit 1 INSUFFICIENT', () => withFixtures((dir) => {
+  const log = writeLog(dir, [LINE('codex', ago(0.5))]);
+  const r = runScript([`--log=${log}`, '--now=garbage']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /INSUFFICIENT/);
+}));
+
+test('[shell] a frozen/stale log surfaces the stale-log warning (wall-clock anchor)', () => withFixtures((dir) => {
+  // newest record is 30d before NOW; anchored to wall-clock (NOW), the whole log is stale.
+  const log = writeLog(dir, [LINE('codex', ago(30))]);
+  const probe = writeProbe(dir, { codex: 'up' }); // declared up but silent for 30d -> FALSE_HEALTHY
+  const r = runScript([`--log=${log}`, `--probe-table=${probe}`, `--now=${NOW}`, '--probe']);
+  assert.equal(r.status, 2, r.stderr); // outage IS detectable now (was the bridge-002 blind spot)
+  assert.match(r.stdout, /log stale/);
+}));

--- a/tools/instrument-truth-sensor.test.mjs
+++ b/tools/instrument-truth-sensor.test.mjs
@@ -1,0 +1,175 @@
+// instrument-truth-sensor.test.mjs — the meta-immune doctor's teeth.
+//
+// Expresses the divergence-detection CONTRACT with synthetic fixture records (no live files,
+// no cheval, no hang). Asserts the three named cases from bead arrakis-estate-immune-epic-4xw6.1:
+//   (a) a voice with recent finals but ABSENT from the probe table   -> INVISIBLE (lying)
+//   (b) a voice the probe calls down/unknown but with fresh finals    -> DIVERGENT (lying)
+//   (c) all-consistent                                                -> TRUTHFUL / exit 0
+// plus the false-positive GUARD that makes the sensor honest:
+//   (d) a voice the probe calls down that is genuinely STALE          -> CONSISTENT (NOT lying)
+//   (e) the inverse lie: probe calls up, voice has gone silent        -> FALSE_HEALTHY (lying)
+//
+// Run: node tools/instrument-truth-sensor.test.mjs   (or: node --test tools/instrument-truth-sensor.test.mjs)
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  voiceOf,
+  analyzeVoiceTruth,
+  DEFAULT_FRESHNESS_MS,
+} from './instrument-truth-sensor.mjs';
+
+// ── fixture builders ────────────────────────────────────────────────────────
+// one MODELINV-shaped record; a successful "final" carries payload.final_model_id.
+const SAMPLE_MODEL = {
+  claude: 'anthropic:claude-headless',
+  codex: 'openai:codex-headless',
+  gemini: 'google:gemini-headless',
+  cursor: 'cursor:cursor-headless',
+  grok: 'xai:grok-build',
+};
+const rec = (voice, tsUtc, { final = true } = {}) => ({
+  primitive_id: 'MODELINV',
+  event_type: 'model.invoke.complete',
+  ts_utc: tsUtc,
+  payload: { final_model_id: final ? SAMPLE_MODEL[voice] : null },
+});
+
+const DAY = 86_400_000;
+const NOW = '2026-06-26T12:00:00.000Z';
+const nowMs = Date.parse(NOW);
+const ago = (days) => new Date(nowMs - days * DAY).toISOString();
+
+// ── voiceOf: provider-prefix -> canonical cheval voice ──────────────────────
+test('voiceOf maps every observed provider prefix to a canonical voice', () => {
+  assert.equal(voiceOf('anthropic:claude-headless'), 'claude');
+  assert.equal(voiceOf('anthropic:claude-opus-4-8'), 'claude');
+  assert.equal(voiceOf('bedrock:us.anthropic.claude-opus-4-8'), 'claude'); // anthropic via bedrock
+  assert.equal(voiceOf('openai:codex-headless'), 'codex');
+  assert.equal(voiceOf('google:gemini-headless'), 'gemini');
+  assert.equal(voiceOf('cursor:cursor-headless'), 'cursor');
+  assert.equal(voiceOf('xai:grok-build'), 'grok');
+  assert.equal(voiceOf(null), null);
+  assert.equal(voiceOf(''), null);
+});
+
+// ── (a) INVISIBLE: live voice the probe doesn't even list ───────────────────
+test('(a) a fresh voice ABSENT from the probe table is flagged INVISIBLE (lying)', () => {
+  const records = [rec('codex', ago(0.5)), rec('cursor', ago(0.5))];
+  const probeTable = { codex: 'up' }; // cursor invisible to the probe
+  const r = analyzeVoiceTruth({ records, probeTable, now: NOW });
+  const cursor = r.voices.find((v) => v.voice === 'cursor');
+  assert.equal(cursor.classification, 'INVISIBLE');
+  assert.equal(cursor.lying, true);
+  assert.equal(cursor.finals, 1);
+  assert.deepEqual(r.lyingInstruments.map((v) => v.voice), ['cursor']);
+  assert.equal(r.verdict, 'LYING');
+  assert.equal(r.exitCode, 2);
+});
+
+// ── (b) DIVERGENT: probe says down/unknown, ground truth says alive ─────────
+test('(b) a voice the probe calls "unknown" with fresh finals is flagged DIVERGENT (lying)', () => {
+  const records = [rec('claude', ago(1.5)), rec('codex', ago(0.5))];
+  const probeTable = { claude: 'unknown', codex: 'up' }; // the doctor.py probe artifact
+  const r = analyzeVoiceTruth({ records, probeTable, now: NOW });
+  const claude = r.voices.find((v) => v.voice === 'claude');
+  assert.equal(claude.classification, 'DIVERGENT');
+  assert.equal(claude.declared, 'unknown');
+  assert.equal(claude.fresh, true);
+  assert.equal(claude.lying, true);
+  assert.equal(r.exitCode, 2);
+});
+
+test('(b′) "down" + fresh is also DIVERGENT', () => {
+  const records = [rec('claude', ago(1))];
+  const r = analyzeVoiceTruth({ records, probeTable: { claude: 'down' }, now: NOW });
+  assert.equal(r.voices.find((v) => v.voice === 'claude').classification, 'DIVERGENT');
+  assert.equal(r.exitCode, 2);
+});
+
+// ── (c) all-consistent -> TRUTHFUL / exit 0 ─────────────────────────────────
+test('(c) declared health matching ground truth across all voices -> TRUTHFUL / exit 0', () => {
+  const records = [rec('codex', ago(0.5)), rec('claude', ago(1))];
+  const probeTable = { codex: 'up', claude: 'up' };
+  const r = analyzeVoiceTruth({ records, probeTable, now: NOW });
+  assert.equal(r.verdict, 'TRUTHFUL');
+  assert.equal(r.exitCode, 0);
+  assert.equal(r.lyingInstruments.length, 0);
+  for (const v of r.voices) assert.equal(v.classification, 'CONSISTENT');
+});
+
+// ── (d) the false-positive GUARD: a genuinely-dead voice is NOT a lying instrument ──
+test('(d) probe="down" + STALE finals (genuinely dead, e.g. gemini) is CONSISTENT, NOT flagged', () => {
+  // gemini-shaped: it has finals, but the last one is well outside the freshness window.
+  const records = [rec('gemini', ago(9)), rec('codex', ago(0.5))];
+  const probeTable = { gemini: 'down', codex: 'up' };
+  const r = analyzeVoiceTruth({ records, probeTable, now: NOW });
+  const gemini = r.voices.find((v) => v.voice === 'gemini');
+  assert.equal(gemini.fresh, false);
+  assert.equal(gemini.finals, 1, 'still counts the historical final');
+  assert.equal(gemini.classification, 'CONSISTENT');
+  assert.equal(gemini.lying, false, 'legitimately down is divergence-free, not a lie');
+  assert.equal(r.exitCode, 0);
+});
+
+// ── (e) the inverse lie: probe="up" but the voice has gone silent ────────────
+test('(e) probe="up" + STALE finals is FALSE_HEALTHY (the inverse lie, also flagged)', () => {
+  const records = [rec('grok', ago(20)), rec('codex', ago(0.5))];
+  const probeTable = { grok: 'up', codex: 'up' };
+  const r = analyzeVoiceTruth({ records, probeTable, now: NOW });
+  const grok = r.voices.find((v) => v.voice === 'grok');
+  assert.equal(grok.classification, 'FALSE_HEALTHY');
+  assert.equal(grok.lying, true);
+  assert.equal(r.exitCode, 2);
+});
+
+test('(e′) probe="up" for a voice with ZERO finals ever is FALSE_HEALTHY', () => {
+  const records = [rec('codex', ago(0.5))];
+  const probeTable = { codex: 'up', grok: 'up' }; // grok declared up but never produced a final
+  const r = analyzeVoiceTruth({ records, probeTable, now: NOW });
+  const grok = r.voices.find((v) => v.voice === 'grok');
+  assert.equal(grok.finals, 0);
+  assert.equal(grok.classification, 'FALSE_HEALTHY');
+  assert.equal(r.exitCode, 2);
+});
+
+// ── a voice that is both invisible AND inactive is NOT a lie (nothing claims/does anything) ──
+test('a stale, ABSENT voice is DARK and not flagged (no claim, no activity)', () => {
+  const records = [rec('codex', ago(0.5)), rec('gemini', ago(30))];
+  const probeTable = { codex: 'up' }; // gemini absent AND ancient
+  const r = analyzeVoiceTruth({ records, probeTable, now: NOW });
+  const gemini = r.voices.find((v) => v.voice === 'gemini');
+  assert.equal(gemini.classification, 'DARK');
+  assert.equal(gemini.lying, false);
+  assert.equal(r.exitCode, 0);
+});
+
+// ── records with no final (failed invocations) don't manufacture a voice ────
+test('records with final_model_id=null contribute no successful final', () => {
+  const records = [rec('cursor', ago(0.5), { final: false }), rec('codex', ago(0.5))];
+  const r = analyzeVoiceTruth({ records, probeTable: { codex: 'up' }, now: NOW });
+  // cursor only ever had a null-final record -> never seen as a live voice -> not present
+  assert.equal(r.voices.find((v) => v.voice === 'cursor'), undefined);
+  assert.equal(r.exitCode, 0);
+});
+
+// ── `now` defaults to the newest record ts (robust against a stale log snapshot) ──
+test('now defaults to the newest record ts when omitted', () => {
+  // newest record is gemini @ -? ; build so the newest is codex, claude lags by 1.5d.
+  const records = [rec('claude', '2026-06-24T00:00:00.000Z'), rec('codex', '2026-06-25T12:00:00.000Z')];
+  const r = analyzeVoiceTruth({ records, probeTable: { claude: 'unknown', codex: 'up' } });
+  assert.equal(r.reference, '2026-06-25T12:00:00.000Z');
+  // claude lags the newest record by 1.5d < 3d default -> still fresh -> DIVERGENT against "unknown"
+  assert.equal(r.voices.find((v) => v.voice === 'claude').fresh, true);
+  assert.equal(r.exitCode, 2);
+});
+
+// ── freshness window is configurable; the default is the documented 3 days ──
+test('freshnessMs default is 3 days and is honored', () => {
+  assert.equal(DEFAULT_FRESHNESS_MS, 3 * DAY);
+  const records = [rec('claude', ago(5)), rec('codex', ago(0.5))];
+  // with a 7-day window claude @5d is fresh -> DIVERGENT; with the 3-day default it is stale -> CONSISTENT
+  const wide = analyzeVoiceTruth({ records, probeTable: { claude: 'unknown', codex: 'up' }, now: NOW, freshnessMs: 7 * DAY });
+  assert.equal(wide.voices.find((v) => v.voice === 'claude').classification, 'DIVERGENT');
+  const narrow = analyzeVoiceTruth({ records, probeTable: { claude: 'unknown', codex: 'up' }, now: NOW });
+  assert.equal(narrow.voices.find((v) => v.voice === 'claude').classification, 'CONSISTENT');
+});


### PR DESCRIPTION
> **Draft — door frozen.** Campaign M0 doctor half (read-only). The merge gate is still being un-frozen (G1); this lands as a reviewable draft, not for merge.

## What it does
`tools/instrument-truth-sensor.mjs` — the **read-only DOCTOR** half of campaign M0 (G-IMMUNE: *every verdict/health/goal/sensor re-derives from a ground source; 0 lying instruments*).

It detects **lying instruments** — health/verdict instruments whose **declared** state diverges from **ground truth**. First verified instance: cheval voice health, re-derived from `.run/model-invoke.jsonl` (the MODELINV audit chain). The static cheval doctor (`doctor.py`) misreports the council — it calls `claude` `"unknown"` (a `--max-budget-usd 0.001` probe artifact) while the log shows ~538 successful finals, and it is **blind to `cursor`** (45 fresh finals, the real idle capacity), which never appears in its probe table. This sensor re-derives each voice's real health and flags the divergence.

Hoisted from the `gate-freeze.mjs` pattern (PR #317): a **pure exported core** `analyzeVoiceTruth({ records, probeTable, now, freshnessMs })` that takes already-parsed records + the declared probe set and returns the divergence verdict, plus a **thin I/O wrapper** that reads the jsonl. **Exit code IS the verdict** — `0` TRUTHFUL · `2` LYING · `1` INSUFFICIENT (no records / unreadable → *never* asserts "truthful" without evidence). `board` / `--json` / `--probe` renderers.

**The honest core is the false-positive guard:** a voice that is *genuinely down* is **CONSISTENT, not a lie** — only the *divergence* between declared and real health is flagged. The inverse lie (declared `up` but gone silent → `FALSE_HEALTHY`) is flagged too.

| classification | meaning | flagged? |
|---|---|---|
| `INVISIBLE` | live finals, absent from the probe table | ✅ lying |
| `DIVERGENT` | probe says down/unknown, but fresh finals | ✅ lying |
| `FALSE_HEALTHY` | probe says up, but gone silent | ✅ lying |
| `CONSISTENT` | declaration matches ground truth (incl. *genuinely* down) | ✓ truthful |
| `DARK` | absent from probe AND inactive | ✓ ignored |

## Live verdict (against the real `.run/model-invoke.jsonl`, 1420 records)
```
voice     finals  last-final   age   declared   verdict
⚠ claude     538  2026-06-24   1.9d  unknown   DIVERGENT
✓ codex      422  2026-06-25   1.5d  up        CONSISTENT
✓ gemini     299  2026-06-17   8.9d  down      CONSISTENT
⚠ cursor      45  2026-06-25   1.6d  ABSENT    INVISIBLE
✓ grok         2  2026-06-25   1.5d  up        CONSISTENT
```
**LYING — exit 2.** `claude:DIVERGENT` (doctor.py's false "unknown" over a live workhorse) and `cursor:INVISIBLE` (the idle capacity the probe can't see). `gemini` is correctly **CONSISTENT** — genuinely dead (9d stale), declared down — the guard does not false-flag an outage as a lie.

## Tests
`tools/instrument-truth-sensor.test.mjs` — **12 fixture tests, all green** (`node tools/instrument-truth-sensor.test.mjs`, exit 0). No live deps: synthetic records cover (a) INVISIBLE, (b) DIVERGENT, (c) all-consistent→exit 0, (d) the genuinely-dead-is-CONSISTENT guard, (e) FALSE_HEALTHY (incl. zero-finals), DARK, null-finals, `now`-defaulting, and the configurable freshness window.

## Safety
- **Read-only.** Reads ONLY `.run/model-invoke.jsonl` — never invokes `doctor.py` or any slow/hanging external command. Bounded tail (`MAX_RECORDS`).
- **App-zone** (`tools/`). No `.claude/` (System-Zone) edits, no money path, no infra.
- Built in an **isolated git worktree** off `origin/main`; the operator's working tree was never touched.

## Bead
`arrakis-estate-immune-epic-4xw6.1` (M0 — meta-immune doctor). This is the **doctor** half only. **Deferred to the operator's reviewed `/run`:** the M0 enforcing CI lint (System-Zone), G2 STUB inversion + `scoring.ts` (System-Zone, needs multi-model review which is currently down), G3 ledger adapter (money path), G4 loa-cli (in-flight collision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)