### PR TITLE
[codex] Add Eileen daily implementation agent runbook

### DIFF
--- a/eileendailyimplementationagentmodeagent.md
+++ b/eileendailyimplementationagentmodeagent.md
@@ -1,6 +1,6 @@
 # Eileen Daily Implementation Agent Mode Agent
 
-This file is the repo-local runbook for the daily GPT-5.5 Thinking implementation agent. The daily agent prompt must explicitly read this file before editing this repo. This file is intentionally separate from `AGENTS.md`; it is a workflow contract for converting Daily Deep Research Report issues into additive implementation PRs.
+This is the repo-local runbook for the daily GPT-5.5 Thinking implementation agent. The daily agent prompt must explicitly read this file before editing this repo. The agent must first explain what should be implemented, why it matters, why it fits this repo, how it advances the repo endgame, and how the implementation remains safe at scale.
 
 ## Repository responsibility
 
@@ -10,100 +10,65 @@ This repo is not the place for character voice/persona behavior, Straylight esta
 
 ## Existing repo instructions
 
-This repo already has `AGENTS.md`. Follow it together with this file. If there is a conflict, follow the stricter rule. Preserve existing tool rules such as using the repo-approved task/search tools when working locally.
+This repo also has `AGENTS.md`; follow it together with this file. If there is a conflict, follow the stricter rule.
 
 ## Eligible input
 
-Only implement from a Daily Deep Research Report issue or follow-up plan-audit issue/comment that contains:
+Only implement from a Daily Deep Research Report issue or follow-up plan-audit item with `PROPOSED_NEXT_LANE_SEED`, candidate ID, repo-fit reasoning, acceptance criteria, rollback path, and `VERDICT: ACCEPT_PLAN`.
 
-- `PROPOSED_NEXT_LANE_SEED`
-- candidate ID
-- repo-fit reasoning
-- acceptance criteria
-- rollback path
-- `VERDICT: ACCEPT_PLAN`
+Without `VERDICT: ACCEPT_PLAN`, the agent may self-audit only docs, fixtures, tests, or checkers. Product/runtime/payment-sensitive work requires explicit external acceptance.
 
-If the candidate lacks `VERDICT: ACCEPT_PLAN`, the agent may perform in-run plan audit only for docs, fixtures, tests, or checkers. Product/runtime/payment-sensitive work requires explicit external acceptance.
+## Mandatory pre-implementation thesis
 
-## Selection rule
+Before editing, write this in the run log and later carry it into the PR body:
 
-Pick at most one candidate per run. Prefer product-safety, observability, access-control, billing-shape, or documentation improvements that do not change default customer behavior.
+1. Candidate chosen: issue, candidate ID, and verdict.
+2. What should be implemented: precise change, not a vague theme.
+3. Why this should be implemented now: source evidence plus current repo state.
+4. Why this belongs in `loa-freeside`: repo-fit and why sibling repos should not own it.
+5. What this is good for: customer/product/platform leverage.
+6. Why this approach should work: mechanism, expected behavior, and proof path.
+7. Endgame contribution: how this moves Freeside toward scalable agentic community infrastructure.
+8. Creative/innovative extension path: future lanes after this PR, clearly marked as future work.
+9. Mass-user scaling impact: cost, latency, tenant isolation, queue/backpressure, rate-limit, billing, and ops impact.
+10. Security scope: auth, wallet, entitlement, payment, tenant data, secret, webhook, and API trust boundaries.
+11. Simplification / exploit-prevention argument: how the change avoids complex or fragile surfaces.
+12. Non-goals and forbidden surfaces.
+13. Tests/checks and rollback path.
 
-Priority order:
-
-1. docs-only design gates
-2. fixture-only product/access examples
-3. test-only coverage
-4. checker/validator-only additions
-5. default-off adapters or capability quote sketches
+If the agent cannot complete this thesis convincingly, it must not implement.
 
 ## Additive-only policy
 
 Nothing currently working may stop functioning.
 
-Allowed by default:
+Allowed by default: new docs, examples, fixtures, tests, validators/checkers, default-off experimental adapters, and design-gate documents for payment/access surfaces.
 
-- new docs
-- new examples/fixtures
-- new tests
-- new validation/checker scripts
-- default-off experimental adapters
-- design-gate documents for payment/access surfaces
-
-Forbidden without explicit Eileen approval:
-
-- deleting files
-- changing live entitlement behavior
-- changing default billing/payment behavior
-- changing wallet verification semantics
-- changing public API routes by default
-- production migrations
-- broad refactors
-- unrelated dependency upgrades
-- secrets or real env changes
-- sibling repo mutation
-- deployment changes
-- auto-merge
-- closing source issues
+Forbidden without explicit Eileen approval: deleting files, changing live entitlement behavior, changing default billing/payment behavior, changing wallet verification semantics, changing public API routes by default, production migrations, broad refactors, unrelated dependency upgrades, secrets or real env changes, sibling repo mutation, deployment changes, auto-merge, or closing source issues.
 
 ## Freeside-specific stop conditions
 
-Stop and return `VERDICT: NEEDS_HUMAN` if the candidate would:
-
-- affect real billing, x402 settlement, NOWPayments, Paddle, or user payment flows
-- alter token-gating or wallet verification behavior by default
-- change tenant/customer data handling
-- change production Discord/Telegram behavior
-- introduce product claims that are not backed by implementation evidence
+Stop and return `VERDICT: NEEDS_HUMAN` if the candidate would affect real billing/x402/NOWPayments/Paddle/user payment flows, alter token-gating or wallet verification by default, change tenant/customer data handling, change production Discord/Telegram behavior, or introduce product claims not backed by implementation evidence.
 
 ## Implementation steps
 
 1. Read `AGENTS.md`, this file, README/package scripts, and relevant docs near the target surface.
-2. Inspect the source issue and confirm `VERDICT: ACCEPT_PLAN`.
+2. Confirm the source item has `VERDICT: ACCEPT_PLAN`.
 3. Check for obvious duplicate open issues/PRs.
-4. Write a short plan: selected candidate, implementation class, allowed files, forbidden surfaces, checks, rollback.
+4. Write the mandatory pre-implementation thesis.
 5. Create a branch named `daily-impl/YYYY-MM-DD-loa-freeside-<candidate>`.
 6. Implement exactly one candidate with a minimal diff.
-7. Run relevant checks from the repo.
-8. Open a draft PR.
-9. Add `CODEX AUDIT REQUEST` to the PR body.
-10. Comment: `@codex review for additive-only scope violations, accidental default-behavior changes, payment/access-control regressions, failing or missing tests, rollback clarity, repo-boundary violations, and security regressions`.
-11. Do not merge and do not close the source issue.
+7. Prefer simpler code and explicit checks over clever abstractions.
+8. Run relevant checks.
+9. Open a draft PR.
+10. Add `CODEX AUDIT REQUEST` and the required traceability report.
+11. Comment: `@codex review for additive-only scope violations, accidental default-behavior changes, payment/access-control regressions, scaling risks, security regressions, exploit-prone complexity, failing or missing tests, rollback clarity, and repo-boundary violations`.
+12. Do not merge and do not close the source issue.
 
-## PR body requirements
+## Required PR traceability report
 
-The PR must include:
-
-- source issue
-- candidate ID
-- implementation class
-- what changed
-- what did not change
-- checks run
-- skipped or failing checks
-- rollback path
-- Codex audit request
+Every implementation PR must include source issue and candidate ID, pre-implementation thesis summary, what changed with file-by-file rationale, why each changed file is good for this repo, why it advances the repo endgame, why it should work, mass-user scaling analysis, security scope and exploit-prevention analysis, simplicity analysis, tests/checks, skipped checks, rollback path, future creative/innovative solution paths not implemented, and `CODEX AUDIT REQUEST`.
 
 ## Final run report
 
-Report the selected repo, source issue, branch, PR URL, files changed, checks run, Codex review status, blockers, and whether any boundary was approached.
+Report selected repo, source issue, branch, PR URL, files changed, checks run, Codex review status, blockers, and boundaries approached.

--- a/eileendailyimplementationagentmodeagent.md
+++ b/eileendailyimplementationagentmodeagent.md
@@ -1,0 +1,109 @@
+# Eileen Daily Implementation Agent Mode Agent
+
+This file is the repo-local runbook for the daily GPT-5.5 Thinking implementation agent. The daily agent prompt must explicitly read this file before editing this repo. This file is intentionally separate from `AGENTS.md`; it is a workflow contract for converting Daily Deep Research Report issues into additive implementation PRs.
+
+## Repository responsibility
+
+`0xHoneyJar/loa-freeside` owns the Freeside product/platform: token-gating, wallet verification, holder intelligence, AI community operations, Discord/Telegram/REST product infrastructure, billing, model budgets, BYOK, x402/crypto payment surfaces, and access/entitlement infrastructure.
+
+This repo is not the place for character voice/persona behavior, Straylight estate semantics, Hounfour schema-only packages, Finn experiment verdicts, Aleph research-précis doctrine, or Arcturus revenue-oracle proofs.
+
+## Existing repo instructions
+
+This repo already has `AGENTS.md`. Follow it together with this file. If there is a conflict, follow the stricter rule. Preserve existing tool rules such as using the repo-approved task/search tools when working locally.
+
+## Eligible input
+
+Only implement from a Daily Deep Research Report issue or follow-up plan-audit issue/comment that contains:
+
+- `PROPOSED_NEXT_LANE_SEED`
+- candidate ID
+- repo-fit reasoning
+- acceptance criteria
+- rollback path
+- `VERDICT: ACCEPT_PLAN`
+
+If the candidate lacks `VERDICT: ACCEPT_PLAN`, the agent may perform in-run plan audit only for docs, fixtures, tests, or checkers. Product/runtime/payment-sensitive work requires explicit external acceptance.
+
+## Selection rule
+
+Pick at most one candidate per run. Prefer product-safety, observability, access-control, billing-shape, or documentation improvements that do not change default customer behavior.
+
+Priority order:
+
+1. docs-only design gates
+2. fixture-only product/access examples
+3. test-only coverage
+4. checker/validator-only additions
+5. default-off adapters or capability quote sketches
+
+## Additive-only policy
+
+Nothing currently working may stop functioning.
+
+Allowed by default:
+
+- new docs
+- new examples/fixtures
+- new tests
+- new validation/checker scripts
+- default-off experimental adapters
+- design-gate documents for payment/access surfaces
+
+Forbidden without explicit Eileen approval:
+
+- deleting files
+- changing live entitlement behavior
+- changing default billing/payment behavior
+- changing wallet verification semantics
+- changing public API routes by default
+- production migrations
+- broad refactors
+- unrelated dependency upgrades
+- secrets or real env changes
+- sibling repo mutation
+- deployment changes
+- auto-merge
+- closing source issues
+
+## Freeside-specific stop conditions
+
+Stop and return `VERDICT: NEEDS_HUMAN` if the candidate would:
+
+- affect real billing, x402 settlement, NOWPayments, Paddle, or user payment flows
+- alter token-gating or wallet verification behavior by default
+- change tenant/customer data handling
+- change production Discord/Telegram behavior
+- introduce product claims that are not backed by implementation evidence
+
+## Implementation steps
+
+1. Read `AGENTS.md`, this file, README/package scripts, and relevant docs near the target surface.
+2. Inspect the source issue and confirm `VERDICT: ACCEPT_PLAN`.
+3. Check for obvious duplicate open issues/PRs.
+4. Write a short plan: selected candidate, implementation class, allowed files, forbidden surfaces, checks, rollback.
+5. Create a branch named `daily-impl/YYYY-MM-DD-loa-freeside-<candidate>`.
+6. Implement exactly one candidate with a minimal diff.
+7. Run relevant checks from the repo.
+8. Open a draft PR.
+9. Add `CODEX AUDIT REQUEST` to the PR body.
+10. Comment: `@codex review for additive-only scope violations, accidental default-behavior changes, payment/access-control regressions, failing or missing tests, rollback clarity, repo-boundary violations, and security regressions`.
+11. Do not merge and do not close the source issue.
+
+## PR body requirements
+
+The PR must include:
+
+- source issue
+- candidate ID
+- implementation class
+- what changed
+- what did not change
+- checks run
+- skipped or failing checks
+- rollback path
+- Codex audit request
+
+## Final run report
+
+Report the selected repo, source issue, branch, PR URL, files changed, checks run, Codex review status, blockers, and whether any boundary was approached.


### PR DESCRIPTION
## Summary

Adds top-level `eileendailyimplementationagentmodeagent.md` as the repo-local runbook for the daily GPT-5.5 Thinking implementation agent.

## Scope

Docs-only. This does not change runtime behavior, package files, tests, or CI.

## Why

The daily implementation agent needs a durable repo-local file that explains how to convert Daily Deep Research Report issues into one additive PR while preserving this repo's boundaries.

## Validation

Not run; docs-only runbook addition.

## Notes

This file is intentionally separate from `AGENTS.md`. This repo already has `AGENTS.md`; this new file is the implementation-agent-specific runbook. The daily agent-mode prompt should explicitly read `eileendailyimplementationagentmodeagent.md` before editing this repo.

No Codex review was triggered automatically.