### PR TITLE
[codex] Audit lane: platform topology, registry truth, and capability evidence

### DIFF
--- a/.github/workflows/postinstall-wrapper-check.yml
+++ b/.github/workflows/postinstall-wrapper-check.yml
@@ -1,0 +1,31 @@
+name: Postinstall Wrapper Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'package.json'
+      - 'scripts/postinstall.mjs'
+      - 'scripts/check-postinstall-wrapper.mjs'
+      - '.github/workflows/postinstall-wrapper-check.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'package.json'
+      - 'scripts/postinstall.mjs'
+      - 'scripts/check-postinstall-wrapper.mjs'
+      - '.github/workflows/postinstall-wrapper-check.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  postinstall-wrapper:
+    name: Postinstall Wrapper Contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: 22
+      - run: node scripts/check-postinstall-wrapper.mjs

--- a/docs/audit-lanes/2026-06-27-platform-topology-truth.md
+++ b/docs/audit-lanes/2026-06-27-platform-topology-truth.md
@@ -1,0 +1,37 @@
+# Audit lane: Platform topology, registry truth, and capability evidence
+
+## Purpose
+
+This draft PR distills Freeside's workspace topology, registry truth, CLI doctor, install-script, public-claim, and capability-evidence issues into one implementation lane. It is a routing artifact and does not claim the fixes are complete yet.
+
+## Issue coverage
+
+Refs #328, #330, #331, #332, #333, #334, #336, #337, #338, #339, #343, #344, #346, #347, #349, #351, #352, #353, #356, #357, #358, #359, #361, #362, #364.
+
+## Preserved state
+
+Preserve current Freeside platform behavior while making repo topology, registry source, CLI freshness, install side effects, and public capability claims verifiable.
+
+## Target
+
+Establish a checked source of truth for workspace layout, registry data, root scripts, README capability claims, and validation coverage.
+
+## Expected artifacts
+
+Likely scope includes root package/workspace files, registry artifacts, CLI doctor code, README/docs, topology manifests, validation scripts, and CI checks.
+
+## Allowed scope
+
+Allowed: focused topology, registry, docs, scripts, and CI changes. Not allowed: payment lifecycle changes, unrelated product direction, or adjacent repo edits.
+
+## Decision
+
+Use one topology/truth PR because these issues share one root contract: repo-visible product claims should be generated, checked, or explicitly sourced.
+
+## Rollback
+
+Rollback is the closing PR revert; implementation commits should keep generated checks and docs updates contained.
+
+## Non-claims
+
+This lane does not certify all Freeside runtime behavior and does not close issue references until implementation evidence is present.

--- a/docs/audit-lanes/2026-06-27-platform-topology-truth.md
+++ b/docs/audit-lanes/2026-06-27-platform-topology-truth.md
@@ -28,10 +28,23 @@ Allowed: focused topology, registry, docs, scripts, and CI changes. Not allowed:
 
 Use one topology/truth PR because these issues share one root contract: repo-visible product claims should be generated, checked, or explicitly sourced.
 
+## Postinstall contract
+
+Root `postinstall` must be side-effect-light by default. A normal dependency install must not rebuild Hounfour dist artifacts automatically.
+
+Operators who need a local Hounfour dist refresh have two explicit paths:
+
+1. Run `pnpm run build:hounfour`.
+2. Set `FREESIDE_REBUILD_HOUNFOUR_ON_INSTALL=1` before install to opt into the wrapper calling `scripts/rebuild-hounfour-dist.sh`.
+
+The wrapper must propagate the rebuild script exit status when opt-in is enabled. This keeps install deterministic while preserving the existing rebuild command for operator-controlled use.
+
+Validation hook: `node scripts/check-postinstall-wrapper.mjs` verifies that package scripts and wrapper behavior preserve this contract.
+
 ## Rollback
 
 Rollback is the closing PR revert; implementation commits should keep generated checks and docs updates contained.
 
 ## Non-claims
 
-This lane does not certify all Freeside runtime behavior and does not close issue references until implementation evidence is present.
+This lane does not certify all Freeside runtime behavior and does not close issue references until implementation evidence is present. Current implementation covers the postinstall side-effect slice; registry truth, CLI freshness, workspace topology, and README capability evidence remain separate follow-up work unless additional commits are added.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "scripts": {
     "build:hounfour": "scripts/rebuild-hounfour-dist.sh",
-    "postinstall": "scripts/rebuild-hounfour-dist.sh"
+    "postinstall": "node scripts/postinstall.mjs"
   },
   "devDependencies": {
     "@0xhoneyjar/loa-hounfour": "github:0xHoneyJar/loa-hounfour#aed755f7fea8d2739cf9c755b45aaa580b6af6a9",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   },
   "scripts": {
     "build:hounfour": "scripts/rebuild-hounfour-dist.sh",
-    "postinstall": "node scripts/postinstall.mjs"
+    "postinstall": "node scripts/postinstall.mjs",
+    "check:postinstall-wrapper": "node scripts/check-postinstall-wrapper.mjs"
   },
   "devDependencies": {
     "@0xhoneyjar/loa-hounfour": "github:0xHoneyJar/loa-hounfour#aed755f7fea8d2739cf9c755b45aaa580b6af6a9",

--- a/scripts/check-postinstall-wrapper.mjs
+++ b/scripts/check-postinstall-wrapper.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+const wrapper = readFileSync('scripts/postinstall.mjs', 'utf8');
+const failures = [];
+
+function require(condition, message) {
+  if (!condition) failures.push(message);
+}
+
+require(
+  pkg.scripts?.postinstall === 'node scripts/postinstall.mjs',
+  'package.json postinstall must point at scripts/postinstall.mjs',
+);
+
+require(
+  pkg.scripts?.['build:hounfour'] === 'scripts/rebuild-hounfour-dist.sh',
+  'build:hounfour must remain the explicit rebuild command',
+);
+
+require(
+  wrapper.includes('FREESIDE_REBUILD_HOUNFOUR_ON_INSTALL') && wrapper.includes("=== '1'"),
+  'postinstall wrapper must require explicit FREESIDE_REBUILD_HOUNFOUR_ON_INSTALL=1 opt-in',
+);
+
+require(
+  wrapper.includes('scripts/rebuild-hounfour-dist.sh'),
+  'postinstall wrapper must call the existing rebuild script only on opt-in',
+);
+
+require(
+  wrapper.includes('process.exit(result.status ?? 1)'),
+  'postinstall wrapper must propagate rebuild command failure status',
+);
+
+if (failures.length > 0) {
+  console.error('Postinstall wrapper check failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log('Postinstall wrapper check passed.');

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+
+const shouldRebuild = process.env.FREESIDE_REBUILD_HOUNFOUR_ON_INSTALL === '1';
+
+if (!shouldRebuild) {
+  console.log('[postinstall] Skipping Hounfour dist rebuild. Set FREESIDE_REBUILD_HOUNFOUR_ON_INSTALL=1 to opt in.');
+  process.exit(0);
+}
+
+const result = spawnSync('bash', ['scripts/rebuild-hounfour-dist.sh'], {
+  stdio: 'inherit',
+  env: process.env,
+});
+
+if (result.error) {
+  console.error(`[postinstall] Failed to start Hounfour rebuild: ${result.error.message}`);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary

This PR distills the Freeside workspace topology, registry truth, CLI doctor, install-script, README capability, and validation-evidence issues into one implementation lane.

## Issue coverage

Refs #328, #330, #331, #332, #333, #334, #336, #337, #338, #339, #343, #344, #346, #347, #349, #351, #352, #353, #356, #357, #358, #359, #361, #362, #364.

## What changed

Adds `docs/audit-lanes/2026-06-27-platform-topology-truth.md` as the lane map for the related issues and proposal comments.

## Non-claim

This PR does not claim the implementation fixes are complete until follow-up commits add the checks, docs, scripts, and evidence.

## Branch status

Needs base sync from `main`: diverged, `ahead_by: 7`, `behind_by: 8`. Fresh accept verdict required before merge.