### PR TITLE
fix(operator-dash): validate beacon SHAPE not just status (close the masked-200 false positive)

### DIFF
--- a/tools/operator-dash/beacon-classify.test.ts
+++ b/tools/operator-dash/beacon-classify.test.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env tsx
+// The METER for the beacon classifier (Kuang iter-2). Deterministic, no network —
+// it settles whether classifyBeacon catches the storage masked-200 that fooled the
+// iter-1 status-only probe. A passing run is the gate: the false positive is closed.
+import { classifyBeacon } from "./beacon-classify";
+
+// the actual storage-api catch-all the iter-1 probe captured (GraphQL playground HTML)
+const STORAGE_HTML =
+  '<!DOCTYPE html>\n<html><head><title>GraphQL playground</title></head>' +
+  '<body><div id="graphiql">Loading...</div></body></html>';
+const BEACON_V3 = JSON.stringify({
+  schema_version: "3",
+  slug: "activities-api",
+  publisher: "0xHoneyJar",
+  is: { one_liner: "x", scope: [] },
+  is_not: [],
+});
+const BEACON_V2 = JSON.stringify({ schema_version: "2", name: "x", capabilities: [] });
+
+const cases: Array<[string, () => boolean]> = [
+  ["storage catch-all 200 HTML → masked (THE iter-1 false positive — must NOT be live)",
+    () => classifyBeacon(200, STORAGE_HTML) === "masked"],
+  ["valid BeaconV3 200 → live", () => classifyBeacon(200, BEACON_V3) === "live"],
+  ["valid BeaconV2 200 → live", () => classifyBeacon(200, BEACON_V2) === "live"],
+  ["401 → auth-gated (NOT dark — ADR-007 D-8 may intend it)", () => classifyBeacon(401, "") === "auth-gated"],
+  ["403 → auth-gated", () => classifyBeacon(403, "") === "auth-gated"],
+  ["404 → 404 (no route)", () => classifyBeacon(404, "") === "404"],
+  ["503 broken-build → scaffold (route exists, not serving)", () => classifyBeacon(503, '{"error":"beacon_unavailable"}') === "scaffold"],
+  ["200 empty body → masked", () => classifyBeacon(200, "") === "masked"],
+  ["200 JSON-but-not-a-beacon → masked", () => classifyBeacon(200, '{"hello":"world"}') === "masked"],
+];
+
+let pass = 0;
+let fail = 0;
+for (const [name, fn] of cases) {
+  let ok = false;
+  try {
+    ok = fn();
+  } catch {
+    ok = false;
+  }
+  console.log(`  ${ok ? "✓" : "✗ FAIL"} ${name}`);
+  ok ? pass++ : fail++;
+}
+console.log(`\n  ${pass}/${pass + fail} passed — beacon classifier meter`);
+process.exit(fail === 0 ? 0 : 1);

--- a/tools/operator-dash/beacon-classify.ts
+++ b/tools/operator-dash/beacon-classify.ts
@@ -1,0 +1,45 @@
+// beacon-classify.ts — shape-validating beacon classifier.
+//
+// Kuang R&D metaloop, iteration 2 (2026-06-27). Fixes the false-positive the iter-1
+// discovery audit found: probeBeacon() classified ANY 2xx as a "live" beacon without
+// reading the body — so storage-api's GraphQL-playground catch-all (200 text/html)
+// masked as discoverable. A 200 is the building flattering you; a parseable BeaconV3
+// is the behavior. The discovery meter validates the SHAPE, not the HTTP status.
+//
+// Pure + side-effect-free so the meter (dash.beacon-classify.test.ts) can settle it
+// deterministically against fixtures — no network.
+
+export type BeaconState =
+  | "live" // 2xx AND a parseable BeaconV3
+  | "masked" // 2xx but NOT a beacon (catch-all 200 — the storage case)
+  | "auth-gated" // 401/403 — per-building beacons MAY be authenticated (ADR-007 D-8); verify intent
+  | "scaffold" // 5xx / unexpected — route exists but broken (the score "beacon_unavailable" case)
+  | "404" // no route
+  | "unreachable" // DNS/network/timeout
+  | "not-registered";
+
+/** Does a 2xx body actually look like a BeaconV3? Required: a recognizable identity field
+ *  (slug|name|is) AND a recognizable schema marker (schema_version 2/3 | capabilities | is). */
+export function isBeaconShape(body: string): boolean {
+  let d: unknown;
+  try {
+    d = JSON.parse(body);
+  } catch {
+    return false; // not JSON at all (HTML playground, plain text) → not a beacon
+  }
+  if (!d || typeof d !== "object") return false;
+  const o = d as Record<string, unknown>;
+  const hasSchema =
+    ["2", "3"].includes(String(o.schema_version)) || "capabilities" in o || "is" in o;
+  const hasIdentity = "slug" in o || "name" in o || "is" in o;
+  return hasSchema && hasIdentity;
+}
+
+/** Classify a beacon probe response by STATUS + SHAPE. The whole point: a 2xx alone is
+ *  never "live" — it must carry a valid BeaconV3 body. */
+export function classifyBeacon(status: number, body: string): BeaconState {
+  if (status === 404) return "404";
+  if (status === 401 || status === 403) return "auth-gated";
+  if (status >= 200 && status < 300) return isBeaconShape(body) ? "live" : "masked";
+  return "scaffold"; // 5xx / other — route present but not serving a beacon
+}

--- a/tools/operator-dash/dash.ts
+++ b/tools/operator-dash/dash.ts
@@ -29,6 +29,8 @@ import { readFileSync, existsSync } from "node:fs";
 
 // ─────────────────────────── types ──────────────────────────────────────────
 
+import { classifyBeacon, type BeaconState } from "./beacon-classify";
+
 type ProbeState = "up" | "down" | "degraded" | "scaffold" | "unreachable" | "auth-gated";
 
 type EndpointProbe = {
@@ -50,7 +52,7 @@ type EndpointProbe = {
 type FederationTile = {
   slug: string;
   registryEntry: { beaconUrl: string; visibility: string; owner: string } | null;
-  beaconState: "live" | "scaffold" | "404" | "unreachable" | "not-registered";
+  beaconState: BeaconState;
   beaconLatencyMs: number | null;
   // building, not yet declared in registry, but we know about it:
   knownLive: boolean;
@@ -235,9 +237,15 @@ async function probeBeacon(beaconUrl: string): Promise<{ state: FederationTile["
   try {
     const res = await fetch(beaconUrl, { signal: ctrl.signal });
     clearTimeout(t);
-    if (res.status === 404) return { state: "404", latency: Date.now() - start };
-    if (res.status >= 200 && res.status < 300) return { state: "live", latency: Date.now() - start };
-    return { state: "scaffold", latency: Date.now() - start };
+    // Kuang iter-2: classify by SHAPE, not just status — a catch-all 200 (e.g. a GraphQL
+    // playground) is NOT a live beacon. The meter validates the body parses as a BeaconV3.
+    let body = "";
+    try {
+      body = await res.text();
+    } catch {
+      body = "";
+    }
+    return { state: classifyBeacon(res.status, body), latency: Date.now() - start };
   } catch {
     clearTimeout(t);
     return { state: "unreachable", latency: null };
@@ -546,6 +554,8 @@ function stateLabel(s: ProbeState): string {
 function tileColor(t: FederationTile): string {
   if (t.knownLive && t.hostStatus && t.hostStatus < 400) return "#1f8a3f";
   if (t.beaconState === "live") return "#1f8a3f";
+  if (t.beaconState === "masked") return "#dc2626"; // 200 but NOT a beacon — the deceptive one (red)
+  if (t.beaconState === "auth-gated") return "#e3a008"; // verify intent (ADR-007 D-8)
   if (t.beaconState === "404") return "#f97316";
   if (t.beaconState === "scaffold") return "#e3a008";
   if (t.beaconState === "not-registered") return "#7c6cff";

--- a/tools/operator-dash/dash.ts
+++ b/tools/operator-dash/dash.ts
@@ -231,12 +231,12 @@ function loadRegistry(): Record<string, { beacon_url: string; visibility: string
 }
 
 async function probeBeacon(beaconUrl: string): Promise<{ state: FederationTile["beaconState"]; latency: number | null }> {
-  const ctrl = new AbortController();
-  const t = setTimeout(() => ctrl.abort(), 5000);
   const start = Date.now();
   try {
-    const res = await fetch(beaconUrl, { signal: ctrl.signal });
-    clearTimeout(t);
+    // AbortSignal.timeout stays armed through the body read — a manual timer cleared
+    // right after the headers arrive leaves res.text() unbounded, so a stalling body
+    // would hang the whole dash. This bounds the entire probe (headers + body) to 5s.
+    const res = await fetch(beaconUrl, { signal: AbortSignal.timeout(5000) });
     // Kuang iter-2: classify by SHAPE, not just status — a catch-all 200 (e.g. a GraphQL
     // playground) is NOT a live beacon. The meter validates the body parses as a BeaconV3.
     let body = "";
@@ -247,7 +247,6 @@ async function probeBeacon(beaconUrl: string): Promise<{ state: FederationTile["
     }
     return { state: classifyBeacon(res.status, body), latency: Date.now() - start };
   } catch {
-    clearTimeout(t);
     return { state: "unreachable", latency: null };
   }
 }


### PR DESCRIPTION
## What
The operator-dash beacon prober classified any `2xx` as "live" — so a host returning HTTP 200 with a non-BeaconV3 body (a parked page, a generic API root) read as a false "live". This adds **shape validation**: `probeBeacon` now reads the body and `classifyBeacon(status, body)` distinguishes `live / masked / auth-gated / scaffold / 404 / unreachable` by validating the BeaconV3 shape — not just the status.

## Why
Built during the Kuang overnight run (the H1 beacon-discovery work). The "masked-200" false positive is the exact error class that made the early beacon probes unreliable; this closes it in the dashboard prober. It sat **built + tested but unshipped** — this ships it (closing the deployed-but-unconsumed loop).

## Tests
`beacon-classify.test.ts` — independently re-run, **green** (pure functions, no network).

## Scope
3 files, +105/-4 — `beacon-classify.ts` (new pure classifier) + its test + `dash.ts` (probeBeacon reads body + updated color map). Dev tool only (`tools/operator-dash`).

Built E2E by the Icebreaker loop. **Reviewable — not auto-merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
