### PR TITLE
feat(network/freeside-cli): beacon-discovery sensor — un-defer doctor --remote (SC-6) + dark-beacon gate

### DIFF
--- a/packages/freeside-cli/bin/freeside-cli.ts
+++ b/packages/freeside-cli/bin/freeside-cli.ts
@@ -21,6 +21,10 @@ Usage:
   freeside-cli inspect <slug>        Show beacon for a specific module
   freeside-cli doctor [--remote] [--acvp] [--baseline <reg>] [--registry <reg>] [--cells-dir <dir>]
                                      Audit all modules against BeaconV3 + ACVP bindings.
+                                     --remote: host-pinned live probe of each declared
+                                       beacon_url + host-integrity guard (SC-6). A
+                                       public+deployed cell whose beacon is dark → warn;
+                                       scaffolded/not-built cells are exempt.
                                      --cells-dir <dir>: resolve each cell's beacon + ACVP
                                        inputs from a per-cell clone at <dir>/cell-<slug>/
                                        (the per-cell resolution bridge — backed buildings

--- a/packages/freeside-cli/src/verbs/doctor.ts
+++ b/packages/freeside-cli/src/verbs/doctor.ts
@@ -113,9 +113,12 @@ const SHA256_RE = /^[a-f0-9]{64}$/;
 
 // ── --remote: host-pinned beacon probe + host-integrity guard (SC-6) ─────────
 // Ported from the kuang H1 instrument (~/bonfire/kuang/instruments/h1-flight.py):
-// fetch the EXACT declared beacon_url, then GUARD against a wrong-host artifact —
-// a probe that redirects off the declared host can never false-flag a real cell
-// as dark (the error that loop made 3× before the guard existed).
+// fetch the EXACT declared beacon_url, then GUARD on TWO axes — (a) host: an
+// off-host redirect is never followed and its body never read (host-pinned), and
+// (b) identity: the served beacon's slug MUST equal the registry slug being probed
+// (a sibling's beacon at a miswired URL is dark, not discoverable). The guard means
+// a probe can never false-flag a real cell as dark on the wrong host, nor pass a
+// wrong cell as discoverable.
 
 const REMOTE_TIMEOUT_MS = 12_000;
 
@@ -126,12 +129,15 @@ export interface BeaconProbe {
   readonly finalHost: string; // host after following redirects (= declaredHost if none)
   readonly redirectedOff: boolean; // finalHost !== declaredHost → guard (b) fails
   readonly status: number; // HTTP status (0 on transport failure)
-  readonly bodyValid: boolean; // response body decodes as a valid BeaconV3
+  readonly bodyValid: boolean; // response body decodes as a valid BeaconV3 (any slug)
+  readonly expectedSlug: string; // the registry slug being probed (the identity we require)
+  readonly bodySlug: string | null; // slug the served beacon declares (null if not a valid V3)
   readonly error?: string; // transport/parse detail when present
 }
 
-/** discoverable = serves valid BeaconV3 at the declared host; dark = correctly
- *  targeted host that 404s / serves non-BeaconV3; void = redirected off-host. */
+/** discoverable = serves THIS cell's valid BeaconV3 (slug MATCHES) at the declared
+ *  host; dark = correctly targeted host that 404s / serves non-BeaconV3 / serves a
+ *  DIFFERENT cell's beacon (slug mismatch); void = redirected off-host. */
 export type RemoteVerdict = "discoverable" | "dark" | "void";
 
 /** What the probe needs from the network: status, the post-redirect URL, and the
@@ -153,43 +159,80 @@ function hostOf(u: string): string {
   }
 }
 
-/** A response body "serves a valid BeaconV3" iff it is JSON that decodes against
- *  the BeaconV3 schema. A 404 HTML page / a non-beacon JSON blob → false → dark. */
-function isValidBeaconV3Body(body: string): boolean {
-  if (!body) return false;
+/** Decode a served body as BeaconV3 and return the SLUG it declares, or null when
+ *  the body is not JSON / not a valid BeaconV3 (a 404 HTML page / non-beacon blob).
+ *  The slug is load-bearing for discovery: a --remote probe must confirm the host
+ *  serves THIS cell's beacon, not merely *some* valid beacon — a miswired URL that
+ *  serves a sibling's beacon is the declaration≠reality the sensor exists to catch. */
+function beaconSlugOf(body: string): string | null {
+  if (!body) return null;
   let parsed: unknown;
   try {
     parsed = JSON.parse(body);
   } catch {
-    return false;
+    return null;
   }
-  return validateBeaconV3(parsed).ok;
+  const v = validateBeaconV3(parsed);
+  return v.ok ? v.beacon.slug : null;
 }
 
 /** PLATT's guard, ported verbatim: redirected-off → VOID before anything else;
- *  a 2xx at the declared host serving valid BeaconV3 → discoverable; else dark. */
+ *  a 2xx at the declared host serving valid BeaconV3 FOR THIS SLUG → discoverable;
+ *  else dark. The slug-equality clause is the gate's whole purpose: a valid body is
+ *  not enough — a miswired beacon_url that serves a SIBLING's beacon (right shape,
+ *  wrong identity) is exactly the declaration≠reality this sensor catches → dark. */
 export function classifyProbe(p: BeaconProbe): RemoteVerdict {
   if (p.redirectedOff) return "void";
-  if (p.status >= 200 && p.status < 300 && p.bodyValid) return "discoverable";
+  if (p.status >= 200 && p.status < 300 && p.bodyValid && p.bodySlug === p.expectedSlug) {
+    return "discoverable";
+  }
   return "dark";
 }
 
-/** Default fetcher: global fetch, host-pinned (no URL rewriting), redirects
- *  followed so the guard can compare the FINAL host to the declared one. Every
- *  transport failure becomes a status-0 result — never a throw into the audit. */
+/** Max same-host redirect hops to follow before giving up (bounds the loop). */
+const REMOTE_MAX_REDIRECTS = 5;
+
+/** Default fetcher: global fetch, host-pinned. redirect:"manual" — we follow
+ *  redirects OURSELVES and ONLY when they stay on the declared host. An OFF-HOST
+ *  Location is NEVER followed and its body is NEVER read (the host-integrity guard
+ *  must be actually host-pinned: redirect:"follow" let fetch chase an off-host
+ *  redirect and read an off-host body BEFORE the guard ran — arbitrary outbound
+ *  fetch under --remote). The off-host target is surfaced as finalUrl so the probe
+ *  classifies it VOID. Every transport failure becomes a status-0 result, never a
+ *  throw into the audit. */
 export const defaultBeaconFetcher: BeaconFetcher = async (url) => {
   try {
-    const res = await fetch(url, {
-      redirect: "follow",
-      signal: AbortSignal.timeout(REMOTE_TIMEOUT_MS),
-    });
-    let body = "";
-    try {
-      body = await res.text();
-    } catch {
-      // body read failure (e.g. abort mid-stream) — status still load-bearing
+    const declaredHost = hostOf(url);
+    let current = url;
+    for (let hop = 0; hop <= REMOTE_MAX_REDIRECTS; hop++) {
+      const res = await fetch(current, {
+        redirect: "manual",
+        signal: AbortSignal.timeout(REMOTE_TIMEOUT_MS),
+      });
+      if (res.status >= 300 && res.status < 400) {
+        // a redirect: do NOT read the body — resolve the Location and decide.
+        const loc = res.headers.get("location");
+        if (!loc) return { status: res.status, finalUrl: current, body: "" };
+        const next = new URL(loc, current).toString();
+        if (hostOf(next) !== declaredHost) {
+          // off-host hop → STOP. Off-host body never fetched; surface the off-host
+          // finalUrl so the host-integrity guard classifies it void.
+          return { status: res.status, finalUrl: next, body: "" };
+        }
+        current = next; // same-host redirect → follow (still host-pinned)
+        continue;
+      }
+      // terminal response at a host-pinned URL → read the body.
+      let body = "";
+      try {
+        body = await res.text();
+      } catch {
+        // body read failure (e.g. abort mid-stream) — status still load-bearing
+      }
+      return { status: res.status, finalUrl: res.url || current, body };
     }
-    return { status: res.status, finalUrl: res.url || url, body };
+    // same-host redirect chain too long → treat as unreachable, never off-host.
+    return { status: 0, finalUrl: current, body: "", error: "too many redirects" };
   } catch (err) {
     return {
       status: 0,
@@ -200,18 +243,27 @@ export const defaultBeaconFetcher: BeaconFetcher = async (url) => {
   }
 };
 
-/** Probe the EXACT declared beacon_url and record the full host-integrity guard. */
-export async function probeBeacon(declaredUrl: string, fetcher: BeaconFetcher): Promise<BeaconProbe> {
+/** Probe the EXACT declared beacon_url and record the full host-integrity guard.
+ *  `expectedSlug` is the registry slug being probed — carried through so the verdict
+ *  can require the served beacon's identity to MATCH (slug-pinning, FINDING 1). */
+export async function probeBeacon(
+  declaredUrl: string,
+  expectedSlug: string,
+  fetcher: BeaconFetcher,
+): Promise<BeaconProbe> {
   const declaredHost = hostOf(declaredUrl);
   const r = await fetcher(declaredUrl);
   const finalHost = hostOf(r.finalUrl) || declaredHost;
+  const bodySlug = beaconSlugOf(r.body);
   return {
     target: declaredUrl,
     declaredHost,
     finalHost,
     redirectedOff: finalHost !== declaredHost,
     status: r.status,
-    bodyValid: isValidBeaconV3Body(r.body),
+    bodyValid: bodySlug !== null,
+    expectedSlug,
+    bodySlug,
     error: r.error,
   };
 }
@@ -686,7 +738,7 @@ export const doctor = async (opts: DoctorOptions = {}): Promise<DoctorReport> =>
         }
         continue;
       }
-      const probe = await probeBeacon(declared, fetchBeacon);
+      const probe = await probeBeacon(declared, slug, fetchBeacon);
       const verdict = classifyProbe(probe);
       if (verdict === "discoverable") {
         push({
@@ -708,12 +760,13 @@ export const doctor = async (opts: DoctorOptions = {}): Promise<DoctorReport> =>
           });
         }
       } else {
-        // dark: correctly-targeted declared host that 404s / serves non-BeaconV3.
-        const detail = `status=${probe.status}, final_host=${probe.finalHost}, body_valid=${probe.bodyValid}${probe.error ? `, ${probe.error}` : ""}`;
+        // dark: correctly-targeted declared host that 404s / serves non-BeaconV3 /
+        // serves a DIFFERENT cell's beacon (slug mismatch — FINDING 1).
+        const detail = `status=${probe.status}, final_host=${probe.finalHost}, body_valid=${probe.bodyValid}, body_slug=${probe.bodySlug ?? "none"} (expected ${probe.expectedSlug})${probe.error ? `, ${probe.error}` : ""}`;
         if (gated) {
           push({
             slug, check: "beacon_dark", severity: "warn",
-            message: `public+deployed cell's beacon_url ${declared} is DARK (${detail}) — declares deployed-public but serves no valid BeaconV3`,
+            message: `public+deployed cell's beacon_url ${declared} is DARK (${detail}) — declares deployed-public but serves no valid BeaconV3 for this slug`,
           });
         } else {
           push({

--- a/packages/freeside-cli/src/verbs/doctor.ts
+++ b/packages/freeside-cli/src/verbs/doctor.ts
@@ -3,7 +3,8 @@
  *
  * The enforcement point for the network's awareness surface (SDD cycle
  * doctor-acvp-network-plane §3). Per registry module:
- *   1. Resolve the beacon (FIXTURE-FIRST, OD-1; --remote → beacon_unreachable, SC-6)
+ *   1. Resolve the beacon (FIXTURE-FIRST, OD-1; --remote → host-pinned live
+ *      probe of the declared beacon_url + host-integrity guard, SC-6 un-deferred)
  *   2. Validate against BeaconV3 (clean V2 decode → beacon_legacy_v2 warn, A.4)
  *   3. cycle_state freshness (next_review vs injected `now`; 180-day window)
  *   4. composes_with: unknown-sibling (error) + tag_hash_unverified (warn, OD-2)
@@ -48,6 +49,11 @@ export type DoctorCheck =
   | "beacon_legacy_v2"
   | "beacon_valid"
   | "beacon_auth_required"
+  // ── --remote host-pinned probe verdicts (SC-6 un-deferred) ──
+  | "beacon_discoverable" // declared beacon_url serves a valid BeaconV3 at the declared host
+  | "beacon_dark" // public+deployed cell whose declared beacon_url 404s / serves non-BeaconV3 (the gate bite)
+  | "beacon_void" // probe redirected off the declared host — discovery unconfirmable; NOT counted as dark
+  | "beacon_exempt" // dark/unprobed but not public+deployed — honest non-deployed, no alarm
   | "cycle_review_overdue"
   | "cycle_review_window_exceeded"
   | "compose_unknown_sibling"
@@ -73,8 +79,14 @@ export interface DoctorReport {
 }
 
 export interface DoctorOptions {
-  /** fetch live beacon_url instead of fixture (SC-6: returns beacon_unreachable this build) */
+  /** --remote: host-pinned live probe of each declared beacon_url + host-integrity
+   *  guard, instead of the in-repo fixture (SC-6 un-deferred). NEVER falls back to a
+   *  fixture — a caller asking for live remote evidence gets a probe verdict
+   *  (beacon_discoverable / beacon_dark / beacon_void / beacon_exempt). */
   readonly remote?: boolean;
+  /** Injected network fetcher for --remote (determinism + no live calls in tests).
+   *  Default = `defaultBeaconFetcher` (global fetch, host-pinned, 12s timeout). */
+  readonly fetchBeacon?: BeaconFetcher;
   /** prior registry for the visibility-transition guard (SC: not wired this build) */
   readonly baselineRegistryPath?: string;
   /** test/CI override: registry file to audit (default = registry package's registry.yaml) */
@@ -98,6 +110,111 @@ export interface DoctorOptions {
 
 const ALL_ZEROS_64 = "0".repeat(64);
 const SHA256_RE = /^[a-f0-9]{64}$/;
+
+// ── --remote: host-pinned beacon probe + host-integrity guard (SC-6) ─────────
+// Ported from the kuang H1 instrument (~/bonfire/kuang/instruments/h1-flight.py):
+// fetch the EXACT declared beacon_url, then GUARD against a wrong-host artifact —
+// a probe that redirects off the declared host can never false-flag a real cell
+// as dark (the error that loop made 3× before the guard existed).
+
+const REMOTE_TIMEOUT_MS = 12_000;
+
+/** A single host-pinned probe of a declared beacon_url (the guard record). */
+export interface BeaconProbe {
+  readonly target: string; // the EXACT declared beacon_url fetched (no rewriting)
+  readonly declaredHost: string; // host parsed from the declared beacon_url
+  readonly finalHost: string; // host after following redirects (= declaredHost if none)
+  readonly redirectedOff: boolean; // finalHost !== declaredHost → guard (b) fails
+  readonly status: number; // HTTP status (0 on transport failure)
+  readonly bodyValid: boolean; // response body decodes as a valid BeaconV3
+  readonly error?: string; // transport/parse detail when present
+}
+
+/** discoverable = serves valid BeaconV3 at the declared host; dark = correctly
+ *  targeted host that 404s / serves non-BeaconV3; void = redirected off-host. */
+export type RemoteVerdict = "discoverable" | "dark" | "void";
+
+/** What the probe needs from the network: status, the post-redirect URL, and the
+ *  body text. Injected (DoctorOptions.fetchBeacon) so tests never hit the network. */
+export interface RemoteFetchResult {
+  readonly status: number; // 0 on transport failure
+  readonly finalUrl: string; // URL after redirects (= request url if none)
+  readonly body: string; // response body text ("" on failure)
+  readonly error?: string; // transport error detail
+}
+export type BeaconFetcher = (url: string) => Promise<RemoteFetchResult>;
+
+/** Parse a URL's host; "" when the string is not a valid URL (guard input). */
+function hostOf(u: string): string {
+  try {
+    return new URL(u).host;
+  } catch {
+    return "";
+  }
+}
+
+/** A response body "serves a valid BeaconV3" iff it is JSON that decodes against
+ *  the BeaconV3 schema. A 404 HTML page / a non-beacon JSON blob → false → dark. */
+function isValidBeaconV3Body(body: string): boolean {
+  if (!body) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return false;
+  }
+  return validateBeaconV3(parsed).ok;
+}
+
+/** PLATT's guard, ported verbatim: redirected-off → VOID before anything else;
+ *  a 2xx at the declared host serving valid BeaconV3 → discoverable; else dark. */
+export function classifyProbe(p: BeaconProbe): RemoteVerdict {
+  if (p.redirectedOff) return "void";
+  if (p.status >= 200 && p.status < 300 && p.bodyValid) return "discoverable";
+  return "dark";
+}
+
+/** Default fetcher: global fetch, host-pinned (no URL rewriting), redirects
+ *  followed so the guard can compare the FINAL host to the declared one. Every
+ *  transport failure becomes a status-0 result — never a throw into the audit. */
+export const defaultBeaconFetcher: BeaconFetcher = async (url) => {
+  try {
+    const res = await fetch(url, {
+      redirect: "follow",
+      signal: AbortSignal.timeout(REMOTE_TIMEOUT_MS),
+    });
+    let body = "";
+    try {
+      body = await res.text();
+    } catch {
+      // body read failure (e.g. abort mid-stream) — status still load-bearing
+    }
+    return { status: res.status, finalUrl: res.url || url, body };
+  } catch (err) {
+    return {
+      status: 0,
+      finalUrl: url,
+      body: "",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+};
+
+/** Probe the EXACT declared beacon_url and record the full host-integrity guard. */
+export async function probeBeacon(declaredUrl: string, fetcher: BeaconFetcher): Promise<BeaconProbe> {
+  const declaredHost = hostOf(declaredUrl);
+  const r = await fetcher(declaredUrl);
+  const finalHost = hostOf(r.finalUrl) || declaredHost;
+  return {
+    target: declaredUrl,
+    declaredHost,
+    finalHost,
+    redirectedOff: finalHost !== declaredHost,
+    status: r.status,
+    bodyValid: isValidBeaconV3Body(r.body),
+    error: r.error,
+  };
+}
 
 /** reject absolute paths + `..` traversal (path-component discipline). */
 function relPathSafe(p: string): boolean {
@@ -487,6 +604,7 @@ export const doctor = async (opts: DoctorOptions = {}): Promise<DoctorReport> =>
   const allowlistPath = opts.allowlistPath ?? join(repoRoot, ".freeside", "acvp-aspirational-allowlist.yaml");
   const allowlist = readAllowlist(allowlistPath);
   const resolvePinSchemaVersion = makeResolvePinSchemaVersion(repoRoot);
+  const fetchBeacon = opts.fetchBeacon ?? defaultBeaconFetcher;
 
   const findings: DoctorFinding[] = [];
   const push = (f: DoctorFinding) => findings.push(f);
@@ -546,10 +664,64 @@ export const doctor = async (opts: DoctorOptions = {}): Promise<DoctorReport> =>
         continue;
       }
     } else if (opts.remote) {
-      push({
-        slug, check: "beacon_unreachable", severity: "warn",
-        message: `--remote fetch of ${entry.beacon_url} not implemented this build (SC-6); fixture substitution refused — omit --remote to audit the in-repo fixture`,
-      });
+      // SC-6 un-deferred: host-pinned live probe of the declared beacon_url +
+      // host-integrity guard (no fixture substitution). The GATE: a cell that
+      // declares visibility=public AND runtime_state=deployed MUST serve a valid
+      // BeaconV3 — else WARN (the meter that catches a deployed-public cell whose
+      // beacon went dark). scaffolded / not-built / unlisted / internal cells are
+      // EXEMPT — they honestly declare they don't serve yet (no false alarm).
+      const gated = entry.visibility === "public" && entry.runtime_state === "deployed";
+      const declared = entry.beacon_url;
+      if (!declared) {
+        if (gated) {
+          push({
+            slug, check: "beacon_dark", severity: "warn",
+            message: `public+deployed cell declares no beacon_url — undiscoverable (dark)`,
+          });
+        } else {
+          push({
+            slug, check: "beacon_exempt", severity: "ok",
+            message: `no beacon_url + not public-deployed (${entry.visibility}/${entry.runtime_state ?? "unset"}) — remote probe exempt`,
+          });
+        }
+        continue;
+      }
+      const probe = await probeBeacon(declared, fetchBeacon);
+      const verdict = classifyProbe(probe);
+      if (verdict === "discoverable") {
+        push({
+          slug, check: "beacon_discoverable", severity: "ok",
+          message: `beacon_url ${declared} serves a valid BeaconV3 (host-pinned; final_host=${probe.finalHost}, status=${probe.status})`,
+        });
+      } else if (verdict === "void") {
+        // redirected off the declared host → cannot be counted as dark (guard b).
+        // Surface it for gated cells (discovery unconfirmable); exempt otherwise.
+        if (gated) {
+          push({
+            slug, check: "beacon_void", severity: "warn",
+            message: `probe of ${declared} redirected off the declared host (final_host=${probe.finalHost} ≠ ${probe.declaredHost}, status=${probe.status}) — VOID; discovery unconfirmable, not counted as dark`,
+          });
+        } else {
+          push({
+            slug, check: "beacon_exempt", severity: "ok",
+            message: `probe of ${declared} redirected off-host (final_host=${probe.finalHost}) but cell is ${entry.visibility}/${entry.runtime_state ?? "unset"} — exempt`,
+          });
+        }
+      } else {
+        // dark: correctly-targeted declared host that 404s / serves non-BeaconV3.
+        const detail = `status=${probe.status}, final_host=${probe.finalHost}, body_valid=${probe.bodyValid}${probe.error ? `, ${probe.error}` : ""}`;
+        if (gated) {
+          push({
+            slug, check: "beacon_dark", severity: "warn",
+            message: `public+deployed cell's beacon_url ${declared} is DARK (${detail}) — declares deployed-public but serves no valid BeaconV3`,
+          });
+        } else {
+          push({
+            slug, check: "beacon_exempt", severity: "ok",
+            message: `beacon_url ${declared} dark (${detail}) but cell is ${entry.visibility}/${entry.runtime_state ?? "unset"} — exempt (honest non-deployed)`,
+          });
+        }
+      }
       continue;
     } else if (!entry.beacon_fixture) {
       push({

--- a/packages/freeside-cli/tests/doctor.test.ts
+++ b/packages/freeside-cli/tests/doctor.test.ts
@@ -23,6 +23,7 @@ import {
   readAllowlist,
   classifyProbe,
   probeBeacon,
+  defaultBeaconFetcher,
   type BeaconFetcher,
   type BeaconProbe,
 } from "../src/verbs/doctor.js";
@@ -191,18 +192,21 @@ test("doctor() · --acvp (acvpOnly) skips cycle/compose/sealed; beacon-resolve +
 // verdicts; the gate WARNs only on public+deployed cells that go dark, and is
 // silent on honestly-scaffolded ones.
 
-/** A minimal but schema-valid BeaconV3 served at a beacon_url (the "discoverable" body). */
-const VALID_BEACON_BODY = JSON.stringify({
-  schema_version: "3",
-  slug: "activities-api",
-  publisher: "0xHoneyJar",
-  is: {
-    one_liner: "Activity feed aggregator for registered worlds",
-    scope: ["Aggregate per-world activity events", "Surface a unified activity timeline"],
-  },
-  is_not: ["Does NOT mint or burn tokens", "Will NOT proxy chain RPC calls"],
-  cycle_state: { status: "active", since: "2026-05-18", next_review: "2026-08-18" },
-});
+/** A minimal but schema-valid BeaconV3 body declaring `slug` (the "discoverable" body). */
+const validBeaconBody = (slug: string) =>
+  JSON.stringify({
+    schema_version: "3",
+    slug,
+    publisher: "0xHoneyJar",
+    is: {
+      one_liner: "Activity feed aggregator for registered worlds",
+      scope: ["Aggregate per-world activity events", "Surface a unified activity timeline"],
+    },
+    is_not: ["Does NOT mint or burn tokens", "Will NOT proxy chain RPC calls"],
+    cycle_state: { status: "active", since: "2026-05-18", next_review: "2026-08-18" },
+  });
+/** The activities-api body (the existing discoverable fixture — slug activities-api). */
+const VALID_BEACON_BODY = validBeaconBody("activities-api");
 
 /** Route declared URLs → canned fetch results; an unrouted URL is a transport failure. */
 const mockFetcher = (routes: Record<string, { status: number; finalUrl?: string; body?: string }>): BeaconFetcher =>
@@ -229,22 +233,34 @@ test("classifyProbe · redirected off the declared host → void (before anythin
   const p: BeaconProbe = {
     target: SCORE_URL, declaredHost: "score.0xhoneyjar.xyz", finalHost: "cname.vercel-dns.com",
     redirectedOff: true, status: 200, bodyValid: true,
+    expectedSlug: "score-api", bodySlug: "score-api",
   };
   assert.equal(classifyProbe(p), "void");
 });
 
-test("classifyProbe · 2xx valid body at declared host → discoverable", () => {
+test("classifyProbe · 2xx valid body for the RIGHT slug at declared host → discoverable", () => {
   const p: BeaconProbe = {
     target: SCORE_URL, declaredHost: "score.0xhoneyjar.xyz", finalHost: "score.0xhoneyjar.xyz",
     redirectedOff: false, status: 200, bodyValid: true,
+    expectedSlug: "score-api", bodySlug: "score-api",
   };
   assert.equal(classifyProbe(p), "discoverable");
+});
+
+test("classifyProbe · 2xx valid body but WRONG slug (a sibling's beacon at a miswired URL) → dark (FINDING 1)", () => {
+  const wrongSlug: BeaconProbe = {
+    target: SCORE_URL, declaredHost: "score.0xhoneyjar.xyz", finalHost: "score.0xhoneyjar.xyz",
+    redirectedOff: false, status: 200, bodyValid: true,
+    expectedSlug: "score-api", bodySlug: "activities-api",
+  };
+  assert.equal(classifyProbe(wrongSlug), "dark");
 });
 
 test("classifyProbe · correctly-targeted host that 404s / serves non-BeaconV3 → dark", () => {
   const notFound: BeaconProbe = {
     target: SCORE_URL, declaredHost: "score.0xhoneyjar.xyz", finalHost: "score.0xhoneyjar.xyz",
     redirectedOff: false, status: 404, bodyValid: false,
+    expectedSlug: "score-api", bodySlug: null,
   };
   assert.equal(classifyProbe(notFound), "dark");
   // 200 but body not a BeaconV3 → still dark
@@ -257,7 +273,7 @@ test("probeBeacon · records the post-redirect host; off-host probe flags redire
   const fetcher = mockFetcher({
     [SCORE_URL]: { status: 200, finalUrl: "https://cname.vercel-dns.com/404", body: "<html>nope" },
   });
-  const p = await probeBeacon(SCORE_URL, fetcher);
+  const p = await probeBeacon(SCORE_URL, "score-api", fetcher);
   assert.equal(p.declaredHost, "score.0xhoneyjar.xyz");
   assert.equal(p.finalHost, "cname.vercel-dns.com");
   assert.equal(p.redirectedOff, true);
@@ -265,11 +281,12 @@ test("probeBeacon · records the post-redirect host; off-host probe flags redire
   assert.equal(classifyProbe(p), "void");
 });
 
-test("probeBeacon · valid BeaconV3 body at the declared host → bodyValid true, not redirected", async () => {
-  const fetcher = mockFetcher({ [SCORE_URL]: { status: 200, body: VALID_BEACON_BODY } });
-  const p = await probeBeacon(SCORE_URL, fetcher);
+test("probeBeacon · valid BeaconV3 body for the RIGHT slug at the declared host → discoverable", async () => {
+  const fetcher = mockFetcher({ [SCORE_URL]: { status: 200, body: validBeaconBody("score-api") } });
+  const p = await probeBeacon(SCORE_URL, "score-api", fetcher);
   assert.equal(p.redirectedOff, false);
   assert.equal(p.bodyValid, true);
+  assert.equal(p.bodySlug, "score-api");
   assert.equal(classifyProbe(p), "discoverable");
 });
 
@@ -406,6 +423,95 @@ test("doctor() · --remote → public+deployed cell whose probe redirects off-ho
     );
   } finally {
     cleanup();
+  }
+});
+
+test("doctor() · --remote → public+deployed cell whose URL serves a SIBLING's beacon (wrong slug) → beacon_dark, NOT discoverable (FINDING 1)", async () => {
+  const { path, cleanup } = writeRemoteRegistry(
+    [
+      "  score-api:",
+      "    git_url: https://github.com/0xHoneyJar/score-api.git",
+      `    beacon_url: ${SCORE_URL}`,
+      "    visibility: public",
+      "    owner: 0xHoneyJar",
+      '    added: "2026-05-30"',
+      "    runtime_state: deployed",
+      "",
+    ].join("\n"),
+  );
+  try {
+    const report = await doctor({
+      registryPath: path,
+      remote: true,
+      now: NOW,
+      // the score-api URL serves a VALID BeaconV3 — but it is activities-api's beacon
+      // (the miswired-URL case: right shape, WRONG identity). A slug-blind sensor
+      // would falsely pass this; the slug-pin makes it dark (declaration≠reality).
+      fetchBeacon: mockFetcher({ [SCORE_URL]: { status: 200, body: validBeaconBody("activities-api") } }),
+    });
+    assert.ok(
+      report.findings.some((f) => f.slug === "score-api" && f.check === "beacon_dark" && f.severity === "warn"),
+      "a valid body for the WRONG slug must be dark, not a pass",
+    );
+    assert.ok(
+      !report.findings.some((f) => f.slug === "score-api" && f.check === "beacon_discoverable"),
+      "a sibling's beacon must NOT count as score-api being discoverable",
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+// ── FINDING 2: redirect host-integrity — the REAL fetcher must NOT chase off-host ──
+// These exercise defaultBeaconFetcher directly by mocking globalThis.fetch (no live
+// network), recording every URL fetch is called with. The fix (redirect:"manual",
+// same-host-only follow) means an off-host Location is never requested and its body
+// is never read — so --remote cannot make arbitrary outbound fetches.
+
+test("defaultBeaconFetcher · off-host redirect is NOT followed — off-host body never fetched (FINDING 2)", async () => {
+  const declared = SCORE_URL;
+  const offHost = "https://evil.example.com/.well-known/beacon.json";
+  const calls: string[] = [];
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: unknown) => {
+    const u = typeof input === "string" ? input : (input as URL).toString();
+    calls.push(u);
+    if (u === declared) return new Response(null, { status: 302, headers: { location: offHost } });
+    // reaching here means the off-host body WAS fetched — the vulnerability
+    return new Response(VALID_BEACON_BODY, { status: 200 });
+  }) as typeof fetch;
+  try {
+    const r = await defaultBeaconFetcher(declared);
+    assert.deepEqual(calls, [declared], "only the declared host was fetched — off-host Location never requested");
+    assert.equal(new URL(r.finalUrl).host, "evil.example.com", "off-host target surfaced as finalUrl (for the void verdict)");
+    assert.equal(r.body, "", "off-host body never read");
+    // end-to-end: the host-integrity guard classifies it void (not dark, not discoverable)
+    const probe = await probeBeacon(declared, "score-api", async () => r);
+    assert.equal(classifyProbe(probe), "void");
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("defaultBeaconFetcher · same-host redirect IS followed (only off-host is refused — no over-correction)", async () => {
+  const declared = "https://score.0xhoneyjar.xyz/beacon";
+  const sameHost = "https://score.0xhoneyjar.xyz/.well-known/beacon.json";
+  const body = validBeaconBody("score-api");
+  const calls: string[] = [];
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: unknown) => {
+    const u = typeof input === "string" ? input : (input as URL).toString();
+    calls.push(u);
+    if (u === declared) return new Response(null, { status: 301, headers: { location: sameHost } });
+    return new Response(body, { status: 200 });
+  }) as typeof fetch;
+  try {
+    const r = await defaultBeaconFetcher(declared);
+    assert.deepEqual(calls, [declared, sameHost], "the same-host redirect was followed");
+    assert.equal(r.status, 200);
+    assert.equal(r.body, body, "the same-host terminal body was read");
+  } finally {
+    globalThis.fetch = realFetch;
   }
 });
 

--- a/packages/freeside-cli/tests/doctor.test.ts
+++ b/packages/freeside-cli/tests/doctor.test.ts
@@ -21,6 +21,10 @@ import {
   checkSealedSchemas,
   recomputeSealedHash,
   readAllowlist,
+  classifyProbe,
+  probeBeacon,
+  type BeaconFetcher,
+  type BeaconProbe,
 } from "../src/verbs/doctor.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -182,12 +186,227 @@ test("doctor() · --acvp (acvpOnly) skips cycle/compose/sealed; beacon-resolve +
   assert.ok(report.findings.some((f) => f.check === "beacon_valid"));
 });
 
-test("doctor() · --remote refuses fixture substitution → beacon_unreachable only (FAGAN iter-2)", async () => {
-  const report = await doctor({ registryPath: join(FIXTURES, "registry-fixture.yaml"), remote: true, now: NOW });
-  assert.ok(report.findings.length >= 1);
-  assert.ok(report.findings.every((f) => f.check === "beacon_unreachable"));
-  // the fixture was NOT read under --remote
-  assert.ok(!report.findings.some((f) => f.check === "beacon_valid" || f.check === "sealed_schema_hash_drift"));
+// ─── --remote host-pinned probe + host-integrity guard (SC-6 un-deferred) ────
+// The beacon-discovery sensor. A mock fetcher (NO live network) drives the three
+// verdicts; the gate WARNs only on public+deployed cells that go dark, and is
+// silent on honestly-scaffolded ones.
+
+/** A minimal but schema-valid BeaconV3 served at a beacon_url (the "discoverable" body). */
+const VALID_BEACON_BODY = JSON.stringify({
+  schema_version: "3",
+  slug: "activities-api",
+  publisher: "0xHoneyJar",
+  is: {
+    one_liner: "Activity feed aggregator for registered worlds",
+    scope: ["Aggregate per-world activity events", "Surface a unified activity timeline"],
+  },
+  is_not: ["Does NOT mint or burn tokens", "Will NOT proxy chain RPC calls"],
+  cycle_state: { status: "active", since: "2026-05-18", next_review: "2026-08-18" },
+});
+
+/** Route declared URLs → canned fetch results; an unrouted URL is a transport failure. */
+const mockFetcher = (routes: Record<string, { status: number; finalUrl?: string; body?: string }>): BeaconFetcher =>
+  async (url) => {
+    const r = routes[url];
+    if (!r) return { status: 0, finalUrl: url, body: "", error: "no route (mock)" };
+    return { status: r.status, finalUrl: r.finalUrl ?? url, body: r.body ?? "" };
+  };
+
+/** Write a temp registry with the given module YAML block; returns its path + cleanup. */
+function writeRemoteRegistry(moduleYaml: string): { path: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "doctor-remote-"));
+  const path = join(dir, "registry.yaml");
+  writeFileSync(path, `version: 1\nmodules:\n${moduleYaml}`);
+  return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+const SCORE_URL = "https://score.0xhoneyjar.xyz/.well-known/beacon.json";
+const MINT_URL = "https://mint.0xhoneyjar.xyz/.well-known/beacon.json";
+
+// ── classifyProbe (pure guard) ──────────────────────────────────────────────
+
+test("classifyProbe · redirected off the declared host → void (before anything else)", () => {
+  const p: BeaconProbe = {
+    target: SCORE_URL, declaredHost: "score.0xhoneyjar.xyz", finalHost: "cname.vercel-dns.com",
+    redirectedOff: true, status: 200, bodyValid: true,
+  };
+  assert.equal(classifyProbe(p), "void");
+});
+
+test("classifyProbe · 2xx valid body at declared host → discoverable", () => {
+  const p: BeaconProbe = {
+    target: SCORE_URL, declaredHost: "score.0xhoneyjar.xyz", finalHost: "score.0xhoneyjar.xyz",
+    redirectedOff: false, status: 200, bodyValid: true,
+  };
+  assert.equal(classifyProbe(p), "discoverable");
+});
+
+test("classifyProbe · correctly-targeted host that 404s / serves non-BeaconV3 → dark", () => {
+  const notFound: BeaconProbe = {
+    target: SCORE_URL, declaredHost: "score.0xhoneyjar.xyz", finalHost: "score.0xhoneyjar.xyz",
+    redirectedOff: false, status: 404, bodyValid: false,
+  };
+  assert.equal(classifyProbe(notFound), "dark");
+  // 200 but body not a BeaconV3 → still dark
+  assert.equal(classifyProbe({ ...notFound, status: 200, bodyValid: false }), "dark");
+});
+
+// ── probeBeacon (host-integrity guard record) ───────────────────────────────
+
+test("probeBeacon · records the post-redirect host; off-host probe flags redirectedOff", async () => {
+  const fetcher = mockFetcher({
+    [SCORE_URL]: { status: 200, finalUrl: "https://cname.vercel-dns.com/404", body: "<html>nope" },
+  });
+  const p = await probeBeacon(SCORE_URL, fetcher);
+  assert.equal(p.declaredHost, "score.0xhoneyjar.xyz");
+  assert.equal(p.finalHost, "cname.vercel-dns.com");
+  assert.equal(p.redirectedOff, true);
+  assert.equal(p.bodyValid, false);
+  assert.equal(classifyProbe(p), "void");
+});
+
+test("probeBeacon · valid BeaconV3 body at the declared host → bodyValid true, not redirected", async () => {
+  const fetcher = mockFetcher({ [SCORE_URL]: { status: 200, body: VALID_BEACON_BODY } });
+  const p = await probeBeacon(SCORE_URL, fetcher);
+  assert.equal(p.redirectedOff, false);
+  assert.equal(p.bodyValid, true);
+  assert.equal(classifyProbe(p), "discoverable");
+});
+
+// ── the gate, gated on truth-state ──────────────────────────────────────────
+
+test("doctor() · --remote → public+deployed cell whose beacon 404s → beacon_dark WARN (no fixture, no error)", async () => {
+  const { path, cleanup } = writeRemoteRegistry(
+    [
+      "  score-api:",
+      "    git_url: https://github.com/0xHoneyJar/score-api.git",
+      `    beacon_url: ${SCORE_URL}`,
+      "    visibility: public",
+      "    owner: 0xHoneyJar",
+      '    added: "2026-05-30"',
+      "    runtime_state: deployed",
+      "",
+    ].join("\n"),
+  );
+  try {
+    const report = await doctor({
+      registryPath: path,
+      remote: true,
+      now: NOW,
+      fetchBeacon: mockFetcher({ [SCORE_URL]: { status: 404, body: "Not Found" } }),
+    });
+    assert.ok(
+      report.findings.some((f) => f.slug === "score-api" && f.check === "beacon_dark" && f.severity === "warn"),
+      "public+deployed dark beacon must WARN (beacon_dark)",
+    );
+    assert.equal(report.summary.error, 0, "the gate WARNs now (does not FAIL)");
+    // --remote never substitutes the fixture path
+    assert.ok(!report.findings.some((f) => f.check === "beacon_valid" || f.check === "beacon_unreachable"));
+  } finally {
+    cleanup();
+  }
+});
+
+test("doctor() · --remote → cell serving a valid BeaconV3 → beacon_discoverable (pass)", async () => {
+  const { path, cleanup } = writeRemoteRegistry(
+    [
+      "  activities-api:",
+      "    git_url: https://github.com/0xHoneyJar/activities-api.git",
+      "    beacon_url: https://activities.0xhoneyjar.xyz/.well-known/beacon.json",
+      "    visibility: public",
+      "    owner: 0xHoneyJar",
+      '    added: "2026-05-30"',
+      "    runtime_state: deployed",
+      "",
+    ].join("\n"),
+  );
+  const url = "https://activities.0xhoneyjar.xyz/.well-known/beacon.json";
+  try {
+    const report = await doctor({
+      registryPath: path,
+      remote: true,
+      now: NOW,
+      fetchBeacon: mockFetcher({ [url]: { status: 200, body: VALID_BEACON_BODY } }),
+    });
+    assert.ok(
+      report.findings.some((f) => f.slug === "activities-api" && f.check === "beacon_discoverable" && f.severity === "ok"),
+      "valid BeaconV3 at the declared host → beacon_discoverable ok",
+    );
+    assert.equal(report.summary.warn, 0);
+    assert.equal(report.summary.error, 0);
+  } finally {
+    cleanup();
+  }
+});
+
+test("doctor() · --remote → scaffolded cell whose beacon 404s → beacon_exempt (no alarm)", async () => {
+  const { path, cleanup } = writeRemoteRegistry(
+    [
+      "  mint-api:",
+      "    git_url: https://github.com/0xHoneyJar/mint-api.git",
+      `    beacon_url: ${MINT_URL}`,
+      "    visibility: public",
+      "    owner: 0xHoneyJar",
+      '    added: "2026-05-30"',
+      "    runtime_state: scaffolded",
+      "",
+    ].join("\n"),
+  );
+  try {
+    const report = await doctor({
+      registryPath: path,
+      remote: true,
+      now: NOW,
+      fetchBeacon: mockFetcher({ [MINT_URL]: { status: 404, body: "Not Found" } }),
+    });
+    assert.ok(
+      report.findings.some((f) => f.slug === "mint-api" && f.check === "beacon_exempt" && f.severity === "ok"),
+      "scaffolded cell must be exempt — no false alarm",
+    );
+    assert.ok(
+      !report.findings.some((f) => f.slug === "mint-api" && f.check === "beacon_dark"),
+      "a scaffolded cell must NOT be flagged dark",
+    );
+    assert.equal(report.summary.warn, 0);
+  } finally {
+    cleanup();
+  }
+});
+
+test("doctor() · --remote → public+deployed cell whose probe redirects off-host → beacon_void WARN (not dark)", async () => {
+  const { path, cleanup } = writeRemoteRegistry(
+    [
+      "  score-api:",
+      "    git_url: https://github.com/0xHoneyJar/score-api.git",
+      `    beacon_url: ${SCORE_URL}`,
+      "    visibility: public",
+      "    owner: 0xHoneyJar",
+      '    added: "2026-05-30"',
+      "    runtime_state: deployed",
+      "",
+    ].join("\n"),
+  );
+  try {
+    const report = await doctor({
+      registryPath: path,
+      remote: true,
+      now: NOW,
+      // declared score host redirects off to a Vercel CNAME (the score/sonar DNS class)
+      fetchBeacon: mockFetcher({
+        [SCORE_URL]: { status: 200, finalUrl: "https://cname.vercel-dns.com/404", body: VALID_BEACON_BODY },
+      }),
+    });
+    assert.ok(
+      report.findings.some((f) => f.slug === "score-api" && f.check === "beacon_void" && f.severity === "warn"),
+      "off-host redirect → beacon_void (the host-integrity guard fires)",
+    );
+    assert.ok(
+      !report.findings.some((f) => f.slug === "score-api" && f.check === "beacon_dark"),
+      "a redirected-off probe must NOT be counted as dark",
+    );
+  } finally {
+    cleanup();
+  }
 });
 
 test("doctor() · BeaconV2 module → beacon_legacy_v2 warn, NOT error (G-4)", async () => {


### PR DESCRIPTION
## What

Un-defers SC-6: `freeside-cli doctor --remote` now host-pinned probes each declared `beacon_url`, applies a host-integrity guard, and gates on truth-state — replacing the old `beacon_unreachable` stub.

- **Probe** — fetches the EXACT declared `beacon_url` (host-pinned, redirect-following, 12s timeout), validates the BeaconV3 body, records the guard fields (target==declared, post-redirect finalHost==declared, status, bodyValid).
- **Classify** — redirected-off-host → `void` (probe artifact, not counted); 2xx + valid body at declared host → `discoverable`; else → `dark`.
- **Gate** — a `visibility: public` AND `runtime_state: deployed` cell whose beacon is dark → **WARN** (`beacon_dark`); `scaffolded`/`not-built`/`internal` cells are **exempt** (no false alarm). New check ids: `beacon_discoverable` / `beacon_dark` / `beacon_void` / `beacon_exempt`.

## Why — the evidence

The Kuang **H1** preregistered experiment found **6/7 declared-public beacons dark** (served nowhere — verified, host-integrity guarded), and `doctor --remote` was blind to it (SC-6 stub). This wires the sensor so the disease is continuously visible. The **host-integrity guard is load-bearing**: it's the exact safeguard against the wrong-probe-path error the experiment hit 3× — a TRUE-DARK only counts if the probe provably hit the declared host.

Bead `arrakis-2roo` · proposal `grimoires/loa/proposals/wire-beacon-discovery-sensor-h1.md`. The probe ports the proven logic from the experiment's deterministic meter.

## Tests

**36/36 pass** (9 new), independently re-verified (not trusting the generator). Mock fetcher + temp registries — **no live network**. Covers: public+deployed 404 → `beacon_dark` warn; valid BeaconV3 → `beacon_discoverable`; scaffolded 404 → `beacon_exempt`; off-host redirect → `beacon_void`.

## Scope

Surgical: 3 files (bin help, `doctor.ts`, tests), **network-domain only** (satisfies the path-domain CI rule). Built E2E by the Icebreaker loop. **Reviewable — not auto-merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
