### PR TITLE
payment webhook lifecycle hardening

### DIFF
--- a/.github/workflows/nowpayments-webhook-policy.yml
+++ b/.github/workflows/nowpayments-webhook-policy.yml
@@ -1,0 +1,33 @@
+name: NOWPayments Webhook Policy
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'package.json'
+      - 'packages/routes/webhooks.routes.ts'
+      - 'scripts/check-nowpayments-webhook-policy.mjs'
+      - 'docs/payment-webhook-lifecycle-runbook.md'
+      - '.github/workflows/nowpayments-webhook-policy.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'package.json'
+      - 'packages/routes/webhooks.routes.ts'
+      - 'scripts/check-nowpayments-webhook-policy.mjs'
+      - 'docs/payment-webhook-lifecycle-runbook.md'
+      - '.github/workflows/nowpayments-webhook-policy.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  nowpayments-policy:
+    name: NOWPayments Policy Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: 22
+      - run: node scripts/check-nowpayments-webhook-policy.mjs

--- a/docs/audit-lanes/2026-06-27-payment-webhook-lifecycle.md
+++ b/docs/audit-lanes/2026-06-27-payment-webhook-lifecycle.md
@@ -1,0 +1,37 @@
+# Audit lane: Payment webhook lifecycle hardening
+
+## Purpose
+
+This draft PR distills Freeside's payment webhook and credit-lifecycle issues into one implementation lane. It is a routing artifact and does not claim the fixes are complete yet.
+
+## Issue coverage
+
+Refs #325, #326, #327, #329, #335, #340, #341, #342, #345, #348, #350, #354, #355, #360, #363.
+
+## Preserved state
+
+Preserve current Freeside platform behavior outside the payment webhook and credit-lifecycle surfaces named by these issues.
+
+## Target
+
+Define and prove a durable payment webhook state machine covering raw body verification, timestamp policy, duplicate handling, status progression, dependency failures, feature flags, retries, and credit minting evidence.
+
+## Expected artifacts
+
+Likely scope includes `packages/routes/webhooks.routes.ts`, payment/billing service tests, webhook fixtures, feature-flag checks, and operator runbook updates.
+
+## Allowed scope
+
+Allowed: focused payment code, tests, fixtures, and docs. Not allowed: unrelated registry, topology, CLI, or product-direction changes.
+
+## Decision
+
+Use one payment lifecycle PR because these issues share one root contract: payment receipt, processing, retry, and credit mutation must be explicit and auditable.
+
+## Rollback
+
+Rollback is the closing PR revert; implementation commits should keep payment behavior changes contained.
+
+## Non-claims
+
+This lane does not claim all Freeside production readiness and does not close issue references until implementation evidence is present.

--- a/docs/payment-webhook-lifecycle-runbook.md
+++ b/docs/payment-webhook-lifecycle-runbook.md
@@ -1,0 +1,54 @@
+# Payment Webhook Lifecycle Runbook
+
+This runbook scopes the NOWPayments webhook changes in PR #365.
+
+## Raw body policy
+
+The webhook signature check must use the exact raw request body bytes supplied by upstream Express middleware.
+
+Accepted raw body shapes:
+
+- `string`
+- `Buffer`
+
+Rejected raw body shapes:
+
+- parsed object bodies;
+- arrays;
+- missing body values;
+- reconstructed JSON.
+
+## Timestamp policy
+
+If `updated_at` is present, it must parse as a finite timestamp and must not be older than 24 hours.
+
+If `updated_at` is absent, the handler accepts the signed payload as a legacy provider shape and logs that the timestamp is absent. This preserves compatibility while making timestamp absence visible.
+
+## Receipt and processing policy
+
+`webhook_events` records receipt. It is not the processing terminal.
+
+A duplicate receipt continues through idempotent status and credit-lot processing so provider retries can recover partial failures.
+
+## Retryable failures
+
+The handler intentionally returns `500` for:
+
+- receipt insert failure;
+- credit-lot mint failure.
+
+These responses are retryable. Operators should treat repeated retryable failures as payment lifecycle incidents and inspect database/Redis availability plus the credit-lot ledger.
+
+## Non-claims
+
+This runbook does not claim full production billing readiness. It does not replace reconciliation jobs, provider-side retry guarantees, feature-flag rollout evidence, or full integration tests.
+
+## Local policy check
+
+Run:
+
+```bash
+node scripts/check-nowpayments-webhook-policy.mjs
+```
+
+The checker verifies that the handler keeps the raw-body, duplicate-receipt, retryable-failure, and timestamp-policy contracts visible in source.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   },
   "scripts": {
     "build:hounfour": "scripts/rebuild-hounfour-dist.sh",
-    "postinstall": "scripts/rebuild-hounfour-dist.sh"
+    "postinstall": "scripts/rebuild-hounfour-dist.sh",
+    "check:nowpayments-webhook-policy": "node scripts/check-nowpayments-webhook-policy.mjs"
   },
   "devDependencies": {
     "@0xhoneyjar/loa-hounfour": "github:0xHoneyJar/loa-hounfour#aed755f7fea8d2739cf9c755b45aaa580b6af6a9",

--- a/packages/routes/webhooks.routes.test.ts
+++ b/packages/routes/webhooks.routes.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Webhook Routes Tests — NOWPayments IPN durable-capture failure path
+ *
+ * Regression for the silent-drop money bug (Eileen #326):
+ * the webhook_events INSERT is the FIRST durable capture of an IPN event.
+ * If that INSERT fails transiently, we must NOT ack with 200 (NOWPayments
+ * would never retry → a `finished` payment strands credits). The handler
+ * must return a retriable 503 so the provider re-delivers the event.
+ *
+ * @see webhooks.routes.ts Step 3 (webhook_events INSERT catch)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createHmac } from 'crypto';
+import express from 'express';
+import request from 'supertest';
+
+// Mock the credit-ledger handler so its DB-bound deps never load — this test
+// only exercises the webhook_events INSERT-failure path (which returns before
+// the handler is ever called).
+vi.mock('../services/nowpayments-handler.js', () => ({
+  processPaymentForLedger: vi.fn(),
+  verifyPaymentExists: vi.fn(),
+}));
+
+import { createWebhookRouter } from './webhooks.routes.js';
+
+const IPN_SECRET = 'test-ipn-secret';
+
+/** Mirror of the route's canonical key-sort used for HMAC computation. */
+function sortKeys(obj: unknown): unknown {
+  if (obj === null || obj === undefined || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) return obj.map(sortKeys);
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(obj as Record<string, unknown>).sort()) {
+    sorted[key] = sortKeys((obj as Record<string, unknown>)[key]);
+  }
+  return sorted;
+}
+
+function signedBody(payload: Record<string, unknown>): { raw: string; sig: string } {
+  const raw = JSON.stringify(sortKeys(payload));
+  const sig = createHmac('sha512', IPN_SECRET).update(raw).digest('hex');
+  return { raw, sig };
+}
+
+describe('POST /webhooks/nowpayments — webhook_events INSERT failure', () => {
+  it('returns retriable 503 (NOT 200) so NOWPayments re-delivers the event', async () => {
+    // pool.query rejects → the webhook_events INSERT (the first durable capture) fails.
+    const pool = { query: vi.fn().mockRejectedValue(new Error('db unavailable')) };
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    const app = express();
+    app.use(express.text({ type: 'application/json' }));
+    app.use(
+      '/webhooks',
+      createWebhookRouter({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pool: pool as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        redis: {} as any,
+        ipnSecret: IPN_SECRET,
+        logger,
+        featureBillingEnabled: true,
+      }),
+    );
+
+    const payload = {
+      payment_id: 987654321,
+      payment_status: 'finished',
+      order_id: 'order-1',
+    };
+    const { raw, sig } = signedBody(payload);
+
+    const res = await request(app)
+      .post('/webhooks/nowpayments')
+      .set('x-nowpayments-sig', sig)
+      .set('content-type', 'application/json')
+      .send(raw);
+
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ status: 'error', reason: 'internal' });
+    // Only the webhook_events INSERT was attempted — we bailed on its failure.
+    expect(pool.query).toHaveBeenCalledTimes(1);
+    // The INSERT must match the LIVE schema — the prior version named a phantom
+    // `event_type` column that does not exist, so real IPNs would have failed on it
+    // (then this PR's 503 would retry-loop forever). The mock can't hit the DB, so we
+    // assert the SQL the handler issues matches the real column set.
+    const insertSql = (pool.query as any).mock.calls[0][0] as string;
+    expect(insertSql).not.toMatch(/event_type/);
+    expect(insertSql).toMatch(/\(provider, event_id, payload, processed_at\)/);
+  });
+
+  it('rejects duplicated signature headers before durable capture', async () => {
+    const pool = { query: vi.fn() };
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    const app = express();
+    app.use(express.text({ type: 'application/json' }));
+    app.use(
+      '/webhooks',
+      createWebhookRouter({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pool: pool as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        redis: {} as any,
+        ipnSecret: IPN_SECRET,
+        logger,
+        featureBillingEnabled: true,
+      }),
+    );
+
+    const payload = {
+      payment_id: 987654321,
+      payment_status: 'finished',
+      order_id: 'order-1',
+    };
+    const { raw, sig } = signedBody(payload);
+
+    const res = await request(app)
+      .post('/webhooks/nowpayments')
+      .set('x-nowpayments-sig', [sig, sig])
+      .set('content-type', 'application/json')
+      .send(raw);
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ status: 'rejected', reason: 'missing_signature' });
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+});

--- a/packages/routes/webhooks.routes.ts
+++ b/packages/routes/webhooks.routes.ts
@@ -6,12 +6,12 @@
  * Security:
  *   - HMAC-SHA512 signature verification via x-nowpayments-sig header
  *   - 401 on invalid/missing signature (NOT 200 — per acceptance criteria)
- *   - 200 for all valid signatures (including duplicates)
+ *   - Requires exact raw body; reconstructed JSON is never signed
  *   - Feature flag: FEATURE_BILLING_ENABLED must be true
  *   - Webhook rate limiting: 100 req/min per IP, 1KB max payload
  *
  * Idempotency:
- *   - INSERT INTO webhook_events ON CONFLICT DO NOTHING (dedup)
+ *   - webhook_events records receipt only; duplicates continue through idempotent processing
  *   - INSERT INTO credit_lots ON CONFLICT (payment_id) DO NOTHING
  *   - Redis INCRBY only if credit_lots INSERT returned id
  *
@@ -66,6 +66,8 @@ const STATUS_ORDINAL: Record<string, number> = {
   expired: 5,
 };
 
+const MAX_WEBHOOK_AGE_MS = 24 * 60 * 60 * 1000;
+
 /** Dependencies injected at server init */
 interface WebhookDeps {
   pool: Pool;
@@ -110,11 +112,18 @@ export function createWebhookRouter(deps: WebhookDeps): Router {
       return;
     }
 
-    // Use raw body for HMAC computation (must be configured via middleware)
-    const rawBody = typeof req.body === 'string'
-      ? req.body
-      : JSON.stringify(sortKeys(req.body));
+    // HMAC must use the exact raw body bytes provided to Express raw/text middleware.
+    // Reconstructing JSON changes byte order/spacing and can verify a different message.
+    if (typeof req.body !== 'string') {
+      logger.error(
+        { bodyType: typeof req.body, hasBody: req.body !== undefined },
+        'NOWPayments webhook raw body missing — refusing reconstructed HMAC',
+      );
+      res.status(400).json({ status: 'rejected', reason: 'missing_raw_body' });
+      return;
+    }
 
+    const rawBody = req.body;
     const computedSig = createHmac('sha512', ipnSecret)
       .update(rawBody)
       .digest('hex');
@@ -122,7 +131,7 @@ export function createWebhookRouter(deps: WebhookDeps): Router {
     // Constant-time comparison
     if (!timingSafeCompare(computedSig, signature)) {
       logger.warn(
-        { paymentId: req.body?.payment_id },
+        { rawBodyLength: rawBody.length },
         'Invalid NOWPayments webhook signature',
       );
       res.status(401).json({ status: 'rejected', reason: 'invalid_signature' });
@@ -132,7 +141,15 @@ export function createWebhookRouter(deps: WebhookDeps): Router {
     // -------------------------------------------------------------------
     // Step 2: Parse and validate payload
     // -------------------------------------------------------------------
-    const payload = req.body as NowpaymentsWebhookPayload;
+    let payload: NowpaymentsWebhookPayload;
+    try {
+      payload = JSON.parse(rawBody) as NowpaymentsWebhookPayload;
+    } catch (err) {
+      logger.warn({ err }, 'Signed NOWPayments webhook body is not valid JSON');
+      res.status(400).json({ status: 'rejected', reason: 'invalid_json' });
+      return;
+    }
+
     const paymentId = String(payload.payment_id);
 
     if (!paymentId || !payload.payment_status) {
@@ -140,37 +157,45 @@ export function createWebhookRouter(deps: WebhookDeps): Router {
       return;
     }
 
-    // Log timestamp age as metric only (NOT used for rejection per AC)
     if (payload.updated_at) {
-      const ageMs = Date.now() - new Date(payload.updated_at).getTime();
+      const updatedAtMs = new Date(payload.updated_at).getTime();
+      if (!Number.isFinite(updatedAtMs)) {
+        res.status(400).json({ status: 'rejected', reason: 'invalid_updated_at' });
+        return;
+      }
+      const ageMs = Date.now() - updatedAtMs;
       logger.info(
         { paymentId, ageMs, status: payload.payment_status },
-        'Webhook timestamp age (metric only)',
+        'Webhook timestamp age',
       );
+      if (ageMs > MAX_WEBHOOK_AGE_MS) {
+        logger.warn({ paymentId, ageMs }, 'Stale NOWPayments webhook rejected');
+        res.status(400).json({ status: 'rejected', reason: 'stale_webhook' });
+        return;
+      }
     }
 
     // -------------------------------------------------------------------
-    // Step 3: Idempotent webhook_events INSERT (dedup)
+    // Step 3: Idempotent webhook_events INSERT (receipt dedup only)
     // -------------------------------------------------------------------
     try {
+      const eventId = `${paymentId}:${payload.payment_status}:${payload.updated_at ?? 'no-updated-at'}`;
       const dedupResult = await pool.query<{ id: string }>(
         `INSERT INTO webhook_events (provider, event_id, event_type, payload, processed_at)
          VALUES ('nowpayments', $1, $2, $3, NOW())
          ON CONFLICT (provider, event_id) DO NOTHING
          RETURNING id`,
-        [paymentId, payload.payment_status, JSON.stringify(payload)],
+        [eventId, payload.payment_status, JSON.stringify(payload)],
       );
 
       if (dedupResult.rows.length === 0) {
-        // Duplicate webhook — already processed
-        logger.info({ paymentId }, 'Duplicate webhook (already in webhook_events)');
-        res.status(200).json({ status: 'duplicate' });
-        return;
+        // Duplicate receipt is not a processing terminal. Downstream status and lot
+        // writes are idempotent, so continue to allow provider retry after partial failure.
+        logger.info({ paymentId, eventId }, 'Duplicate webhook receipt; continuing idempotent processing');
       }
     } catch (err) {
       logger.error({ paymentId, err }, 'Failed to insert webhook_events');
-      // Return 200 so NOWPayments doesn't retry on our DB errors
-      res.status(200).json({ status: 'error', reason: 'internal' });
+      res.status(500).json({ status: 'error', reason: 'receipt_insert_failed' });
       return;
     }
 
@@ -201,7 +226,8 @@ export function createWebhookRouter(deps: WebhookDeps): Router {
 
       // Allow failed/refunded/expired from any non-terminal state
       const isTerminalTransition = ['failed', 'refunded', 'expired'].includes(payload.payment_status);
-      const isTerminalCurrent = ['finished', 'failed', 'refunded', 'expired'].includes(statusResult.rows[0].status);
+      const isTerminalCurrent = ['failed', 'refunded', 'expired'].includes(statusResult.rows[0].status);
+      const isDuplicateFinished = statusResult.rows[0].status === 'finished' && payload.payment_status === 'finished';
 
       if (isTerminalCurrent) {
         logger.info({ paymentId, current: statusResult.rows[0].status, incoming: payload.payment_status },
@@ -210,7 +236,14 @@ export function createWebhookRouter(deps: WebhookDeps): Router {
         return;
       }
 
-      if (!isTerminalTransition && currentOrdinal <= existingOrdinal) {
+      if (statusResult.rows[0].status === 'finished' && !isDuplicateFinished) {
+        logger.info({ paymentId, current: statusResult.rows[0].status, incoming: payload.payment_status },
+          'Payment already finished; non-finished transition skipped');
+        res.status(200).json({ status: 'skipped', reason: 'terminal_state' });
+        return;
+      }
+
+      if (!isDuplicateFinished && !isTerminalTransition && currentOrdinal <= existingOrdinal) {
         logger.info(
           { paymentId, current: statusResult.rows[0].status, incoming: payload.payment_status },
           'Backward status transition rejected (monotonicity)',
@@ -229,7 +262,7 @@ export function createWebhookRouter(deps: WebhookDeps): Router {
       `UPDATE crypto_payments
        SET status = $2,
            actually_paid = COALESCE($3, actually_paid),
-           finished_at = CASE WHEN $4 THEN NOW() ELSE finished_at END,
+           finished_at = CASE WHEN $4 THEN COALESCE(finished_at, NOW()) ELSE finished_at END,
            updated_at = NOW()
        WHERE payment_id = $1`,
       [paymentId, payload.payment_status, payload.actually_paid, isFinished],
@@ -255,9 +288,9 @@ export function createWebhookRouter(deps: WebhookDeps): Router {
           amountMicro: lotResult.amountUsdMicro.toString(),
         }, 'NOWPayments webhook: credit lot processing complete');
       } catch (err) {
-        // Lot minting failure should not fail the webhook response.
-        // Reconciliation sweep will catch missed mints.
-        logger.error({ paymentId, err }, 'Credit lot minting failed — will retry via reconciliation');
+        logger.error({ paymentId, err }, 'Credit lot minting failed — returning retryable error');
+        res.status(500).json({ status: 'error', reason: 'credit_lot_mint_failed' });
+        return;
       }
     }
 
@@ -293,21 +326,6 @@ export function createWebhookRouter(deps: WebhookDeps): Router {
 // --------------------------------------------------------------------------
 // Helpers
 // --------------------------------------------------------------------------
-
-/**
- * Sort object keys recursively for canonical HMAC computation.
- * NOWPayments signs over JSON with sorted keys.
- */
-function sortKeys(obj: unknown): unknown {
-  if (obj === null || obj === undefined || typeof obj !== 'object') return obj;
-  if (Array.isArray(obj)) return obj.map(sortKeys);
-
-  const sorted: Record<string, unknown> = {};
-  for (const key of Object.keys(obj as Record<string, unknown>).sort()) {
-    sorted[key] = sortKeys((obj as Record<string, unknown>)[key]);
-  }
-  return sorted;
-}
 
 /**
  * Constant-time string comparison using timingSafeEqual.

--- a/packages/routes/webhooks.routes.ts
+++ b/packages/routes/webhooks.routes.ts
@@ -114,7 +114,10 @@ export function createWebhookRouter(deps: WebhookDeps): Router {
 
     // HMAC must use the exact raw body bytes provided to Express raw/text middleware.
     // Reconstructing JSON changes byte order/spacing and can verify a different message.
-    if (typeof req.body !== 'string') {
+    let rawBody: string | Buffer;
+    if (typeof req.body === 'string' || Buffer.isBuffer(req.body)) {
+      rawBody = req.body;
+    } else {
       logger.error(
         { bodyType: typeof req.body, hasBody: req.body !== undefined },
         'NOWPayments webhook raw body missing — refusing reconstructed HMAC',
@@ -123,7 +126,6 @@ export function createWebhookRouter(deps: WebhookDeps): Router {
       return;
     }
 
-    const rawBody = req.body;
     const computedSig = createHmac('sha512', ipnSecret)
       .update(rawBody)
       .digest('hex');
@@ -141,9 +143,10 @@ export function createWebhookRouter(deps: WebhookDeps): Router {
     // -------------------------------------------------------------------
     // Step 2: Parse and validate payload
     // -------------------------------------------------------------------
+    const rawJson = Buffer.isBuffer(rawBody) ? rawBody.toString('utf8') : rawBody;
     let payload: NowpaymentsWebhookPayload;
     try {
-      payload = JSON.parse(rawBody) as NowpaymentsWebhookPayload;
+      payload = JSON.parse(rawJson) as NowpaymentsWebhookPayload;
     } catch (err) {
       logger.warn({ err }, 'Signed NOWPayments webhook body is not valid JSON');
       res.status(400).json({ status: 'rejected', reason: 'invalid_json' });

--- a/packages/routes/webhooks.routes.ts
+++ b/packages/routes/webhooks.routes.ts
@@ -101,7 +101,7 @@ export function createWebhookRouter(deps: WebhookDeps): Router {
     // -------------------------------------------------------------------
     // Step 1: HMAC-SHA512 signature verification
     // -------------------------------------------------------------------
-    const signature = req.headers['x-nowpayments-sig'] as string | undefined;
+    const signature = normalizeSingleHeader(req.headers['x-nowpayments-sig']);
 
     if (!signature || !ipnSecret) {
       logger.warn(
@@ -329,6 +329,17 @@ export function createWebhookRouter(deps: WebhookDeps): Router {
 // --------------------------------------------------------------------------
 // Helpers
 // --------------------------------------------------------------------------
+
+/**
+ * Express request headers can be string, string[], or undefined. HMAC input must
+ * be one unambiguous signature string; duplicated signature headers are treated
+ * as missing rather than guessing which value to verify.
+ */
+function normalizeSingleHeader(header: string | string[] | undefined): string | undefined {
+  if (Array.isArray(header)) return undefined;
+  const trimmed = header?.trim();
+  return trimmed ? trimmed : undefined;
+}
 
 /**
  * Constant-time string comparison using timingSafeEqual.

--- a/packages/routes/webhooks.routes.ts
+++ b/packages/routes/webhooks.routes.ts
@@ -184,11 +184,11 @@ export function createWebhookRouter(deps: WebhookDeps): Router {
     try {
       const eventId = `${paymentId}:${payload.payment_status}:${payload.updated_at ?? 'no-updated-at'}`;
       const dedupResult = await pool.query<{ id: string }>(
-        `INSERT INTO webhook_events (provider, event_id, event_type, payload, processed_at)
-         VALUES ('nowpayments', $1, $2, $3, NOW())
+        `INSERT INTO webhook_events (provider, event_id, payload, processed_at)
+         VALUES ('nowpayments', $1, $2, NOW())
          ON CONFLICT (provider, event_id) DO NOTHING
          RETURNING id`,
-        [eventId, payload.payment_status, JSON.stringify(payload)],
+        [eventId, JSON.stringify(payload)],
       );
 
       if (dedupResult.rows.length === 0) {
@@ -198,7 +198,7 @@ export function createWebhookRouter(deps: WebhookDeps): Router {
       }
     } catch (err) {
       logger.error({ paymentId, err }, 'Failed to insert webhook_events');
-      res.status(500).json({ status: 'error', reason: 'receipt_insert_failed' });
+      res.status(503).json({ status: 'error', reason: 'internal' });
       return;
     }
 

--- a/scripts/check-nowpayments-webhook-policy.mjs
+++ b/scripts/check-nowpayments-webhook-policy.mjs
@@ -9,6 +9,10 @@ function require(condition, message) {
   if (!condition) failures.push(message);
 }
 
+function occurrences(pattern) {
+  return source.split(pattern).length - 1;
+}
+
 require(
   source.includes("typeof req.body === 'string'") && source.includes('Buffer.isBuffer(req.body)'),
   'webhook handler must accept exact raw body as string or Buffer',
@@ -25,6 +29,11 @@ require(
 );
 
 require(
+  occurrences("req.headers['x-nowpayments-sig']") === 1,
+  'NOWPayments signature header must only be read once through the normalization helper',
+);
+
+require(
   source.includes('function normalizeSingleHeader(header: string | string[] | undefined)') &&
     source.includes('Array.isArray(header)') &&
     source.includes('return undefined'),
@@ -32,8 +41,22 @@ require(
 );
 
 require(
+  source.includes('const trimmed = header?.trim();') &&
+    source.includes('return trimmed ? trimmed : undefined'),
+  'signature normalization must reject empty or whitespace-only signature headers',
+);
+
+require(
   !source.includes("req.headers['x-nowpayments-sig'] as string"),
   'webhook handler must not cast x-nowpayments-sig directly from Express headers',
+);
+
+require(
+  !source.includes("req.headers['x-nowpayments-sig'].join") &&
+    !source.includes('x-nowpayments-sig'].join') &&
+    !source.includes('Array.isArray(signature)') &&
+    !source.includes('Array.isArray(req.headers'),
+  'webhook handler must not join or select from duplicated signature headers',
 );
 
 require(

--- a/scripts/check-nowpayments-webhook-policy.mjs
+++ b/scripts/check-nowpayments-webhook-policy.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync('packages/routes/webhooks.routes.ts', 'utf8');
+const failures = [];
+
+function require(condition, message) {
+  if (!condition) failures.push(message);
+}
+
+require(
+  source.includes("typeof req.body === 'string'") && source.includes('Buffer.isBuffer(req.body)'),
+  'webhook handler must accept exact raw body as string or Buffer',
+);
+
+require(
+  !source.includes('JSON.stringify(sortKeys(req.body))'),
+  'webhook handler must not reconstruct JSON for signature input',
+);
+
+require(
+  source.includes('receipt_insert_failed') && source.includes('res.status(500)'),
+  'webhook receipt insert failure must be retryable',
+);
+
+require(
+  source.includes('Duplicate receipt') && source.includes('continuing idempotent processing'),
+  'duplicate receipt must continue through idempotent processing',
+);
+
+require(
+  source.includes('credit_lot_mint_failed') && source.includes('return;'),
+  'credit lot mint failure must return a retryable response before success',
+);
+
+require(
+  source.includes('stale_webhook') && source.includes('invalid_updated_at'),
+  'timestamp policy must reject stale and invalid updated_at values',
+);
+
+if (failures.length > 0) {
+  console.error('NOWPayments webhook policy check failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log('NOWPayments webhook policy check passed.');

--- a/scripts/check-nowpayments-webhook-policy.mjs
+++ b/scripts/check-nowpayments-webhook-policy.mjs
@@ -20,6 +20,23 @@ require(
 );
 
 require(
+  source.includes("normalizeSingleHeader(req.headers['x-nowpayments-sig'])"),
+  'NOWPayments signature header must be normalized before HMAC comparison',
+);
+
+require(
+  source.includes('function normalizeSingleHeader(header: string | string[] | undefined)') &&
+    source.includes('Array.isArray(header)') &&
+    source.includes('return undefined'),
+  'signature normalization must reject duplicated/array headers instead of casting them to string',
+);
+
+require(
+  !source.includes("req.headers['x-nowpayments-sig'] as string"),
+  'webhook handler must not cast x-nowpayments-sig directly from Express headers',
+);
+
+require(
   source.includes('receipt_insert_failed') && source.includes('res.status(500)'),
   'webhook receipt insert failure must be retryable',
 );

--- a/scripts/check-nowpayments-webhook-policy.mjs
+++ b/scripts/check-nowpayments-webhook-policy.mjs
@@ -53,7 +53,6 @@ require(
 
 require(
   !source.includes("req.headers['x-nowpayments-sig'].join") &&
-    !source.includes('x-nowpayments-sig'].join') &&
     !source.includes('Array.isArray(signature)') &&
     !source.includes('Array.isArray(req.headers'),
   'webhook handler must not join or select from duplicated signature headers',


### PR DESCRIPTION
## Summary

This draft PR distills the Freeside payment webhook, credit-lifecycle, feature-flag, retry, and operator-runbook issues into one implementation lane.

## Issue coverage

Refs #325, #326, #327, #329, #335, #340, #341, #342, #345, #348, #350, #354, #355, #360, #363.

## What changed

Adds `docs/audit-lanes/2026-06-27-payment-webhook-lifecycle.md` as the lane map for the related issues and proposal comments.

## Non-claim

This PR does not claim the implementation fixes are complete until follow-up commits add the code, tests, fixtures, and runbook evidence.

## Branch status

Needs base sync from `main`: diverged, `ahead_by: 13`, `behind_by: 8`. Do not merge until the branch is synced and a fresh accept verdict is posted.