### PR TITLE
feat(shared/immune): G1 / G-DOOR — gh-signoff / local-green merge gate (keystone)

### DIFF
--- a/decisions/EXCEPTIONS.md
+++ b/decisions/EXCEPTIONS.md
@@ -1,0 +1,23 @@
+# Decision Exceptions Ledger
+
+> The single canonical record of sanctioned, one-time bypasses of an otherwise-binding gate.
+> Referenced by `.github/workflows/path-domain-check.yml` (ADR-007 §D-3). Every entry is a
+> deliberate, logged exception — NOT a precedent. Reuse of any bypass requires a NEW entry (and,
+> for ADR-bound rules, an ADR amendment). An empty cell in "Consumed" means the exception is
+> still available for its single use; once used, mark it consumed with the PR/commit that used it.
+
+| # | Date | Rule bypassed | Scope (single-use) | Why | Mirrors | Consumed |
+|---|------|---------------|--------------------|-----|---------|----------|
+| EXC-001 | 2026-06-26 | `main` branch protection — required status checks + required approving reviews (admin override, `enforce_admins: false`) | The **G1 / G-DOOR gate-fix PR** that introduces the `loa-signoff` + cheval-council door (`tools/loa-signoff.sh`, `tools/council-signoff.sh`, `grimoires/loa/context/g1-ghsignoff-door.md`). This PR is itself trapped behind the gate it opens (the new `loa-signoff` required check is not active until the protection flip in Step 1 of the design doc). It may be admin-merged **exactly once** to bootstrap the new gate. | ADR-007 §D-3 `adr-007-bootstrap` single-use bootstrap-bypass pattern | _(pending — record the merge SHA/PR here when used)_ |
+
+## How to consume EXC-001 (the one sanctioned bootstrap admin-merge)
+
+```bash
+# SINGLE-USE. After this merge, the door is bootstrapped; flip branch protection (design-doc
+# Step 1/2) so future PRs are gated by loa-signoff + the council review — NOT by admin override.
+gh pr merge <THE_G1_DOOR_PR> --squash --admin --repo 0xHoneyJar/loa-freeside
+```
+
+Then return to `grimoires/loa/context/g1-ghsignoff-door.md` § "THE OPERATOR'S ONE STEP" and run
+Steps 1–3 (require `loa-signoff`, set the approval bar, enable auto-merge). Any subsequent
+admin-merge of a different PR is a NEW exception and needs its own row above.

--- a/grimoires/loa/context/g1-ghsignoff-door.md
+++ b/grimoires/loa/context/g1-ghsignoff-door.md
@@ -1,0 +1,216 @@
+---
+status: candidate
+mode: arch
+date: 2026-06-26
+kind: design-doc
+goal: grimoires/loa/context/goals/goal-1-unfreeze-the-door.md
+beads_bead: arrakis-estate-immune-epic-4xw6.2
+domain: shared
+use_label: usable
+note: The gh-signoff/local-green door. App-zone build (tools/ + grimoires/ + decisions/). The branch-protection flip is the operator's ONE step — documented here, NOT executed by the agent.
+---
+
+# G1 / G-DOOR — the gh-signoff / local-green merge gate
+
+> The keystone. `main`'s merge gate is a **broken cut vertex** (EULER, betweenness ≈ 1.0):
+> every authored→merged path runs through it, and it currently *severs* the value graph —
+> 30 rotting PRs, trapped gate-fix PRs, no council-merge authority are all downstream of
+> this one frozen door. Un-freeze it and 4 of 5 apparent estate problems dissolve for free.
+
+## Why it is frozen (grounded 2026-06-26, live `gh api`)
+
+```
+main branch protection (live):
+  strict: true
+  required_status_checks.contexts: ["Build", "Unit Tests", "Lint", "Security Scan", "Docker Build"]
+  required_approving_review_count: 2
+  enforce_admins: false
+```
+
+Three fused failures:
+
+1. **`Unit Tests` is a REQUIRED check that is RED at the tip of `main` itself** — for
+   ENVIRONMENT not CODE reasons. A required check red on (almost) every PR is a numb gate:
+   it freezes the whole backlog behind one signal ([[ci-sensors-must-not-be-numb]]).
+2. **The required-context names are stale / name-collided** — `Build` / `Lint` /
+   `Security Scan` / `Docker Build` do not all map to running job names, so even a green
+   suite need not deterministically satisfy the gate.
+3. **2 approvals + `enforce_admins: false`** — the local cheval council posts ZERO GitHub
+   reviews, so 2-of-2 is unmeetable solo, and admin-bypass became *cheaper than the verified
+   path* (the consumption-gradient slip at the highest-leverage node).
+
+## The decision (operator-made, not re-litigated)
+
+**gh-signoff / local-green** — the DHH / `basecamp/gh-signoff` / Depot synthesis. Make
+LOCAL-green the truth: run the repo's real suite on a dev box; the council runs LOCAL
+(cheval **cannot** run in GitHub Actions — no OAuth subscription sessions on ephemeral
+runners, `ANTHROPIC_API_KEY` is stripped). Two new signals become the gate; the perpetually-red
+cloud checks are demoted to informational (they keep running, just not *required*).
+
+`basecamp/gh-signoff` is a tiny `gh` extension: `gh signoff` posts a `signoff` **commit
+status** to a PR, and branch protection requires that status instead of flaky cloud CI. We
+implement that exact pattern, specialized to this repo's suite + a refuse-on-red floor + a
+cross-model council review.
+
+## The door as doctor → aligner → teeth (the immune triad)
+
+| Role | Instrument | What it does |
+|------|-----------|--------------|
+| **Doctor** (senses, fails LOUD) | `tools/gate-freeze-sensor.mjs` (the `gate-freeze` sensor; canonical source `~/bonfire/gate-freeze.mjs`) | Computes each required check's freeze-ratio across the open-PR backlog; names the single check doing the freezing. Exit code IS the verdict: `0` = no frozen check, `2` = FROZEN. Run it to *confirm the door stays open*. |
+| **Aligner** (makes local-green the truth) | `tools/loa-signoff.sh` + `tools/council-signoff.sh` | Bridge local-green and the local council into the two GitHub signals branch protection requires. |
+| **Teeth** (cannot silently re-freeze) | `loa-signoff` + cheval-council fail-closed + the re-freeze sensor on a schedule | A green attestation requires a green suite (no other path writes it). The council never approves a degraded panel. A re-freeze is auto-detected and beaded — the gate cannot silently rot again. |
+
+## The two tools (the build — App-zone, this PR)
+
+### `tools/loa-signoff.sh` — the local-green attestation
+
+Runs the repo's real suite locally; **on GREEN** posts a `loa-signoff` commit status
+(`state=success`, `context=loa-signoff`) to the PR's head SHA via `gh api`. **On RED** it
+refuses, posts nothing, exits non-zero — *we never sign off a red suite; that is the whole
+point.* Read-only w.r.t. the repo; the only mutation is the status POST.
+
+```bash
+tools/loa-signoff.sh <pr-number>        # resolve head SHA from the PR, run suite, sign off
+tools/loa-signoff.sh --sha <SHA>        # sign off a specific commit
+tools/loa-signoff.sh <pr> --dry-run     # run suite, print the intended POST, mutate nothing
+```
+
+Suite command is configurable (defaults to the canonical Unit Tests invocation):
+
+```bash
+LOA_SIGNOFF_SUITE_CMD="npm test"      # default
+LOA_SIGNOFF_SUITE_DIR="themes/sietch" # default — the canonical Unit Tests cwd (ci.yml unit-tests job)
+```
+
+> The posted status description names the exact command that was run, so the attestation is
+> self-describing about its scope. To fully mirror the cloud `Unit Tests` job (which runs
+> `bash scripts/check-redis-imports.sh` before `npm test`), set
+> `LOA_SIGNOFF_SUITE_CMD='bash scripts/check-redis-imports.sh && (cd themes/sietch && npm test)'`
+> with `LOA_SIGNOFF_SUITE_DIR=.`.
+
+### `tools/council-signoff.sh` — the cross-model council as a GitHub approval
+
+Runs the LOCAL cheval cross-model FAGAN council (codex + cursor + claude, subscription CLIs —
+no API key) on a PR's diff via construct-fagan's `council-review-pr.sh` → `cheval-council.sh`.
+On a clean verdict it posts an **APPROVING** GitHub review (= 1 of the required approvals).
+
+```bash
+tools/council-signoff.sh <pr-number>          # run council; APPROVED → approving review
+tools/council-signoff.sh <pr> --dry-run       # run council, print intent, post nothing
+tools/council-signoff.sh <pr> --comment-only  # post a COMMENT review (see self-review caveat)
+tools/council-signoff.sh <pr> --preflight     # probe voice liveness before dispatch
+```
+
+**Fail-closed (the council's load-bearing guarantee, preserved):**
+
+| Council outcome | Action |
+|---|---|
+| exit 0 · `APPROVED` · `multi_perspective_met` · ≥2 voices survived | `gh pr review --approve` |
+| exit 1 · `CHANGES_REQUIRED` | `gh pr review --request-changes` |
+| exit 3 · all voices dropped | **NEVER approve** — post nothing, exit 3 |
+| exit 2 · council infra error | **NEVER approve** — post nothing, exit 2 |
+| `APPROVED` but <2 voices survived (single-perspective) | **NEVER approve** — a halved panel is not a council, exit 3 |
+
+≥2 *distinct families that actually survived* is the bar — convergence alone is not proof
+([[council-convergence-not-proof]]).
+
+> **Self-review caveat (operator step):** GitHub forbids approving / requesting-changes on
+> your OWN PR. When the council runs under the PR author's identity, use `--comment-only` (a
+> COMMENT review is always permitted) and make the commented council **count as** an approval,
+> OR run the council under a distinct bot/reviewer identity. This is one of the operator-only
+> steps the harness must not auto-resolve.
+
+## THE OPERATOR'S ONE STEP — flip the gate (branch-protection mutation)
+
+The agent does NOT mutate branch protection (no creative latitude for release/gate automation —
+it is documented here only). Run these after this PR is reviewed. All are surgical sub-endpoint
+PATCHes — they touch ONLY the named setting, not the whole protection object.
+
+**Step 0 — bootstrap admin-merge of THIS door PR (the single sanctioned exception).**
+This door PR is itself a gate-fix trapped behind the gate it opens (the new `loa-signoff`
+gate is not active until Step 1). Merge it ONCE with the admin override, mirroring the
+`adr-007-bootstrap` single-exception pattern. A `decisions/EXCEPTIONS.md` entry records it.
+
+```bash
+# SINGLE-USE. Records an EXCEPTIONS.md entry. Do not reuse this bypass for other PRs.
+gh pr merge <THIS_PR> --squash --admin --repo 0xHoneyJar/loa-freeside
+```
+
+**Step 1 — require `loa-signoff`, demote the flaky cloud checks to informational.**
+`strict: true` is kept (operator preference — PRs rebase before merge). `Build` / `Unit Tests`
+/ `Lint` / `Security Scan` / `Docker Build` keep running; they are simply no longer *required*.
+
+```bash
+gh api -X PATCH repos/0xHoneyJar/loa-freeside/branches/main/protection/required_status_checks \
+  --input - <<'JSON'
+{
+  "strict": true,
+  "contexts": ["loa-signoff"]
+}
+JSON
+```
+
+**Step 2 — set the approval bar to what the council can satisfy.**
+Pick ONE:
+
+```bash
+# Option A (recommended): 1 approval — satisfiable by the council ALONE (council = 1).
+gh api -X PATCH repos/0xHoneyJar/loa-freeside/branches/main/protection/required_pull_request_reviews \
+  -F required_approving_review_count=1
+
+# Option B (belt-and-suspenders): keep 2 — council = 1, operator = 1.
+gh api -X PATCH repos/0xHoneyJar/loa-freeside/branches/main/protection/required_pull_request_reviews \
+  -F required_approving_review_count=2
+```
+
+**Step 3 (optional) — enable GitHub-native auto-merge** so a PR merges itself once
+`loa-signoff` is green and the approval bar is met:
+
+```bash
+gh pr merge <pr> --auto --squash --repo 0xHoneyJar/loa-freeside
+```
+
+**Verify the new gate (read-only):**
+
+```bash
+gh api repos/0xHoneyJar/loa-freeside/branches/main/protection \
+  --jq '{contexts: .required_status_checks.contexts, approvals: .required_pull_request_reviews.required_approving_review_count, strict: .required_status_checks.strict}'
+# expect: {"contexts":["loa-signoff"], "approvals":1, "strict":true}
+```
+
+## The daily flow once the door is open
+
+```bash
+tools/loa-signoff.sh <pr>      # green suite → loa-signoff=success on the head SHA
+tools/council-signoff.sh <pr>  # clean cross-model council → approving review
+# → GitHub auto-merge fires (Step 3) once loa-signoff is green + approval bar met
+```
+
+Then the 4 trapped gate-fix PRs (#307 / #308 / #310 / #315) flow through the opened door.
+
+## The re-freeze sensor (teeth — the gate cannot silently rot again)
+
+Wire the `gate-freeze` sensor as the standing re-freeze guard. Its exit code is the verdict
+(`0` open, `2` FROZEN), so it gates:
+
+```bash
+# canonical source: ~/bonfire/gate-freeze.mjs — lands in-repo as tools/gate-freeze-sensor.mjs
+node tools/gate-freeze-sensor.mjs 0xHoneyJar/loa-freeside --probe   # one-line STATUS tile
+node tools/gate-freeze-sensor.mjs 0xHoneyJar/loa-freeside           # full board
+# exit 2 = a required check is freezing the backlog again → auto-file a bead + alert
+```
+
+Run it on a schedule (or post-merge). A non-zero exit means a required check has re-frozen the
+backlog — the immune response is to auto-bead it and surface LOUD, never let it rot quietly.
+This closes the loop: the door is not just opened, it is *kept* open under a sensor that fails
+loud on regression.
+
+## Boundaries / honest state
+
+- **App-zone only.** This PR ships `tools/` + `grimoires/` + `decisions/EXCEPTIONS.md`. It does
+  NOT edit `.claude/` (System zone) and does NOT mutate branch protection (operator's step).
+- The fixture tests (`tools/*.test.sh`, 19 cases) prove the floors with no live `gh`/cheval. A
+  live `loa-signoff --dry-run` was smoke-tested read-only against real `gh`.
+- The two-red-cause local suite fix (opossum `./lib/circuit` npm-vs-pnpm + `logger.fatal`) and
+  landing `tools/gate-freeze-sensor.mjs` in-repo are tracked separately — this door is the
+  structural gate redesign, not the env bug-fixes.

--- a/tools/council-signoff.sh
+++ b/tools/council-signoff.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# =============================================================================
+# tools/council-signoff.sh — the cross-model COUNCIL as a GitHub approving review
+# =============================================================================
+# WHY THIS EXISTS (G1 / G-DOOR — un-freeze the front door)
+#   `main` requires 2 approving reviews, but the LOCAL cheval council (the
+#   cross-model FAGAN gate — codex + cursor + claude, subscription CLIs) posts
+#   ZERO GitHub reviews. So 2-of-2 was unmeetable solo and the gate-fix PRs
+#   stayed trapped. cheval CANNOT run in GitHub Actions (no OAuth subscription
+#   sessions on ephemeral runners; ANTHROPIC_API_KEY is stripped) — so the
+#   council runs LOCAL and this script is the bridge: it runs the council on a
+#   PR's diff and, when the verdict is APPROVED by ≥2 surviving distinct model
+#   families, posts an APPROVING GitHub review. That review = 1 of the required
+#   approvals (council = 1, operator = 1).
+#
+# FAIL-CLOSED (the council's load-bearing guarantee, preserved here):
+#   - exit 3 (all voices dropped)        → NEVER approve. A degraded council that
+#                                          could reach zero models must not pass.
+#   - exit 2 (council infra failure)     → NEVER approve.
+#   - APPROVED but <2 voices survived    → NEVER approve. `multi_perspective_met`
+#     (single-perspective)                 must hold; a halved panel is not a council.
+#   - CHANGES_REQUIRED                    → request-changes (or --comment-only).
+#   Approving requires: exit 0 AND verdict APPROVED AND multi_perspective_met
+#   AND voices_survived ≥ 2. ([[council-convergence-not-proof]]: ≥2 distinct
+#   families that actually survived — not convergence alone.)
+#
+#   The ONLY mutation is the `gh pr review` POST. --dry-run mutates nothing.
+#
+# Usage:
+#   tools/council-signoff.sh <pr-number> [--repo owner/name] [--preflight]
+#   tools/council-signoff.sh <pr> --dry-run        # run council, print intent, post nothing
+#   tools/council-signoff.sh <pr> --comment-only   # post a COMMENT review (use when GitHub
+#                                                  # blocks approving your own PR — the operator
+#                                                  # then counts the commented council as approved)
+#
+# Configurable (env):
+#   LOA_COUNCIL_BIN     council command: <pr> [--repo R] → result JSON on stdout, council exit code
+#                       (default: construct-fagan's council-review-pr.sh; resolved via
+#                        CONSTRUCT_FAGAN_DIR or ~/Documents/GitHub/construct-fagan)
+#   CONSTRUCT_FAGAN_DIR construct-fagan checkout root (to locate the default council bin)
+#   LOA_GH_BIN          gh binary (test seam)   (default: "gh")
+#
+# Exit: 0 APPROVED + review posted (or dry-run) · 1 CHANGES_REQUIRED · 2 infra/usage
+#       · 3 council fail-closed (all voices dropped / single-perspective) — never approved
+# =============================================================================
+set -uo pipefail
+
+err()  { printf '[council-signoff] %s\n' "$*" >&2; }
+note() { printf '[council-signoff] %s\n' "$*" >&2; }
+
+GH_BIN="${LOA_GH_BIN:-gh}"
+gh_cli() { command "$GH_BIN" "$@"; }
+
+PR=""; REPO=""; DRY_RUN=0; COMMENT_ONLY=0; PREFLIGHT=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)         REPO="${2:-}"; shift 2 ;;
+    --dry-run)      DRY_RUN=1; shift ;;
+    --comment-only) COMMENT_ONLY=1; shift ;;
+    --preflight)    PREFLIGHT=1; shift ;;
+    -h|--help)
+      sed -n '2,45p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    -*)             err "unknown flag: $1"; exit 2 ;;
+    *)              if [[ -z "$PR" ]]; then PR="$1"; else err "unexpected argument: $1"; exit 2; fi; shift ;;
+  esac
+done
+[[ -n "$PR" ]] || { err "usage: council-signoff.sh <pr-number> [--repo owner/name] [--dry-run] [--comment-only] [--preflight]"; exit 2; }
+
+# --- Resolve repo (owner/name) -----------------------------------------------
+if [[ -z "$REPO" ]]; then
+  REPO="$(gh_cli repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)"
+fi
+[[ -n "$REPO" ]] || { err "could not resolve repo — pass --repo owner/name"; exit 2; }
+
+# --- Resolve the council command ---------------------------------------------
+COUNCIL_BIN="${LOA_COUNCIL_BIN:-}"
+if [[ -z "$COUNCIL_BIN" ]]; then
+  for cand in \
+    "${CONSTRUCT_FAGAN_DIR:-}/scripts/council-review-pr.sh" \
+    "$HOME/Documents/GitHub/construct-fagan/scripts/council-review-pr.sh"; do
+    [[ -n "$cand" && -f "$cand" ]] && { COUNCIL_BIN="$cand"; break; }
+  done
+fi
+[[ -n "$COUNCIL_BIN" && -f "$COUNCIL_BIN" ]] || {
+  err "council command not found — set LOA_COUNCIL_BIN=<path/to/council-review-pr.sh> (or CONSTRUCT_FAGAN_DIR)"; exit 2; }
+
+# --- Run the council on the PR diff ------------------------------------------
+note "running cross-model council on PR #$PR ($REPO) via $(basename "$COUNCIL_BIN")…"
+council_args=("$PR" --repo "$REPO")
+[[ "$PREFLIGHT" -eq 1 ]] && council_args+=(--preflight)
+
+council_ec=0
+json="$(command "$COUNCIL_BIN" "${council_args[@]}")" || council_ec=$?
+
+# --- Honor the council's fail-closed verdicts BEFORE any review --------------
+if [[ "$council_ec" -eq 3 ]]; then
+  err "✗ COUNCIL FAIL-CLOSED (exit 3 — all voices dropped). NEVER approving a degraded council. Posting nothing."
+  exit 3
+fi
+if [[ "$council_ec" -eq 2 ]]; then
+  err "✗ COUNCIL INFRA ERROR (exit 2 — could not run: cheval.py missing / bad input / empty diff). Posting nothing."
+  exit 2
+fi
+
+# --- Parse the verdict envelope ----------------------------------------------
+if ! jq empty <<<"$json" >/dev/null 2>&1; then
+  err "✗ council produced no parseable JSON (exit $council_ec). Posting nothing."
+  exit 2
+fi
+verdict="$(jq -r '.verdict // "CHANGES_REQUIRED"' <<<"$json" 2>/dev/null || echo CHANGES_REQUIRED)"
+mpm="$(jq -r '.panel.multi_perspective_met // false' <<<"$json" 2>/dev/null || echo false)"
+survived="$(jq -r '.panel.voices_survived // 0' <<<"$json" 2>/dev/null | tr -dc '0-9')"; survived="${survived:-0}"
+summary="$(jq -r '.summary // "(no summary)"' <<<"$json" 2>/dev/null || echo "(no summary)")"
+voices_md="$(jq -r '(.panel.voices // [])[] | "- **\(.voice)** (\(.model_ran // "unknown")): \(.verdict) — \(.finding_count // 0) finding(s)"' <<<"$json" 2>/dev/null || true)"
+[[ -n "$voices_md" ]] || voices_md="- (no surviving voice detail in envelope)"
+
+note "council verdict=$verdict · voices_survived=$survived · multi_perspective_met=$mpm"
+
+# --- Decide the GitHub review event ------------------------------------------
+# Approving requires a CLEAN council with a real cross-family panel.
+review_event=""; verdict_line=""
+if [[ "$verdict" == "APPROVED" && "$council_ec" -eq 0 ]]; then
+  if [[ "$mpm" == "true" && "$survived" -ge 2 ]]; then
+    review_event="approve"
+    verdict_line="**Verdict: APPROVED** — $survived distinct model families survived and converged clean."
+  else
+    err "✗ COUNCIL FAIL-CLOSED — verdict APPROVED but only $survived voice(s) survived (multi_perspective_met=$mpm)."
+    err "  A single-perspective panel is NOT a council. NEVER approving on a halved panel. Posting nothing."
+    exit 3
+  fi
+else
+  review_event="request-changes"
+  verdict_line="**Verdict: CHANGES_REQUIRED** — at least one voice raised a blocking finding."
+fi
+
+# --comment-only downgrades the event to a non-blocking COMMENT review (always
+# permitted, even on your own PR — GitHub blocks self-approve / self-request-changes).
+gh_event="$review_event"
+if [[ "$COMMENT_ONLY" -eq 1 ]]; then gh_event="comment"; fi
+
+# --- Build the review body ----------------------------------------------------
+BODY="$(mktemp)"; trap 'rm -f "$BODY"' EXIT
+# shellcheck disable=SC2016  # backticks below are literal Markdown code spans, not command subs
+{
+  printf '## 🤖 cheval cross-model FAGAN council — automated review\n\n'
+  printf '%s\n\n' "$verdict_line"
+  printf '%s\n\n' "$summary"
+  printf '### Per-voice verdicts\n%s\n\n' "$voices_md"
+  printf '> Routed through the LOCAL cheval council (subscription CLIs — no API key; cheval cannot\n'
+  printf '> run in GitHub Actions). Per-voice model attribution + verdict-quality envelopes are\n'
+  printf '> recorded in `.run/model-invoke.jsonl` (MODELINV audit). This review is the cross-model\n'
+  printf '> gate satisfying one required approval (council = 1).\n'
+} >"$BODY"
+
+# --- Map the event to gh flags -----------------------------------------------
+case "$gh_event" in
+  approve)         gh_flag=(--approve) ;;
+  request-changes) gh_flag=(--request-changes) ;;
+  comment)         gh_flag=(--comment) ;;
+esac
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  note "DRY-RUN — would post a '$gh_event' review on PR #$PR (mutating nothing). Body:"
+  sed 's/^/    /' "$BODY" >&2
+  [[ "$review_event" == "approve" ]] && exit 0 || exit 1
+fi
+
+if gh_cli pr review "$PR" --repo "$REPO" "${gh_flag[@]}" --body-file "$BODY" >/dev/null; then
+  note "✓ posted '$gh_event' review on PR #$PR"
+else
+  err "✗ 'gh pr review --$gh_event' failed (gh error above). NOTE: GitHub forbids approving / requesting-changes on"
+  err "  your OWN PR — re-run with --comment-only to post the council verdict as a COMMENT instead."
+  exit 2
+fi
+
+[[ "$review_event" == "approve" ]] && exit 0 || exit 1

--- a/tools/council-signoff.test.sh
+++ b/tools/council-signoff.test.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# =============================================================================
+# tools/council-signoff.test.sh — fixture-driven tests for council-signoff.sh
+# =============================================================================
+# No live cheval, no live gh. Seams:
+#   LOA_COUNCIL_BIN → a fake council emitting a canned verdict JSON + chosen exit
+#   LOA_GH_BIN      → a fake gh that LOGS the `pr review` call (and succeeds)
+# Proves: APPROVED+≥2 → approving review · CHANGES_REQUIRED → request-changes ·
+#   all-dropped (exit 3) → fail-closed, NO review · APPROVED-but-1-voice →
+#   fail-closed, NO review · --dry-run → no review · --comment-only → comment.
+# Exit: 0 all pass · 1 a test failed.
+# =============================================================================
+# shellcheck disable=SC2015  # `cond && ok || bad` is the assertion idiom here; ok/bad always return 0
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+SUT="$HERE/council-signoff.sh"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+FAKE_GH_LOG="$WORK/gh.log"
+
+# --- fake gh: logs argv, answers read calls, succeeds on `pr review` ----------
+FAKE_GH="$WORK/fake-gh.sh"
+cat >"$FAKE_GH" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$FAKE_GH_LOG"
+case "$1 $2" in
+  "repo view") echo "owner/fake-repo" ;;
+  *)           : ;;
+esac
+exit 0
+EOF
+chmod +x "$FAKE_GH"
+
+# --- fake council: emits $FAKE_COUNCIL_JSON, exits $FAKE_COUNCIL_EC -----------
+FAKE_COUNCIL="$WORK/fake-council.sh"
+cat >"$FAKE_COUNCIL" <<'EOF'
+#!/usr/bin/env bash
+cat "$FAKE_COUNCIL_JSON"
+exit "${FAKE_COUNCIL_EC:-0}"
+EOF
+chmod +x "$FAKE_COUNCIL"
+
+# --- canned verdict envelopes (mirror cheval-council.sh's contract) ----------
+J_APPROVED="$WORK/approved.json"
+cat >"$J_APPROVED" <<'EOF'
+{"verdict":"APPROVED","summary":"cheval-routed · 2/3 voices survived · multi_perspective=true · verdict APPROVED","panel":{"routed_via":"cheval","voices":[{"voice":"jam-reviewer-claude-headless","model_ran":"claude-headless","verdict":"APPROVED","finding_count":0,"findings":[]},{"voice":"jam-reviewer-gpt","model_ran":"codex","verdict":"APPROVED","finding_count":0,"findings":[]}],"dropped":[{"voice":"jam-reviewer-cursor","reason":"exit:2/empty"}],"voices_survived":2,"voices_planned":3,"multi_perspective_met":true}}
+EOF
+
+J_CHANGES="$WORK/changes.json"
+cat >"$J_CHANGES" <<'EOF'
+{"verdict":"CHANGES_REQUIRED","summary":"cheval-routed · 2/3 survived · verdict CHANGES_REQUIRED","panel":{"voices":[{"voice":"jam-reviewer-gpt","model_ran":"codex","verdict":"CHANGES_REQUIRED","finding_count":1,"findings":[{"severity":"major","title":"null deref"}]},{"voice":"jam-reviewer-claude-headless","model_ran":"claude-headless","verdict":"APPROVED","finding_count":0}],"voices_survived":2,"voices_planned":3,"multi_perspective_met":true}}
+EOF
+
+J_DROPPED="$WORK/dropped.json"
+cat >"$J_DROPPED" <<'EOF'
+{"verdict":"CHANGES_REQUIRED","error":"all_voices_dropped","panel":{"voices":[],"dropped":[{"voice":"a","reason":"exit:2/empty"}]}}
+EOF
+
+J_SINGLE="$WORK/single.json"
+cat >"$J_SINGLE" <<'EOF'
+{"verdict":"APPROVED","summary":"single-voice panel","panel":{"voices":[{"voice":"jam-reviewer-gpt","model_ran":"codex","verdict":"APPROVED","finding_count":0}],"voices_survived":1,"voices_planned":3,"multi_perspective_met":false}}
+EOF
+
+PASS=0; FAIL=0
+ok()  { printf '  ok   — %s\n' "$1"; PASS=$((PASS+1)); }
+bad() { printf '  FAIL — %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+run_sut() {  # $1=json file, $2=council exit code, rest=SUT args
+  local jf="$1" cec="$2"; shift 2
+  FAKE_GH_LOG="$FAKE_GH_LOG" \
+  LOA_GH_BIN="$FAKE_GH" \
+  LOA_COUNCIL_BIN="$FAKE_COUNCIL" \
+  FAKE_COUNCIL_JSON="$jf" \
+  FAKE_COUNCIL_EC="$cec" \
+  bash "$SUT" 42 --repo "0xHoneyJar/loa-freeside" "$@"
+}
+
+echo "== council-signoff.test =="
+
+# 1. APPROVED + 2 voices survived → approving review, exit 0 -------------------
+: >"$FAKE_GH_LOG"
+ec=0; run_sut "$J_APPROVED" 0 >/dev/null 2>&1 || ec=$?
+[[ "$ec" -eq 0 ]] && ok "APPROVED exits 0" || bad "APPROVED expected exit 0, got $ec"
+if grep -q "pr review 42" "$FAKE_GH_LOG" && grep -q -- "--approve" "$FAKE_GH_LOG"; then ok "APPROVED posted an approving review"; else bad "APPROVED did not post --approve (log: $(tr '\n' '|' <"$FAKE_GH_LOG"))"; fi
+
+# 2. CHANGES_REQUIRED → request-changes, exit 1 -------------------------------
+: >"$FAKE_GH_LOG"
+ec=0; run_sut "$J_CHANGES" 1 >/dev/null 2>&1 || ec=$?
+[[ "$ec" -eq 1 ]] && ok "CHANGES_REQUIRED exits 1" || bad "CHANGES expected exit 1, got $ec"
+if grep -q -- "--request-changes" "$FAKE_GH_LOG" && ! grep -q -- "--approve" "$FAKE_GH_LOG"; then ok "CHANGES posted --request-changes, not --approve"; else bad "CHANGES posted wrong review event"; fi
+
+# 3. all voices dropped (council exit 3) → FAIL-CLOSED, no review, exit 3 ------
+: >"$FAKE_GH_LOG"
+ec=0; run_sut "$J_DROPPED" 3 >/dev/null 2>&1 || ec=$?
+[[ "$ec" -eq 3 ]] && ok "all-dropped exits 3 (fail-closed)" || bad "all-dropped expected exit 3, got $ec"
+if grep -q "pr review" "$FAKE_GH_LOG"; then bad "all-dropped MUST NOT post a review"; else ok "all-dropped posted no review"; fi
+
+# 4. APPROVED but only 1 voice survived → FAIL-CLOSED, no review, exit 3 -------
+: >"$FAKE_GH_LOG"
+ec=0; run_sut "$J_SINGLE" 0 >/dev/null 2>&1 || ec=$?
+[[ "$ec" -eq 3 ]] && ok "single-voice APPROVED fails closed (exit 3)" || bad "single-voice expected exit 3, got $ec"
+if grep -q "pr review" "$FAKE_GH_LOG"; then bad "single-voice MUST NOT approve a halved panel"; else ok "single-voice posted no review"; fi
+
+# 5. --dry-run on APPROVED → no review POST, exit 0 ---------------------------
+: >"$FAKE_GH_LOG"
+ec=0; run_sut "$J_APPROVED" 0 --dry-run >/dev/null 2>&1 || ec=$?
+[[ "$ec" -eq 0 ]] && ok "dry-run APPROVED exits 0" || bad "dry-run APPROVED expected exit 0, got $ec"
+if grep -q "pr review" "$FAKE_GH_LOG"; then bad "dry-run MUST NOT post a review"; else ok "dry-run posted no review"; fi
+
+# 6. --comment-only on APPROVED → posts a COMMENT review (not approve) --------
+: >"$FAKE_GH_LOG"
+ec=0; run_sut "$J_APPROVED" 0 --comment-only >/dev/null 2>&1 || ec=$?
+[[ "$ec" -eq 0 ]] && ok "comment-only APPROVED exits 0" || bad "comment-only expected exit 0, got $ec"
+if grep -q -- "--comment" "$FAKE_GH_LOG" && ! grep -q -- "--approve" "$FAKE_GH_LOG"; then ok "comment-only posted --comment (not --approve)"; else bad "comment-only posted wrong event"; fi
+
+echo "== council-signoff: $PASS passed, $FAIL failed =="
+[[ "$FAIL" -eq 0 ]]

--- a/tools/loa-signoff.sh
+++ b/tools/loa-signoff.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# =============================================================================
+# tools/loa-signoff.sh — the LOCAL-GREEN attestation (the gh-signoff bridge)
+# =============================================================================
+# WHY THIS EXISTS (G1 / G-DOOR — un-freeze the front door)
+#   `main`'s merge gate is a broken cut vertex: a REQUIRED `Unit Tests` status
+#   check that is RED at the tip of `main` itself froze 27/27 open PRs behind a
+#   gate the gate-fix PRs are themselves trapped behind. The fix (decided by the
+#   operator) is the DHH / basecamp/gh-signoff / Depot synthesis: make LOCAL-green
+#   the truth. Run the repo's real suite on a dev box; on green, post a `loa-signoff`
+#   COMMIT STATUS to the PR's head SHA. Branch protection then requires `loa-signoff`
+#   instead of the flaky cloud `Unit Tests` check (which keeps running, demoted to
+#   informational). The sign-off IS the bridge from local-green to the CI gate.
+#
+#   This is the SAME idea as basecamp/gh-signoff (`gh signoff` posts a `signoff`
+#   commit status), specialized to this repo's suite + a refuse-on-red floor.
+#
+# THE FLOOR (the whole point): we NEVER sign off a red suite. On RED this refuses,
+#   posts nothing, and exits non-zero. A green attestation means a green suite —
+#   no other path writes the status. ([[ci-sensors-must-not-be-numb]],
+#   [[gate-output-never-piped]]: the EXIT CODE is the verdict.)
+#
+#   Read-only with respect to the repo. The ONLY mutation is the commit-status
+#   POST (the signoff itself) via `gh api` (your auth — no API key, no app-code).
+#
+# Usage:
+#   tools/loa-signoff.sh <pr-number>            # resolve head SHA from the PR, run suite, sign off
+#   tools/loa-signoff.sh --sha <SHA>            # sign off a specific commit SHA
+#   tools/loa-signoff.sh <pr> --dry-run         # run suite, print the intended POST, mutate nothing
+#   tools/loa-signoff.sh <pr> --repo owner/name # explicit repo (else inferred via gh)
+#
+# Configurable (env):
+#   LOA_SIGNOFF_SUITE_CMD   suite command           (default: "npm test")
+#   LOA_SIGNOFF_SUITE_DIR   dir to run it in         (default: "themes/sietch" — the canonical Unit Tests cwd)
+#   LOA_SIGNOFF_CONTEXT     commit-status context    (default: "loa-signoff")
+#   LOA_SIGNOFF_OPERATOR    handle in the description (default: gh login)
+#   LOA_SIGNOFF_REPO        owner/name               (default: inferred via `gh repo view`)
+#   LOA_GH_BIN              gh binary (test seam)     (default: "gh")
+#
+# Exit: 0 signed off (or dry-run on green) · 1 suite RED (refused, posted nothing)
+#       · 2 usage / infra error
+# =============================================================================
+set -uo pipefail
+
+err()  { printf '[loa-signoff] %s\n' "$*" >&2; }
+note() { printf '[loa-signoff] %s\n' "$*" >&2; }
+
+GH_BIN="${LOA_GH_BIN:-gh}"
+gh_cli() { command "$GH_BIN" "$@"; }
+
+PR=""; SHA=""; REPO="${LOA_SIGNOFF_REPO:-}"; DRY_RUN=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sha)      SHA="${2:-}"; shift 2 ;;
+    --repo)     REPO="${2:-}"; shift 2 ;;
+    --dry-run)  DRY_RUN=1; shift ;;
+    -h|--help)
+      sed -n '2,42p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    -*)         err "unknown flag: $1"; exit 2 ;;
+    *)          if [[ -z "$PR" ]]; then PR="$1"; else err "unexpected argument: $1"; exit 2; fi; shift ;;
+  esac
+done
+
+[[ -n "$PR" || -n "$SHA" ]] || { err "usage: loa-signoff.sh <pr-number> | --sha <SHA> [--dry-run] [--repo owner/name]"; exit 2; }
+
+SUITE_CMD="${LOA_SIGNOFF_SUITE_CMD:-npm test}"
+SUITE_DIR="${LOA_SIGNOFF_SUITE_DIR:-themes/sietch}"
+CONTEXT="${LOA_SIGNOFF_CONTEXT:-loa-signoff}"
+
+# --- Resolve repo (owner/name) -----------------------------------------------
+if [[ -z "$REPO" ]]; then
+  REPO="$(gh_cli repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)"
+fi
+[[ -n "$REPO" ]] || { err "could not resolve repo — pass --repo owner/name or set LOA_SIGNOFF_REPO"; exit 2; }
+
+# --- Resolve the head SHA to sign off ----------------------------------------
+if [[ -z "$SHA" ]]; then
+  SHA="$(gh_cli pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid 2>/dev/null || true)"
+  [[ -n "$SHA" ]] || { err "could not resolve head SHA for PR #$PR in $REPO (auth? wrong PR?)"; exit 2; }
+fi
+SHORT_SHA="${SHA:0:12}"
+
+# --- Resolve the operator handle for the attestation description -------------
+OPERATOR="${LOA_SIGNOFF_OPERATOR:-}"
+if [[ -z "$OPERATOR" ]]; then
+  OPERATOR="$(gh_cli api user -q .login 2>/dev/null || true)"
+  [[ -n "$OPERATOR" ]] || OPERATOR="$(git config user.name 2>/dev/null || echo local)"
+fi
+
+note "repo=$REPO · sha=$SHORT_SHA · suite='( cd $SUITE_DIR && $SUITE_CMD )' · operator=$OPERATOR${DRY_RUN:+ · DRY-RUN}"
+
+# --- Run the suite locally ----------------------------------------------------
+# eval of the configured command string: the trust boundary is the operator's own
+# machine + their own env, which is exactly where a "local-green" attestation runs.
+note "running suite locally — this is the attestation; a RED suite signs off NOTHING…"
+suite_ec=0
+( cd "$SUITE_DIR" && eval "$SUITE_CMD" ) || suite_ec=$?
+
+if [[ "$suite_ec" -ne 0 ]]; then
+  err "✗ SUITE RED (exit $suite_ec) — REFUSING to sign off. No status posted. (That is the whole point.)"
+  err "  fix the suite, then re-run. The gate stays honest: a green attestation requires a green suite."
+  exit 1
+fi
+note "✓ suite GREEN"
+
+# --- Post the loa-signoff commit status (the ONLY mutation) ------------------
+DESC="loa-signoff: '$SUITE_CMD' green @ $SHORT_SHA · by $OPERATOR"
+DESC="${DESC:0:140}"  # GitHub status descriptions cap at 140 chars
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  note "DRY-RUN — would POST commit status (mutating nothing):"
+  printf '  gh api repos/%s/statuses/%s -f state=success -f context=%s -f description=%q\n' \
+    "$REPO" "$SHA" "$CONTEXT" "$DESC" >&2
+  note "✓ dry-run complete (suite was green; no status written)"
+  exit 0
+fi
+
+if gh_cli api "repos/$REPO/statuses/$SHA" \
+     -f state=success \
+     -f context="$CONTEXT" \
+     -f description="$DESC" >/dev/null; then
+  note "✓ SIGNED OFF — '$CONTEXT' = success posted to $REPO @ $SHORT_SHA"
+  exit 0
+else
+  err "✗ suite was green but the status POST failed (gh api error) — see above. Nothing was signed off."
+  exit 2
+fi

--- a/tools/loa-signoff.test.sh
+++ b/tools/loa-signoff.test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# =============================================================================
+# tools/loa-signoff.test.sh — fixture-driven tests for loa-signoff.sh
+# =============================================================================
+# No live `gh`, no live suite. Seams:
+#   LOA_GH_BIN          → a fake gh that LOGS every call and returns canned data
+#   LOA_SIGNOFF_SUITE_CMD/DIR → an injected fake suite (exit 0 = green, non-0 = red)
+# Proves the floor: RED suite → no signoff + non-zero · GREEN → signoff posted ·
+#   --dry-run on GREEN → mutates nothing · bad usage → exit 2.
+# Exit: 0 all pass · 1 a test failed.
+# =============================================================================
+# shellcheck disable=SC2015  # `cond && ok || bad` is the assertion idiom here; ok/bad always return 0
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+SUT="$HERE/loa-signoff.sh"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+FAKE_GH_LOG="$WORK/gh.log"
+
+# --- fake gh: logs argv, answers the read calls, succeeds on the POST ---------
+FAKE_GH="$WORK/fake-gh.sh"
+cat >"$FAKE_GH" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$FAKE_GH_LOG"
+case "$1 $2" in
+  "api user")   echo "test-operator" ;;
+  "repo view")  echo "owner/fake-repo" ;;
+  "pr view")    echo "fakesha0000000000000000000000000000000000" ;;
+  *)            : ;;   # api statuses POST, etc. → succeed silently
+esac
+exit 0
+EOF
+chmod +x "$FAKE_GH"
+
+PASS=0; FAIL=0
+ok()   { printf '  ok   — %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  FAIL — %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+run_sut() {  # run the SUT with the fakes wired; capture exit code
+  FAKE_GH_LOG="$FAKE_GH_LOG" \
+  LOA_GH_BIN="$FAKE_GH" \
+  LOA_SIGNOFF_REPO="0xHoneyJar/loa-freeside" \
+  LOA_SIGNOFF_SUITE_DIR="$WORK" \
+  bash "$SUT" "$@"
+}
+
+SHA="abc123def456abc123def456abc123def456abcd"
+
+echo "== loa-signoff.test =="
+
+# 1. RED suite → refuse, exit 1, post NOTHING ---------------------------------
+: >"$FAKE_GH_LOG"
+ec=0; LOA_SIGNOFF_SUITE_CMD="exit 7" run_sut --sha "$SHA" >/dev/null 2>&1 || ec=$?
+[[ "$ec" -eq 1 ]] && ok "red suite exits 1" || bad "red suite expected exit 1, got $ec"
+if grep -q "statuses/" "$FAKE_GH_LOG"; then bad "red suite MUST NOT post a status"; else ok "red suite posted no status"; fi
+
+# 2. GREEN suite → sign off (status POST), exit 0 -----------------------------
+: >"$FAKE_GH_LOG"
+ec=0; LOA_SIGNOFF_SUITE_CMD="exit 0" run_sut --sha "$SHA" >/dev/null 2>&1 || ec=$?
+[[ "$ec" -eq 0 ]] && ok "green suite exits 0" || bad "green suite expected exit 0, got $ec"
+if grep -q "statuses/$SHA" "$FAKE_GH_LOG" && grep -q "state=success" "$FAKE_GH_LOG" && grep -q "context=loa-signoff" "$FAKE_GH_LOG"; then
+  ok "green suite posted loa-signoff=success to head SHA"
+else
+  bad "green suite did not post the expected status (log: $(tr '\n' '|' <"$FAKE_GH_LOG"))"
+fi
+
+# 3. --dry-run on GREEN → no POST, exit 0 -------------------------------------
+: >"$FAKE_GH_LOG"
+ec=0; LOA_SIGNOFF_SUITE_CMD="exit 0" run_sut --sha "$SHA" --dry-run >/dev/null 2>&1 || ec=$?
+[[ "$ec" -eq 0 ]] && ok "dry-run green exits 0" || bad "dry-run green expected exit 0, got $ec"
+if grep -q "statuses/" "$FAKE_GH_LOG"; then bad "dry-run MUST NOT post a status"; else ok "dry-run posted no status"; fi
+
+# 4. bad usage (no pr / no sha) → exit 2 --------------------------------------
+ec=0; run_sut >/dev/null 2>&1 || ec=$?
+[[ "$ec" -eq 2 ]] && ok "no args exits 2" || bad "no args expected exit 2, got $ec"
+
+echo "== loa-signoff: $PASS passed, $FAIL failed =="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## G1 / G-DOOR — the gh-signoff / local-green merge gate (the keystone)

Builds the **two new required signals** for the gh-signoff/local-green door (operator-decided),
plus the design doc and the single-use bootstrap exception. Bead: `arrakis-estate-immune-epic-4xw6.2`.

`main`'s merge gate is a **broken cut vertex** (EULER, betweenness ≈ 1.0): a REQUIRED `Unit Tests`
check red at the tip of `main` froze the backlog, and the LOCAL cheval council posts **zero** GitHub
reviews so 2-of-2 approvals was unmeetable solo. Un-freeze this one door and 4 of 5 estate problems
dissolve.

### What ships (App-zone only — `tools/` + `grimoires/` + `decisions/`)

| File | Role |
|------|------|
| `tools/loa-signoff.sh` | **Aligner.** Runs the repo's real suite locally; **ON GREEN** posts a `loa-signoff` commit status to the PR head SHA via `gh api`; **ON RED** refuses, posts nothing, exits non-zero. The only mutation is the status POST. |
| `tools/council-signoff.sh` | **Aligner.** Runs the LOCAL cross-model FAGAN council (codex + cursor + claude, subscription CLIs — no API key) on a PR diff; APPROVED + ≥2 distinct families survived → approving GitHub review; CHANGES_REQUIRED → request-changes; **all-dropped (exit 3) / single-perspective → fail-closed, never approves.** |
| `tools/loa-signoff.test.sh` · `tools/council-signoff.test.sh` | 19 fixture-driven tests — no live `gh`/cheval (binary-injection seams). |
| `grimoires/loa/context/g1-ghsignoff-door.md` | doctor→aligner→teeth design + the **exact operator branch-protection commands** + the re-freeze sensor wiring. |
| `decisions/EXCEPTIONS.md` | EXC-001 — the single-use bootstrap admin-merge for this gate-fix PR. |

shellcheck clean · 19/19 tests green · `loa-signoff --dry-run` smoke-tested read-only against live `gh`.

### Why DRAFT
This is the structural gate redesign. It does **not** mutate branch protection — that is the
operator's one step (below). It also leaves the two-red-cause local suite fix (opossum `./lib/circuit`
npm-vs-pnpm + `logger.fatal`) and landing `tools/gate-freeze-sensor.mjs` in-repo as tracked follow-ups.

---

## THE OPERATOR'S ONE STEP — flip the gate (you run these; the agent did not)

Live `main` protection today: `strict=true` · required contexts `[Build, Unit Tests, Lint, Security Scan, Docker Build]` · `required_approving_review_count=2` · `enforce_admins=false`.

**Step 0 — bootstrap admin-merge of THIS PR (the single sanctioned exception, EXC-001).**
This PR is trapped behind the gate it opens; merge it once with the admin override:
```bash
gh pr merge <THIS_PR> --squash --admin --repo 0xHoneyJar/loa-freeside
```

**Step 1 — require `loa-signoff`, demote the flaky cloud checks to informational** (they keep running, just not required; `strict` kept):
```bash
gh api -X PATCH repos/0xHoneyJar/loa-freeside/branches/main/protection/required_status_checks \
  --input - <<'JSON'
{ "strict": true, "contexts": ["loa-signoff"] }
JSON
```

**Step 2 — set the approval bar (pick one):**
```bash
# Option A (recommended): 1 approval — satisfiable by the council alone.
gh api -X PATCH repos/0xHoneyJar/loa-freeside/branches/main/protection/required_pull_request_reviews \
  -F required_approving_review_count=1
# Option B: keep 2 — council = 1, operator = 1.
gh api -X PATCH repos/0xHoneyJar/loa-freeside/branches/main/protection/required_pull_request_reviews \
  -F required_approving_review_count=2
```

**Step 3 (optional) — enable GitHub-native auto-merge:**
```bash
gh pr merge <pr> --auto --squash --repo 0xHoneyJar/loa-freeside
```

**Verify:**
```bash
gh api repos/0xHoneyJar/loa-freeside/branches/main/protection \
  --jq '{contexts: .required_status_checks.contexts, approvals: .required_pull_request_reviews.required_approving_review_count, strict: .required_status_checks.strict}'
# expect: {"contexts":["loa-signoff"], "approvals":1, "strict":true}
```

**Self-review caveat:** GitHub forbids approving your OWN PR. When the council runs under the PR
author's identity, use `tools/council-signoff.sh <pr> --comment-only` and count the commented
council as the approval, OR run it under a distinct reviewer identity. (Documented in the design doc.)

### Daily flow once open
```bash
tools/loa-signoff.sh <pr>      # green suite → loa-signoff=success on head SHA
tools/council-signoff.sh <pr>  # clean council → approving review
# → auto-merge fires once loa-signoff is green + approval bar met
```
Then the 4 trapped gate-fix PRs (#307 / #308 / #310 / #315) flow through the opened door.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
