### PR TITLE
feat(network/mcp-gateway): BEACON federation — tenant membership from registry (T1+T2, WIP)

### DIFF
--- a/.github/workflows/mcp-gateway-ci.yml
+++ b/.github/workflows/mcp-gateway-ci.yml
@@ -35,9 +35,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # pnpm version comes from the root package.json `packageManager` field —
+      # do NOT also pin `version:` here, or action-setup errors on the conflict.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/mcp-gateway-ci.yml
+++ b/.github/workflows/mcp-gateway-ci.yml
@@ -1,0 +1,67 @@
+name: MCP Gateway CI
+
+# The MCP federation gateway (apps/mcp-gateway) had NO build gate — an
+# incomplete @0xhoneyjar→@freeside beacon-schema rename broke its build on main
+# and went uncaught (PR #376). This is the gate that would have failed: it
+# typechecks, builds, and tests the gateway against the live workspace package.
+#
+# NOTE: apps/mcp-gateway/pnpm-workspace.yaml globs `packages/*` relative to the
+# gateway dir; the Dockerfile supplies them via `COPY packages ./packages`. CI
+# mirrors that by staging the one real workspace dep (@freeside/beacon-schema)
+# before install.
+
+on:
+  pull_request:
+    paths:
+      - 'apps/mcp-gateway/**'
+      - 'packages/beacon-schema/**'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/mcp-gateway/**'
+      - 'packages/beacon-schema/**'
+
+concurrency:
+  group: mcp-gateway-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mcp-gateway-ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: apps/mcp-gateway
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # Mirror the Dockerfile: the gateway's workspace resolves `workspace:*`
+      # from packages/ staged inside the gateway dir.
+      - name: Stage workspace package (beacon-schema)
+        working-directory: .
+        run: |
+          mkdir -p apps/mcp-gateway/packages
+          cp -r packages/beacon-schema apps/mcp-gateway/packages/beacon-schema
+
+      - name: Install
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Build workspace package
+        run: pnpm --filter @freeside/beacon-schema build
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: pnpm test

--- a/apps/mcp-gateway/Dockerfile
+++ b/apps/mcp-gateway/Dockerfile
@@ -9,7 +9,7 @@ COPY packages ./packages
 RUN pnpm install --no-frozen-lockfile
 
 # Build the workspace package first (gateway tsc imports its compiled output)
-RUN pnpm --filter @0xhoneyjar/beacon-schema build
+RUN pnpm --filter @freeside/beacon-schema build
 
 # Now build the gateway
 COPY tsconfig.json ./

--- a/apps/mcp-gateway/package.json
+++ b/apps/mcp-gateway/package.json
@@ -17,7 +17,7 @@
     "smoke:auth": "tsx scripts/smoke-auth.ts",
     "smoke:prod": "tsx scripts/smoke-prod.ts",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test tests/credentials-resolver.test.ts tests/beacon-resolver.test.ts tests/beacon-cache.test.ts tests/registry-membership.test.ts tests/tenant-policy.test.ts"
+    "test": "tsx --test tests/credentials-resolver.test.ts tests/beacon-resolver.test.ts tests/beacon-cache.test.ts tests/registry-membership.test.ts tests/tenant-policy.test.ts tests/tenant-table.test.ts"
   },
   "dependencies": {
     "@freeside/beacon-schema": "workspace:*",

--- a/apps/mcp-gateway/package.json
+++ b/apps/mcp-gateway/package.json
@@ -20,7 +20,7 @@
     "test": "tsx --test tests/credentials-resolver.test.ts tests/beacon-resolver.test.ts tests/beacon-cache.test.ts"
   },
   "dependencies": {
-    "@0xhoneyjar/beacon-schema": "workspace:*",
+    "@freeside/beacon-schema": "workspace:*",
     "@hono/node-server": "^1.14.1",
     "effect": "^3.21.2",
     "hono": "^4.7.0"

--- a/apps/mcp-gateway/package.json
+++ b/apps/mcp-gateway/package.json
@@ -17,7 +17,7 @@
     "smoke:auth": "tsx scripts/smoke-auth.ts",
     "smoke:prod": "tsx scripts/smoke-prod.ts",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test tests/credentials-resolver.test.ts tests/beacon-resolver.test.ts tests/beacon-cache.test.ts"
+    "test": "tsx --test tests/credentials-resolver.test.ts tests/beacon-resolver.test.ts tests/beacon-cache.test.ts tests/registry-membership.test.ts tests/tenant-policy.test.ts"
   },
   "dependencies": {
     "@freeside/beacon-schema": "workspace:*",

--- a/apps/mcp-gateway/package.json
+++ b/apps/mcp-gateway/package.json
@@ -17,7 +17,7 @@
     "smoke:auth": "tsx scripts/smoke-auth.ts",
     "smoke:prod": "tsx scripts/smoke-prod.ts",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test tests/credentials-resolver.test.ts tests/beacon-resolver.test.ts tests/beacon-cache.test.ts tests/registry-membership.test.ts tests/tenant-policy.test.ts tests/tenant-table.test.ts"
+    "test": "tsx --test --test-force-exit tests/credentials-resolver.test.ts tests/beacon-resolver.test.ts tests/beacon-cache.test.ts tests/registry-membership.test.ts tests/tenant-policy.test.ts tests/tenant-table.test.ts tests/federation-endpoint.test.ts"
   },
   "dependencies": {
     "@freeside/beacon-schema": "workspace:*",

--- a/apps/mcp-gateway/pnpm-lock.yaml
+++ b/apps/mcp-gateway/pnpm-lock.yaml
@@ -1,10 +1,14 @@
-lockfileVersion: '6.0'
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 importers:
 
   .:
     dependencies:
-      '@0xhoneyjar/beacon-schema':
+      '@freeside/beacon-schema':
         specifier: workspace:*
         version: link:packages/beacon-schema
       '@hono/node-server':
@@ -48,269 +52,318 @@ importers:
 
 packages:
 
-  /@esbuild/aix-ppc64@0.25.12:
+  '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/android-arm64@0.25.12:
+  '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/android-arm@0.25.12:
+  '@esbuild/android-arm@0.25.12':
     resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/android-x64@0.25.12:
+  '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/darwin-arm64@0.25.12:
+  '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/darwin-x64@0.25.12:
+  '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/freebsd-arm64@0.25.12:
+  '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/freebsd-x64@0.25.12:
+  '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-arm64@0.25.12:
+  '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-arm@0.25.12:
+  '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-ia32@0.25.12:
+  '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-loong64@0.25.12:
+  '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-mips64el@0.25.12:
+  '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-ppc64@0.25.12:
+  '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-riscv64@0.25.12:
+  '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-s390x@0.25.12:
+  '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-x64@0.25.12:
+  '@esbuild/linux-x64@0.25.12':
     resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/netbsd-arm64@0.25.12:
+  '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/netbsd-x64@0.25.12:
+  '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/openbsd-arm64@0.25.12:
+  '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/openbsd-x64@0.25.12:
+  '@esbuild/openbsd-x64@0.25.12':
     resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/openharmony-arm64@0.25.12:
+  '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/sunos-x64@0.25.12:
+  '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/win32-arm64@0.25.12:
+  '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/win32-ia32@0.25.12:
+  '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/win32-x64@0.25.12:
+  '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@hono/node-server@1.14.1(hono@4.7.0):
+  '@hono/node-server@1.14.1':
     resolution: {integrity: sha512-vmbuM+HPinjWzPe7FFPWMMQMsbKE9gDPhaH0FFdqbGpkT5lp++tcWDTxwBl5EgS5y6JVgIaCdjeHRfQ4XRBRjQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
-    dependencies:
-      hono: 4.7.0
-    dev: false
 
-  /@standard-schema/spec@1.1.0:
+  '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  /@types/node@22.0.0:
+  '@types/node@22.0.0':
     resolution: {integrity: sha512-VT7KSYudcPOzP5Q0wfbowyNLaVR8QWUdw+088uFWwfvpY6uCWaXpqV6ieLAu9WBcnTa7H4Z5RLK8I5t2FuOcqw==}
+
+  effect@3.21.2:
+    resolution: {integrity: sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  hono@4.7.0:
+    resolution: {integrity: sha512-hV97aIR4WYbG30k234sD9B3VNr1ZWdQRmrVF76LKFlmI7O9Yo70mG9+mFwyQ6Sjrz4wH71GfnBxv6CPjcx3QNw==}
+    engines: {node: '>=16.9.0'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  tsx@4.20.0:
+    resolution: {integrity: sha512-TsmdeXxcZYiJ2MKV7fdq38na0CKyLRtCeMqTeHMmrVXQ/gf5yTeJohh+sgr7MnMGsjeKXzHzy+TwOOTR1arl+Q==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.7.2:
+    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.11.1:
+    resolution: {integrity: sha512-mIDEX2ek50x0OlRgxryxsenE5XaQD4on5U2inY7RApK3SOJpofyw7uW2AyfMKkhAxXIceo2DeWGVGwyvng1GNQ==}
+
+  yaml@2.6.0:
+    resolution: {integrity: sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==}
+    engines: {node: '>= 14'}
+    hasBin: true
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@hono/node-server@1.14.1(hono@4.7.0)':
+    dependencies:
+      hono: 4.7.0
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/node@22.0.0':
     dependencies:
       undici-types: 6.11.1
-    dev: true
 
-  /effect@3.21.2:
-    resolution: {integrity: sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==}
+  effect@3.21.2:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
-  /esbuild@0.25.12:
-    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
-    engines: {node: '>=18'}
-    hasBin: true
-    requiresBuild: true
+  esbuild@0.25.12:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.12
       '@esbuild/android-arm': 0.25.12
@@ -338,63 +391,33 @@ packages:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
-    dev: true
 
-  /fast-check@3.23.2:
-    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
-    engines: {node: '>=8.0.0'}
+  fast-check@3.23.2:
     dependencies:
       pure-rand: 6.1.0
 
-  /fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-    requiresBuild: true
-    dev: true
+  fsevents@2.3.3:
     optional: true
 
-  /get-tsconfig@4.14.0:
-    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+  get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
-    dev: true
 
-  /hono@4.7.0:
-    resolution: {integrity: sha512-hV97aIR4WYbG30k234sD9B3VNr1ZWdQRmrVF76LKFlmI7O9Yo70mG9+mFwyQ6Sjrz4wH71GfnBxv6CPjcx3QNw==}
-    engines: {node: '>=16.9.0'}
-    dev: false
+  hono@4.7.0: {}
 
-  /pure-rand@6.1.0:
-    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+  pure-rand@6.1.0: {}
 
-  /resolve-pkg-maps@1.0.0:
-    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
-    dev: true
+  resolve-pkg-maps@1.0.0: {}
 
-  /tsx@4.20.0:
-    resolution: {integrity: sha512-TsmdeXxcZYiJ2MKV7fdq38na0CKyLRtCeMqTeHMmrVXQ/gf5yTeJohh+sgr7MnMGsjeKXzHzy+TwOOTR1arl+Q==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
+  tsx@4.20.0:
     dependencies:
       esbuild: 0.25.12
       get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
-  /typescript@5.7.2:
-    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: true
+  typescript@5.7.2: {}
 
-  /undici-types@6.11.1:
-    resolution: {integrity: sha512-mIDEX2ek50x0OlRgxryxsenE5XaQD4on5U2inY7RApK3SOJpofyw7uW2AyfMKkhAxXIceo2DeWGVGwyvng1GNQ==}
-    dev: true
+  undici-types@6.11.1: {}
 
-  /yaml@2.6.0:
-    resolution: {integrity: sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==}
-    engines: {node: '>= 14'}
-    hasBin: true
-    dev: false
+  yaml@2.6.0: {}

--- a/apps/mcp-gateway/src/app.ts
+++ b/apps/mcp-gateway/src/app.ts
@@ -21,7 +21,7 @@
 
 import { Hono } from "hono";
 import { JSONSchema, Schema } from "effect";
-import { BeaconV2JsonSchema } from "@0xhoneyjar/beacon-schema";
+import { BeaconV2JsonSchema } from "@freeside/beacon-schema";
 import { TENANTS, TenantSchema, TenantsSchema, findTenant, type Tenant } from "./tenants.js";
 import { checkAccess, isAuthorizedOperator } from "./auth.js";
 import { refreshAllBeacons, startBeaconRefresh } from "./beacon-cache.js";
@@ -237,7 +237,7 @@ app.get("/schema/federation.json", (c) => c.json(JSONSchema.make(FederationManif
 
 // Beacon v2 schema export (Cycle C v0.3 P3) — partner authors / construct
 // build steps validate their beacon.yaml against this. Sourced from the
-// @0xhoneyjar/beacon-schema package so this stays in lockstep with what
+// @freeside/beacon-schema package so this stays in lockstep with what
 // the gateway actually decodes at refresh time.
 app.get("/.well-known/beacon-schema/v2.json", (c) => c.json(BeaconV2JsonSchema));
 

--- a/apps/mcp-gateway/src/beacon-cache.ts
+++ b/apps/mcp-gateway/src/beacon-cache.ts
@@ -30,7 +30,7 @@
  */
 
 import { Data, Duration, Effect, Schedule, Schema } from "effect";
-import { BeaconV2Schema, type BeaconV2 } from "@0xhoneyjar/beacon-schema";
+import { BeaconV2Schema, type BeaconV2 } from "@freeside/beacon-schema";
 import { TENANTS } from "./tenants.js";
 
 // ────── constants ──────

--- a/apps/mcp-gateway/src/beacon-resolver.ts
+++ b/apps/mcp-gateway/src/beacon-resolver.ts
@@ -29,7 +29,7 @@
 
 import { BEACON_CACHE } from "./beacon-cache.js";
 import type { Tenant } from "./tenants.js";
-import type { BeaconV2 } from "@0xhoneyjar/beacon-schema";
+import type { BeaconV2 } from "@freeside/beacon-schema";
 
 // ────── types ──────
 

--- a/apps/mcp-gateway/src/registry-membership.ts
+++ b/apps/mcp-gateway/src/registry-membership.ts
@@ -1,0 +1,85 @@
+/**
+ * registry-membership.ts — derive the gateway's federation MEMBERSHIP from the
+ * freeside registry (BEACON federation, first cut).
+ *
+ * Per grimoires/loa/context/beacon-federation-architecture.md (the-weaver +
+ * EVANS, converged): `federation.json` is a JOIN, not a projection.
+ *
+ *   registry owns → MEMBERSHIP (which cells exist + upstream + source-visibility + lifecycle)
+ *   gateway  owns → POLICY     (access, gateway-visibility, status — see tenant-policy.ts)
+ *   cell     owns → its beacon (capabilities/auth/pricing — overlaid by beacon-resolver.ts)
+ *
+ * This module owns ONLY the membership half. It is PURE (no I/O): `deriveMembers`
+ * takes an already-parsed registry-modules map and returns the deployed,
+ * reachable members. Boot-time wiring (reading registry.yaml via
+ * @freeside/freeside-registry's loadRegistry) is a separate, deploy-touching step
+ * — kept out of here so the derivation logic stays unit-testable without the
+ * loader, the workspace dep, or the filesystem.
+ */
+
+/**
+ * The subset of a registry module entry this derivation reads. Structurally a
+ * subset of @freeside/freeside-registry's `ModuleEntry` — so the parsed registry
+ * can be passed straight in once the loader is wired.
+ *
+ * loa:shortcut: local view type; unify with @freeside/freeside-registry's
+ *   ModuleEntry when that workspace dep is added to the gateway (the boot-wiring
+ *   step). Upgrade trigger: the loadRegistry() boot wiring lands.
+ */
+export type RegistryModuleView = {
+  visibility: "public" | "internal" | "unlisted";
+  beacon_url: string | null;
+  deployment_url?: string | null;
+  runtime_state?: "deployed" | "not-built" | "scaffolded";
+};
+
+/** One registry-derived federation member. The gateway joins this with its own
+ *  policy (tenant-policy.ts) to produce a Tenant row. */
+export type RegistryMember = {
+  /** The registry key — also the gateway routing slug. */
+  slug: string;
+  /** Upstream origin (https, no trailing slash) — the cell's deployment_url. */
+  upstream: string;
+  /** The registry's *source* visibility. NOTE: this is NOT gateway-visibility.
+   *  The gateway never derives its discovery-scope from this (the homonym
+   *  keystone — score is registry-public yet gateway-internal). Carried for
+   *  provenance/diagnostics only. */
+  sourceVisibility: "public" | "internal" | "unlisted";
+  /** The cell's own beacon pointer (may be null for in-repo library cells). */
+  beaconUrl: string | null;
+};
+
+/** Strip a single trailing slash so upstreams satisfy the gateway's
+ *  UpstreamUrlSchema (`https://…` with no trailing slash). */
+function normalizeUpstream(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+/**
+ * Derive federation members from a parsed registry-modules map.
+ *
+ * Membership rule (first cut): a cell is a member iff it is **deployed** AND has
+ * a reachable `https://` upstream. `not-built` / `scaffolded` cells and cells
+ * with a null/`~` deployment_url are excluded — the gateway federates running
+ * services, not declarations of intent.
+ *
+ * Pure + deterministic: sorts by slug so the manifest order is stable.
+ */
+export function deriveMembers(
+  modules: Record<string, RegistryModuleView>,
+): RegistryMember[] {
+  const members: RegistryMember[] = [];
+  for (const [slug, entry] of Object.entries(modules)) {
+    if (entry.runtime_state !== "deployed") continue;
+    const upstream = entry.deployment_url;
+    if (!upstream || !/^https:\/\//.test(upstream)) continue;
+    members.push({
+      slug,
+      upstream: normalizeUpstream(upstream),
+      sourceVisibility: entry.visibility,
+      beaconUrl: entry.beacon_url,
+    });
+  }
+  members.sort((a, b) => a.slug.localeCompare(b.slug));
+  return members;
+}

--- a/apps/mcp-gateway/src/tenant-policy.ts
+++ b/apps/mcp-gateway/src/tenant-policy.ts
@@ -1,0 +1,104 @@
+/**
+ * tenant-policy.ts — the gateway-owned A-axis POLICY for BEACON federation.
+ *
+ * Membership comes from the registry (registry-membership.ts); THIS module
+ * decides how the gateway *treats* each member: routing slug, access gate,
+ * gateway-visibility (discovery scope on the manifests), and operational status.
+ *
+ * The keystone (per the converged architecture): gateway-visibility is NEVER
+ * derived from the registry's `visibility`. They are a homonym across two
+ * bounded contexts — `score-api` is registry-`public` yet gateway-`internal`.
+ * So a registry member is **fail-closed to internal** until the gateway grants
+ * it an explicit policy here. Deriving membership from the registry can never,
+ * by construction, leak a cell into the public federation manifest.
+ *
+ * Pure data + lookup — no I/O. Not yet wired into the live TENANTS (that join is
+ * the deploy-touching follow-on); adding this module does not change gateway
+ * behavior.
+ */
+
+import type { Tenant } from "./tenants.js";
+
+/** The A-axis the gateway owns for one tenant. */
+export type GatewayPolicy = {
+  /** Gateway routing slug — appears in URLs as /{slug}/…. MAY differ from the
+   *  registry key (the gateway routes `score`; the registry key is `score-api`). */
+  slug: string;
+  /** Gateway access gate — orthogonal to the upstream's own `auth`. */
+  access: "open" | "allowlist" | "api-key" | "x402";
+  /** Discovery scope on the federation manifests (gateway-owned, NOT registry). */
+  visibility: "public" | "internal" | "unlisted";
+  /** `paused` → 503 without dropping the tenant from the manifest. */
+  status: "live" | "paused";
+  /** Registry rows carry no name/description; the gateway owns display names. */
+  name: string;
+  description: string;
+};
+
+/**
+ * Explicit gateway policy for registry-derived members, keyed by **registry
+ * slug**. A member listed here is the gateway granting it a route + a treatment.
+ * Anything not listed is fail-closed (see policyForMember).
+ *
+ * `score-api` → routed as `score`, gateway-`internal`, api-key. This is the
+ * homonym in action: registry-`public`, gateway-`internal`, deliberately.
+ */
+export const REGISTRY_TENANT_POLICY: Record<string, GatewayPolicy> = {
+  "score-api": {
+    slug: "score",
+    access: "api-key",
+    visibility: "internal",
+    status: "live",
+    name: "Score Mibera",
+    description:
+      "Factor metadata + behavioral signals from score-api. Zone digests, top movers, narrative shape. Internal — gated by API key for known callers.",
+  },
+};
+
+/** Fail-closed default A-axis (the keystone): an unknown registry member is
+ *  internal + api-key, routed by its own registry slug. Never public. */
+const FAIL_CLOSED = {
+  access: "api-key",
+  visibility: "internal",
+  status: "live",
+} as const satisfies Pick<GatewayPolicy, "access" | "visibility" | "status">;
+
+/** Resolve the gateway policy for a registry-derived member. Explicit grant wins;
+ *  otherwise fail-closed to internal/api-key (routed by the registry slug). */
+export function policyForMember(registrySlug: string): GatewayPolicy {
+  const granted = REGISTRY_TENANT_POLICY[registrySlug];
+  if (granted) return granted;
+  return {
+    slug: registrySlug,
+    ...FAIL_CLOSED,
+    name: registrySlug,
+    description: `Registry-derived cell "${registrySlug}" — no explicit gateway policy; fail-closed to internal.`,
+  };
+}
+
+/**
+ * Gateway-NATIVE tenants — served by the gateway but with **no registry row**
+ * (they are `construct-X` MCPs, not `freeside-X` buildings). The gateway owns
+ * their full existence; they are not derived from registry membership.
+ *
+ * `codex` is the canonical case: the Mibera lore MCP. This is the same row that
+ * lived in RAW_TENANTS, lifted here intact.
+ */
+export const GATEWAY_NATIVE_TENANTS: ReadonlyArray<Tenant> = [
+  {
+    slug: "codex",
+    name: "Mibera Codex",
+    description:
+      "Anti-hallucination lookup MCP for Mibera lore — zones, archetypes, factors, grails, miberas. Read by narrative bots and operator harnesses.",
+    publisher: "0xHoneyJar",
+    upstream: "https://codex-mcp-production.up.railway.app",
+    auth: "none",
+    documentation: "https://codex.0xhoneyjar.xyz",
+    status: "live",
+    visibility: "public",
+    access: "open",
+    capabilities: ["tools"],
+    pricing: { model: "free", description: "free as in libre — read-only canon" },
+    owner: { handle: "0xHoneyJar", contact: "https://github.com/0xHoneyJar" },
+  },
+];

--- a/apps/mcp-gateway/src/tenant-table.ts
+++ b/apps/mcp-gateway/src/tenant-table.ts
@@ -1,0 +1,63 @@
+/**
+ * tenant-table.ts — the JOIN (BEACON federation T3).
+ *
+ * `buildTenants` is the pure heart of the converged architecture: `federation.json` is a JOIN of
+ * registry MEMBERSHIP (registry-membership.ts) + gateway POLICY (tenant-policy.ts) + gateway-NATIVE
+ * tenants — NOT the hardcoded `RAW_TENANTS` existence list. Each registry member is routed + gated by
+ * the gateway's own policy (fail-closed); its B-axis (capabilities/auth/pricing) is a minimal curator
+ * fallback here and is overlaid from the cell's served beacon by beacon-resolver.ts at request time.
+ *
+ * Pure + deterministic (no I/O). Boot-time wiring — feeding `deriveMembers(loadRegistry().modules)` into
+ * this join in place of `RAW_TENANTS` — is the deploy-touching follow-on (it adds the
+ * @freeside/freeside-registry workspace dep + the Dockerfile builder/runtime stages). This module is the
+ * logic that wiring will call; adding it does not change live gateway behavior.
+ */
+
+import type { Tenant } from "./tenants.js";
+import type { RegistryMember } from "./registry-membership.js";
+import { policyForMember } from "./tenant-policy.js";
+
+/**
+ * Project one registry member through the gateway's policy into a Tenant row. The A-axis (slug,
+ * visibility, access, status, name/description) is the gateway's POLICY (fail-closed for ungranted
+ * members — registry-visibility never crosses into gateway-visibility). The B-axis is a minimal
+ * first-party fallback; the cell's beacon overlays the real values via beacon-resolver.
+ */
+function memberToTenant(member: RegistryMember): Tenant {
+  const policy = policyForMember(member.slug);
+  return {
+    // ── A-axis · gateway policy (NOT derived from member.sourceVisibility) ──
+    slug: policy.slug,
+    name: policy.name,
+    description: policy.description,
+    upstream: member.upstream,
+    status: policy.status,
+    visibility: policy.visibility,
+    access: policy.access,
+    // ── B-axis · curator fallback (beacon-resolver overlays from the served beacon) ──
+    publisher: "0xHoneyJar",
+    auth: "none",
+    capabilities: ["tools"],
+  };
+}
+
+/**
+ * JOIN registry membership + gateway policy + gateway-native tenants → the tenant table.
+ *
+ * Native tenants (gateway-owned existence, e.g. `codex` — no registry row) come first and are
+ * authoritative: if a registry member's policy routes it to a slug a native already owns, the native
+ * wins (a building can never shadow a gateway-native MCP). Deterministic order: natives as listed, then
+ * registry members in their (already slug-sorted) order.
+ */
+export function buildTenants(
+  members: readonly RegistryMember[],
+  natives: readonly Tenant[],
+): Tenant[] {
+  const bySlug = new Map<string, Tenant>();
+  for (const t of natives) bySlug.set(t.slug, t);
+  for (const member of members) {
+    const t = memberToTenant(member);
+    if (!bySlug.has(t.slug)) bySlug.set(t.slug, t); // native wins on slug collision
+  }
+  return [...bySlug.values()];
+}

--- a/apps/mcp-gateway/tests/beacon-resolver.test.ts
+++ b/apps/mcp-gateway/tests/beacon-resolver.test.ts
@@ -16,7 +16,7 @@ import {
 } from "../src/beacon-resolver.js";
 import { BEACON_CACHE } from "../src/beacon-cache.js";
 import type { Tenant } from "../src/tenants.js";
-import type { BeaconV2 } from "@0xhoneyjar/beacon-schema";
+import type { BeaconV2 } from "@freeside/beacon-schema";
 
 // ── fixtures ──
 

--- a/apps/mcp-gateway/tests/federation-endpoint.test.ts
+++ b/apps/mcp-gateway/tests/federation-endpoint.test.ts
@@ -1,0 +1,40 @@
+/**
+ * END-TO-END meter for the BEACON federation security keystone (#378, no-registry-public-leak).
+ *
+ * The unit layers are already pinned: tenant-policy.test.ts proves gateway-visibility is never derived from
+ * registry-visibility (fails closed to internal), and registry-membership.test.ts proves source-visibility is
+ * carried as PROVENANCE, not policy. What was NOT pinned — and what the claim's "end-to-end" demands — is the
+ * actual served surface: a request to `/.well-known/federation.json` must expose ONLY gateway-public tenants,
+ * so registry-visibility can never promote a cell onto the auth-free public discovery surface. (Surfaced as a
+ * chronic gap by the Refusal's worldline: asserted across the codebase, never exercised at the endpoint.)
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import app from "../src/app.js";
+import { TENANTS } from "../src/tenants.js";
+
+const publicManifestSlugs = async (): Promise<string[]> => {
+  const res = await app.request("/.well-known/federation.json");
+  assert.equal(res.status, 200, "the public discovery surface must be reachable");
+  const manifest = (await res.json()) as { tenants: Array<{ slug: string }> };
+  return manifest.tenants.map((t) => t.slug).sort();
+};
+
+test("GET /.well-known/federation.json serves EXACTLY the gateway-public tenants — no leak, no omission (#378)", async () => {
+  const served = await publicManifestSlugs();
+  const gatewayPublic = TENANTS.filter((t) => t.visibility === "public").map((t) => t.slug).sort();
+  // EXACT equality is the keystone end-to-end: every served member is gateway-public (no registry-visibility
+  // leak), and every gateway-public member is served (no silent omission). The endpoint filter is honest.
+  assert.deepEqual(served, gatewayPublic, "the public manifest must equal the gateway-public set exactly");
+});
+
+test("the registry-public / gateway-internal cell `score` never reaches the PUBLIC manifest (the keystone scenario)", async () => {
+  // `score` is registry-public (it exists + is visible in the freeside registry) yet gateway-internal (its
+  // gateway policy is internal/api-key — see tenant-policy.test.ts). It is the exact "can registry-visibility
+  // promote a cell into the PUBLIC manifest?" question. The answer must be NO.
+  const score = TENANTS.find((t) => t.slug === "score");
+  assert.equal(score?.visibility, "internal", "fixture guard: `score` must be gateway-internal for this keystone to mean anything");
+  const served = await publicManifestSlugs();
+  assert.ok(!served.includes("score"), "`score` (registry-public, gateway-internal) LEAKED into the public federation manifest");
+  assert.ok(served.length > 0, "positive control: gateway-public cells ARE served (the endpoint is not trivially empty)");
+});

--- a/apps/mcp-gateway/tests/registry-membership.test.ts
+++ b/apps/mcp-gateway/tests/registry-membership.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Meter for registry-membership (BEACON federation T1 / AC-1).
+ * Pure derivation — no loader, no filesystem.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { deriveMembers, type RegistryModuleView } from "../src/registry-membership.js";
+
+const fixture: Record<string, RegistryModuleView> = {
+  // deployed + https → member
+  "activities-api": {
+    visibility: "public",
+    beacon_url: "https://activities.0xhoneyjar.xyz/.well-known/beacon.json",
+    deployment_url: "https://activities-api-production.up.railway.app",
+    runtime_state: "deployed",
+  },
+  // deployed, registry-public, trailing slash → member (normalized)
+  "score-api": {
+    visibility: "public",
+    beacon_url: null,
+    deployment_url: "https://score-api-production.up.railway.app/",
+    runtime_state: "deployed",
+  },
+  // not-built + null deployment → excluded
+  "ledger-api": {
+    visibility: "internal",
+    beacon_url: null,
+    deployment_url: null,
+    runtime_state: "not-built",
+  },
+  // scaffolded → excluded
+  "billing-api": {
+    visibility: "internal",
+    beacon_url: null,
+    deployment_url: null,
+    runtime_state: "scaffolded",
+  },
+  // missing runtime_state → excluded (no honest deploy signal)
+  "ghost-api": {
+    visibility: "public",
+    beacon_url: null,
+    deployment_url: "https://ghost.up.railway.app",
+  },
+  // http (not https) → excluded (gateway never proxies plaintext)
+  "plain-api": {
+    visibility: "public",
+    beacon_url: null,
+    deployment_url: "http://plain.up.railway.app",
+    runtime_state: "deployed",
+  },
+};
+
+test("deriveMembers: only deployed cells with an https upstream become members (sorted)", () => {
+  const members = deriveMembers(fixture);
+  assert.deepEqual(
+    members.map((m) => m.slug),
+    ["activities-api", "score-api"],
+  );
+});
+
+test("deriveMembers: normalizes the trailing slash off the upstream", () => {
+  const score = deriveMembers(fixture).find((m) => m.slug === "score-api");
+  assert.equal(score?.upstream, "https://score-api-production.up.railway.app");
+});
+
+test("deriveMembers: excludes not-built, scaffolded, stateless, and plaintext cells", () => {
+  const slugs = deriveMembers(fixture).map((m) => m.slug);
+  for (const excluded of ["ledger-api", "billing-api", "ghost-api", "plain-api"]) {
+    assert.ok(!slugs.includes(excluded), `${excluded} must not be a member`);
+  }
+});
+
+test("deriveMembers: carries registry source-visibility for provenance, not as policy", () => {
+  const score = deriveMembers(fixture).find((m) => m.slug === "score-api");
+  // score is registry-PUBLIC here; the gateway's internal policy is decided
+  // elsewhere (tenant-policy.ts). Membership must not leak policy intent.
+  assert.equal(score?.sourceVisibility, "public");
+});

--- a/apps/mcp-gateway/tests/tenant-policy.test.ts
+++ b/apps/mcp-gateway/tests/tenant-policy.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Meter for tenant-policy (BEACON federation T2 / AC-2) — the security keystone.
+ * Gateway-visibility is gateway-owned; registry membership fails closed.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  policyForMember,
+  GATEWAY_NATIVE_TENANTS,
+} from "../src/tenant-policy.js";
+
+test("score-api: gateway policy is internal/api-key, routed as `score` (NOT registry-public)", () => {
+  const p = policyForMember("score-api");
+  assert.equal(p.slug, "score"); // gateway routes `score`, registry key is `score-api`
+  assert.equal(p.visibility, "internal");
+  assert.equal(p.access, "api-key");
+});
+
+test("unknown registry member fails CLOSED — internal, api-key, never public", () => {
+  const p = policyForMember("some-new-cell");
+  assert.equal(p.visibility, "internal", "a new cell must never default to public");
+  assert.equal(p.access, "api-key");
+  assert.equal(p.slug, "some-new-cell"); // routed by its own registry slug
+});
+
+test("the fail-closed default can never yield gateway-visibility=public", () => {
+  // Sweep a range of unknown slugs — none may resolve to public.
+  for (const slug of ["a", "billing-api", "worlds-api", "x402-cell", "score"]) {
+    if (slug === "score") continue; // `score` is not a registry key; `score-api` is
+    assert.notEqual(
+      policyForMember(slug).visibility,
+      "public",
+      `${slug} must fail closed, not public`,
+    );
+  }
+});
+
+test("codex is a gateway-NATIVE tenant: present, public, open, no registry row needed", () => {
+  const codex = GATEWAY_NATIVE_TENANTS.find((t) => t.slug === "codex");
+  assert.ok(codex, "codex must remain a gateway-native tenant");
+  assert.equal(codex?.visibility, "public");
+  assert.equal(codex?.access, "open");
+  assert.equal(codex?.auth, "none");
+});

--- a/apps/mcp-gateway/tests/tenant-table.test.ts
+++ b/apps/mcp-gateway/tests/tenant-table.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Meter for the JOIN (BEACON federation T3 / AC-3) + the end-to-end security keystone.
+ * Pure — buildTenants over fixtures, no I/O.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildTenants } from "../src/tenant-table.js";
+import type { RegistryMember } from "../src/registry-membership.js";
+import { GATEWAY_NATIVE_TENANTS } from "../src/tenant-policy.js";
+
+const scoreApi: RegistryMember = {
+  slug: "score-api",
+  upstream: "https://score-api-production.up.railway.app",
+  sourceVisibility: "public",
+  beaconUrl: null,
+};
+
+test("buildTenants JOINs gateway-native + registry members (RAW_TENANTS existence list replaced)", () => {
+  const tenants = buildTenants([scoreApi], GATEWAY_NATIVE_TENANTS);
+  const slugs = tenants.map((t) => t.slug);
+  assert.ok(slugs.includes("codex"), "gateway-native codex present");
+  assert.ok(slugs.includes("score"), "score-api routed to gateway slug `score`");
+  const score = tenants.find((t) => t.slug === "score");
+  assert.equal(score?.upstream, "https://score-api-production.up.railway.app");
+  assert.equal(score?.visibility, "internal"); // gateway policy — NOT registry-public
+  assert.equal(score?.access, "api-key");
+});
+
+// THE SECURITY KEYSTONE end-to-end — a registry-public cell must never become gateway-public
+// through the join. This is the precise `public-leak` guard (registry-public ↛ public manifest).
+test("registry-public member with no gateway policy → gateway-visibility INTERNAL (registry-public leak guard)", () => {
+  const newPublicCell: RegistryMember = {
+    slug: "shiny-new-cell",
+    upstream: "https://shiny.up.railway.app",
+    sourceVisibility: "public", // registry says PUBLIC …
+    beaconUrl: null,
+  };
+  const t = buildTenants([newPublicCell], []).find((x) => x.slug === "shiny-new-cell");
+  // … yet the gateway fails it closed: registry-visibility never promotes gateway-visibility.
+  assert.equal(t?.visibility, "internal", "a registry-public cell must NOT reach the public federation manifest");
+  assert.equal(t?.access, "api-key");
+});
+
+test("gateway-native wins on slug collision — a building cannot shadow codex", () => {
+  const fakeCodex: RegistryMember = {
+    slug: "codex",
+    upstream: "https://evil.example",
+    sourceVisibility: "public",
+    beaconUrl: null,
+  };
+  const codex = buildTenants([fakeCodex], GATEWAY_NATIVE_TENANTS).filter((t) => t.slug === "codex");
+  assert.equal(codex.length, 1);
+  assert.equal(codex[0]?.upstream, "https://codex-mcp-production.up.railway.app"); // the native, not the impostor
+});


### PR DESCRIPTION
> **Draft / WIP** — stacked on #376 (the gateway build-fix; base of this PR). Merge #376 first.

## BEACON federation — derive gateway tenant membership from the registry

Implements the converged architecture in `grimoires/loa/context/beacon-federation-architecture.md` (the-weaver + EVANS): `federation.json` is a **JOIN**, not a projection of one central SoT.

```
registry owns → MEMBERSHIP (which cells exist + upstream + source-visibility + lifecycle)
gateway  owns → POLICY     (access, gateway-visibility, status)
cell     owns → its beacon  (capabilities/auth/pricing — already overlaid by beacon-resolver.ts)
```

### Done in this PR (T1 + T2 — pure, deploy-safe, NOT yet wired into live `TENANTS`)

- **`registry-membership.ts`** — `deriveMembers()`: derive members from the registry (deployed cells with an `https` upstream; excludes not-built/scaffolded/stateless/plaintext). Pure, no I/O.
- **`tenant-policy.ts`** — the gateway-owned A-axis POLICY + the **fail-closed security keystone**: an unknown registry member resolves to `internal`/`api-key`, **never public**. Registry-`visibility` never promotes gateway-`visibility` (the homonym — `score-api` is registry-public yet gateway-internal). Plus the gateway-native `codex` tenant (no registry row).
- **8 new unit meters** (`tsx --test`); **29/29 gateway tests green** locally. Behavior unchanged — these modules aren't wired in yet.

### Remaining (the deploy-touching follow-on — deliberately separate)

- **T3** — refactor `tenants.ts` to JOIN membership + policy + native, replacing the hardcoded `RAW_TENANTS` existence/upstream list (changes live `TENANTS`).
- **T4** — boot wiring: add `@freeside/freeside-registry` as a workspace dep + the Dockerfile builder/runtime stages + CI staging (the cascade that makes `loadRegistry()` resolve at build + runtime).
- **T5** — `/federation.json` integration test: a registry cell flipped to `visibility: public` must NOT reach the public manifest (the registry→public leak guard).

### Why split here

T1+T2 are pure logic with a real test meter; T3–T5 touch the deployed gateway's Docker build + the live tenant table — the exact class of deploy wiring whose breakage #376 fixes. Landing the verified core first, then the integration with care.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
