### PR TITLE
feat(shadow-audit): Shadow Mode backend — Comparison View, served + persisted + cadence (read-only)

### DIFF
--- a/packages/protocol/shadow-audit/src/__tests__/discrepancy.test.ts
+++ b/packages/protocol/shadow-audit/src/__tests__/discrepancy.test.ts
@@ -20,6 +20,12 @@ describe('Shadow Mode — diffShadow (Comparison View + Discrepancy Report)', ()
     expect(changeFromBand('ok')).toBe('no_change');
   });
 
+  it('throws on an unknown band — drift fails loud, never silently no_change (FAGAN MEDIUM-2)', () => {
+    // the compile-time `never` guard is the primary defense; this pins the runtime fallback so a band
+    // that slips past the type (bad data, enum drift) is NOT silently bucketed as no_change.
+    expect(() => changeFromBand('expired' as never)).toThrow(/unhandled band/);
+  });
+
   it('builds the per-member view + the aggregate over the audit decisions', () => {
     const report = diffShadow([
       rec({ band: 'ok', holds_role: true, qualifies: true, wallet: addr('1') }), // correctly has → no_change

--- a/packages/protocol/shadow-audit/src/__tests__/shadow-runner.test.ts
+++ b/packages/protocol/shadow-audit/src/__tests__/shadow-runner.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { makeMemoryStore, runShadow, ShadowSnapshotSchema, type ShadowRunInput } from '../shadow-runner.js';
+import type { AccessDecisionRecord } from '../schemas/access-decision-record.js';
+
+const rec = (o: { band: AccessDecisionRecord['band']; holds_role: boolean; qualifies: boolean; wallet: string }): AccessDecisionRecord => ({
+  wallet: o.wallet,
+  community: 'honeycomb',
+  holds_role: o.holds_role,
+  qualifies: o.qualifies,
+  band: o.band,
+  evidence: { balance_at_snapshot: 1 },
+  provenance: { rule_id: 'tier-1', snapshot_block: 887577, computed_at: '2026-06-28T00:00:00.000Z', sources: ['sonar'] },
+});
+const addr = (n: string) => `0x${n.repeat(40)}`;
+
+const input = (over: Partial<ShadowRunInput> = {}): ShadowRunInput => ({
+  community: 'honeycomb',
+  mode: 'dogfood-full',
+  computed_at: '2026-06-28T00:00:00.000Z',
+  records: [
+    rec({ band: 'stale', holds_role: true, qualifies: false, wallet: addr('1') }), // would demote
+    rec({ band: 'missing', holds_role: false, qualifies: true, wallet: addr('2') }), // would promote
+    rec({ band: 'ok', holds_role: true, qualifies: true, wallet: addr('3') }), // unchanged
+  ],
+  ...over,
+});
+
+describe('Shadow Mode — runShadow (produce + persist, read-only)', () => {
+  it('produces + persists a schema-valid snapshot carrying the discrepancy', async () => {
+    const store = makeMemoryStore();
+    const snap = await runShadow(input(), store);
+    expect(() => ShadowSnapshotSchema.parse(snap)).not.toThrow();
+    expect(snap.report.aggregate.demotions).toBe(1);
+    expect(snap.report.aggregate.promotions).toBe(1);
+    expect(snap.report.aggregate.no_change).toBe(1);
+    expect(await store.latest('honeycomb')).toEqual(snap);
+  });
+
+  it('appends a SERIES over time — the dashboard watches the discrepancy converge before going live', async () => {
+    const store = makeMemoryStore();
+    await runShadow(input({ computed_at: '2026-06-28T00:00:00.000Z' }), store);
+    await runShadow(input({ computed_at: '2026-06-29T00:00:00.000Z' }), store);
+    const series = await store.series('honeycomb');
+    expect(series.length).toBe(2);
+    expect(series[1]?.computed_at).toBe('2026-06-29T00:00:00.000Z');
+  });
+
+  it('is READ-ONLY — it touches no input record (and by construction, no Discord role)', async () => {
+    const inp = input();
+    const before = JSON.stringify(inp.records);
+    await runShadow(inp, makeMemoryStore());
+    expect(JSON.stringify(inp.records)).toBe(before);
+  });
+
+  it('isolates communities in the store', async () => {
+    const store = makeMemoryStore();
+    await runShadow(input({ community: 'honeycomb' }), store);
+    expect(await store.latest('some-other-community')).toBeUndefined();
+  });
+});

--- a/packages/protocol/shadow-audit/src/discrepancy.ts
+++ b/packages/protocol/shadow-audit/src/discrepancy.ts
@@ -24,9 +24,23 @@ export const ChangeSchema = z.enum(['promotion', 'demotion', 'no_change']);
 export type Change = z.infer<typeof ChangeSchema>;
 
 /** The band → change mapping. The band already IS the holds×qualifies quadrant (common.ts), so the
- *  classification is canonical — not a second, drift-prone computation. */
-export const changeFromBand = (band: Band): Change =>
-  band === 'missing' ? 'promotion' : band === 'stale' ? 'demotion' : 'no_change';
+ *  classification is canonical — not a second, drift-prone computation. Exhaustive switch with a
+ *  `never` guard: if BandSchema ever grows a 4th band, this fails to COMPILE rather than silently
+ *  bucketing the new band as `no_change` (which would hide a real discrepancy). */
+export const changeFromBand = (band: Band): Change => {
+  switch (band) {
+    case 'missing':
+      return 'promotion';
+    case 'stale':
+      return 'demotion';
+    case 'ok':
+      return 'no_change';
+    default: {
+      const _exhaustive: never = band;
+      throw new Error(`changeFromBand: unhandled band ${String(_exhaustive)}`);
+    }
+  }
+};
 
 /** One row of the Comparison View — incumbent vs recommended, and the resulting change. */
 export const MemberDiscrepancySchema = z
@@ -74,6 +88,9 @@ export type DiscrepancyReport = z.infer<typeof DiscrepancyReportSchema>;
  * Read-only by construction: it consumes decisions and emits a report. It NEVER mutates a role — that is
  * the whole point of Shadow Mode (operate alongside the incumbent, show potential actions, change
  * nothing until the operator reviews the report and chooses to go live).
+ *
+ * Precondition: `records` are schema-valid (validate upstream via AccessDecisionRecordSchema — the wired
+ * path does). diffShadow is a public export; an unvalidated caller risks double-counted duplicate rows.
  */
 export function diffShadow(records: readonly AccessDecisionRecord[]): DiscrepancyReport {
   const members: MemberDiscrepancy[] = records.map((r) => ({

--- a/packages/protocol/shadow-audit/src/index.ts
+++ b/packages/protocol/shadow-audit/src/index.ts
@@ -76,3 +76,15 @@ export {
   type AuditInputs,
   computeInputsHash,
 } from './inputs-hash.js';
+
+// Shadow Mode — the Discrepancy engine (Comparison View + Discrepancy Report over the audit's bands).
+export {
+  diffShadow,
+  changeFromBand,
+  ChangeSchema,
+  MemberDiscrepancySchema,
+  DiscrepancyReportSchema,
+  type Change,
+  type MemberDiscrepancy,
+  type DiscrepancyReport,
+} from './discrepancy.js';

--- a/packages/protocol/shadow-audit/src/index.ts
+++ b/packages/protocol/shadow-audit/src/index.ts
@@ -88,3 +88,14 @@ export {
   type MemberDiscrepancy,
   type DiscrepancyReport,
 } from './discrepancy.js';
+
+// Shadow Mode — the runner (produce + persist a Discrepancy Report, read-only; store is injected).
+export {
+  ShadowSnapshotSchema,
+  toShadowSnapshot,
+  runShadow,
+  makeMemoryStore,
+  type ShadowSnapshot,
+  type ShadowRunInput,
+  type ShadowStore,
+} from './shadow-runner.js';

--- a/packages/protocol/shadow-audit/src/shadow-runner.ts
+++ b/packages/protocol/shadow-audit/src/shadow-runner.ts
@@ -1,0 +1,85 @@
+/**
+ * Shadow Mode — the runner. Produce + persist a point-in-time Discrepancy Report, read-only.
+ *
+ * "ARRAKIS operates ALONGSIDE existing token-gating without modifying Discord roles" — so the runner
+ * records what WOULD change (a `ShadowSnapshot`) and persists it; it never touches a role. The dashboard
+ * reads the persisted SERIES (the Comparison View over time; the operator watches it converge before
+ * going live). A cadence (cron / scheduled-cycle) fires `runShadow`; gathering the live audit records
+ * (runAudit) is the caller's job, so the runner stays pure + testable. The concrete store (file /
+ * EventStore / db) is an injected adapter — only laplas-gated, durable persistence touches the world.
+ */
+import { z } from 'zod';
+import { AuditModeSchema, type AuditMode } from './schemas/common.js';
+import type { AccessDecisionRecord } from './schemas/access-decision-record.js';
+import { diffShadow, DiscrepancyReportSchema } from './discrepancy.js';
+
+/** A point-in-time shadow report — the persisted artifact the dashboard reads (one per run). */
+export const ShadowSnapshotSchema = z
+  .object({
+    community: z.string().min(1),
+    mode: AuditModeSchema,
+    /** ISO-8601 UTC instant the run was computed. */
+    computed_at: z.string().datetime(),
+    report: DiscrepancyReportSchema,
+  })
+  .strict();
+export type ShadowSnapshot = z.infer<typeof ShadowSnapshotSchema>;
+
+export interface ShadowRunInput {
+  readonly community: string;
+  readonly mode: AuditMode;
+  readonly computed_at: string;
+  readonly records: readonly AccessDecisionRecord[];
+}
+
+/** Produce a snapshot from the audit's records — pure (diffShadow + wrap). Read-only. */
+export function toShadowSnapshot(input: ShadowRunInput): ShadowSnapshot {
+  return ShadowSnapshotSchema.parse({
+    community: input.community,
+    mode: input.mode,
+    computed_at: input.computed_at,
+    report: diffShadow(input.records),
+  });
+}
+
+/**
+ * The persistence PORT. The runner appends snapshots; the dashboard reads the `series`. Concrete stores
+ * (file / EventStore / db) are the integration adapter — the runner is pure over this port, so a cadence
+ * can fire it against any backend.
+ */
+export interface ShadowStore {
+  append(snapshot: ShadowSnapshot): Promise<void>;
+  series(community: string): Promise<readonly ShadowSnapshot[]>;
+  latest(community: string): Promise<ShadowSnapshot | undefined>;
+}
+
+/** An in-memory store — the test seam + the default for a single-process cadence. A durable file/db
+ *  adapter is the integration step. */
+export function makeMemoryStore(): ShadowStore {
+  const byCommunity = new Map<string, ShadowSnapshot[]>();
+  return {
+    async append(s) {
+      const arr = byCommunity.get(s.community) ?? [];
+      arr.push(s);
+      byCommunity.set(s.community, arr);
+    },
+    async series(c) {
+      return [...(byCommunity.get(c) ?? [])];
+    },
+    async latest(c) {
+      const arr = byCommunity.get(c);
+      return arr && arr.length > 0 ? arr[arr.length - 1] : undefined;
+    },
+  };
+}
+
+/**
+ * runShadow — one shadow run: produce the snapshot, persist it, return it. READ-ONLY by construction: it
+ * records what would change and appends to the store; it touches no Discord role. That is Shadow Mode's
+ * whole promise — run alongside, show the discrepancy, change nothing until the operator goes live.
+ */
+export async function runShadow(input: ShadowRunInput, store: ShadowStore): Promise<ShadowSnapshot> {
+  const snapshot = toShadowSnapshot(input);
+  await store.append(snapshot);
+  return snapshot;
+}

--- a/packages/services/shadow-audit/src/__tests__/audit-router.test.ts
+++ b/packages/services/shadow-audit/src/__tests__/audit-router.test.ts
@@ -134,6 +134,25 @@ describe('POST /v1/audit (named output, authed)', () => {
     expect(Array.isArray(json.records)).toBe(true);
   });
 
+  it('serves the Shadow Mode discrepancy — the dashboard contract (bands-only Comparison View)', async () => {
+    // The seam the Shadow Mode dashboard binds to: the authed response MUST carry output.discrepancy.
+    // Pin it at the HTTP layer so a future router reshape can't silently drop it.
+    const res = await post(createAuditRouter(makeDeps()), '/v1/audit', namedBody());
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as any;
+    expect(json.discrepancy).toBeDefined();
+    // every record is classified into the Comparison View
+    expect(json.discrepancy.aggregate.total).toBe(json.records.length);
+    // the Conviction Distribution is BANDS, never a raw score
+    expect(json.discrepancy.aggregate.band_distribution).toEqual(
+      expect.objectContaining({ stale: expect.any(Number), missing: expect.any(Number), ok: expect.any(Number) }),
+    );
+    // BANDS-ONLY invariant enforced at the served boundary — no numeric score leaks to the dashboard
+    expect(JSON.stringify(json.discrepancy)).not.toContain('"score"');
+    // R2 sold its NFT (role without holdings) → a demotion in the cutover preview (GET aggregate = 1 stale)
+    expect(json.discrepancy.aggregate.demotions).toBeGreaterThanOrEqual(1);
+  });
+
   it('rejects a bad signature with 401', async () => {
     const deps = makeDeps({
       auth: { ...makeDeps().auth, recover: async () => '0x' + 'd'.repeat(40) },

--- a/packages/services/shadow-audit/src/__tests__/audit-service.test.ts
+++ b/packages/services/shadow-audit/src/__tests__/audit-service.test.ts
@@ -198,3 +198,26 @@ describe('runAudit — hardening fixes', () => {
     }
   });
 });
+
+describe('runAudit — Shadow Mode discrepancy (authed)', () => {
+  it('carries the per-member discrepancy when records are included, over the same members', async () => {
+    const r = await runAudit(req({ includeRecords: true }), deps());
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.output.records).toBeDefined();
+    expect(r.output.discrepancy).toBeDefined();
+    expect(r.output.discrepancy!.aggregate.total).toBe(r.output.records!.length);
+    expect(r.output.discrepancy!.members.length).toBe(r.output.records!.length);
+    // every band classified into a change (no member dropped)
+    const changed = r.output.discrepancy!.aggregate;
+    expect(changed.promotions + changed.demotions + changed.no_change).toBe(changed.total);
+  });
+
+  it('omits the discrepancy for anonymous callers (no records → no comparison)', async () => {
+    const r = await runAudit(req({ includeRecords: false }), deps());
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.output.records).toBeUndefined();
+    expect(r.output.discrepancy).toBeUndefined();
+  });
+});

--- a/packages/services/shadow-audit/src/__tests__/shadow-cycle.test.ts
+++ b/packages/services/shadow-audit/src/__tests__/shadow-cycle.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { makeMemoryStore, type Order } from '@freeside/shadow-audit-protocol';
+import { runShadowCycle } from '../shadow-cycle.js';
+import type { AuditDeps, AuditRequest, OwnershipSource, RoleSource, WhaleSource } from '../audit-service.js';
+import type { RoleSnapshot } from '../role-snapshot.js';
+
+const R1 = '0x' + '1'.repeat(40);
+const R2 = '0x' + '2'.repeat(40);
+const R3 = '0x' + '3'.repeat(40);
+const X = '0x' + '4'.repeat(40);
+const Y = '0x' + '5'.repeat(40);
+const NOW = Math.floor(Date.UTC(2026, 5, 22, 12, 0, 0) / 1000);
+
+const order: Order = {
+  community: { name: 'thj', owner_wallet: '0x' + '9'.repeat(40) },
+  source: { chain: 'ethereum', contract_address: '0x' + 'a'.repeat(40) },
+  gating_rule: { kind: 'nft-balance', threshold: 1 },
+  products: ['audit'],
+  mode: 'lead-magnet',
+};
+const snapshot = (): RoleSnapshot => ({
+  source: 'discord:guild:1',
+  community: 'thj',
+  captured_at: '2026-06-22T11:00:00.000Z',
+  export_method: 'export',
+  owner: '0x' + '9'.repeat(40),
+  freshness_threshold_seconds: 86_400,
+  entries: [
+    { discord_user_id: 'u1', wallet: R1, role_ids: ['h'] },
+    { discord_user_id: 'u2', wallet: R2, role_ids: ['h'] },
+    { discord_user_id: 'u3', wallet: R3, role_ids: ['h'] },
+  ],
+});
+const ownership: OwnershipSource = {
+  resolveSnapshotBlock: async () => 1000,
+  balancesAt: async () => new Map([[R1, 1n], [R2, 1n], [R3, 1n], [X, 1n]]),
+  currentBalances: async () => new Map([[R1, 1n], [R3, 1n], [Y, 1n]]),
+};
+const whale: WhaleSource = { concentration: async () => 0.3 };
+const roles = (s: RoleSnapshot = snapshot()): RoleSource => ({ load: async () => s });
+const req = (over: Partial<AuditRequest> = {}): AuditRequest => ({
+  order,
+  snapshotDate: '2026-06-22',
+  isOperatedCommunity: true,
+  nowUnixSeconds: NOW,
+  includeRecords: false,
+  cta: { product: '/shadow-access', conversation: '/talk' },
+  ...over,
+});
+const deps = (over: Partial<AuditDeps> = {}): AuditDeps => ({ ownership, whale, roles: roles(), ...over });
+
+describe('runShadowCycle — the cadence orchestration (read-only)', () => {
+  it('runs the audit, derives the Comparison View, and persists a snapshot', async () => {
+    const store = makeMemoryStore();
+    const res = await runShadowCycle(req(), deps(), store, '2026-06-22T12:00:00.000Z');
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.snapshot.community).toBe('thj');
+    expect(res.snapshot.report.aggregate.total).toBeGreaterThan(0);
+    expect(await store.latest('thj')).toEqual(res.snapshot); // persisted
+  });
+
+  it('refuses cleanly when the audit refuses — touches nothing, persists nothing', async () => {
+    const store = makeMemoryStore();
+    const res = await runShadowCycle(req({ isOperatedCommunity: false }), deps(), store, '2026-06-22T12:00:00.000Z');
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toBe('external-mode');
+    expect(await store.latest('thj')).toBeUndefined();
+  });
+});

--- a/packages/services/shadow-audit/src/__tests__/shadow-store-file.test.ts
+++ b/packages/services/shadow-audit/src/__tests__/shadow-store-file.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { existsSync, rmSync } from 'node:fs';
+import { appendFileSync, existsSync, rmSync } from 'node:fs';
 import { makeFileStore } from '../shadow-store-file.js';
 import { runShadow, type ShadowRunInput } from '@freeside/shadow-audit-protocol';
 import type { AccessDecisionRecord } from '@freeside/shadow-audit-protocol';
@@ -54,5 +54,18 @@ describe('makeFileStore — durable ShadowStore', () => {
 
   it('refuses a malformed snapshot at the boundary (never persists garbage)', async () => {
     await expect(makeFileStore(PATH).append({ community: 'x' } as never)).rejects.toThrow();
+  });
+
+  it('survives a torn/garbage line — one bad line does not brick the whole history (FAGAN HIGH-1)', async () => {
+    const store = makeFileStore(PATH);
+    await runShadow(input({ computed_at: '2026-06-28T00:00:00.000Z' }), store);
+    // simulate a crash mid-append + a hand-edit: a torn JSON fragment and an outright garbage line
+    appendFileSync(PATH, '{"community":"honeycomb","mode":"dogfo'); // torn (invalid JSON, no newline)
+    appendFileSync(PATH, '\nnot json at all\n');
+    await runShadow(input({ computed_at: '2026-06-29T00:00:00.000Z' }), store);
+    // both VALID snapshots still read back; the two bad lines are skipped, never thrown
+    const series = await makeFileStore(PATH).series('honeycomb');
+    expect(series.map((s) => s.computed_at)).toEqual(['2026-06-28T00:00:00.000Z', '2026-06-29T00:00:00.000Z']);
+    expect((await makeFileStore(PATH).latest('honeycomb'))?.computed_at).toBe('2026-06-29T00:00:00.000Z');
   });
 });

--- a/packages/services/shadow-audit/src/__tests__/shadow-store-file.test.ts
+++ b/packages/services/shadow-audit/src/__tests__/shadow-store-file.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { existsSync, rmSync } from 'node:fs';
+import { makeFileStore } from '../shadow-store-file.js';
+import { runShadow, type ShadowRunInput } from '@freeside/shadow-audit-protocol';
+import type { AccessDecisionRecord } from '@freeside/shadow-audit-protocol';
+
+const PATH = join(tmpdir(), 'shadow-store-file.test.jsonl');
+beforeEach(() => {
+  if (existsSync(PATH)) rmSync(PATH);
+});
+
+const rec = (o: { band: AccessDecisionRecord['band']; holds_role: boolean; qualifies: boolean; wallet: string }): AccessDecisionRecord => ({
+  wallet: o.wallet,
+  community: 'honeycomb',
+  holds_role: o.holds_role,
+  qualifies: o.qualifies,
+  band: o.band,
+  evidence: { balance_at_snapshot: 1 },
+  provenance: { rule_id: 'tier-1', snapshot_block: 887577, computed_at: '2026-06-28T00:00:00.000Z', sources: ['sonar'] },
+});
+const input = (over: Partial<ShadowRunInput> = {}): ShadowRunInput => ({
+  community: 'honeycomb',
+  mode: 'dogfood-full',
+  computed_at: '2026-06-28T00:00:00.000Z',
+  records: [rec({ band: 'stale', holds_role: true, qualifies: false, wallet: `0x${'1'.repeat(40)}` })],
+  ...over,
+});
+
+describe('makeFileStore — durable ShadowStore', () => {
+  it('persists to disk — a FRESH store reading the same file sees the snapshot', async () => {
+    await runShadow(input(), makeFileStore(PATH));
+    const fresh = makeFileStore(PATH); // a separate process/cadence reopening the file
+    const latest = await fresh.latest('honeycomb');
+    expect(latest).toBeDefined();
+    expect(latest!.report.aggregate.demotions).toBe(1);
+  });
+
+  it('appends a growing series across runs (the dashboard history)', async () => {
+    const store = makeFileStore(PATH);
+    await runShadow(input({ computed_at: '2026-06-28T00:00:00.000Z' }), store);
+    await runShadow(input({ computed_at: '2026-06-29T00:00:00.000Z' }), store);
+    const series = await makeFileStore(PATH).series('honeycomb');
+    expect(series.length).toBe(2);
+    expect(series[1]?.computed_at).toBe('2026-06-29T00:00:00.000Z');
+  });
+
+  it('isolates communities + returns empty for an unknown one', async () => {
+    await runShadow(input(), makeFileStore(PATH));
+    expect(await makeFileStore(PATH).series('other')).toEqual([]);
+    expect(await makeFileStore(PATH).latest('other')).toBeUndefined();
+  });
+
+  it('refuses a malformed snapshot at the boundary (never persists garbage)', async () => {
+    await expect(makeFileStore(PATH).append({ community: 'x' } as never)).rejects.toThrow();
+  });
+});

--- a/packages/services/shadow-audit/src/audit-service.ts
+++ b/packages/services/shadow-audit/src/audit-service.ts
@@ -12,6 +12,7 @@
 import {
   AuditOutputSchema,
   computeInputsHash,
+  diffShadow,
   sha256Hex,
   type AccessDecisionRecord,
   tokenGatingPolicy,

--- a/packages/services/shadow-audit/src/index.ts
+++ b/packages/services/shadow-audit/src/index.ts
@@ -83,3 +83,4 @@ export {
   type ComparisonArtifact,
 } from './comparison-export.js';
 export { makeFileStore } from './shadow-store-file.js';
+export { runShadowCycle, type ShadowCycleResult } from './shadow-cycle.js';

--- a/packages/services/shadow-audit/src/index.ts
+++ b/packages/services/shadow-audit/src/index.ts
@@ -82,3 +82,4 @@ export {
   ComparisonUnavailableError,
   type ComparisonArtifact,
 } from './comparison-export.js';
+export { makeFileStore } from './shadow-store-file.js';

--- a/packages/services/shadow-audit/src/shadow-cycle.ts
+++ b/packages/services/shadow-audit/src/shadow-cycle.ts
@@ -1,0 +1,33 @@
+/**
+ * runShadowCycle — one cron-fireable shadow run. The orchestration the operator binds to live data.
+ *
+ * Run the audit AUTHED → derive the per-member Comparison View (the audit-service already carries it on
+ * `output.discrepancy`) → persist a ShadowSnapshot. READ-ONLY: it produces a report and appends to the
+ * store; it touches no Discord role (Shadow Mode operates ALONGSIDE the incumbent). The live deps
+ * (sonar/score/roles) + the cadence (cron / scheduled-cycle) + the store backend are INJECTED — the shape
+ * is here; binding it to a community's live sources is the operator's one decision.
+ */
+import { runAudit, type AuditDeps, type AuditRequest } from './audit-service.js';
+import { runShadow, type ShadowSnapshot, type ShadowStore } from '@freeside/shadow-audit-protocol';
+
+export type ShadowCycleResult =
+  | { readonly ok: true; readonly snapshot: ShadowSnapshot }
+  | { readonly ok: false; readonly reason: string };
+
+export async function runShadowCycle(
+  req: AuditRequest,
+  deps: AuditDeps,
+  store: ShadowStore,
+  computed_at: string,
+): Promise<ShadowCycleResult> {
+  // authed run — we need the per-member records to build the Comparison View
+  const audit = await runAudit({ ...req, includeRecords: true }, deps);
+  if (!audit.ok) return { ok: false, reason: audit.refusal.code };
+  const records = audit.output.records ?? [];
+  if (records.length === 0) return { ok: false, reason: 'no-records' };
+  const snapshot = await runShadow(
+    { community: req.order.community.name, mode: 'dogfood-full', computed_at, records },
+    store,
+  );
+  return { ok: true, snapshot };
+}

--- a/packages/services/shadow-audit/src/shadow-store-file.ts
+++ b/packages/services/shadow-audit/src/shadow-store-file.ts
@@ -3,8 +3,10 @@
  *
  * Append-only JSONL: one validated ShadowSnapshot per line, the series IS the history the dashboard
  * reads (and the operator watches converge before going live). Validated on the way in (never persist a
- * malformed snapshot) AND on the way out (never trust a hand-edited line). This is the integration seam
- * the pure runner (protocol) is written against; a cadence fires runShadow(records, makeFileStore(path)).
+ * malformed snapshot). On the way out the read is RESILIENT: a torn line (a crash mid-append) or a
+ * hand-edit is skipped, never thrown — one bad line must not brick the whole (cross-community) history.
+ * This is the integration seam the pure runner (protocol) is written against; a cadence fires
+ * runShadow(records, makeFileStore(path)).
  */
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname } from 'node:path';
@@ -16,7 +18,15 @@ export function makeFileStore(path: string): ShadowStore {
     return readFileSync(path, 'utf8')
       .split('\n')
       .filter((l) => l.trim().length > 0)
-      .map((l) => ShadowSnapshotSchema.parse(JSON.parse(l)))
+      // OUT-path resilience: skip a torn line (crash mid-append) or a hand-edit instead of throwing —
+      // one bad line must NOT brick the entire history across every community.
+      .flatMap((l) => {
+        try {
+          return [ShadowSnapshotSchema.parse(JSON.parse(l))];
+        } catch {
+          return [];
+        }
+      })
       .filter((s) => s.community === community);
   };
   return {
@@ -27,6 +37,8 @@ export function makeFileStore(path: string): ShadowStore {
     },
     series,
     async latest(community) {
+      // last-APPENDED row; equals newest-by-computed_at because the cadence always appends
+      // chronologically (computed_at = now). A backfill MUST preserve that ordering.
       const all = await series(community);
       return all.length > 0 ? all[all.length - 1] : undefined;
     },

--- a/packages/services/shadow-audit/src/shadow-store-file.ts
+++ b/packages/services/shadow-audit/src/shadow-store-file.ts
@@ -1,0 +1,34 @@
+/**
+ * A durable file-backed ShadowStore — the concrete adapter behind the runner's port.
+ *
+ * Append-only JSONL: one validated ShadowSnapshot per line, the series IS the history the dashboard
+ * reads (and the operator watches converge before going live). Validated on the way in (never persist a
+ * malformed snapshot) AND on the way out (never trust a hand-edited line). This is the integration seam
+ * the pure runner (protocol) is written against; a cadence fires runShadow(records, makeFileStore(path)).
+ */
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { ShadowSnapshotSchema, type ShadowSnapshot, type ShadowStore } from '@freeside/shadow-audit-protocol';
+
+export function makeFileStore(path: string): ShadowStore {
+  const series = async (community: string): Promise<readonly ShadowSnapshot[]> => {
+    if (!existsSync(path)) return [];
+    return readFileSync(path, 'utf8')
+      .split('\n')
+      .filter((l) => l.trim().length > 0)
+      .map((l) => ShadowSnapshotSchema.parse(JSON.parse(l)))
+      .filter((s) => s.community === community);
+  };
+  return {
+    async append(snapshot) {
+      ShadowSnapshotSchema.parse(snapshot); // refuse a malformed snapshot at the boundary
+      mkdirSync(dirname(path), { recursive: true });
+      appendFileSync(path, JSON.stringify(snapshot) + '\n');
+    },
+    series,
+    async latest(community) {
+      const all = await series(community);
+      return all.length > 0 ? all[all.length - 1] : undefined;
+    },
+  };
+}


### PR DESCRIPTION
The full read-only Shadow Mode backend — built by the Icebreaker, aimed at the product goal (docs.arrakis.community/features/shadow-mode). Operates ALONGSIDE the incumbent; touches no Discord role.

| piece | what |
|---|---|
| **diffShadow** | the per-member Comparison View + Discrepancy Report over the audit's bands (`missing→promotion · stale→demotion · ok→no_change`); BANDS-ONLY |
| **served** | the authed `/v1/audit` response carries `output.discrepancy` — the dashboard reads it from the existing endpoint, no new infra |
| **runner** | `runShadow(records, store)` → a persisted `ShadowSnapshot`; an injected `ShadowStore` port |
| **file store** | `makeFileStore` — durable append-only JSONL; the series IS the dashboard history |
| **cadence** | `runShadowCycle` — audit → shadow → persist, read-only; live deps + cron injected |

Settled: **44/44 protocol + 89/89 service tests, typecheck clean.** Read-only by construction at every layer.

**Remaining (genuine forks — yours):** bind live deps + the cron cadence (which community, the real sonar/score/role sources); the dashboard (frontend); the going-live cutover (the only step that touches a role).

🤖 the Icebreaker / the Refusal