### PR TITLE
refactor(shared/immune): collapse tools/{loa,council}-signoff.sh to loa-cli shims

### DIFF
--- a/grimoires/loa/context/g1-ghsignoff-door.md
+++ b/grimoires/loa/context/g1-ghsignoff-door.md
@@ -62,6 +62,13 @@ cross-model council review.
 
 ## The two tools (the build — App-zone, this PR)
 
+> **Hoisted into loa-cli (2026-06-27).** The implementation now lives in the `loa` launcher
+> as two operator-only verbs — `loa signoff <pr>` and `loa council <pr>` (pure-node, zero-dep,
+> unit-tested in `loa-cli/test/security/signoff_gate.mjs`), so EVERY repo gets the door through
+> the one binary. `tools/loa-signoff.sh` / `tools/council-signoff.sh` are now thin shims that
+> forward to `loa signoff` / `loa council` — the usage below is unchanged (the shim passes every
+> arg through). loa-cli is the source of truth; the per-repo copy is gone.
+
 ### `tools/loa-signoff.sh` — the local-green attestation
 
 Runs the repo's real suite locally; **on GREEN** posts a `loa-signoff` commit status

--- a/tools/council-signoff.sh
+++ b/tools/council-signoff.sh
@@ -16,7 +16,8 @@
 # =============================================================================
 set -euo pipefail
 command -v loa >/dev/null 2>&1 || {
-  echo "tools/council-signoff.sh: \`loa\` (loa-cli) is not on PATH — install it: (cd ~/Documents/GitHub/loa-cli && npm link)" >&2; exit 2; }
-loa council --help >/dev/null 2>&1 || {
-  echo "tools/council-signoff.sh: your \`loa\` predates the 'council' verb — the impl moved to loa-cli; update it (git -C ~/Documents/GitHub/loa-cli pull origin main)." >&2; exit 2; }
+  echo "tools/council-signoff.sh: \`loa\` (loa-cli) is not on PATH — install loa-cli and \`npm link\` it globally." >&2; exit 2; }
+# Verb-recognition probe by CONTENT, not --help's exit code (robust to whatever exit status help uses).
+loa council --help 2>&1 | grep -q 'loa council <pr>' || {
+  echo "tools/council-signoff.sh: this \`loa\` does not provide the 'council' verb (predates the hoist, or is broken) — update your loa-cli checkout (pull main + re-\`npm link\`)." >&2; exit 2; }
 exec loa council "$@"

--- a/tools/council-signoff.sh
+++ b/tools/council-signoff.sh
@@ -1,177 +1,22 @@
 #!/usr/bin/env bash
 # =============================================================================
-# tools/council-signoff.sh — the cross-model COUNCIL as a GitHub approving review
+# tools/council-signoff.sh — SHIM. The implementation now lives in loa-cli: `loa council`.
 # =============================================================================
-# WHY THIS EXISTS (G1 / G-DOOR — un-freeze the front door)
-#   `main` requires 2 approving reviews, but the LOCAL cheval council (the
-#   cross-model FAGAN gate — codex + cursor + claude, subscription CLIs) posts
-#   ZERO GitHub reviews. So 2-of-2 was unmeetable solo and the gate-fix PRs
-#   stayed trapped. cheval CANNOT run in GitHub Actions (no OAuth subscription
-#   sessions on ephemeral runners; ANTHROPIC_API_KEY is stripped) — so the
-#   council runs LOCAL and this script is the bridge: it runs the council on a
-#   PR's diff and, when the verdict is APPROVED by ≥2 surviving distinct model
-#   families, posts an APPROVING GitHub review. That review = 1 of the required
-#   approvals (council = 1, operator = 1).
+# The cross-model FAGAN council → GitHub approving review (FAIL-CLOSED: a degraded or
+# single-perspective panel is NEVER approved; approving requires council exit 0 AND
+# verdict APPROVED AND >=2 surviving distinct model families) was HOISTED into the `loa`
+# launcher so EVERY repo gets the gate through the one binary. The logic is now
+# pure-node, zero-dep, with all I/O dependency-injected, and unit-tested in
+# loa-cli/test/security/signoff_gate.mjs. loa-cli is the source of truth; this wrapper
+# forwards every arg to `loa council` UNCHANGED.
 #
-# FAIL-CLOSED (the council's load-bearing guarantee, preserved here):
-#   - exit 3 (all voices dropped)        → NEVER approve. A degraded council that
-#                                          could reach zero models must not pass.
-#   - exit 2 (council infra failure)     → NEVER approve.
-#   - APPROVED but <2 voices survived    → NEVER approve. `multi_perspective_met`
-#     (single-perspective)                 must hold; a halved panel is not a council.
-#   - CHANGES_REQUIRED                    → request-changes (or --comment-only).
-#   Approving requires: exit 0 AND verdict APPROVED AND multi_perspective_met
-#   AND voices_survived ≥ 2. ([[council-convergence-not-proof]]: ≥2 distinct
-#   families that actually survived — not convergence alone.)
-#
-#   The ONLY mutation is the `gh pr review` POST. --dry-run mutates nothing.
-#
-# Usage:
-#   tools/council-signoff.sh <pr-number> [--repo owner/name] [--preflight]
-#   tools/council-signoff.sh <pr> --dry-run        # run council, print intent, post nothing
-#   tools/council-signoff.sh <pr> --comment-only   # post a COMMENT review (use when GitHub
-#                                                  # blocks approving your own PR — the operator
-#                                                  # then counts the commented council as approved)
-#
-# Configurable (env):
-#   LOA_COUNCIL_BIN     council command: <pr> [--repo R] → result JSON on stdout, council exit code
-#                       (default: construct-fagan's council-review-pr.sh; resolved via
-#                        CONSTRUCT_FAGAN_DIR or ~/Documents/GitHub/construct-fagan)
-#   CONSTRUCT_FAGAN_DIR construct-fagan checkout root (to locate the default council bin)
-#   LOA_GH_BIN          gh binary (test seam)   (default: "gh")
-#
-# Exit: 0 APPROVED + review posted (or dry-run) · 1 CHANGES_REQUIRED · 2 infra/usage
-#       · 3 council fail-closed (all voices dropped / single-perspective) — never approved
+# Same flags: <pr> | --repo owner/name | --dry-run | --comment-only | --preflight
+# Same env:   LOA_COUNCIL_BIN · CONSTRUCT_FAGAN_DIR · LOA_SIGNOFF_REPO
+# Exit codes are loa's, propagated verbatim (0 approved · 1 changes · 2 infra · 3 fail-closed).
 # =============================================================================
-set -uo pipefail
-
-err()  { printf '[council-signoff] %s\n' "$*" >&2; }
-note() { printf '[council-signoff] %s\n' "$*" >&2; }
-
-GH_BIN="${LOA_GH_BIN:-gh}"
-gh_cli() { command "$GH_BIN" "$@"; }
-
-PR=""; REPO=""; DRY_RUN=0; COMMENT_ONLY=0; PREFLIGHT=0
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --repo)         REPO="${2:-}"; shift 2 ;;
-    --dry-run)      DRY_RUN=1; shift ;;
-    --comment-only) COMMENT_ONLY=1; shift ;;
-    --preflight)    PREFLIGHT=1; shift ;;
-    -h|--help)
-      sed -n '2,45p' "$0" | sed 's/^# \{0,1\}//'
-      exit 0 ;;
-    -*)             err "unknown flag: $1"; exit 2 ;;
-    *)              if [[ -z "$PR" ]]; then PR="$1"; else err "unexpected argument: $1"; exit 2; fi; shift ;;
-  esac
-done
-[[ -n "$PR" ]] || { err "usage: council-signoff.sh <pr-number> [--repo owner/name] [--dry-run] [--comment-only] [--preflight]"; exit 2; }
-
-# --- Resolve repo (owner/name) -----------------------------------------------
-if [[ -z "$REPO" ]]; then
-  REPO="$(gh_cli repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)"
-fi
-[[ -n "$REPO" ]] || { err "could not resolve repo — pass --repo owner/name"; exit 2; }
-
-# --- Resolve the council command ---------------------------------------------
-COUNCIL_BIN="${LOA_COUNCIL_BIN:-}"
-if [[ -z "$COUNCIL_BIN" ]]; then
-  for cand in \
-    "${CONSTRUCT_FAGAN_DIR:-}/scripts/council-review-pr.sh" \
-    "$HOME/Documents/GitHub/construct-fagan/scripts/council-review-pr.sh"; do
-    [[ -n "$cand" && -f "$cand" ]] && { COUNCIL_BIN="$cand"; break; }
-  done
-fi
-[[ -n "$COUNCIL_BIN" && -f "$COUNCIL_BIN" ]] || {
-  err "council command not found — set LOA_COUNCIL_BIN=<path/to/council-review-pr.sh> (or CONSTRUCT_FAGAN_DIR)"; exit 2; }
-
-# --- Run the council on the PR diff ------------------------------------------
-note "running cross-model council on PR #$PR ($REPO) via $(basename "$COUNCIL_BIN")…"
-council_args=("$PR" --repo "$REPO")
-[[ "$PREFLIGHT" -eq 1 ]] && council_args+=(--preflight)
-
-council_ec=0
-json="$(command "$COUNCIL_BIN" "${council_args[@]}")" || council_ec=$?
-
-# --- Honor the council's fail-closed verdicts BEFORE any review --------------
-if [[ "$council_ec" -eq 3 ]]; then
-  err "✗ COUNCIL FAIL-CLOSED (exit 3 — all voices dropped). NEVER approving a degraded council. Posting nothing."
-  exit 3
-fi
-if [[ "$council_ec" -eq 2 ]]; then
-  err "✗ COUNCIL INFRA ERROR (exit 2 — could not run: cheval.py missing / bad input / empty diff). Posting nothing."
-  exit 2
-fi
-
-# --- Parse the verdict envelope ----------------------------------------------
-if ! jq empty <<<"$json" >/dev/null 2>&1; then
-  err "✗ council produced no parseable JSON (exit $council_ec). Posting nothing."
-  exit 2
-fi
-verdict="$(jq -r '.verdict // "CHANGES_REQUIRED"' <<<"$json" 2>/dev/null || echo CHANGES_REQUIRED)"
-mpm="$(jq -r '.panel.multi_perspective_met // false' <<<"$json" 2>/dev/null || echo false)"
-survived="$(jq -r '.panel.voices_survived // 0' <<<"$json" 2>/dev/null | tr -dc '0-9')"; survived="${survived:-0}"
-summary="$(jq -r '.summary // "(no summary)"' <<<"$json" 2>/dev/null || echo "(no summary)")"
-voices_md="$(jq -r '(.panel.voices // [])[] | "- **\(.voice)** (\(.model_ran // "unknown")): \(.verdict) — \(.finding_count // 0) finding(s)"' <<<"$json" 2>/dev/null || true)"
-[[ -n "$voices_md" ]] || voices_md="- (no surviving voice detail in envelope)"
-
-note "council verdict=$verdict · voices_survived=$survived · multi_perspective_met=$mpm"
-
-# --- Decide the GitHub review event ------------------------------------------
-# Approving requires a CLEAN council with a real cross-family panel.
-review_event=""; verdict_line=""
-if [[ "$verdict" == "APPROVED" && "$council_ec" -eq 0 ]]; then
-  if [[ "$mpm" == "true" && "$survived" -ge 2 ]]; then
-    review_event="approve"
-    verdict_line="**Verdict: APPROVED** — $survived distinct model families survived and converged clean."
-  else
-    err "✗ COUNCIL FAIL-CLOSED — verdict APPROVED but only $survived voice(s) survived (multi_perspective_met=$mpm)."
-    err "  A single-perspective panel is NOT a council. NEVER approving on a halved panel. Posting nothing."
-    exit 3
-  fi
-else
-  review_event="request-changes"
-  verdict_line="**Verdict: CHANGES_REQUIRED** — at least one voice raised a blocking finding."
-fi
-
-# --comment-only downgrades the event to a non-blocking COMMENT review (always
-# permitted, even on your own PR — GitHub blocks self-approve / self-request-changes).
-gh_event="$review_event"
-if [[ "$COMMENT_ONLY" -eq 1 ]]; then gh_event="comment"; fi
-
-# --- Build the review body ----------------------------------------------------
-BODY="$(mktemp)"; trap 'rm -f "$BODY"' EXIT
-# shellcheck disable=SC2016  # backticks below are literal Markdown code spans, not command subs
-{
-  printf '## 🤖 cheval cross-model FAGAN council — automated review\n\n'
-  printf '%s\n\n' "$verdict_line"
-  printf '%s\n\n' "$summary"
-  printf '### Per-voice verdicts\n%s\n\n' "$voices_md"
-  printf '> Routed through the LOCAL cheval council (subscription CLIs — no API key; cheval cannot\n'
-  printf '> run in GitHub Actions). Per-voice model attribution + verdict-quality envelopes are\n'
-  printf '> recorded in `.run/model-invoke.jsonl` (MODELINV audit). This review is the cross-model\n'
-  printf '> gate satisfying one required approval (council = 1).\n'
-} >"$BODY"
-
-# --- Map the event to gh flags -----------------------------------------------
-case "$gh_event" in
-  approve)         gh_flag=(--approve) ;;
-  request-changes) gh_flag=(--request-changes) ;;
-  comment)         gh_flag=(--comment) ;;
-esac
-
-if [[ "$DRY_RUN" -eq 1 ]]; then
-  note "DRY-RUN — would post a '$gh_event' review on PR #$PR (mutating nothing). Body:"
-  sed 's/^/    /' "$BODY" >&2
-  [[ "$review_event" == "approve" ]] && exit 0 || exit 1
-fi
-
-if gh_cli pr review "$PR" --repo "$REPO" "${gh_flag[@]}" --body-file "$BODY" >/dev/null; then
-  note "✓ posted '$gh_event' review on PR #$PR"
-else
-  err "✗ 'gh pr review --$gh_event' failed (gh error above). NOTE: GitHub forbids approving / requesting-changes on"
-  err "  your OWN PR — re-run with --comment-only to post the council verdict as a COMMENT instead."
-  exit 2
-fi
-
-[[ "$review_event" == "approve" ]] && exit 0 || exit 1
+set -euo pipefail
+command -v loa >/dev/null 2>&1 || {
+  echo "tools/council-signoff.sh: \`loa\` (loa-cli) is not on PATH — install it: (cd ~/Documents/GitHub/loa-cli && npm link)" >&2; exit 2; }
+loa council --help >/dev/null 2>&1 || {
+  echo "tools/council-signoff.sh: your \`loa\` predates the 'council' verb — the impl moved to loa-cli; update it (git -C ~/Documents/GitHub/loa-cli pull origin main)." >&2; exit 2; }
+exec loa council "$@"

--- a/tools/council-signoff.test.sh
+++ b/tools/council-signoff.test.sh
@@ -1,117 +1,34 @@
 #!/usr/bin/env bash
 # =============================================================================
-# tools/council-signoff.test.sh — fixture-driven tests for council-signoff.sh
+# tools/council-signoff.test.sh — the SHIM delegates to `loa council`, args + exit intact.
 # =============================================================================
-# No live cheval, no live gh. Seams:
-#   LOA_COUNCIL_BIN → a fake council emitting a canned verdict JSON + chosen exit
-#   LOA_GH_BIN      → a fake gh that LOGS the `pr review` call (and succeeds)
-# Proves: APPROVED+≥2 → approving review · CHANGES_REQUIRED → request-changes ·
-#   all-dropped (exit 3) → fail-closed, NO review · APPROVED-but-1-voice →
-#   fail-closed, NO review · --dry-run → no review · --comment-only → comment.
-# Exit: 0 all pass · 1 a test failed.
-# =============================================================================
-# shellcheck disable=SC2015  # `cond && ok || bad` is the assertion idiom here; ok/bad always return 0
+# tools/council-signoff.sh is now a thin shim; the real council LOGIC (fail-closed verdicts,
+# the >=2-distinct-family approve gate, --comment-only mapping, bin resolution) is tested in
+# loa-cli/test/security/signoff_gate.mjs. Here we only guard the shim contract: forward args
+# to `loa council` verbatim, propagate loa's exit, fail clearly when `loa` is absent.
 set -uo pipefail
-
-HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-SUT="$HERE/council-signoff.sh"
-WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
-FAKE_GH_LOG="$WORK/gh.log"
-
-# --- fake gh: logs argv, answers read calls, succeeds on `pr review` ----------
-FAKE_GH="$WORK/fake-gh.sh"
-cat >"$FAKE_GH" <<'EOF'
-#!/usr/bin/env bash
-printf '%s\n' "$*" >>"$FAKE_GH_LOG"
-case "$1 $2" in
-  "repo view") echo "owner/fake-repo" ;;
-  *)           : ;;
-esac
-exit 0
-EOF
-chmod +x "$FAKE_GH"
-
-# --- fake council: emits $FAKE_COUNCIL_JSON, exits $FAKE_COUNCIL_EC -----------
-FAKE_COUNCIL="$WORK/fake-council.sh"
-cat >"$FAKE_COUNCIL" <<'EOF'
-#!/usr/bin/env bash
-cat "$FAKE_COUNCIL_JSON"
-exit "${FAKE_COUNCIL_EC:-0}"
-EOF
-chmod +x "$FAKE_COUNCIL"
-
-# --- canned verdict envelopes (mirror cheval-council.sh's contract) ----------
-J_APPROVED="$WORK/approved.json"
-cat >"$J_APPROVED" <<'EOF'
-{"verdict":"APPROVED","summary":"cheval-routed · 2/3 voices survived · multi_perspective=true · verdict APPROVED","panel":{"routed_via":"cheval","voices":[{"voice":"jam-reviewer-claude-headless","model_ran":"claude-headless","verdict":"APPROVED","finding_count":0,"findings":[]},{"voice":"jam-reviewer-gpt","model_ran":"codex","verdict":"APPROVED","finding_count":0,"findings":[]}],"dropped":[{"voice":"jam-reviewer-cursor","reason":"exit:2/empty"}],"voices_survived":2,"voices_planned":3,"multi_perspective_met":true}}
-EOF
-
-J_CHANGES="$WORK/changes.json"
-cat >"$J_CHANGES" <<'EOF'
-{"verdict":"CHANGES_REQUIRED","summary":"cheval-routed · 2/3 survived · verdict CHANGES_REQUIRED","panel":{"voices":[{"voice":"jam-reviewer-gpt","model_ran":"codex","verdict":"CHANGES_REQUIRED","finding_count":1,"findings":[{"severity":"major","title":"null deref"}]},{"voice":"jam-reviewer-claude-headless","model_ran":"claude-headless","verdict":"APPROVED","finding_count":0}],"voices_survived":2,"voices_planned":3,"multi_perspective_met":true}}
-EOF
-
-J_DROPPED="$WORK/dropped.json"
-cat >"$J_DROPPED" <<'EOF'
-{"verdict":"CHANGES_REQUIRED","error":"all_voices_dropped","panel":{"voices":[],"dropped":[{"voice":"a","reason":"exit:2/empty"}]}}
-EOF
-
-J_SINGLE="$WORK/single.json"
-cat >"$J_SINGLE" <<'EOF'
-{"verdict":"APPROVED","summary":"single-voice panel","panel":{"voices":[{"voice":"jam-reviewer-gpt","model_ran":"codex","verdict":"APPROVED","finding_count":0}],"voices_survived":1,"voices_planned":3,"multi_perspective_met":false}}
-EOF
-
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PASS=0; FAIL=0
-ok()  { printf '  ok   — %s\n' "$1"; PASS=$((PASS+1)); }
-bad() { printf '  FAIL — %s\n' "$1"; FAIL=$((FAIL+1)); }
+ck(){ if [ "$1" = "$2" ]; then PASS=$((PASS+1)); echo "  ✓ $3"; else FAIL=$((FAIL+1)); echo "  ✗ FAIL $3 (got '$1' want '$2')"; fi }
 
-run_sut() {  # $1=json file, $2=council exit code, rest=SUT args
-  local jf="$1" cec="$2"; shift 2
-  FAKE_GH_LOG="$FAKE_GH_LOG" \
-  LOA_GH_BIN="$FAKE_GH" \
-  LOA_COUNCIL_BIN="$FAKE_COUNCIL" \
-  FAKE_COUNCIL_JSON="$jf" \
-  FAKE_COUNCIL_EC="$cec" \
-  bash "$SUT" 42 --repo "0xHoneyJar/loa-freeside" "$@"
-}
+echo "council-signoff.test — shim → 'loa council' (logic lives in loa-cli/signoff_gate.mjs)"
 
-echo "== council-signoff.test =="
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+REC="$TMP/rec"
+cat > "$TMP/loa" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "council" ] && [ "\$2" = "--help" ]; then exit 0; fi
+printf '%s\n' "\$*" > "$REC"
+exit 3
+EOF
+chmod +x "$TMP/loa"
 
-# 1. APPROVED + 2 voices survived → approving review, exit 0 -------------------
-: >"$FAKE_GH_LOG"
-ec=0; run_sut "$J_APPROVED" 0 >/dev/null 2>&1 || ec=$?
-[[ "$ec" -eq 0 ]] && ok "APPROVED exits 0" || bad "APPROVED expected exit 0, got $ec"
-if grep -q "pr review 42" "$FAKE_GH_LOG" && grep -q -- "--approve" "$FAKE_GH_LOG"; then ok "APPROVED posted an approving review"; else bad "APPROVED did not post --approve (log: $(tr '\n' '|' <"$FAKE_GH_LOG"))"; fi
+ec=0; PATH="$TMP:$PATH" bash "$HERE/council-signoff.sh" 7 --repo o/r --comment-only >/dev/null 2>&1 || ec=$?
+ck "$ec" 3 "propagates loa's exit code (sentinel 3 — fail-closed range preserved)"
+ck "$(cat "$REC" 2>/dev/null)" "council 7 --repo o/r --comment-only" "forwards 'council 7 --repo o/r --comment-only' verbatim"
 
-# 2. CHANGES_REQUIRED → request-changes, exit 1 -------------------------------
-: >"$FAKE_GH_LOG"
-ec=0; run_sut "$J_CHANGES" 1 >/dev/null 2>&1 || ec=$?
-[[ "$ec" -eq 1 ]] && ok "CHANGES_REQUIRED exits 1" || bad "CHANGES expected exit 1, got $ec"
-if grep -q -- "--request-changes" "$FAKE_GH_LOG" && ! grep -q -- "--approve" "$FAKE_GH_LOG"; then ok "CHANGES posted --request-changes, not --approve"; else bad "CHANGES posted wrong review event"; fi
+ec2=0; PATH="/usr/bin:/bin" bash "$HERE/council-signoff.sh" 7 >/dev/null 2>&1 || ec2=$?
+ck "$ec2" 2 "no loa on PATH → exit 2 with a clear install message"
 
-# 3. all voices dropped (council exit 3) → FAIL-CLOSED, no review, exit 3 ------
-: >"$FAKE_GH_LOG"
-ec=0; run_sut "$J_DROPPED" 3 >/dev/null 2>&1 || ec=$?
-[[ "$ec" -eq 3 ]] && ok "all-dropped exits 3 (fail-closed)" || bad "all-dropped expected exit 3, got $ec"
-if grep -q "pr review" "$FAKE_GH_LOG"; then bad "all-dropped MUST NOT post a review"; else ok "all-dropped posted no review"; fi
-
-# 4. APPROVED but only 1 voice survived → FAIL-CLOSED, no review, exit 3 -------
-: >"$FAKE_GH_LOG"
-ec=0; run_sut "$J_SINGLE" 0 >/dev/null 2>&1 || ec=$?
-[[ "$ec" -eq 3 ]] && ok "single-voice APPROVED fails closed (exit 3)" || bad "single-voice expected exit 3, got $ec"
-if grep -q "pr review" "$FAKE_GH_LOG"; then bad "single-voice MUST NOT approve a halved panel"; else ok "single-voice posted no review"; fi
-
-# 5. --dry-run on APPROVED → no review POST, exit 0 ---------------------------
-: >"$FAKE_GH_LOG"
-ec=0; run_sut "$J_APPROVED" 0 --dry-run >/dev/null 2>&1 || ec=$?
-[[ "$ec" -eq 0 ]] && ok "dry-run APPROVED exits 0" || bad "dry-run APPROVED expected exit 0, got $ec"
-if grep -q "pr review" "$FAKE_GH_LOG"; then bad "dry-run MUST NOT post a review"; else ok "dry-run posted no review"; fi
-
-# 6. --comment-only on APPROVED → posts a COMMENT review (not approve) --------
-: >"$FAKE_GH_LOG"
-ec=0; run_sut "$J_APPROVED" 0 --comment-only >/dev/null 2>&1 || ec=$?
-[[ "$ec" -eq 0 ]] && ok "comment-only APPROVED exits 0" || bad "comment-only expected exit 0, got $ec"
-if grep -q -- "--comment" "$FAKE_GH_LOG" && ! grep -q -- "--approve" "$FAKE_GH_LOG"; then ok "comment-only posted --comment (not --approve)"; else bad "comment-only posted wrong event"; fi
-
-echo "== council-signoff: $PASS passed, $FAIL failed =="
-[[ "$FAIL" -eq 0 ]]
+echo ""
+[ "$FAIL" -eq 0 ] && { echo "council-signoff.test: PASS ($PASS)"; exit 0; } || { echo "council-signoff.test: FAIL ($FAIL)"; exit 1; }

--- a/tools/council-signoff.test.sh
+++ b/tools/council-signoff.test.sh
@@ -17,14 +17,16 @@ TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 REC="$TMP/rec"
 cat > "$TMP/loa" <<EOF
 #!/usr/bin/env bash
-if [ "\$1" = "council" ] && [ "\$2" = "--help" ]; then exit 0; fi
+# the shim probes verb-recognition by CONTENT: emit the usage line on 'council --help'
+if [ "\$1" = "council" ] && [ "\$2" = "--help" ]; then echo "loa council <pr> [--repo owner/name]"; exit 0; fi
 printf '%s\n' "\$*" > "$REC"
-exit 3
+exit 42
 EOF
 chmod +x "$TMP/loa"
 
+# 42 = an arbitrary, unambiguous sentinel (NOT the real fail-closed 3) — proves verbatim propagation
 ec=0; PATH="$TMP:$PATH" bash "$HERE/council-signoff.sh" 7 --repo o/r --comment-only >/dev/null 2>&1 || ec=$?
-ck "$ec" 3 "propagates loa's exit code (sentinel 3 — fail-closed range preserved)"
+ck "$ec" 42 "propagates loa's exit code verbatim (arbitrary sentinel 42, distinct from real codes)"
 ck "$(cat "$REC" 2>/dev/null)" "council 7 --repo o/r --comment-only" "forwards 'council 7 --repo o/r --comment-only' verbatim"
 
 ec2=0; PATH="/usr/bin:/bin" bash "$HERE/council-signoff.sh" 7 >/dev/null 2>&1 || ec2=$?

--- a/tools/loa-signoff.sh
+++ b/tools/loa-signoff.sh
@@ -18,7 +18,9 @@
 # =============================================================================
 set -euo pipefail
 command -v loa >/dev/null 2>&1 || {
-  echo "tools/loa-signoff.sh: \`loa\` (loa-cli) is not on PATH — install it: (cd ~/Documents/GitHub/loa-cli && npm link)" >&2; exit 2; }
-loa signoff --help >/dev/null 2>&1 || {
-  echo "tools/loa-signoff.sh: your \`loa\` predates the 'signoff' verb — the impl moved to loa-cli; update it (git -C ~/Documents/GitHub/loa-cli pull origin main)." >&2; exit 2; }
+  echo "tools/loa-signoff.sh: \`loa\` (loa-cli) is not on PATH — install loa-cli and \`npm link\` it globally." >&2; exit 2; }
+# Verb-recognition probe by CONTENT, not --help's exit code (a loa predating the hoist prints the
+# generic launcher banner instead of the signoff usage). Robust to whatever exit status help uses.
+loa signoff --help 2>&1 | grep -q 'loa signoff <pr>' || {
+  echo "tools/loa-signoff.sh: this \`loa\` does not provide the 'signoff' verb (predates the hoist, or is broken) — update your loa-cli checkout (pull main + re-\`npm link\`)." >&2; exit 2; }
 exec loa signoff "$@"

--- a/tools/loa-signoff.sh
+++ b/tools/loa-signoff.sh
@@ -23,4 +23,7 @@ command -v loa >/dev/null 2>&1 || {
 # generic launcher banner instead of the signoff usage). Robust to whatever exit status help uses.
 loa signoff --help 2>&1 | grep -q 'loa signoff <pr>' || {
   echo "tools/loa-signoff.sh: this \`loa\` does not provide the 'signoff' verb (predates the hoist, or is broken) — update your loa-cli checkout (pull main + re-\`npm link\`)." >&2; exit 2; }
+# freeside's suite lives in themes/sietch; loa signoff now defaults to '.' (generic), so this repo's
+# shim pins its own dir. Operator override still wins (only set when unset).
+export LOA_SIGNOFF_SUITE_DIR="${LOA_SIGNOFF_SUITE_DIR:-themes/sietch}"
 exec loa signoff "$@"

--- a/tools/loa-signoff.sh
+++ b/tools/loa-signoff.sh
@@ -1,128 +1,24 @@
 #!/usr/bin/env bash
 # =============================================================================
-# tools/loa-signoff.sh — the LOCAL-GREEN attestation (the gh-signoff bridge)
+# tools/loa-signoff.sh — SHIM. The implementation now lives in loa-cli: `loa signoff`.
 # =============================================================================
-# WHY THIS EXISTS (G1 / G-DOOR — un-freeze the front door)
-#   `main`'s merge gate is a broken cut vertex: a REQUIRED `Unit Tests` status
-#   check that is RED at the tip of `main` itself froze 27/27 open PRs behind a
-#   gate the gate-fix PRs are themselves trapped behind. The fix (decided by the
-#   operator) is the DHH / basecamp/gh-signoff / Depot synthesis: make LOCAL-green
-#   the truth. Run the repo's real suite on a dev box; on green, post a `loa-signoff`
-#   COMMIT STATUS to the PR's head SHA. Branch protection then requires `loa-signoff`
-#   instead of the flaky cloud `Unit Tests` check (which keeps running, demoted to
-#   informational). The sign-off IS the bridge from local-green to the CI gate.
+# The local-green attestation (run the suite; on GREEN post a `loa-signoff` commit
+# status — a RED suite signs off NOTHING) was HOISTED into the `loa` launcher so EVERY
+# repo gets the door through the one binary, not a per-repo copy of this script. The
+# logic is now pure-node, zero-dep, finn-safe, and unit-tested in
+# loa-cli/test/security/signoff_gate.mjs (30 assertions; the privilege boundary +
+# fail-closed floor). loa-cli is the source of truth; this wrapper preserves the
+# freeside-local path `tools/loa-signoff.sh <pr>` (muscle memory + the door doc's
+# examples) by forwarding every arg to `loa signoff` UNCHANGED.
 #
-#   This is the SAME idea as basecamp/gh-signoff (`gh signoff` posts a `signoff`
-#   commit status), specialized to this repo's suite + a refuse-on-red floor.
-#
-# THE FLOOR (the whole point): we NEVER sign off a red suite. On RED this refuses,
-#   posts nothing, and exits non-zero. A green attestation means a green suite —
-#   no other path writes the status. ([[ci-sensors-must-not-be-numb]],
-#   [[gate-output-never-piped]]: the EXIT CODE is the verdict.)
-#
-#   Read-only with respect to the repo. The ONLY mutation is the commit-status
-#   POST (the signoff itself) via `gh api` (your auth — no API key, no app-code).
-#
-# Usage:
-#   tools/loa-signoff.sh <pr-number>            # resolve head SHA from the PR, run suite, sign off
-#   tools/loa-signoff.sh --sha <SHA>            # sign off a specific commit SHA
-#   tools/loa-signoff.sh <pr> --dry-run         # run suite, print the intended POST, mutate nothing
-#   tools/loa-signoff.sh <pr> --repo owner/name # explicit repo (else inferred via gh)
-#
-# Configurable (env):
-#   LOA_SIGNOFF_SUITE_CMD   suite command           (default: "npm test")
-#   LOA_SIGNOFF_SUITE_DIR   dir to run it in         (default: "themes/sietch" — the canonical Unit Tests cwd)
-#   LOA_SIGNOFF_CONTEXT     commit-status context    (default: "loa-signoff")
-#   LOA_SIGNOFF_OPERATOR    handle in the description (default: gh login)
-#   LOA_SIGNOFF_REPO        owner/name               (default: inferred via `gh repo view`)
-#   LOA_GH_BIN              gh binary (test seam)     (default: "gh")
-#
-# Exit: 0 signed off (or dry-run on green) · 1 suite RED (refused, posted nothing)
-#       · 2 usage / infra error
+# Same flags: <pr> | --sha <SHA> | --repo owner/name | --dry-run
+# Same env:   LOA_SIGNOFF_SUITE_CMD · LOA_SIGNOFF_SUITE_DIR · LOA_SIGNOFF_CONTEXT
+#             · LOA_SIGNOFF_OPERATOR · LOA_SIGNOFF_REPO
+# Exit codes are loa's, propagated verbatim (0 signed-off · 1 suite RED · 2 usage/infra).
 # =============================================================================
-set -uo pipefail
-
-err()  { printf '[loa-signoff] %s\n' "$*" >&2; }
-note() { printf '[loa-signoff] %s\n' "$*" >&2; }
-
-GH_BIN="${LOA_GH_BIN:-gh}"
-gh_cli() { command "$GH_BIN" "$@"; }
-
-PR=""; SHA=""; REPO="${LOA_SIGNOFF_REPO:-}"; DRY_RUN=0
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --sha)      SHA="${2:-}"; shift 2 ;;
-    --repo)     REPO="${2:-}"; shift 2 ;;
-    --dry-run)  DRY_RUN=1; shift ;;
-    -h|--help)
-      sed -n '2,42p' "$0" | sed 's/^# \{0,1\}//'
-      exit 0 ;;
-    -*)         err "unknown flag: $1"; exit 2 ;;
-    *)          if [[ -z "$PR" ]]; then PR="$1"; else err "unexpected argument: $1"; exit 2; fi; shift ;;
-  esac
-done
-
-[[ -n "$PR" || -n "$SHA" ]] || { err "usage: loa-signoff.sh <pr-number> | --sha <SHA> [--dry-run] [--repo owner/name]"; exit 2; }
-
-SUITE_CMD="${LOA_SIGNOFF_SUITE_CMD:-npm test}"
-SUITE_DIR="${LOA_SIGNOFF_SUITE_DIR:-themes/sietch}"
-CONTEXT="${LOA_SIGNOFF_CONTEXT:-loa-signoff}"
-
-# --- Resolve repo (owner/name) -----------------------------------------------
-if [[ -z "$REPO" ]]; then
-  REPO="$(gh_cli repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)"
-fi
-[[ -n "$REPO" ]] || { err "could not resolve repo — pass --repo owner/name or set LOA_SIGNOFF_REPO"; exit 2; }
-
-# --- Resolve the head SHA to sign off ----------------------------------------
-if [[ -z "$SHA" ]]; then
-  SHA="$(gh_cli pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid 2>/dev/null || true)"
-  [[ -n "$SHA" ]] || { err "could not resolve head SHA for PR #$PR in $REPO (auth? wrong PR?)"; exit 2; }
-fi
-SHORT_SHA="${SHA:0:12}"
-
-# --- Resolve the operator handle for the attestation description -------------
-OPERATOR="${LOA_SIGNOFF_OPERATOR:-}"
-if [[ -z "$OPERATOR" ]]; then
-  OPERATOR="$(gh_cli api user -q .login 2>/dev/null || true)"
-  [[ -n "$OPERATOR" ]] || OPERATOR="$(git config user.name 2>/dev/null || echo local)"
-fi
-
-note "repo=$REPO · sha=$SHORT_SHA · suite='( cd $SUITE_DIR && $SUITE_CMD )' · operator=$OPERATOR${DRY_RUN:+ · DRY-RUN}"
-
-# --- Run the suite locally ----------------------------------------------------
-# eval of the configured command string: the trust boundary is the operator's own
-# machine + their own env, which is exactly where a "local-green" attestation runs.
-note "running suite locally — this is the attestation; a RED suite signs off NOTHING…"
-suite_ec=0
-( cd "$SUITE_DIR" && eval "$SUITE_CMD" ) || suite_ec=$?
-
-if [[ "$suite_ec" -ne 0 ]]; then
-  err "✗ SUITE RED (exit $suite_ec) — REFUSING to sign off. No status posted. (That is the whole point.)"
-  err "  fix the suite, then re-run. The gate stays honest: a green attestation requires a green suite."
-  exit 1
-fi
-note "✓ suite GREEN"
-
-# --- Post the loa-signoff commit status (the ONLY mutation) ------------------
-DESC="loa-signoff: '$SUITE_CMD' green @ $SHORT_SHA · by $OPERATOR"
-DESC="${DESC:0:140}"  # GitHub status descriptions cap at 140 chars
-
-if [[ "$DRY_RUN" -eq 1 ]]; then
-  note "DRY-RUN — would POST commit status (mutating nothing):"
-  printf '  gh api repos/%s/statuses/%s -f state=success -f context=%s -f description=%q\n' \
-    "$REPO" "$SHA" "$CONTEXT" "$DESC" >&2
-  note "✓ dry-run complete (suite was green; no status written)"
-  exit 0
-fi
-
-if gh_cli api "repos/$REPO/statuses/$SHA" \
-     -f state=success \
-     -f context="$CONTEXT" \
-     -f description="$DESC" >/dev/null; then
-  note "✓ SIGNED OFF — '$CONTEXT' = success posted to $REPO @ $SHORT_SHA"
-  exit 0
-else
-  err "✗ suite was green but the status POST failed (gh api error) — see above. Nothing was signed off."
-  exit 2
-fi
+set -euo pipefail
+command -v loa >/dev/null 2>&1 || {
+  echo "tools/loa-signoff.sh: \`loa\` (loa-cli) is not on PATH — install it: (cd ~/Documents/GitHub/loa-cli && npm link)" >&2; exit 2; }
+loa signoff --help >/dev/null 2>&1 || {
+  echo "tools/loa-signoff.sh: your \`loa\` predates the 'signoff' verb — the impl moved to loa-cli; update it (git -C ~/Documents/GitHub/loa-cli pull origin main)." >&2; exit 2; }
+exec loa signoff "$@"

--- a/tools/loa-signoff.test.sh
+++ b/tools/loa-signoff.test.sh
@@ -1,78 +1,38 @@
 #!/usr/bin/env bash
 # =============================================================================
-# tools/loa-signoff.test.sh — fixture-driven tests for loa-signoff.sh
+# tools/loa-signoff.test.sh — the SHIM delegates to `loa signoff`, args + exit intact.
 # =============================================================================
-# No live `gh`, no live suite. Seams:
-#   LOA_GH_BIN          → a fake gh that LOGS every call and returns canned data
-#   LOA_SIGNOFF_SUITE_CMD/DIR → an injected fake suite (exit 0 = green, non-0 = red)
-# Proves the floor: RED suite → no signoff + non-zero · GREEN → signoff posted ·
-#   --dry-run on GREEN → mutates nothing · bad usage → exit 2.
-# Exit: 0 all pass · 1 a test failed.
-# =============================================================================
-# shellcheck disable=SC2015  # `cond && ok || bad` is the assertion idiom here; ok/bad always return 0
+# tools/loa-signoff.sh is now a thin shim; the real signoff LOGIC (suite-run, fail-closed
+# RED-refusal, the commit-status POST, the privilege boundary) is tested in
+# loa-cli/test/security/signoff_gate.mjs (30 assertions). Here we only guard the shim
+# contract: it forwards every arg to `loa signoff` verbatim and propagates loa's exit code,
+# and fails clearly when `loa` is absent. A mock `loa` on PATH keeps this offline.
 set -uo pipefail
-
-HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-SUT="$HERE/loa-signoff.sh"
-WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
-FAKE_GH_LOG="$WORK/gh.log"
-
-# --- fake gh: logs argv, answers the read calls, succeeds on the POST ---------
-FAKE_GH="$WORK/fake-gh.sh"
-cat >"$FAKE_GH" <<'EOF'
-#!/usr/bin/env bash
-printf '%s\n' "$*" >>"$FAKE_GH_LOG"
-case "$1 $2" in
-  "api user")   echo "test-operator" ;;
-  "repo view")  echo "owner/fake-repo" ;;
-  "pr view")    echo "fakesha0000000000000000000000000000000000" ;;
-  *)            : ;;   # api statuses POST, etc. → succeed silently
-esac
-exit 0
-EOF
-chmod +x "$FAKE_GH"
-
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PASS=0; FAIL=0
-ok()   { printf '  ok   — %s\n' "$1"; PASS=$((PASS+1)); }
-bad()  { printf '  FAIL — %s\n' "$1"; FAIL=$((FAIL+1)); }
+ck(){ if [ "$1" = "$2" ]; then PASS=$((PASS+1)); echo "  ✓ $3"; else FAIL=$((FAIL+1)); echo "  ✗ FAIL $3 (got '$1' want '$2')"; fi }
 
-run_sut() {  # run the SUT with the fakes wired; capture exit code
-  FAKE_GH_LOG="$FAKE_GH_LOG" \
-  LOA_GH_BIN="$FAKE_GH" \
-  LOA_SIGNOFF_REPO="0xHoneyJar/loa-freeside" \
-  LOA_SIGNOFF_SUITE_DIR="$WORK" \
-  bash "$SUT" "$@"
-}
+echo "loa-signoff.test — shim → 'loa signoff' (logic lives in loa-cli/signoff_gate.mjs)"
 
-SHA="abc123def456abc123def456abc123def456abcd"
+# A mock `loa`: the guard probe `signoff --help` exits 0 (new-enough loa); any other
+# invocation records its argv and exits with sentinel 7 so we can prove exit-propagation.
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+REC="$TMP/rec"
+cat > "$TMP/loa" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "signoff" ] && [ "\$2" = "--help" ]; then exit 0; fi
+printf '%s\n' "\$*" > "$REC"
+exit 7
+EOF
+chmod +x "$TMP/loa"
 
-echo "== loa-signoff.test =="
+ec=0; PATH="$TMP:$PATH" bash "$HERE/loa-signoff.sh" 323 --repo o/r --dry-run >/dev/null 2>&1 || ec=$?
+ck "$ec" 7 "propagates loa's exit code (sentinel 7)"
+ck "$(cat "$REC" 2>/dev/null)" "signoff 323 --repo o/r --dry-run" "forwards 'signoff 323 --repo o/r --dry-run' verbatim"
 
-# 1. RED suite → refuse, exit 1, post NOTHING ---------------------------------
-: >"$FAKE_GH_LOG"
-ec=0; LOA_SIGNOFF_SUITE_CMD="exit 7" run_sut --sha "$SHA" >/dev/null 2>&1 || ec=$?
-[[ "$ec" -eq 1 ]] && ok "red suite exits 1" || bad "red suite expected exit 1, got $ec"
-if grep -q "statuses/" "$FAKE_GH_LOG"; then bad "red suite MUST NOT post a status"; else ok "red suite posted no status"; fi
+# `loa` absent → clear exit 2 (fail-closed, not a silent no-op)
+ec2=0; PATH="/usr/bin:/bin" bash "$HERE/loa-signoff.sh" 1 >/dev/null 2>&1 || ec2=$?
+ck "$ec2" 2 "no loa on PATH → exit 2 with a clear install message"
 
-# 2. GREEN suite → sign off (status POST), exit 0 -----------------------------
-: >"$FAKE_GH_LOG"
-ec=0; LOA_SIGNOFF_SUITE_CMD="exit 0" run_sut --sha "$SHA" >/dev/null 2>&1 || ec=$?
-[[ "$ec" -eq 0 ]] && ok "green suite exits 0" || bad "green suite expected exit 0, got $ec"
-if grep -q "statuses/$SHA" "$FAKE_GH_LOG" && grep -q "state=success" "$FAKE_GH_LOG" && grep -q "context=loa-signoff" "$FAKE_GH_LOG"; then
-  ok "green suite posted loa-signoff=success to head SHA"
-else
-  bad "green suite did not post the expected status (log: $(tr '\n' '|' <"$FAKE_GH_LOG"))"
-fi
-
-# 3. --dry-run on GREEN → no POST, exit 0 -------------------------------------
-: >"$FAKE_GH_LOG"
-ec=0; LOA_SIGNOFF_SUITE_CMD="exit 0" run_sut --sha "$SHA" --dry-run >/dev/null 2>&1 || ec=$?
-[[ "$ec" -eq 0 ]] && ok "dry-run green exits 0" || bad "dry-run green expected exit 0, got $ec"
-if grep -q "statuses/" "$FAKE_GH_LOG"; then bad "dry-run MUST NOT post a status"; else ok "dry-run posted no status"; fi
-
-# 4. bad usage (no pr / no sha) → exit 2 --------------------------------------
-ec=0; run_sut >/dev/null 2>&1 || ec=$?
-[[ "$ec" -eq 2 ]] && ok "no args exits 2" || bad "no args expected exit 2, got $ec"
-
-echo "== loa-signoff: $PASS passed, $FAIL failed =="
-[[ "$FAIL" -eq 0 ]]
+echo ""
+[ "$FAIL" -eq 0 ] && { echo "loa-signoff.test: PASS ($PASS)"; exit 0; } || { echo "loa-signoff.test: FAIL ($FAIL)"; exit 1; }

--- a/tools/loa-signoff.test.sh
+++ b/tools/loa-signoff.test.sh
@@ -20,7 +20,8 @@ TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 REC="$TMP/rec"
 cat > "$TMP/loa" <<EOF
 #!/usr/bin/env bash
-if [ "\$1" = "signoff" ] && [ "\$2" = "--help" ]; then exit 0; fi
+# the shim probes verb-recognition by CONTENT: emit the usage line on 'signoff --help'
+if [ "\$1" = "signoff" ] && [ "\$2" = "--help" ]; then echo "loa signoff <pr> [--sha <SHA>]"; exit 0; fi
 printf '%s\n' "\$*" > "$REC"
 exit 7
 EOF


### PR DESCRIPTION
## What

The gh-signoff door's two scripts (`tools/loa-signoff.sh`, `tools/council-signoff.sh`) were hoisted into the `loa` launcher as operator-only verbs (`loa signoff` / `loa council` — **loa-cli#7**). This collapses the per-repo copies to **thin shims** that forward every arg to `loa <verb>` unchanged. loa-cli is now the single source of truth; every repo gets the door through the one binary instead of a vendored copy that drifts. **Net −375 lines.**

## Why this is safe

- **No automation referenced these scripts** — the door's `loa-signoff` status is posted by the operator *running* the script manually; no `.github/` workflow calls them (grep-verified). The door design doc + `EXCEPTIONS.md` only *describe* them, and the usage (`tools/loa-signoff.sh <pr>`) is **unchanged** (the shim passes args through).
- **Fail-loud guard:** the shim errors clearly (exit 2) if `loa` is absent or predates the verb — never a silent no-op.
- **Exit codes propagated verbatim** (the door reads the exit code).

## Coverage moved, not lost

The real logic — suite-run, fail-closed RED-refusal, the ≥2-distinct-family approve gate, the **privilege boundary** (operator-only, never finn-reachable) — is now unit-tested in `loa-cli/test/security/signoff_gate.mjs` (**30 assertions**, fully offline). The shim `.test.sh` files keep a minimal local guard: forwards args verbatim · propagates exit · fails clearly with no `loa`.

## Ordering note

Runtime use of the shims needs the global `loa` to include the verbs (loa-cli#7 merged + `loa` updated). This PR is the file collapse; it doesn't require loa to be updated to *merge*, only to *run*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)