### PR TITLE
feat(shared/immune): M0 re-derive-from-ground-truth enforcing lint (stacked on #321)

### DIFF
--- a/.github/workflows/immune-doctors.yml
+++ b/.github/workflows/immune-doctors.yml
@@ -164,3 +164,85 @@ jobs:
           node tools/gate-freeze-sensor.test.mjs
           node tools/instrument-truth-sensor.test.mjs
           bash tools/immune-check.test.sh
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # The M0 / G-IMMUNE enforcing lint (check-instrument-ground-truth.sh). Unlike
+  # the instrument-truth doctor (needs a local .run/model-invoke.jsonl), this one
+  # IS CI-runnable — it only reads checked-in files. Same SOFT design as gate-freeze:
+  # ALWAYS green, the verdict surfaced LOUD via summary + annotation, never a new
+  # required check (a violation here is rare + actionable, but a new blocking gate
+  # would deepen the very freeze this campaign cures). The teeth are the
+  # reviewer-visible registry diff + the local banner tools/immune-check.sh.
+  # ───────────────────────────────────────────────────────────────────────────
+  ground-truth-lint:
+    name: ground-truth-lint (informational)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint immune instruments against their ground sources (read-only; never blocks)
+        run: |
+          set +e   # the lint exits 1 on a violation — we report it, we do NOT fail on it.
+          out="$(bash tools/check-instrument-ground-truth.sh 2>&1)"; lint_exit=$?
+          printf '%s\n' "$out"
+
+          {
+            echo "## Immune Doctors · ground-truth-lint — $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo ""
+            echo "> Informational, non-required. M0 / G-IMMUNE: every verdict/health/sensor instrument"
+            echo "> must register its ground source in \`tools/immune-instruments.yaml\`. This check is"
+            echo "> **always green** by design so it never deepens the freeze it guards against; the"
+            echo "> registry diff + \`tools/immune-check.sh\` are the teeth. (bead arrakis-estate-immune-epic-4xw6.1)"
+            echo ""
+            if [ "$lint_exit" -eq 0 ]; then
+              echo "### ✓ Every immune instrument re-derives from a registered ground source."
+            elif [ "$lint_exit" -eq 1 ]; then
+              echo "### ⚠ An immune instrument is unregistered or its declared ground-source token is missing"
+              echo ""
+              echo "Register the instrument (path + literal ground-source token) in \`tools/immune-instruments.yaml\`,"
+              echo "or mark a non-instrument file with \`# immune-lint:allow <reason>\`."
+            else
+              echo "### · The lint could not run (exit $lint_exit) — a misconfiguration, not a verdict."
+            fi
+            echo ""
+            echo '```'
+            printf '%s\n' "$out"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$lint_exit" -eq 1 ]; then
+            echo "::warning title=Immune instrument ungrounded::a new immune instrument is unregistered or its ground-source token is missing — see job summary. (informational; does not block this PR)"
+          elif [ "$lint_exit" -ne 0 ]; then
+            echo "::warning title=Ground-truth lint misconfigured::the lint exited $lint_exit (argument/IO error) and could not run — see job summary. (informational; does not block this PR)"
+          fi
+
+          # ALWAYS green — informational by design (same rationale as the gate-freeze job).
+          exit 0
+
+      - name: Exercise the M0 acceptance fixture (informational — proves the lint still catches a planted liar)
+        run: |
+          # The lint's M0 acceptance criterion is "a planted self-reporting instrument fails the
+          # lint." Run that fixture here so the proof is exercised on every PR — but SOFT: a fixture
+          # failure means the lint's own logic regressed (rare + actionable), surfaced LOUD via the
+          # summary + a warning, never a red X (this job stays always-green by design).
+          set +e
+          test_out="$(bash tools/check-instrument-ground-truth.test.sh 2>&1)"; test_exit=$?
+          printf '%s\n' "$test_out"
+          {
+            echo "## Immune Doctors · ground-truth-lint · M0 fixture — $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo ""
+            if [ "$test_exit" -eq 0 ]; then
+              echo "### ✓ The planted self-reporting instrument still fails the lint (M0 acceptance holds)."
+            else
+              echo "### ⚠ The M0 acceptance fixture FAILED — the lint's own logic may have regressed."
+            fi
+            echo ""
+            echo '```'
+            printf '%s\n' "$test_out"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$test_exit" -ne 0 ]; then
+            echo "::warning title=M0 fixture regressed::tools/check-instrument-ground-truth.test.sh failed — the lint may no longer catch a planted liar. (informational; does not block this PR)"
+          fi
+          exit 0

--- a/tools/check-instrument-ground-truth.sh
+++ b/tools/check-instrument-ground-truth.sh
@@ -89,11 +89,16 @@ QUIET=0
 PROBE=0
 declare -a SCAN_ROOTS=()
 
-# Name-globs that mark a file as an immune-instrument CANDIDATE. Intentionally
-# narrow — only the three shapes immune instruments are named with.
-_name_is_candidate() {
+# Tri-state classification of a filename (a property of the FILE, evaluated ONCE so
+# it governs BOTH the name path and the opt-in-header path — a *.test.*/*.spec. file
+# carrying an `# immune-instrument` marker in its head is STILL excluded):
+#   0 = name-candidate  (matches an instrument name-glob)
+#   2 = excluded        (a test/spec — never an instrument, regardless of any header)
+#   1 = neither         (not name-matched; the opt-in header may still pull it in)
+# Intentionally narrow — only the three shapes immune instruments are named with.
+_name_candidacy() {
     case "$1" in
-        *.test.*|*.spec.*) return 1 ;;  # tests/specs verify instruments; they are not instruments
+        *.test.*|*.spec.*) return 2 ;;  # tests/specs verify instruments; they are not instruments
         *-sensor.*|*-doctor.*|gate-*.*) return 0 ;;
         *) return 1 ;;
     esac
@@ -145,6 +150,30 @@ if [[ ! -f "$REGISTRY" ]]; then
     printf 'check-instrument-ground-truth.sh: registry not found: %q\n' "$REGISTRY" >&2
     exit 2
 fi
+
+# Validate + canonicalize every scan root up front. Two startup contracts:
+#   (a) each root must EXIST as a directory — a lint that inspects zero files and
+#       exits 0 is the false-green this campaign kills; refuse to scan nothing.
+#   (b) each root must resolve UNDER --repo-root. The registry keys are
+#       repo-root-relative (rel="${f#"$REPO_ROOT/"}"), so a root outside REPO_ROOT
+#       would yield an absolute key that can never match the registry — a confusing
+#       spurious UNREGISTERED. Make the --root/registry-key contract explicit by
+#       failing loud (exit 2) instead. Canonicalizing here also makes the prefix
+#       strip exact for relative/symlinked roots.
+for i in "${!SCAN_ROOTS[@]}"; do
+    root="${SCAN_ROOTS[$i]}"
+    if [[ ! -d "$root" ]]; then
+        printf 'check-instrument-ground-truth.sh: scan root %q is not a directory — refusing to scan nothing\n' "$root" >&2
+        exit 2
+    fi
+    abs_root="$(cd "$root" && pwd)"
+    if [[ "$abs_root" != "$REPO_ROOT" && "$abs_root" != "$REPO_ROOT"/* ]]; then
+        printf 'check-instrument-ground-truth.sh: scan root %q does not resolve under --repo-root %q\n' "$root" "$REPO_ROOT" >&2
+        printf '  (registry keys are repo-root-relative; a root outside it can never match)\n' >&2
+        exit 2
+    fi
+    SCAN_ROOTS[i]="$abs_root"
+done
 
 # --------------------------------------------------------------------------
 # Registry parser (flat YAML map: "<path>:" then "  - \"<token>\"" lines).
@@ -209,25 +238,27 @@ suppressed=0
 _is_suppressed() { grep -qE -- "$SUPPRESS_RE" "$1"; }
 
 for root in "${SCAN_ROOTS[@]}"; do
-    # A missing/unreadable scan root must FAIL LOUD (exit 2), never silently scan
-    # nothing — a lint that inspects zero files and exits 0 is the very false-green
-    # this campaign exists to kill. (find's stderr is left visible for the same reason.)
-    if [[ ! -d "$root" ]]; then
-        printf 'check-instrument-ground-truth.sh: scan root %q is not a directory — refusing to scan nothing\n' "$root" >&2
-        exit 2
-    fi
+    # Roots are validated + canonicalized at startup (exist, under --repo-root).
+    # find's stderr is left visible so an unreadable subtree is never silently skipped.
     while IFS= read -r -d '' f; do
         name="${f##*/}"
+        # Classify the file ONCE (tri-state). `|| class=$?` keeps set -e happy while
+        # capturing a non-zero return; the exclusion (class 2) is evaluated here so a
+        # *.test.*/*.spec. file can never reach the opt-in-header path below.
+        class=0
+        _name_candidacy "$name" || class=$?
         is_cand=0
-        if _name_is_candidate "$name"; then
-            is_cand=1
-        else
-            # opt-in header check. Capture the head into a var and grep a here-string
-            # rather than `head | grep -q`: under pipefail an early grep -q match would
-            # SIGPIPE head and the pipeline would (wrongly) read as no-match.
-            head_txt="$(head -40 -- "$f" 2>/dev/null || true)"
-            if grep -qE -- "$OPTIN_RE" <<< "$head_txt"; then is_cand=1; fi
-        fi
+        case "$class" in
+            0) is_cand=1 ;;   # name-matched instrument candidate
+            2) continue ;;    # excluded test/spec — never a candidate, header or not
+            *)                # 1 = neither: the opt-in header may still pull it in
+                # Capture the head into a var and grep a here-string rather than
+                # `head | grep -q`: under pipefail an early grep -q match would SIGPIPE
+                # head and the pipeline would (wrongly) read as no-match.
+                head_txt="$(head -40 -- "$f" 2>/dev/null || true)"
+                if grep -qE -- "$OPTIN_RE" <<< "$head_txt"; then is_cand=1; fi
+                ;;
+        esac
         [[ $is_cand -eq 1 ]] || continue
 
         rel="${f#"$REPO_ROOT/"}"

--- a/tools/check-instrument-ground-truth.sh
+++ b/tools/check-instrument-ground-truth.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+# =============================================================================
+# tools/check-instrument-ground-truth.sh
+#
+# Campaign: Estate Immune System · M0 / G-IMMUNE — "every verdict/health/goal/
+# sensor re-derives from a ground source; a lint blocks NEW self-reporting
+# instruments." Bead: arrakis-estate-immune-epic-4xw6.1.
+#
+# This is the "re-derive-from-ground-truth" ENFORCING lint — the campaign's
+# anti-recurrence keystone. It dissolves the lying-instruments cluster
+# permanently by making it MECHANICALLY impossible to land a new immune
+# instrument that has not been bound, in a reviewer-visible diff, to the ground
+# source it re-derives its verdict from.
+#
+# IT IS A STRUCTURAL REGRESSION-CATCHER, NOT A SEMANTIC VERIFIER.
+# It enforces exactly TWO mechanical contracts — nothing fuzzier:
+#
+#   (1) REGISTRATION (the teeth). Every file under the scan root that LOOKS like
+#       an immune instrument — name matches `*-sensor.*`, `*-doctor.*`, or
+#       `gate-*.*`, OR it carries an opt-in `# immune-instrument` header — MUST
+#       be a key in the registry (tools/immune-instruments.yaml). A NEW,
+#       unregistered instrument FAILS the lint. That is the
+#       "blocks new self-reporting instruments" mechanism: you cannot add an
+#       instrument without a reviewer signing off on its ground source in the
+#       registry diff.
+#
+#   (2) GROUND-SOURCE PRESENCE (the binding). For every registered instrument,
+#       each declared ground-source token must LITERALLY appear (fixed-string
+#       grep) in the instrument's source. If the declared read is removed or
+#       refactored away, the token vanishes and the lint fails — forcing a
+#       re-confirmation of where the instrument actually gets its truth.
+#
+# WHAT IT DELIBERATELY DOES NOT DO (the fuzziness guard — do NOT add this):
+# it does NOT try to semantically detect "emits a verdict but reads no ground
+# source." That is statically intractable and false-positive-prone. The HUMAN
+# APPROVING THE REGISTRY DIFF owns the semantic judgement ("is this token really
+# the ground source?"). This lint only guarantees the claim was MADE and the
+# declared read still EXISTS — a tight tripwire, never a broad analyzer. Same
+# discipline as tools/check-no-direct-llm-fetch.sh (its sibling): literal
+# substrings, an opt-in registry, a reviewer-visible suppression marker, and the
+# exit code IS the verdict.
+#
+# Suppression (reviewer-visible, per-file): a file the globs catch but that is
+# NOT actually an instrument can opt OUT of the registration requirement with a
+# comment marker anywhere in the file:
+#     # immune-lint:allow <reason>
+# The marker + reason are visible in the PR diff; the human owns the call.
+#
+# ACCEPTED RISKS (PR review remains the gate — mirrors check-no-direct-llm-fetch.sh's
+# accepted-risk stanza). The opt-in / suppression markers are matched LINE-ANCHORED
+# to a real comment start, which defeats same-line string-literal smuggling (tested).
+# It does NOT track quote / template-literal / heredoc state — a contrived file could
+# embed a physical line `# immune-instrument` or `# immune-lint:allow` INSIDE a
+# multiline string to spoof a marker. Defending that fully needs string-context
+# analysis that is statically intractable and false-positive-prone — the exact "broad
+# analyzer" this lint is designed NOT to be (it is a regression-catcher for ACCIDENTAL
+# drift, not an adversarial-evasion boundary). The markers are reviewer-visible by
+# construction, so a spoofed marker is visible in the PR diff and the human review is
+# the real gate; an opt-in false-match also fails TOWARD more governance (it forces a
+# registry row or an explicit suppression), never toward a silent ungrounded instrument.
+#
+# Usage:
+#   tools/check-instrument-ground-truth.sh                 # scan tools/, default registry
+#   tools/check-instrument-ground-truth.sh --root <dir>    # add a scan root (repeatable)
+#   tools/check-instrument-ground-truth.sh --registry <f>  # use a specific registry
+#   tools/check-instrument-ground-truth.sh --repo-root <d> # base for relative path keys
+#   tools/check-instrument-ground-truth.sh --probe         # one-line STATUS tile (banner-style)
+#   tools/check-instrument-ground-truth.sh --quiet         # exit-code only
+#   tools/check-instrument-ground-truth.sh --help
+#
+# Exit codes (the verdict — capture $? before any pipe, per [[gate-output-never-piped]]):
+#   0  clean — every candidate is registered AND every declared token is present
+#   1  violation — an unregistered candidate, a missing declared token, or a
+#      registered instrument whose file is gone
+#   2  argument / I/O error (e.g. registry unreadable)
+#
+# Tested by tools/check-instrument-ground-truth.test.sh (the M0 acceptance
+# fixture: a PLANTED self-reporting instrument must fail this lint with exit 1).
+# =============================================================================
+
+set -euo pipefail
+
+# Repo root defaults to this script's parent dir (tools/..). Overridable so the
+# fixture test can root the lint at a temp dir.
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${LOA_IMMUNE_REPO_ROOT:-$(cd "$SELF_DIR/.." && pwd)}"
+REGISTRY=""
+QUIET=0
+PROBE=0
+declare -a SCAN_ROOTS=()
+
+# Name-globs that mark a file as an immune-instrument CANDIDATE. Intentionally
+# narrow — only the three shapes immune instruments are named with.
+_name_is_candidate() {
+    case "$1" in
+        *.test.*|*.spec.*) return 1 ;;  # tests/specs verify instruments; they are not instruments
+        *-sensor.*|*-doctor.*|gate-*.*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Opt-in header: a file NOT matching the name-globs can still be governed by
+# placing this marker on its own comment line in the head (first 40 lines).
+# Both REs are LINE-ANCHORED to a (possibly indented) comment start — `#` for
+# sh/py, `//` for mjs/ts — so the marker only counts as a real comment, never a
+# match smuggled inside a string literal or a trailing inline-code comment. The
+# OPTIN trailing `[[:space:]:]|$` guard stops a reference to
+# `immune-instruments.yaml` from reading as an opt-in.
+OPTIN_RE='^[[:space:]]*(#|//)[[:space:]]*immune-instrument([[:space:]:]|$)'
+# Reviewer-visible opt-OUT for a glob-matched file that is not really an
+# instrument. The distinctive `:allow` suffix makes a collision implausible.
+SUPPRESS_RE='^[[:space:]]*(#|//)[[:space:]]*immune-lint:allow'
+SUPPRESS_MARKER='# immune-lint:allow'   # display form (also matches `// immune-lint:allow`)
+
+# --------------------------------------------------------------------------
+# CLI arg parsing
+# --------------------------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --quiet|-q) QUIET=1; shift ;;
+        --probe) PROBE=1; shift ;;
+        --root)
+            [[ $# -ge 2 ]] || { printf 'check-instrument-ground-truth.sh: --root requires a path\n' >&2; exit 2; }
+            SCAN_ROOTS+=("$2"); shift 2 ;;
+        --registry)
+            [[ $# -ge 2 ]] || { printf 'check-instrument-ground-truth.sh: --registry requires a path\n' >&2; exit 2; }
+            REGISTRY="$2"; shift 2 ;;
+        --repo-root)
+            [[ $# -ge 2 ]] || { printf 'check-instrument-ground-truth.sh: --repo-root requires a path\n' >&2; exit 2; }
+            REPO_ROOT="$(cd "$2" && pwd)"; shift 2 ;;
+        --help|-h)
+            sed -n '/^# Usage:/,/^# Tested/p' "$0" | sed 's/^# \?//'
+            exit 0 ;;
+        *)
+            printf 'check-instrument-ground-truth.sh: unknown arg %q\n' "$1" >&2
+            exit 2 ;;
+    esac
+done
+
+[[ -n "$REGISTRY" ]] || REGISTRY="$REPO_ROOT/tools/immune-instruments.yaml"
+[[ ${#SCAN_ROOTS[@]} -gt 0 ]] || SCAN_ROOTS=("$REPO_ROOT/tools")
+
+if [[ ! -f "$REGISTRY" ]]; then
+    printf 'check-instrument-ground-truth.sh: registry not found: %q\n' "$REGISTRY" >&2
+    exit 2
+fi
+
+# --------------------------------------------------------------------------
+# Registry parser (flat YAML map: "<path>:" then "  - \"<token>\"" lines).
+# Hermetic — an awk parser for this fixed shape, so the lint needs no `yq`.
+# Emits a tab-delimited stream: "KEY\t<path>" and "TOK\t<path>\t<token>".
+# Full-line comments (^[space]*#) and blank lines are skipped; the comment rule
+# runs first so a comment ending in ':' is never mistaken for a key. tokval()
+# takes the FIRST quoted segment (so a trailing inline comment after the close
+# quote is ignored, per YAML) and strips a trailing " #..." from unquoted values.
+# SQ is a literal single quote passed via -v, so the program needs no shell-side
+# quote escaping.
+# --------------------------------------------------------------------------
+
+# shellcheck disable=SC2016  # the awk program is a literal — $0/regex must NOT expand in bash
+REGISTRY_PARSE_AWK='
+function tokval(s,   r, i) {
+    if (substr(s, 1, 1) == "\"") { r = substr(s, 2); i = index(r, "\""); return (i > 0) ? substr(r, 1, i - 1) : r }
+    if (substr(s, 1, 1) == SQ)   { r = substr(s, 2); i = index(r, SQ);   return (i > 0) ? substr(r, 1, i - 1) : r }
+    sub(/[ \t]+#.*$/, "", s); sub(/[ \t]+$/, "", s); return s
+}
+function keyval(s) {
+    if (s ~ /^".*"$/) return substr(s, 2, length(s) - 2)
+    if (substr(s, 1, 1) == SQ && substr(s, length(s), 1) == SQ) return substr(s, 2, length(s) - 2)
+    return s
+}
+/^[[:space:]]*#/ { next }
+/^[[:space:]]*$/ { next }
+/^[[:space:]]+-[[:space:]]/ {
+    line = $0
+    sub(/^[[:space:]]+-[[:space:]]+/, "", line)
+    if (key != "") print "TOK\t" key "\t" tokval(line)
+    next
+}
+/^[^[:space:]].*:[[:space:]]*$/ {
+    key = $0
+    sub(/:[[:space:]]*$/, "", key)
+    print "KEY\t" keyval(key)
+    next
+}
+'
+
+declare -A REGISTERED=()
+declare -A TOKENS=()        # path -> newline-delimited tokens
+
+while IFS=$'\t' read -r kind a b; do
+    case "$kind" in
+        KEY) REGISTERED["$a"]=1; [[ -n "${TOKENS[$a]+x}" ]] || TOKENS["$a"]="" ;;
+        TOK) TOKENS["$a"]+="$b"$'\n' ;;
+    esac
+done < <(awk -v SQ="'" "$REGISTRY_PARSE_AWK" "$REGISTRY")
+
+# --------------------------------------------------------------------------
+# Pass A — REGISTRATION teeth. Every on-disk candidate must be registered
+# (or carry the suppression marker). An unregistered candidate is a NEW
+# self-reporting instrument that was never bound to a ground source.
+# --------------------------------------------------------------------------
+
+violations=""
+candidates=0
+suppressed=0
+
+_is_suppressed() { grep -qE -- "$SUPPRESS_RE" "$1"; }
+
+for root in "${SCAN_ROOTS[@]}"; do
+    # A missing/unreadable scan root must FAIL LOUD (exit 2), never silently scan
+    # nothing — a lint that inspects zero files and exits 0 is the very false-green
+    # this campaign exists to kill. (find's stderr is left visible for the same reason.)
+    if [[ ! -d "$root" ]]; then
+        printf 'check-instrument-ground-truth.sh: scan root %q is not a directory — refusing to scan nothing\n' "$root" >&2
+        exit 2
+    fi
+    while IFS= read -r -d '' f; do
+        name="${f##*/}"
+        is_cand=0
+        if _name_is_candidate "$name"; then
+            is_cand=1
+        else
+            # opt-in header check. Capture the head into a var and grep a here-string
+            # rather than `head | grep -q`: under pipefail an early grep -q match would
+            # SIGPIPE head and the pipeline would (wrongly) read as no-match.
+            head_txt="$(head -40 -- "$f" 2>/dev/null || true)"
+            if grep -qE -- "$OPTIN_RE" <<< "$head_txt"; then is_cand=1; fi
+        fi
+        [[ $is_cand -eq 1 ]] || continue
+
+        rel="${f#"$REPO_ROOT/"}"
+        candidates=$((candidates + 1))
+
+        if _is_suppressed "$f"; then
+            suppressed=$((suppressed + 1))
+            continue
+        fi
+        if [[ -z "${REGISTERED[$rel]+x}" ]]; then
+            violations+="UNREGISTERED	$rel	candidate immune instrument is not in the registry"$'\n'
+        fi
+    done < <(find "$root" -type f -print0 | sort -z)
+done
+
+# --------------------------------------------------------------------------
+# Pass B — GROUND-SOURCE PRESENCE binding. Every registered instrument's file
+# must exist and literally contain each declared ground-source token.
+# --------------------------------------------------------------------------
+
+registered_checked=0
+for rel in "${!REGISTERED[@]}"; do
+    abs="$REPO_ROOT/$rel"
+    if [[ ! -f "$abs" ]]; then
+        violations+="MISSING_FILE	$rel	registered instrument file not found (remove the registry entry or restore the file)"$'\n'
+        continue
+    fi
+    toks="${TOKENS[$rel]:-}"
+    if [[ -z "${toks//$'\n'/}" ]]; then
+        violations+="NO_TOKEN	$rel	registered instrument declares no ground-source token"$'\n'
+        continue
+    fi
+    registered_checked=$((registered_checked + 1))
+    while IFS= read -r tok; do
+        [[ -n "$tok" ]] || continue
+        if ! grep -qF -- "$tok" "$abs"; then
+            violations+="TOKEN_ABSENT	$rel	declared ground-source token not found in source: ${tok}"$'\n'
+        fi
+    done <<< "$toks"
+done
+
+# --------------------------------------------------------------------------
+# Report — exit code IS the verdict.
+# --------------------------------------------------------------------------
+
+vcount="$(printf '%s' "$violations" | sed '/^$/d' | wc -l | tr -d ' ')"
+
+# --probe: one-line banner-style STATUS tile (mirrors the .mjs doctors' --probe).
+# Exit code keeps the lint's own contract (0 clean / 1 violation) so the tile and
+# the verdict stay consistent.
+if [[ $PROBE -eq 1 ]]; then
+    if [[ -n "$violations" ]]; then
+        printf '⚠ ground-truth-lint · %s violation(s) — unregistered/ungrounded immune instrument(s)\n' "$vcount"
+        exit 1
+    fi
+    printf '✓ ground-truth-lint · %s instrument(s) grounded (candidates=%s, suppressed=%s)\n' \
+        "$registered_checked" "$candidates" "$suppressed"
+    exit 0
+fi
+
+if [[ -n "$violations" ]]; then
+    if [[ $QUIET -eq 0 ]]; then
+        printf 'M0 / G-IMMUNE: immune-instrument ground-truth lint FAILED\n' >&2
+        printf 'Every immune instrument must be registered in %s and bound to a ground source.\n' "${REGISTRY#"$REPO_ROOT/"}" >&2
+        printf '\nViolations:\n' >&2
+        printf '%s' "$violations" | sed '/^$/d' | while IFS=$'\t' read -r code path msg; do
+            printf '  [%s] %s\n        %s\n' "$code" "$path" "$msg" >&2
+        done
+        printf '\nTo fix:\n' >&2
+        printf '  - NEW instrument: add its path + the literal ground-source token(s) it reads\n' >&2
+        printf '    its truth from to %s (a reviewer signs off on the ground source).\n' "${REGISTRY#"$REPO_ROOT/"}" >&2
+        printf '  - NOT an instrument: add the per-file marker  %s <reason>\n' "$SUPPRESS_MARKER" >&2
+        printf '  - TOKEN_ABSENT: the declared read was removed/refactored — re-confirm the\n' >&2
+        printf '    ground source and update the token in the registry.\n' >&2
+    fi
+    exit 1
+fi
+
+if [[ $QUIET -eq 0 ]]; then
+    printf 'OK — every immune instrument re-derives from a registered ground source\n'
+    printf '(candidates=%d, suppressed=%d, registered_checked=%d)\n' \
+        "$candidates" "$suppressed" "$registered_checked"
+fi
+exit 0

--- a/tools/check-instrument-ground-truth.test.sh
+++ b/tools/check-instrument-ground-truth.test.sh
@@ -149,8 +149,53 @@ EOF
 printf '# empty registry\n' > "$T9/registry.yaml"
 check "a *-sensor.spec.mjs file is excluded (not a candidate)" 0 "$(run_lint "$T9")"
 
+# ── Case 10 — a *.test.* file is excluded EVEN WITH the opt-in marker in its head ─
+# Regression proof for the tri-state classification: the *.test.*/*.spec. exclusion is
+# a property of the FILE, evaluated BEFORE the opt-in-header check — so a test file that
+# happens to carry `# immune-instrument` near the top (e.g. it documents/exercises the
+# marker) is STILL not an instrument candidate. (Pre-fix, the header path ran over test
+# files and would have falsely registered this one.)
+T10="$(mk_root)"
+cat > "$T10/tools/marker-bearing-sensor.test.mjs" <<'EOF'
+#!/usr/bin/env node
+// immune-instrument
+// ^ this TEST exercises the opt-in marker; the file is a test, not an instrument.
+console.log('PASS');
+EOF
+printf '# empty registry\n' > "$T10/registry.yaml"
+check "a *.test.* file with the opt-in marker in its head is STILL excluded" 0 "$(run_lint "$T10")"
+
+# ── Case 11 — a --root OUTSIDE --repo-root is refused at startup (exit 2) ──────
+# The registry keys are repo-root-relative; a scan root that doesn't resolve under
+# --repo-root could only ever yield absolute keys that never match — so the lint
+# refuses it loudly (arg/IO error, exit 2) instead of emitting a confusing spurious
+# UNREGISTERED with an absolute path.
+T11="$(mk_root)"
+OUTSIDE="$(mktemp -d)"; mkdir -p "$OUTSIDE/tools"   # a directory NOT under T11
+printf '# empty registry\n' > "$T11/registry.yaml"
+rc11="$(bash "$LINT" --quiet --repo-root "$T11" --root "$OUTSIDE/tools" --registry "$T11/registry.yaml" >"$LINT_OUT" 2>&1; echo $?)"
+check "a --root outside --repo-root is refused (exit 2)" 2 "$rc11"
+rm -rf "$OUTSIDE" 2>/dev/null || true
+
+# ── Case 12 — a registered-but-DELETED instrument yields MISSING_FILE (exit 1) ─
+# Pass B binding: the registry names a file no longer on disk. tools/ is empty, so
+# exit 1 here can ONLY be the MISSING_FILE violation — assert the code too (non-quiet),
+# so a future refactor can't silently turn it into a different failure.
+T12="$(mk_root)"
+cat > "$T12/registry.yaml" <<'EOF'
+tools/ghost-sensor.mjs:
+  - ".run/model-invoke.jsonl"
+EOF
+mf_rc="$(bash "$LINT" --repo-root "$T12" --root "$T12/tools" --registry "$T12/registry.yaml" >"$LINT_OUT" 2>&1; echo $?)"
+check "a registered-but-deleted instrument FAILS (exit 1)" 1 "$mf_rc"
+if grep -q "MISSING_FILE" "$LINT_OUT"; then
+    echo "  ✓ the violation is specifically MISSING_FILE"
+else
+    echo "  ✗ expected a MISSING_FILE violation"; sed 's/^/      /' "$LINT_OUT"; fail=1
+fi
+
 # cleanup
-rm -rf "$T1" "$T2" "$T3" "$T4" "$T5" "$T6" "$T7" "$T8" "$T9" 2>/dev/null || true
+rm -rf "$T1" "$T2" "$T3" "$T4" "$T5" "$T6" "$T7" "$T8" "$T9" "$T10" "$T11" "$T12" 2>/dev/null || true
 
 echo ""
 if [[ "$fail" -eq 0 ]]; then echo "PASS: all check-instrument-ground-truth.sh assertions green"; else echo "FAIL: check-instrument-ground-truth.sh"; fi

--- a/tools/check-instrument-ground-truth.test.sh
+++ b/tools/check-instrument-ground-truth.test.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# =============================================================================
+# tools/check-instrument-ground-truth.test.sh
+#
+# Fixture test for the M0 / G-IMMUNE enforcing lint (check-instrument-ground-truth.sh).
+# Campaign: Estate Immune System · bead arrakis-estate-immune-epic-4xw6.1.
+#
+# THE M0 ACCEPTANCE CRITERION (campaign-immune-estate.md): "a planted
+# self-reporting instrument fails the lint." Case 1 below is exactly that proof —
+# an instrument that emits a verdict but reads no ground source and is not in the
+# registry MUST fail the lint with exit 1.
+#
+# Each case builds an isolated temp repo-root so the cases never interfere and
+# the lint never touches the real tools/. Run:
+#   bash tools/check-instrument-ground-truth.test.sh   (exit 0 = pass, 1 = fail)
+# =============================================================================
+set -uo pipefail
+
+LINT="$(cd "$(dirname "$0")" && pwd)/check-instrument-ground-truth.sh"
+fail=0
+LINT_OUT="$(mktemp)"   # per-run, not a shared /tmp path — safe under parallel runs
+
+# mk_root: print a fresh temp repo-root with an empty tools/ dir.
+mk_root() {
+    local t; t="$(mktemp -d)"
+    mkdir -p "$t/tools"
+    printf '%s' "$t"
+}
+
+# run_lint <repo-root> -> echoes the lint's exit code (scanning <root>/tools).
+run_lint() {
+    bash "$LINT" --quiet --repo-root "$1" --root "$1/tools" --registry "$1/registry.yaml" \
+        >"$LINT_OUT" 2>&1
+    echo $?
+}
+
+check() { # name expected-exit actual-exit
+    if [[ "$2" == "$3" ]]; then
+        echo "  ✓ $1 (exit $3)"
+    else
+        echo "  ✗ $1 — expected exit $2, got $3"; sed 's/^/      /' "$LINT_OUT"; fail=1
+    fi
+}
+
+# ── Case 1 — THE ACCEPTANCE CRITERION: a planted self-reporting instrument ────
+# liar-sensor.mjs emits a verdict, reads NO ground source, and is UNREGISTERED.
+# The lint MUST catch it (exit 1). This is the regression the campaign exists to
+# prevent recurring.
+T1="$(mk_root)"
+cat > "$T1/tools/liar-sensor.mjs" <<'EOF'
+#!/usr/bin/env node
+// A LYING INSTRUMENT: declares a verdict from nothing — reads no ground source.
+console.log('VERDICT: HEALTHY');
+process.exit(0);
+EOF
+printf '# empty registry — the liar is not registered\n' > "$T1/registry.yaml"
+check "planted self-reporting instrument (unregistered) FAILS the lint" 1 "$(run_lint "$T1")"
+
+# ── Case 2 — a registered + grounded instrument passes clean ─────────────────
+T2="$(mk_root)"
+cat > "$T2/tools/good-sensor.mjs" <<'EOF'
+#!/usr/bin/env node
+// Re-derives its verdict from the audit log (the ground source).
+import { readFileSync } from 'node:fs';
+const records = readFileSync('.run/model-invoke.jsonl', 'utf8');
+console.log(records.length ? 'TRUTHFUL' : 'INSUFFICIENT');
+EOF
+cat > "$T2/registry.yaml" <<'EOF'
+tools/good-sensor.mjs:
+  - ".run/model-invoke.jsonl"
+EOF
+check "registered + grounded instrument PASSES" 0 "$(run_lint "$T2")"
+
+# ── Case 3 — the suppression marker exempts a glob-matched non-instrument ─────
+T3="$(mk_root)"
+cat > "$T3/tools/not-really-a-sensor.mjs" <<'EOF'
+#!/usr/bin/env node
+// immune-lint:allow demo helper that matches *-sensor.* but is not an instrument
+console.log('hello');
+EOF
+printf '# empty registry\n' > "$T3/registry.yaml"
+check "suppression marker (# immune-lint:allow) exempts the file" 0 "$(run_lint "$T3")"
+
+# ── Case 4 — a registered instrument whose declared token is ABSENT fails ────
+# (the ground-source binding: the declared read was removed/refactored away).
+T4="$(mk_root)"
+cat > "$T4/tools/drifted-sensor.mjs" <<'EOF'
+#!/usr/bin/env node
+// The declared ground-source read has been removed — only a self-report remains.
+console.log('VERDICT: HEALTHY');
+EOF
+cat > "$T4/registry.yaml" <<'EOF'
+tools/drifted-sensor.mjs:
+  - ".run/model-invoke.jsonl"
+EOF
+check "registered instrument with ABSENT declared token FAILS" 1 "$(run_lint "$T4")"
+
+# ── Case 5 — the opt-in header pulls a non-glob-named file into the lint ──────
+# A file whose NAME doesn't match the globs but carries `# immune-instrument`
+# opts in; if unregistered it must fail (proves the header is honored).
+T5="$(mk_root)"
+cat > "$T5/tools/healthboard.mjs" <<'EOF'
+#!/usr/bin/env node
+// immune-instrument
+console.log('VERDICT: HEALTHY');
+EOF
+printf '# empty registry\n' > "$T5/registry.yaml"
+check "opt-in '# immune-instrument' header pulls a non-glob file in (unregistered FAILS)" 1 "$(run_lint "$T5")"
+
+# ── Case 6 — a test file matching the glob is NOT treated as a candidate ──────
+# *.test.* files verify instruments; they must not themselves require registration.
+T6="$(mk_root)"
+cat > "$T6/tools/whatever-sensor.test.mjs" <<'EOF'
+#!/usr/bin/env node
+// a test for some sensor — not an instrument itself
+console.log('PASS');
+EOF
+printf '# empty registry\n' > "$T6/registry.yaml"
+check "a *-sensor.test.mjs file is excluded (not a candidate)" 0 "$(run_lint "$T6")"
+
+# ── Case 7 — the suppression marker in a STRING LITERAL must NOT suppress ─────
+# (line-anchoring: a smuggled marker that is not a real comment cannot evade
+# the registration teeth.)
+T7="$(mk_root)"
+cat > "$T7/tools/sneaky-sensor.mjs" <<'EOF'
+#!/usr/bin/env node
+console.log('# immune-lint:allow look ma, evading registration');
+EOF
+printf '# empty registry\n' > "$T7/registry.yaml"
+check "marker inside a string literal does NOT suppress (still FAILS)" 1 "$(run_lint "$T7")"
+
+# ── Case 8 — the opt-in marker in a STRING LITERAL must NOT opt a file in ─────
+T8="$(mk_root)"
+cat > "$T8/tools/plainfile.mjs" <<'EOF'
+#!/usr/bin/env node
+const label = "// immune-instrument";   // a string, not a header
+console.log(label);
+EOF
+printf '# empty registry\n' > "$T8/registry.yaml"
+check "opt-in marker inside a string literal does NOT opt the file in (PASSES)" 0 "$(run_lint "$T8")"
+
+# ── Case 9 — a *-sensor.spec.mjs file is excluded (spec tests, like .test.) ───
+T9="$(mk_root)"
+cat > "$T9/tools/widget-sensor.spec.mjs" <<'EOF'
+#!/usr/bin/env node
+// a spec for the widget sensor — not an instrument itself
+console.log('PASS');
+EOF
+printf '# empty registry\n' > "$T9/registry.yaml"
+check "a *-sensor.spec.mjs file is excluded (not a candidate)" 0 "$(run_lint "$T9")"
+
+# cleanup
+rm -rf "$T1" "$T2" "$T3" "$T4" "$T5" "$T6" "$T7" "$T8" "$T9" 2>/dev/null || true
+
+echo ""
+if [[ "$fail" -eq 0 ]]; then echo "PASS: all check-instrument-ground-truth.sh assertions green"; else echo "FAIL: check-instrument-ground-truth.sh"; fi
+exit "$fail"

--- a/tools/immune-check.sh
+++ b/tools/immune-check.sh
@@ -2,24 +2,30 @@
 # =============================================================================
 # tools/immune-check.sh — the LOCAL/BANNER teeth for the estate immune doctors.
 #
-# Runs BOTH read-only immune doctors back-to-back and emits a one-line STATUS
-# tile per doctor (banner-style, the sensors' own --probe tiles), then a single
-# combined verdict + exit code so it can gate a local sweep or a banner row:
+# Runs the read-only immune doctors + the M0 ground-truth lint back-to-back and
+# emits a one-line STATUS tile per check (banner-style, their own --probe tiles),
+# then a single combined verdict + exit code so it can gate a local sweep or a banner row:
 #
-#   exit 0 = HEALTHY      — both doctors clean (no frozen gate, no lying instrument)
-#   exit 2 = PROBLEM      — >=1 doctor reports a real problem (door FROZEN / instrument LYING)
-#   exit 1 = INSUFFICIENT — >=1 doctor could not ground (no gh auth / no audit log) AND none
+#   exit 0 = HEALTHY      — all checks clean (no frozen gate, no lying instrument, no ungrounded one)
+#   exit 2 = PROBLEM      — >=1 check reports a real problem (door FROZEN / instrument LYING / lint VIOLATION)
+#   exit 1 = INSUFFICIENT — >=1 check could not ground (no gh auth / no audit log / lint misconfig) AND none
 #                           reported a problem. Never claims HEALTHY without evidence.
 #
-# The two doctors split by where their ground-truth lives:
+# The ground-truth lint is NOT on the doctors' 0/1/2 severity convention — its own exit contract is
+# 0=clean / 1=violation / 2=arg-error, remapped below (violation→PROBLEM, arg-error→INSUFFICIENT).
+#
+# The checks split by where their ground-truth lives:
 #   - gate-freeze-sensor.mjs   reads the live merge gate via `gh` (G-DOOR). CI-runnable —
 #                              also wired as the informational .github/workflows/immune-doctors.yml.
 #   - instrument-truth-sensor.mjs  reads LOCAL .run/model-invoke.jsonl (M0/G-IMMUNE). NOT
 #                              CI-runnable (no audit log in CI) — this script is its only teeth.
-# This single entry is therefore the union: the one place that runs every doctor the banner
+#   - check-instrument-ground-truth.sh  the M0/G-IMMUNE enforcing lint: every immune instrument
+#                              must register its ground source (tools/immune-instruments.yaml).
+#                              CI-runnable (also wired informationally into immune-doctors.yml).
+# This single entry is therefore the union: the one place that runs every check the banner
 # should surface, including the local-only one CI can never see.
 #
-# Read-only: neither doctor mutates anything (gh reads + a file read). Exit code IS the verdict,
+# Read-only: no check mutates anything (gh reads + file reads only). Exit code IS the verdict,
 # per [[gate-output-never-piped]] — capture $? before any pipe; never `| tail`.
 # Campaign: estate-immune (bead arrakis-estate-immune-epic-4xw6.1, M0/G-DOOR teeth).
 #
@@ -64,6 +70,9 @@ if [[ -z "${IMMUNE_INSTRUMENT_PROBE_CMD:-}" ]]; then
   IMMUNE_INSTRUMENT_PROBE_CMD="node $(printf %q "$TOOLS/instrument-truth-sensor.mjs") --probe"
   [[ -n "$LOG" ]] && IMMUNE_INSTRUMENT_PROBE_CMD+=" $(printf %q "--log=$LOG")"
 fi
+if [[ -z "${IMMUNE_LINT_PROBE_CMD:-}" ]]; then
+  IMMUNE_LINT_PROBE_CMD="bash $(printf %q "$TOOLS/check-instrument-ground-truth.sh") --probe"
+fi
 
 # Run a doctor's probe; capture its tile (stdout+stderr — a doctor's `die` writes its
 # diagnostic to stderr) and its exit code (the verdict). Never pipe; capture $? directly.
@@ -77,6 +86,7 @@ run_doctor() { # cmd -> prints tile to stdout; returns the doctor's exit code
 
 gate_tile="$(run_doctor "$IMMUNE_GATE_PROBE_CMD")";       gate_rc=$?
 instr_tile="$(run_doctor "$IMMUNE_INSTRUMENT_PROBE_CMD")"; instr_rc=$?
+lint_tile="$(run_doctor "$IMMUNE_LINT_PROBE_CMD")";       lint_rc=$?
 
 # Normalize the severity of each exit. The doctors contract 0/1/2; ANY other code (crash,
 # 127 command-not-found, an uncontracted return) is treated as INSUFFICIENT — never HEALTHY.
@@ -85,10 +95,15 @@ instr_tile="$(run_doctor "$IMMUNE_INSTRUMENT_PROBE_CMD")"; instr_rc=$?
 sev() { case "$1" in 0|1|2) echo "$1" ;; *) echo 1 ;; esac; }
 gate_sev="$(sev "$gate_rc")"; instr_sev="$(sev "$instr_rc")"
 
+# The lint is NOT on the doctors' 0/1/2 severity convention. Its exit contract is
+# 0=clean / 1=violation / 2=arg-error: a violation is a real PROBLEM (sev 2) and an
+# arg-error is INSUFFICIENT (sev 1). Remap explicitly — never feed it through sev().
+case "$lint_rc" in 0) lint_sev=0 ;; 1) lint_sev=2 ;; 2) lint_sev=1 ;; *) lint_sev=1 ;; esac
+
 # Aggregate: a real problem (2) dominates; else insufficient (1); else healthy (0).
-if [[ "$gate_sev" -eq 2 || "$instr_sev" -eq 2 ]]; then
+if [[ "$gate_sev" -eq 2 || "$instr_sev" -eq 2 || "$lint_sev" -eq 2 ]]; then
   overall=2; verdict=PROBLEM
-elif [[ "$gate_sev" -eq 1 || "$instr_sev" -eq 1 ]]; then
+elif [[ "$gate_sev" -eq 1 || "$instr_sev" -eq 1 || "$lint_sev" -eq 1 ]]; then
   overall=1; verdict=INSUFFICIENT
 else
   overall=0; verdict=HEALTHY
@@ -105,9 +120,11 @@ if [[ "$JSON" -eq 1 ]]; then
     --arg verdict "$verdict" --argjson exit "$overall" \
     --argjson grc "$gate_rc"  --arg gtile "$gate_tile" \
     --argjson irc "$instr_rc" --arg itile "$instr_tile" \
+    --argjson lrc "$lint_rc"  --arg ltile "$lint_tile" \
     '{verdict:$verdict, exit:$exit, doctors:[
-       {doctor:"gate-freeze",      exit:$grc, tile:$gtile},
-       {doctor:"instrument-truth", exit:$irc, tile:$itile}]}'
+       {doctor:"gate-freeze",       exit:$grc, tile:$gtile},
+       {doctor:"instrument-truth",  exit:$irc, tile:$itile},
+       {doctor:"ground-truth-lint", exit:$lrc, tile:$ltile}]}'
   exit "$overall"
 fi
 
@@ -116,6 +133,7 @@ sym=$([[ "$overall" -eq 0 ]] && echo "✓" || { [[ "$overall" -eq 1 ]] && echo "
 printf '  ╓─ immune-check · estate immune doctors · %s\n' "$(date -u +%Y-%m-%dT%H:%MZ)"
 printf '     %s\n' "$gate_tile"
 printf '     %s\n' "$instr_tile"
+printf '     %s\n' "$lint_tile"
 printf '  ╙─ %s VERDICT: %s (exit %d)\n' "$sym" "$verdict" "$overall"
 
 exit "$overall"

--- a/tools/immune-check.test.sh
+++ b/tools/immune-check.test.sh
@@ -19,12 +19,17 @@ set -uo pipefail
 CHECK="$(cd "$(dirname "$0")" && pwd)/immune-check.sh"
 fail=0
 
-# run the script with stubbed doctor probes that emit a tile and exit a chosen code.
-# $1 = gate exit code, $2 = instrument exit code -> echoes the script's combined exit code;
-# captures the banner to /tmp/immune-check-smoke.out for tile assertions.
+# run the script with stubbed probes that emit a tile and exit a chosen code.
+# $1 = gate exit code, $2 = instrument exit code, $3 = lint exit code (default 0=clean).
+# NOTE: the lint's exit convention is 0=clean / 1=violation / 2=arg-error — distinct from the
+# doctors' 0/1/2 severity. immune-check.sh remaps it (1->PROBLEM, 2->INSUFFICIENT). The 3x3
+# matrix below pins the two DOCTORS with the lint held clean (l=0), so the matrix is unchanged.
+# echoes the script's combined exit code; captures the banner to /tmp/immune-check-smoke.out.
 run() {
+  local lrc="${3:-0}"
   IMMUNE_GATE_PROBE_CMD="printf 'STUB gate-tile g=%s\\n' '$1'; exit $1" \
   IMMUNE_INSTRUMENT_PROBE_CMD="printf 'STUB instr-tile i=%s\\n' '$2'; exit $2" \
+  IMMUNE_LINT_PROBE_CMD="printf 'STUB lint-tile l=%s\\n' '$lrc'; exit $lrc" \
     bash "$CHECK" >/tmp/immune-check-smoke.out 2>&1
   echo $?
 }
@@ -54,13 +59,22 @@ check "(127,0) crash code -> INSUFFICIENT/1 (not HEALTHY)" 1 "$(run 127 0)"
 check "(0,3) uncontracted -> INSUFFICIENT/1 (not HEALTHY)"  1 "$(run 0 3)"
 check "(2,127) problem still dominates a crash -> PROBLEM/2" 2 "$(run 2 127)"
 
-# ── banner surfaces BOTH doctors' tiles (not just the aggregate) ─────────────
-run 2 0 >/dev/null
+# ── the ground-truth lint's INVERTED exit contract is remapped correctly ─────
+# lint 1 = VIOLATION must drive PROBLEM (2); lint 2 = arg-error is INSUFFICIENT (1);
+# lint 0 = clean is harmless. This is the remap that sev() must NOT be used for.
+check "(0,0,lint=1) lint VIOLATION  -> PROBLEM/2"      2 "$(run 0 0 1)"
+check "(0,0,lint=2) lint arg-error  -> INSUFFICIENT/1" 1 "$(run 0 0 2)"
+check "(0,0,lint=0) lint clean       -> HEALTHY/0"     0 "$(run 0 0 0)"
+check "(2,0,lint=0) lint clean doesn't mask a frozen gate -> PROBLEM/2" 2 "$(run 2 0 0)"
+
+# ── banner surfaces ALL THREE tiles (not just the aggregate) ─────────────────
+run 2 0 1 >/dev/null
 if grep -q "STUB gate-tile g=2" /tmp/immune-check-smoke.out && \
-   grep -q "STUB instr-tile i=0" /tmp/immune-check-smoke.out; then
-  echo "  ✓ banner shows both doctor tiles"
+   grep -q "STUB instr-tile i=0" /tmp/immune-check-smoke.out && \
+   grep -q "STUB lint-tile l=1" /tmp/immune-check-smoke.out; then
+  echo "  ✓ banner shows all three check tiles"
 else
-  echo "  ✗ banner is missing a doctor tile"; sed 's/^/      /' /tmp/immune-check-smoke.out; fail=1
+  echo "  ✗ banner is missing a check tile"; sed 's/^/      /' /tmp/immune-check-smoke.out; fail=1
 fi
 if grep -q "PROBLEM (exit 2)" /tmp/immune-check-smoke.out; then
   echo "  ✓ banner footer names the combined verdict"
@@ -73,12 +87,14 @@ fi
 # encoder, not a hand-rolled escaper. We grep the PARSED values via jq -e, never the raw text.
 JSON_OUT="$(IMMUNE_GATE_PROBE_CMD="printf 'line-one\\nline-two\\n'; exit 0" \
            IMMUNE_INSTRUMENT_PROBE_CMD="printf 'i\\n'; exit 2" \
+           IMMUNE_LINT_PROBE_CMD="printf 'l\\n'; exit 0" \
            bash "$CHECK" --json 2>/dev/null)"; json_rc=$?
 if echo "$JSON_OUT" | jq -e \
      '.verdict=="PROBLEM" and .exit==2
       and (.doctors[0].tile | contains("line-one") and contains("line-two"))
-      and (.doctors[1].exit==2)' >/dev/null 2>&1 && [[ "$json_rc" == 2 ]]; then
-  echo "  ✓ --json is parseable, carries both exits+verdict, survives a multiline tile (rc=$json_rc)"
+      and (.doctors[1].exit==2)
+      and (.doctors[2].doctor=="ground-truth-lint" and .doctors[2].exit==0)' >/dev/null 2>&1 && [[ "$json_rc" == 2 ]]; then
+  echo "  ✓ --json is parseable, carries all three exits+verdict, survives a multiline tile (rc=$json_rc)"
 else
   echo "  ✗ --json contract failed (rc=$json_rc): $JSON_OUT"; fail=1
 fi

--- a/tools/immune-check.test.sh
+++ b/tools/immune-check.test.sh
@@ -18,19 +18,21 @@ set -uo pipefail
 
 CHECK="$(cd "$(dirname "$0")" && pwd)/immune-check.sh"
 fail=0
+SMOKE_OUT="$(mktemp)"   # per-run, not a shared /tmp path — safe under parallel runs
+trap 'rm -f "$SMOKE_OUT"' EXIT
 
 # run the script with stubbed probes that emit a tile and exit a chosen code.
 # $1 = gate exit code, $2 = instrument exit code, $3 = lint exit code (default 0=clean).
 # NOTE: the lint's exit convention is 0=clean / 1=violation / 2=arg-error — distinct from the
 # doctors' 0/1/2 severity. immune-check.sh remaps it (1->PROBLEM, 2->INSUFFICIENT). The 3x3
 # matrix below pins the two DOCTORS with the lint held clean (l=0), so the matrix is unchanged.
-# echoes the script's combined exit code; captures the banner to /tmp/immune-check-smoke.out.
+# echoes the script's combined exit code; captures the banner to $SMOKE_OUT (per-run mktemp).
 run() {
   local lrc="${3:-0}"
   IMMUNE_GATE_PROBE_CMD="printf 'STUB gate-tile g=%s\\n' '$1'; exit $1" \
   IMMUNE_INSTRUMENT_PROBE_CMD="printf 'STUB instr-tile i=%s\\n' '$2'; exit $2" \
   IMMUNE_LINT_PROBE_CMD="printf 'STUB lint-tile l=%s\\n' '$lrc'; exit $lrc" \
-    bash "$CHECK" >/tmp/immune-check-smoke.out 2>&1
+    bash "$CHECK" >"$SMOKE_OUT" 2>&1
   echo $?
 }
 
@@ -38,7 +40,7 @@ check() { # name expected-exit actual-exit
   if [[ "$2" == "$3" ]]; then
     echo "  ✓ $1 (exit $3)"
   else
-    echo "  ✗ $1 — expected exit $2, got $3"; sed 's/^/      /' /tmp/immune-check-smoke.out; fail=1
+    echo "  ✗ $1 — expected exit $2, got $3"; sed 's/^/      /' "$SMOKE_OUT"; fail=1
   fi
 }
 
@@ -69,14 +71,14 @@ check "(2,0,lint=0) lint clean doesn't mask a frozen gate -> PROBLEM/2" 2 "$(run
 
 # ── banner surfaces ALL THREE tiles (not just the aggregate) ─────────────────
 run 2 0 1 >/dev/null
-if grep -q "STUB gate-tile g=2" /tmp/immune-check-smoke.out && \
-   grep -q "STUB instr-tile i=0" /tmp/immune-check-smoke.out && \
-   grep -q "STUB lint-tile l=1" /tmp/immune-check-smoke.out; then
+if grep -q "STUB gate-tile g=2" "$SMOKE_OUT" && \
+   grep -q "STUB instr-tile i=0" "$SMOKE_OUT" && \
+   grep -q "STUB lint-tile l=1" "$SMOKE_OUT"; then
   echo "  ✓ banner shows all three check tiles"
 else
-  echo "  ✗ banner is missing a check tile"; sed 's/^/      /' /tmp/immune-check-smoke.out; fail=1
+  echo "  ✗ banner is missing a check tile"; sed 's/^/      /' "$SMOKE_OUT"; fail=1
 fi
-if grep -q "PROBLEM (exit 2)" /tmp/immune-check-smoke.out; then
+if grep -q "PROBLEM (exit 2)" "$SMOKE_OUT"; then
   echo "  ✓ banner footer names the combined verdict"
 else
   echo "  ✗ banner footer missing combined verdict"; fail=1

--- a/tools/immune-instruments.yaml
+++ b/tools/immune-instruments.yaml
@@ -1,0 +1,63 @@
+# =============================================================================
+# tools/immune-instruments.yaml — the ground-truth registry for the estate
+# immune instruments.
+#
+# Campaign: Estate Immune System · M0 / G-IMMUNE ("every verdict/health/goal/
+# sensor re-derives from a ground source; a lint blocks NEW self-reporting
+# instruments"). Bead: arrakis-estate-immune-epic-4xw6.1.
+#
+# WHAT THIS IS — the human-owned half of a two-part contract enforced by
+# tools/check-instrument-ground-truth.sh:
+#
+#   1. REGISTRATION (the teeth): every file under tools/ that LOOKS like an
+#      immune instrument (name matches `*-sensor.*`, `*-doctor.*`, `gate-*.*`,
+#      or carries an opt-in `# immune-instrument` header) MUST appear as a key
+#      below. A NEW unregistered instrument FAILS the lint — that is the
+#      "blocks new self-reporting instruments" mechanism. Registering it forces
+#      a reviewer to name its ground source in the same PR diff.
+#
+#   2. GROUND-SOURCE PRESENCE (the binding): each declared token below must
+#      LITERALLY appear (fixed-string grep) somewhere in the instrument's
+#      source. If an instrument's declared ground-source read is removed or
+#      refactored away, the token vanishes and the lint fails — forcing a
+#      re-confirmation of where the instrument actually gets its truth.
+#
+# WHAT THIS IS NOT — the lint is a STRUCTURAL regression-catcher, NOT a semantic
+# verifier. It cannot decide whether a token is "really" the ground source (that
+# is statically intractable and false-positive-prone). THE HUMAN APPROVING THIS
+# REGISTRY DIFF OWNS THAT JUDGEMENT. A token here is a claim a reviewer signed
+# off on: "this instrument re-derives its verdict from this source, not from a
+# self-reported declaration."
+#
+# SCHEMA (deliberately flat so the lint parses it without a yq dependency — it
+# is still valid YAML for humans and `yq`):
+#
+#   <repo-root-relative path>:
+#     - "<literal ground-source token>"      # one or more; ALL must be present
+#     # rationale comment naming WHY this is the ground source
+#
+# To register a new instrument: add its path key + the literal token(s) it reads
+# its truth from, with a one-line rationale. To intentionally exclude a file the
+# globs catch but that is NOT an instrument, add the reviewer-visible marker
+# `# immune-lint:allow <reason>` inside that file instead of registering it here.
+# =============================================================================
+
+# The merge-gate freeze sensor. Ground truth = the LIVE branch-protection +
+# open-PR backlog read through the `gh` CLI (caller's auth). It never trusts a
+# cached or self-declared gate state — it re-reads the live gate every run.
+tools/gate-freeze-sensor.mjs:
+  - "execFileSync('gh'"
+
+# The meta-immune voice-truth doctor. Ground truth = the MODELINV audit log
+# `.run/model-invoke.jsonl` (the hash-chained record of real successful finals).
+# It re-derives each voice's REAL health from that log instead of trusting the
+# static cheval doctor's self-reported probe table.
+tools/instrument-truth-sensor.mjs:
+  - ".run/model-invoke.jsonl"
+
+# The Straylight stale-artifact doctor. Ground truth = the on-disk truth-surface
+# artifacts it scans (`grimoires/loa/reality/*`) with effective dates derived
+# from `git log` — never a self-declared freshness field it could be lied to by.
+tools/governance-doctor.sh:
+  - "grimoires/loa/reality"
+  - "git log"


### PR DESCRIPTION
## M0 — re-derive-from-ground-truth enforcing lint

> **Draft — stacked on #321** (`campaign/immune-doctor-teeth`, the door-teeth branch with `immune-doctors.yml` + `tools/immune-check.sh`). The door is frozen; review/merge order is #321 first. Bead `arrakis-estate-immune-epic-4xw6.1`.

The campaign's anti-recurrence **keystone**: a lint that makes it mechanically impossible to land a NEW immune instrument that hasn't been bound — in a reviewer-visible diff — to the ground source it re-derives its verdict from. This dissolves the lying-instruments cluster permanently (M0 / G-IMMUNE: "every verdict/health/goal/sensor re-derives from a ground source; a lint blocks new self-reporting instruments").

### What the lint enforces — TWO mechanical contracts, nothing fuzzier
1. **Registration teeth.** Every file under `tools/` that *looks* like an immune instrument — name matches `*-sensor.*` / `*-doctor.*` / `gate-*.*`, or carries an opt-in `# immune-instrument` header — MUST be a key in `tools/immune-instruments.yaml`. A new, **unregistered** instrument FAILS the lint. (`*.test.*` / `*.spec.*` are excluded — they verify instruments, they aren't instruments.)
2. **Ground-source binding.** Each registered instrument's declared ground-source token(s) must **literally appear** (fixed-string grep) in its source. If the declared read is removed/refactored away, the token vanishes and the lint fails — forcing a re-confirmation.

### Structural-not-semantic — the design rationale (fuzziness guard)
It is a **regression-catcher, not a semantic verifier.** It deliberately does NOT try to detect "emits a verdict but reads no ground source" — that is statically intractable and false-positive-prone. **The human approving the registry diff owns the semantic judgement** ("is this token really the ground source?"). The lint only guarantees the claim was *made* and the declared read still *exists*. Same discipline as its sibling `tools/check-no-direct-llm-fetch.sh`: literal substrings, an opt-in registry, a reviewer-visible suppression marker (`# immune-lint:allow <reason>`), and the exit code IS the verdict. Markers are matched **line-anchored to a real comment** (defeats same-line string smuggling, tested); the multiline-string-literal spoof is a **documented accepted risk** — the lexer it would need is exactly the broad analyzer the fuzziness guard forbids, and the markers are reviewer-visible so human review is the gate.

### Files
- **`tools/immune-instruments.yaml`** — the registry. Seeds the 3 existing instruments: `gate-freeze-sensor.mjs → execFileSync('gh'`, `instrument-truth-sensor.mjs → .run/model-invoke.jsonl`, `governance-doctor.sh → grimoires/loa/reality + git log`.
- **`tools/check-instrument-ground-truth.sh`** — the lint. Hermetic (awk YAML parser, **no yq dependency** — runs anywhere). `0 clean / 1 violation / 2 arg-error`; `--probe` one-line tile.
- **`tools/check-instrument-ground-truth.test.sh`** — 9 fixtures.
- **`tools/immune-check.sh`** (+ test) — wires the lint as a third, CI-runnable check with an **explicit severity remap** (the lint's `0/1/2` is NOT the doctors' `0/1/2` convention).
- **`.github/workflows/immune-doctors.yml`** — a NON-REQUIRED, informational job (always exit 0; verdict surfaced LOUD via job summary + `::warning`), plus an informational M0-fixture step. **Never a new required check** — adding one would deepen the very frozen door this campaign cures.

### Planted-regression test result (the M0 acceptance criterion)
A planted self-reporting instrument (emits a verdict, reads no ground source, unregistered) → **lint exits 1** ✓. A registered+grounded instrument → exits 0 ✓. The suppression marker works ✓. All **9/9 fixtures green**; the lint runs **clean on the real `tools/`** (3 instruments, no false positives); `shellcheck` clean.

### Council verdict (cross-model FAGAN, codex + cursor)
Ran the real cheval council on the diff, **3 rounds to convergence**:
- **codex (`openai:codex-headless`): APPROVED, 0 findings — every round.**
- **cursor (`cursor:cursor-headless`): 6 → 3 → 4 findings.** All substantive findings verified against the repo and fixed: quoted-aware registry parser (inline comments now parse, was a TOKEN_ABSENT false-positive); a bad scan root now fails loud (was a silent false-green); markers line-anchored (defeats string-literal smuggling — two new negative fixtures); `*.spec.*` excluded; CI `::warning` on exit-2 misconfig; `immune-check.sh` header updated to a three-check contract; `mktemp` in the test.
- **Rejected (verified, deliberate):** cursor's round-3 push for a quote/heredoc-tracking lexer to defend marker-in-multiline-string evasion — that is the statically-intractable broad analyzer the fuzziness guard forbids (documented as an accepted risk; human review is the gate). Cursor's `.doctors`→`.checks` JSON rename — would break the `--json` contract #321 established; the aggregate verdict is authoritative and each element is name-tagged.

### Out of scope / noted
- One **pre-existing** `shellcheck` SC2015 (info) on `immune-check.sh`'s `sym=$(...)` glyph line is from #321, untouched here (surgical-changes discipline).
- The fixture test follows the immune-kit's local-test convention (like `immune-check.test.sh`); it is also exercised informationally in the CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)