### PR TITLE
feat(platform/coexistence): score-backed IEligibilityChecker — the Shadow Mode order-counter keystone

### DIFF
--- a/packages/adapters/coexistence/index.ts
+++ b/packages/adapters/coexistence/index.ts
@@ -56,6 +56,20 @@ export {
   type ShadowSyncJobOptions,
 } from './shadow-sync-job.js';
 
+// Order-counter foundation: the live eligibility seam + the order book that ACTIVATE
+// the S-25 shadow sync job (score-backed, community- and chain-agnostic).
+export {
+  makeScoreEligibilityChecker,
+  defaultProfileFetcher,
+  type ScoreEligibilityConfig,
+  type CommunityProfileFetcher,
+} from './score-eligibility-checker.js';
+export {
+  makeInMemoryOrderRegistry,
+  type CommunityOrder,
+  type OrderRegistry,
+} from './order-registry.js';
+
 // Sprint S-25: Feature Gate
 export {
   FeatureGate,

--- a/packages/adapters/coexistence/order-registry.test.ts
+++ b/packages/adapters/coexistence/order-registry.test.ts
@@ -73,4 +73,25 @@ describe('makeInMemoryOrderRegistry (the Shadow Mode order book)', () => {
     r.place(order({ communityId: 'a', guildId: 'new' }));
     expect(r.getConfig('a')?.guildId).toBe('new');
   });
+
+  it('a returned config/order is a deep copy — mutating it cannot reach stored state (FAGAN M-2)', () => {
+    const r = makeInMemoryOrderRegistry([order({ communityId: 'a', mode: 'parallel' })]);
+    // try to resurrect a graduated community by flipping the leaked config back to shadow
+    const leaked = r.getConfig('a')!;
+    leaked.mode = 'shadow';
+    expect(r.getConfig('a')?.mode).toBe('parallel'); // store untouched
+    expect(r.getShadowModeCommunities()).toEqual([]); // NOT resurrected into the sweep
+    // and the rules array is not a live reference either
+    const o = r.get('a')!;
+    (o.eligibilityRules as EligibilityRule[]).push(rule);
+    expect(r.getEligibilityRules('a')).toEqual([rule]); // stored single rule, unchanged
+  });
+
+  it('mutating an order AFTER place() does not change stored state (write-path copy)', () => {
+    const r = makeInMemoryOrderRegistry();
+    const o = order({ communityId: 'a', mode: 'shadow' });
+    r.place(o);
+    (o.config as { mode: string }).mode = 'disabled';
+    expect(r.getConfig('a')?.mode).toBe('shadow');
+  });
 });

--- a/packages/adapters/coexistence/order-registry.test.ts
+++ b/packages/adapters/coexistence/order-registry.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { makeInMemoryOrderRegistry, type CommunityOrder } from './order-registry.js';
+import type { CoexistenceConfig } from '@freeside/core/domain';
+import type { EligibilityRule } from './shadow-sync-job.js';
+
+const cfg = (over: Partial<CoexistenceConfig> = {}): CoexistenceConfig => ({
+  communityId: 'pythenians',
+  guildId: 'g1',
+  mode: 'shadow',
+  incumbentInfo: null,
+  syncIntervalHours: 6,
+  lastSyncAt: null,
+  shadowAccuracy: null,
+  shadowDays: 0,
+  minAccuracyForParallel: 0.95,
+  minShadowDaysForParallel: 14,
+  ...over,
+});
+const rule: EligibilityRule = { ruleType: 'score_threshold', chainId: '101', contractAddress: 'pyTh', minScore: 100 };
+const order = (over: Partial<CoexistenceConfig> = {}, rules: EligibilityRule[] = [rule]): CommunityOrder => ({
+  config: cfg(over),
+  eligibilityRules: rules,
+});
+
+describe('makeInMemoryOrderRegistry (the Shadow Mode order book)', () => {
+  it('places + reads an order back', () => {
+    const r = makeInMemoryOrderRegistry();
+    r.place(order());
+    expect(r.get('pythenians')?.config.guildId).toBe('g1');
+    expect(r.getConfig('pythenians')?.mode).toBe('shadow');
+    expect(r.getEligibilityRules('pythenians')).toEqual([rule]);
+  });
+
+  it('seeds from a constructor list', () => {
+    const r = makeInMemoryOrderRegistry([order({ communityId: 'mibera' }, [])]);
+    expect(r.get('mibera')).toBeDefined();
+  });
+
+  it('fail-safe on an un-ordered community: undefined config, [] rules, no throw', () => {
+    const r = makeInMemoryOrderRegistry();
+    expect(r.get('nope')).toBeUndefined();
+    expect(r.getConfig('nope')).toBeUndefined();
+    expect(r.getEligibilityRules('nope')).toEqual([]);
+  });
+
+  it('getShadowModeCommunities returns only mode==="shadow" (graduated communities drop out)', () => {
+    const r = makeInMemoryOrderRegistry([
+      order({ communityId: 'a', mode: 'shadow' }),
+      order({ communityId: 'b', mode: 'parallel' }),
+      order({ communityId: 'c', mode: 'primary' }),
+      order({ communityId: 'd', mode: 'disabled' }),
+    ]);
+    expect(r.getShadowModeCommunities().sort()).toEqual(['a']);
+  });
+
+  it('updateConfig graduates a mode + accrues accuracy in place, preserving the rules', () => {
+    const r = makeInMemoryOrderRegistry([order({ communityId: 'a', mode: 'shadow' })]);
+    r.updateConfig('a', { mode: 'parallel', shadowAccuracy: 0.97, shadowDays: 15 });
+    expect(r.getConfig('a')?.mode).toBe('parallel');
+    expect(r.getConfig('a')?.shadowAccuracy).toBe(0.97);
+    expect(r.getShadowModeCommunities()).toEqual([]); // out of the shadow sweep once graduated
+    expect(r.getEligibilityRules('a')).toEqual([rule]); // rules survived the patch
+  });
+
+  it('updateConfig is a no-op for an un-ordered community (never resurrects)', () => {
+    const r = makeInMemoryOrderRegistry();
+    r.updateConfig('ghost', { mode: 'primary' });
+    expect(r.get('ghost')).toBeUndefined();
+  });
+
+  it('place replaces an existing order for the same community', () => {
+    const r = makeInMemoryOrderRegistry([order({ communityId: 'a', guildId: 'old' })]);
+    r.place(order({ communityId: 'a', guildId: 'new' }));
+    expect(r.getConfig('a')?.guildId).toBe('new');
+  });
+});

--- a/packages/adapters/coexistence/order-registry.ts
+++ b/packages/adapters/coexistence/order-registry.ts
@@ -1,0 +1,68 @@
+/**
+ * The Shadow Mode order book — sprint item ② of the order-counter foundation.
+ *
+ * "Ordering a community" (Freeside-as-Subway) = placing a CommunityOrder: a
+ * CoexistenceConfig (which community, which guild, what mode) + its eligibility rules.
+ * The counter (today: seeded by hand; later: freeside-cli / code mode) WRITES orders
+ * here; the shadow sweep READS them (getShadowModeCommunities → getEligibilityRules →
+ * the IEligibilityChecker). Graduation (shadow → parallel → primary) is an updateConfig.
+ *
+ * In-memory + seedable for run #1 (operator: "run Pythenians manually first, automate
+ * later"). A durable store (Postgres) swaps in behind the same shape when the counter
+ * grows order/apply verbs. Method names mirror ICommunityRepository / IShadowSync so the
+ * sweep wire (item ③) adapts this with no impedance.
+ *
+ * @see grimoires/loa/context/arch-brief-shadow-order-counter-convergence.md
+ */
+import type { CoexistenceConfig } from '@freeside/core/domain';
+import type { EligibilityRule } from './shadow-sync-job.js';
+
+/** One placed order: a community's coexistence config + the rules its eligibility is judged by. */
+export interface CommunityOrder {
+  readonly config: CoexistenceConfig;
+  readonly eligibilityRules: readonly EligibilityRule[];
+}
+
+/** The order book. Reads never throw on an unknown community (fail-safe: absent = not ordered). */
+export interface OrderRegistry {
+  /** Place (or replace) an order. The counter's write verb. */
+  place(order: CommunityOrder): void;
+  /** The full order for a community, or undefined if not ordered. */
+  get(communityId: string): CommunityOrder | undefined;
+  /** The coexistence config (IShadowSync.getConfig shape). */
+  getConfig(communityId: string): CoexistenceConfig | undefined;
+  /** The eligibility rules (ICommunityRepository.getEligibilityRules shape); [] if not ordered. */
+  getEligibilityRules(communityId: string): readonly EligibilityRule[];
+  /** Communities currently in `shadow` mode — what the 6h sweep iterates. */
+  getShadowModeCommunities(): string[];
+  /** Patch a config in place (graduation: mode flip, accuracy/shadowDays accrual). No-op if absent. */
+  updateConfig(communityId: string, patch: Partial<CoexistenceConfig>): void;
+}
+
+export function makeInMemoryOrderRegistry(seed: readonly CommunityOrder[] = []): OrderRegistry {
+  const book = new Map<string, CommunityOrder>();
+  for (const order of seed) book.set(order.config.communityId, order);
+
+  return {
+    place(order) {
+      book.set(order.config.communityId, order);
+    },
+    get(communityId) {
+      return book.get(communityId);
+    },
+    getConfig(communityId) {
+      return book.get(communityId)?.config;
+    },
+    getEligibilityRules(communityId) {
+      return book.get(communityId)?.eligibilityRules ?? [];
+    },
+    getShadowModeCommunities() {
+      return [...book.values()].filter((o) => o.config.mode === 'shadow').map((o) => o.config.communityId);
+    },
+    updateConfig(communityId, patch) {
+      const order = book.get(communityId);
+      if (!order) return; // fail-safe: never resurrect an un-ordered community
+      book.set(communityId, { ...order, config: { ...order.config, ...patch } });
+    },
+  };
+}

--- a/packages/adapters/coexistence/order-registry.ts
+++ b/packages/adapters/coexistence/order-registry.ts
@@ -43,18 +43,26 @@ export function makeInMemoryOrderRegistry(seed: readonly CommunityOrder[] = []):
   const book = new Map<string, CommunityOrder>();
   for (const order of seed) book.set(order.config.communityId, order);
 
+  // Store + return DEEP COPIES. The `readonly` types are compile-time only; this is the runtime
+  // enforcement that a caller cannot reach into stored state through a getter (or by mutating an
+  // order it placed) — e.g. flip a graduated community's mode back to `shadow` and resurrect it
+  // into the sweep, which reads `o.config.mode` live. (FAGAN M-2)
+  const clone = <T>(v: T): T => structuredClone(v);
   return {
     place(order) {
-      book.set(order.config.communityId, order);
+      book.set(order.config.communityId, clone(order));
     },
     get(communityId) {
-      return book.get(communityId);
+      const o = book.get(communityId);
+      return o ? clone(o) : undefined;
     },
     getConfig(communityId) {
-      return book.get(communityId)?.config;
+      const o = book.get(communityId);
+      return o ? clone(o.config) : undefined;
     },
     getEligibilityRules(communityId) {
-      return book.get(communityId)?.eligibilityRules ?? [];
+      const o = book.get(communityId);
+      return o ? clone(o.eligibilityRules) : [];
     },
     getShadowModeCommunities() {
       return [...book.values()].filter((o) => o.config.mode === 'shadow').map((o) => o.config.communityId);

--- a/packages/adapters/coexistence/orders/pythenians.shadow-order.test.ts
+++ b/packages/adapters/coexistence/orders/pythenians.shadow-order.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PYTHENIANS_SHADOW_ORDER,
+  PYTHENIANS_GUILD_ID,
+  PYTHENIANS_COLLECTION,
+} from './pythenians.shadow-order.js';
+import { makeInMemoryOrderRegistry } from '../order-registry.js';
+import { makeScoreEligibilityChecker } from '../score-eligibility-checker.js';
+import type { EligibilityRule } from '../shadow-sync-job.js';
+
+describe('PYTHENIANS_SHADOW_ORDER (run #1 — chain-first, shadow-only, no admin)', () => {
+  it('is a valid shadow order: shadow mode, real guild + Solana collection, nft_ownership rule', () => {
+    expect(PYTHENIANS_SHADOW_ORDER.config.mode).toBe('shadow');
+    expect(PYTHENIANS_SHADOW_ORDER.config.guildId).toBe(PYTHENIANS_GUILD_ID);
+    expect(PYTHENIANS_SHADOW_ORDER.eligibilityRules).toEqual([
+      { ruleType: 'nft_ownership', chainId: '101', contractAddress: PYTHENIANS_COLLECTION },
+    ]);
+  });
+
+  it('places into the order book + shows up in the shadow sweep set (the foundation has a real order)', () => {
+    const r = makeInMemoryOrderRegistry([PYTHENIANS_SHADOW_ORDER]);
+    expect(r.getShadowModeCommunities()).toEqual(['pythenians']);
+    expect(r.getEligibilityRules('pythenians')[0]?.ruleType).toBe('nft_ownership');
+  });
+
+  it('is gated chain-first: an nft_score>0 holder is eligible, a scored non-holder is denied', async () => {
+    const rules = PYTHENIANS_SHADOW_ORDER.eligibilityRules as EligibilityRule[];
+    const holder = makeScoreEligibilityChecker(
+      { endpoint: 'https://score', community: 'pythenians', apiKey: 'k' },
+      async () => ({ status: 200, body: { tier: 'elder', nft_score: 1, combined_score: 500 } }),
+    );
+    const nonHolder = makeScoreEligibilityChecker(
+      { endpoint: 'https://score', community: 'pythenians', apiKey: 'k' },
+      async () => ({ status: 200, body: { tier: 'member', nft_score: 0, combined_score: 50 } }),
+    );
+    expect((await holder.checkEligibility(rules, '0xabc')).eligible).toBe(true);
+    expect((await nonHolder.checkEligibility(rules, '0xabc')).eligible).toBe(false);
+  });
+});

--- a/packages/adapters/coexistence/orders/pythenians.shadow-order.ts
+++ b/packages/adapters/coexistence/orders/pythenians.shadow-order.ts
@@ -1,0 +1,50 @@
+/**
+ * Pythenians — the first real shadow order (run #1). The foundation's first consumer.
+ *
+ * CHAIN-FIRST, NO ADMIN REQUIRED (operator frame 2026-06-28): the order is placed in `shadow`
+ * mode; eligibility is judged by NFT ownership via score-api, which indexes the Solana collection
+ * through svm_gateway. This provides value — the Conviction Distribution + holder analytics — WITHOUT
+ * touching the Discord server or needing admin access. Teams see the value, then adopt; no-risk swap.
+ *
+ * `admin_principals` is empty BY DESIGN: it gates GO-LIVE (the role write), which is deferred until a
+ * team adopts (FR-10 deny-all until then). The full Comparison View (chain vs incumbent Discord roles)
+ * lights up once the bot is invited to the guild — until then the chain side alone is the value.
+ *
+ * This config lives here as the first placed order; it moves to the worlds registry / a durable order
+ * store as the counter (freeside-cli) matures. @see docs-site/06-shadow-mode.md (the doctrine).
+ */
+import type { CommunityOrder } from '../order-registry.js';
+import type { EligibilityRule } from '../shadow-sync-job.js';
+import {
+  DEFAULT_MIN_ACCURACY_FOR_PARALLEL,
+  DEFAULT_MIN_SHADOW_DAYS_FOR_PARALLEL,
+  DEFAULT_SHADOW_SYNC_INTERVAL_HOURS,
+} from '@freeside/core/domain';
+
+export const PYTHENIANS_COMMUNITY = 'pythenians';
+/** The Pythenians Discord guild (shadow target). */
+export const PYTHENIANS_GUILD_ID = '826115122799837205';
+/** The Pythenians Solana collection mint (Metaplex), served by score-api via svm_gateway. */
+export const PYTHENIANS_COLLECTION = 'pyTh2UtBKfuDW6KCdT3swospYeoLmmKaGujWA91Moru';
+
+const pytheniansNftRule: EligibilityRule = {
+  ruleType: 'nft_ownership',
+  chainId: '101', // Solana mainnet-beta
+  contractAddress: PYTHENIANS_COLLECTION,
+};
+
+export const PYTHENIANS_SHADOW_ORDER: CommunityOrder = {
+  config: {
+    communityId: PYTHENIANS_COMMUNITY,
+    guildId: PYTHENIANS_GUILD_ID,
+    mode: 'shadow', // read-only; no Discord mutation, no admin needed
+    incumbentInfo: null, // detected when the bot joins the guild
+    syncIntervalHours: DEFAULT_SHADOW_SYNC_INTERVAL_HOURS,
+    lastSyncAt: null,
+    shadowAccuracy: null,
+    shadowDays: 0,
+    minAccuracyForParallel: DEFAULT_MIN_ACCURACY_FOR_PARALLEL,
+    minShadowDaysForParallel: DEFAULT_MIN_SHADOW_DAYS_FOR_PARALLEL,
+  },
+  eligibilityRules: [pytheniansNftRule],
+};

--- a/packages/adapters/coexistence/score-eligibility-checker.test.ts
+++ b/packages/adapters/coexistence/score-eligibility-checker.test.ts
@@ -41,13 +41,19 @@ describe('makeScoreEligibilityChecker (fail-closed, score-backed)', () => {
     });
   });
 
-  it('nft_ownership: a present tier = holder = eligible', async () => {
-    const c = makeScoreEligibilityChecker(cfg, returning(200, { tier: 'member', combined_score: 10 }));
+  it('nft_ownership: nft_score > 0 = holder = eligible', async () => {
+    const c = makeScoreEligibilityChecker(cfg, returning(200, { tier: 'member', nft_score: 2, combined_score: 10 }));
     expect((await c.checkEligibility([nftRule], W)).eligible).toBe(true);
   });
 
-  it('nft_ownership: null tier + zero nft_score = not a holder = not eligible', async () => {
-    const c = makeScoreEligibilityChecker(cfg, returning(200, { tier: null, combined_score: null, nft_score: 0 }));
+  it('nft_ownership FAILS CLOSED: a present tier with nft_score 0 is NOT a holder (FAGAN H-1)', async () => {
+    // tier/combined_score aggregate non-NFT signals; a scored non-holder must NOT be granted.
+    const c = makeScoreEligibilityChecker(cfg, returning(200, { tier: 'member', combined_score: 10, nft_score: 0 }));
+    expect((await c.checkEligibility([nftRule], W)).eligible).toBe(false);
+  });
+
+  it('nft_ownership: a missing nft_score is NOT a holder (no tier-presence over-grant)', async () => {
+    const c = makeScoreEligibilityChecker(cfg, returning(200, { tier: 'elder', combined_score: 999 }));
     expect((await c.checkEligibility([nftRule], W)).eligible).toBe(false);
   });
 
@@ -86,10 +92,21 @@ describe('makeScoreEligibilityChecker (fail-closed, score-backed)', () => {
     expect((await c.checkEligibility([scoreRule], W)).source).toBe('native_degraded');
   });
 
-  it('token_balance is not evaluable by the score path → not eligible (defer to a chain checker)', async () => {
+  it('token_balance → DEGRADED, not a confident negative (score checker cannot judge it) (FAGAN M-1)', async () => {
     const c = makeScoreEligibilityChecker(cfg, returning(200, { tier: 'elder', combined_score: 999 }));
     const tokRule: EligibilityRule = { ruleType: 'token_balance', chainId: '101', contractAddress: 'pyTh', minAmount: 1n };
-    expect((await c.checkEligibility([tokRule], W)).eligible).toBe(false);
+    expect(await c.checkEligibility([tokRule], W)).toEqual({
+      eligible: false,
+      tier: null,
+      score: null,
+      source: 'native_degraded',
+    });
+  });
+
+  it('a mixed config containing token_balance degrades the whole check (no confident partial answer)', async () => {
+    const c = makeScoreEligibilityChecker(cfg, returning(200, { tier: 'elder', combined_score: 999 }));
+    const tokRule: EligibilityRule = { ruleType: 'token_balance', chainId: '101', contractAddress: 'pyTh', minAmount: 1n };
+    expect((await c.checkEligibility([tokRule, scoreRule], W)).source).toBe('native_degraded');
   });
 
   it('never grants on ANY non-2xx, across the range — even with a juicy body', async () => {

--- a/packages/adapters/coexistence/score-eligibility-checker.test.ts
+++ b/packages/adapters/coexistence/score-eligibility-checker.test.ts
@@ -7,7 +7,11 @@
  * negative (not a holder), distinct from a degrade.
  */
 import { describe, it, expect } from 'vitest';
-import { makeScoreEligibilityChecker, type CommunityProfileFetcher } from './score-eligibility-checker.js';
+import {
+  makeScoreEligibilityChecker,
+  defaultProfileFetcher,
+  type CommunityProfileFetcher,
+} from './score-eligibility-checker.js';
 import type { EligibilityRule } from './shadow-sync-job.js';
 
 const cfg = { endpoint: 'https://score.test', community: 'pythenians', apiKey: 'k' };
@@ -124,5 +128,69 @@ describe('makeScoreEligibilityChecker (fail-closed, score-backed)', () => {
     };
     await makeScoreEligibilityChecker(cfg, spy).checkEligibility([scoreRule], W);
     expect(seen).toEqual({ apiKey: 'k', community: 'pythenians', address: W });
+  });
+
+  describe('onDegraded observability (FAGAN L-1)', () => {
+    it('fires on every degrade with the community + a reason — and NEVER the api key', async () => {
+      const seen: { community: string; reason: string }[] = [];
+      const o = { ...cfg, apiKey: 'SECRET_KEY_XYZ', onDegraded: (i: { community: string; reason: string }) => seen.push(i) };
+      const tokRule: EligibilityRule = { ruleType: 'token_balance', chainId: '101', contractAddress: 'pyTh', minAmount: 1n };
+      await makeScoreEligibilityChecker(o, returning(503, null)).checkEligibility([scoreRule], W);
+      await makeScoreEligibilityChecker(o, throwing()).checkEligibility([scoreRule], W);
+      await makeScoreEligibilityChecker(o, returning(200, { tier: 123 })).checkEligibility([scoreRule], W);
+      await makeScoreEligibilityChecker(o, returning(200, {})).checkEligibility([tokRule], W);
+      expect(seen.map((s) => s.reason)).toEqual(['http_503', 'transport', 'contract-drift', 'token_balance-unevaluable']);
+      expect(seen.every((s) => s.community === 'pythenians')).toBe(true);
+      expect(JSON.stringify(seen)).not.toContain('SECRET'); // the key never reaches the observability hook
+    });
+
+    it('does NOT fire on a clean answer (200 grant/deny or a 404 negative)', async () => {
+      let fired = false;
+      const o = { ...cfg, onDegraded: () => { fired = true; } };
+      await makeScoreEligibilityChecker(o, returning(200, { tier: 'elder', combined_score: 999 })).checkEligibility([scoreRule], W);
+      await makeScoreEligibilityChecker(o, returning(404, null)).checkEligibility([scoreRule], W);
+      expect(fired).toBe(false);
+    });
+  });
+
+  describe('defaultProfileFetcher — the real I/O path (FAGAN L-4)', () => {
+    const withFetch = async (impl: (url: string, init: { headers?: Record<string, string> }) => unknown, run: () => Promise<void>) => {
+      const orig = globalThis.fetch;
+      globalThis.fetch = ((url: string, init: { headers?: Record<string, string> }) => Promise.resolve(impl(url, init))) as unknown as typeof fetch;
+      try { await run(); } finally { globalThis.fetch = orig; }
+    };
+
+    it('builds the community-scoped URL + x-api-key header, returns {status, body}', async () => {
+      let captured: { url?: string; headers?: Record<string, string> } = {};
+      await withFetch(
+        (url, init) => { captured = { url, headers: init.headers }; return { status: 200, json: async () => ({ tier: 'elder' }) }; },
+        async () => {
+          const r = await defaultProfileFetcher({ endpoint: 'https://score.x/', community: 'pythenians', address: '0xWALLET', apiKey: 'K', timeoutMs: 1000 });
+          expect(r).toEqual({ status: 200, body: { tier: 'elder' } });
+        },
+      );
+      expect(captured.url).toBe('https://score.x/v1/wallets/0xWALLET?community=pythenians'); // trailing slash trimmed
+      expect(captured.headers).toEqual({ 'x-api-key': 'K' }); // key in header only, not the URL
+    });
+
+    it('returns a non-200 status (does not throw) for the checker to map', async () => {
+      await withFetch(
+        () => ({ status: 403, json: async () => ({ error: 'out-of-scope' }) }),
+        async () => {
+          const r = await defaultProfileFetcher({ endpoint: 'https://score.x', community: 'c', address: 'w', apiKey: 'K', timeoutMs: 1000 });
+          expect(r.status).toBe(403);
+        },
+      );
+    });
+
+    it('null body when the response is not JSON (no throw)', async () => {
+      await withFetch(
+        () => ({ status: 200, json: async () => { throw new Error('not json'); } }),
+        async () => {
+          const r = await defaultProfileFetcher({ endpoint: 'https://score.x', community: 'c', address: 'w', apiKey: 'K', timeoutMs: 1000 });
+          expect(r).toEqual({ status: 200, body: null });
+        },
+      );
+    });
   });
 });

--- a/packages/adapters/coexistence/score-eligibility-checker.test.ts
+++ b/packages/adapters/coexistence/score-eligibility-checker.test.ts
@@ -1,0 +1,111 @@
+/**
+ * makeScoreEligibilityChecker — fail-closed access-boundary tests.
+ *
+ * This adapter decides Arrakis-eligibility for the shadow order-counter. It is an access
+ * boundary, so the load-bearing invariant is: eligibility is NEVER granted on a degraded
+ * read (non-2xx other than 404, transport failure, or contract drift). A 404 is a real
+ * negative (not a holder), distinct from a degrade.
+ */
+import { describe, it, expect } from 'vitest';
+import { makeScoreEligibilityChecker, type CommunityProfileFetcher } from './score-eligibility-checker.js';
+import type { EligibilityRule } from './shadow-sync-job.js';
+
+const cfg = { endpoint: 'https://score.test', community: 'pythenians', apiKey: 'k' };
+const scoreRule: EligibilityRule = { ruleType: 'score_threshold', chainId: '101', contractAddress: 'pyTh', minScore: 100 };
+const nftRule: EligibilityRule = { ruleType: 'nft_ownership', chainId: '101', contractAddress: 'pyTh' };
+const W = '0xabc';
+
+const returning = (status: number, body: unknown): CommunityProfileFetcher => async () => ({ status, body });
+const throwing = (): CommunityProfileFetcher => async () => {
+  throw new Error('network down');
+};
+
+describe('makeScoreEligibilityChecker (fail-closed, score-backed)', () => {
+  it('grants when combined_score >= the score_threshold rule', async () => {
+    const c = makeScoreEligibilityChecker(cfg, returning(200, { tier: 'elder', combined_score: 150 }));
+    expect(await c.checkEligibility([scoreRule], W)).toEqual({
+      eligible: true,
+      tier: 'elder',
+      score: 150,
+      source: 'score_service',
+    });
+  });
+
+  it('denies (clean) when combined_score < threshold — still a real score_service answer', async () => {
+    const c = makeScoreEligibilityChecker(cfg, returning(200, { tier: 'crowd', combined_score: 50 }));
+    expect(await c.checkEligibility([scoreRule], W)).toEqual({
+      eligible: false,
+      tier: 'crowd',
+      score: 50,
+      source: 'score_service',
+    });
+  });
+
+  it('nft_ownership: a present tier = holder = eligible', async () => {
+    const c = makeScoreEligibilityChecker(cfg, returning(200, { tier: 'member', combined_score: 10 }));
+    expect((await c.checkEligibility([nftRule], W)).eligible).toBe(true);
+  });
+
+  it('nft_ownership: null tier + zero nft_score = not a holder = not eligible', async () => {
+    const c = makeScoreEligibilityChecker(cfg, returning(200, { tier: null, combined_score: null, nft_score: 0 }));
+    expect((await c.checkEligibility([nftRule], W)).eligible).toBe(false);
+  });
+
+  it('404 = a real negative (wallet not a scored holder), NOT degraded', async () => {
+    const c = makeScoreEligibilityChecker(cfg, returning(404, null));
+    expect(await c.checkEligibility([scoreRule], W)).toEqual({
+      eligible: false,
+      tier: null,
+      score: null,
+      source: 'score_service',
+    });
+  });
+
+  it('FAIL-CLOSED on 403 (out-of-scope api key) — degraded, never granted', async () => {
+    const c = makeScoreEligibilityChecker(cfg, returning(403, { error: 'out-of-scope' }));
+    expect(await c.checkEligibility([scoreRule], W)).toEqual({
+      eligible: false,
+      tier: null,
+      score: null,
+      source: 'native_degraded',
+    });
+  });
+
+  it('FAIL-CLOSED on a transport throw (network / timeout) — never grants', async () => {
+    const c = makeScoreEligibilityChecker(cfg, throwing());
+    expect(await c.checkEligibility([scoreRule], W)).toEqual({
+      eligible: false,
+      tier: null,
+      score: null,
+      source: 'native_degraded',
+    });
+  });
+
+  it('FAIL-CLOSED on contract drift (wrong-typed body) — never grants', async () => {
+    const c = makeScoreEligibilityChecker(cfg, returning(200, { tier: 123, combined_score: 'oops' }));
+    expect((await c.checkEligibility([scoreRule], W)).source).toBe('native_degraded');
+  });
+
+  it('token_balance is not evaluable by the score path → not eligible (defer to a chain checker)', async () => {
+    const c = makeScoreEligibilityChecker(cfg, returning(200, { tier: 'elder', combined_score: 999 }));
+    const tokRule: EligibilityRule = { ruleType: 'token_balance', chainId: '101', contractAddress: 'pyTh', minAmount: 1n };
+    expect((await c.checkEligibility([tokRule], W)).eligible).toBe(false);
+  });
+
+  it('never grants on ANY non-2xx, across the range — even with a juicy body', async () => {
+    for (const s of [400, 401, 403, 429, 500, 502, 503]) {
+      const c = makeScoreEligibilityChecker(cfg, returning(s, { tier: 'elder', combined_score: 999 }));
+      expect((await c.checkEligibility([scoreRule], W)).eligible).toBe(false);
+    }
+  });
+
+  it('passes the community-scoped key + the wallet to the fetcher (key never widened)', async () => {
+    let seen: { apiKey?: string; community?: string; address?: string } = {};
+    const spy: CommunityProfileFetcher = async (a) => {
+      seen = { apiKey: a.apiKey, community: a.community, address: a.address };
+      return { status: 200, body: { tier: 'elder', combined_score: 150 } };
+    };
+    await makeScoreEligibilityChecker(cfg, spy).checkEligibility([scoreRule], W);
+    expect(seen).toEqual({ apiKey: 'k', community: 'pythenians', address: W });
+  });
+});

--- a/packages/adapters/coexistence/score-eligibility-checker.ts
+++ b/packages/adapters/coexistence/score-eligibility-checker.ts
@@ -28,6 +28,10 @@ export interface ScoreEligibilityConfig {
   apiKey: string;
   /** per-request timeout (default 5s). */
   timeoutMs?: number;
+  /** Observability hook fired on every fail-closed degrade (L-1). Receives the community + a
+   *  reason — NEVER the api key or wallet. A down score-api degrades the whole boundary closed,
+   *  silently stalling graduation; this is the operator's signal. Optional + side-effect-only. */
+  onDegraded?: (info: { community: string; reason: string }) => void;
 }
 
 /**
@@ -66,6 +70,10 @@ export function makeScoreEligibilityChecker(
   fetcher: CommunityProfileFetcher = defaultProfileFetcher,
 ): IEligibilityChecker {
   const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const degraded = (reason: string): ArrakisEligibilityResult => {
+    config.onDegraded?.({ community: config.community, reason }); // L-1: signal, never the key/wallet
+    return DEGRADED;
+  };
   return {
     async checkEligibility(
       rules: EligibilityRule[],
@@ -75,7 +83,7 @@ export function makeScoreEligibilityChecker(
       // Refuse the whole check (degrade) rather than bank a confident negative for a rule it
       // structurally can't judge — a chain-backed checker owns token_balance. (FAGAN M-1)
       if (rules.some((rule) => rule.ruleType === 'token_balance')) {
-        return DEGRADED;
+        return degraded('token_balance-unevaluable');
       }
       let res: { status: number; body: unknown };
       try {
@@ -87,21 +95,24 @@ export function makeScoreEligibilityChecker(
           timeoutMs,
         });
       } catch {
-        return DEGRADED; // transport failure / timeout → never grant
+        return degraded('transport'); // transport failure / timeout → never grant
       }
 
-      // 404 = a real negative: the wallet is not a scored holder in this community.
+      // 404 = a real negative: the wallet is not a scored holder in this community. NOTE: a 404
+      // from a misprovisioned community slug / wrong route also reads here as "not a holder" (a
+      // confident negative, not a degrade) — wallet-404 is the dominant case, but a whole-community
+      // 404 would silently read everyone ineligible and depress the accuracy metric. (FAGAN L-2)
       if (res.status === 404) {
         return { eligible: false, tier: null, score: null, source: 'score_service' };
       }
       // any other non-2xx (403 out-of-scope key, 429, 5xx, …) → couldn't determine → fail-closed.
       if (res.status < 200 || res.status >= 300) {
-        return DEGRADED;
+        return degraded(`http_${res.status}`);
       }
 
       const parsed = ProfileSchema.safeParse(res.body);
       if (!parsed.success) {
-        return DEGRADED; // contract drift → fail-closed, never silently grant
+        return degraded('contract-drift'); // contract drift → fail-closed, never silently grant
       }
 
       const tier = parsed.data.tier ?? null;

--- a/packages/adapters/coexistence/score-eligibility-checker.ts
+++ b/packages/adapters/coexistence/score-eligibility-checker.ts
@@ -1,0 +1,151 @@
+/**
+ * makeScoreEligibilityChecker — the live IEligibilityChecker for the Shadow Mode
+ * order-counter (the coexistence layer's keystone seam).
+ *
+ * Routes Arrakis-eligibility through score-api's per-community wallet profile, so the
+ * foundation is community- AND chain-agnostic: score-api hides the chain (svm_gateway
+ * for Solana, evm_bronze for EVM), so a Solana community (Pythenians) and an EVM one
+ * resolve through the exact same path. The chain never leaks into the coexistence layer.
+ *
+ * FAIL-CLOSED (this is an access boundary): any error — non-2xx, a 403 out-of-scope key,
+ * a timeout, a transport failure, or a response that doesn't match the contract — yields
+ * { eligible: false } with source 'native_degraded'. Eligibility is NEVER granted on a
+ * degraded read. The community-scoped api key is held server-side only and never logged.
+ * A 404 is treated as a real negative (the wallet is not a scored holder), not a degrade.
+ *
+ * @see grimoires/loa/context/arch-brief-shadow-order-counter-convergence.md
+ */
+import { z } from 'zod';
+import type { ArrakisEligibilityResult } from '@freeside/core/domain';
+import type { EligibilityRule, IEligibilityChecker } from './shadow-sync-job.js';
+
+export interface ScoreEligibilityConfig {
+  /** score-api base URL. */
+  endpoint: string;
+  /** community slug (e.g. 'pythenians'); the api key MUST be scoped to it. */
+  community: string;
+  /** community-scoped x-api-key — server-side only, never logged or returned. */
+  apiKey: string;
+  /** per-request timeout (default 5s). */
+  timeoutMs?: number;
+}
+
+/**
+ * Injectable fetch of ONE community wallet profile — so the checker is testable without
+ * network and the key-handling path is isolated. Returns the HTTP status + parsed body;
+ * throws only on a transport failure (which the checker maps to fail-closed).
+ */
+export type CommunityProfileFetcher = (args: {
+  endpoint: string;
+  community: string;
+  address: string;
+  apiKey: string;
+  timeoutMs: number;
+}) => Promise<{ status: number; body: unknown }>;
+
+const DEGRADED: ArrakisEligibilityResult = {
+  eligible: false,
+  tier: null,
+  score: null,
+  source: 'native_degraded',
+};
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+/** The subset of score-api's CommunityWalletProfile this checker reads. A field of the
+ *  wrong type fails the parse → fail-closed (contract drift never silently grants). */
+const ProfileSchema = z.object({
+  tier: z.string().nullable().optional(),
+  tier_class: z.string().nullable().optional(),
+  combined_score: z.number().nullable().optional(),
+  nft_score: z.number().nullable().optional(),
+});
+
+export function makeScoreEligibilityChecker(
+  config: ScoreEligibilityConfig,
+  fetcher: CommunityProfileFetcher = defaultProfileFetcher,
+): IEligibilityChecker {
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  return {
+    async checkEligibility(
+      rules: EligibilityRule[],
+      walletAddress: string,
+    ): Promise<ArrakisEligibilityResult> {
+      let res: { status: number; body: unknown };
+      try {
+        res = await fetcher({
+          endpoint: config.endpoint,
+          community: config.community,
+          address: walletAddress,
+          apiKey: config.apiKey,
+          timeoutMs,
+        });
+      } catch {
+        return DEGRADED; // transport failure / timeout → never grant
+      }
+
+      // 404 = a real negative: the wallet is not a scored holder in this community.
+      if (res.status === 404) {
+        return { eligible: false, tier: null, score: null, source: 'score_service' };
+      }
+      // any other non-2xx (403 out-of-scope key, 429, 5xx, …) → couldn't determine → fail-closed.
+      if (res.status < 200 || res.status >= 300) {
+        return DEGRADED;
+      }
+
+      const parsed = ProfileSchema.safeParse(res.body);
+      if (!parsed.success) {
+        return DEGRADED; // contract drift → fail-closed, never silently grant
+      }
+
+      const tier = parsed.data.tier ?? null;
+      const score = parsed.data.combined_score ?? null;
+      const nftScore = parsed.data.nft_score ?? null;
+      const eligible = rules.some((rule) => satisfies(rule, { tier, score, nftScore }));
+      return { eligible, tier, score, source: 'score_service' };
+    },
+  };
+}
+
+function satisfies(
+  rule: EligibilityRule,
+  p: { tier: string | null; score: number | null; nftScore: number | null },
+): boolean {
+  switch (rule.ruleType) {
+    case 'score_threshold':
+      return rule.minScore != null && p.score != null && p.score >= rule.minScore;
+    case 'nft_ownership':
+      // score-api only scores holders → a present tier (or positive nft_score) = holds.
+      return p.tier !== null || (p.nftScore !== null && p.nftScore > 0);
+    case 'token_balance':
+      // raw on-chain balance is not served by the community profile; this score-backed
+      // checker cannot evaluate it — a chain-backed checker owns token_balance.
+      return false;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Default network fetcher. Never throws on a non-2xx (it returns the status so the
+ * checker maps it); throws only on a transport failure → fail-closed upstream.
+ */
+export const defaultProfileFetcher: CommunityProfileFetcher = async ({
+  endpoint,
+  community,
+  address,
+  apiKey,
+  timeoutMs,
+}) => {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const base = endpoint.replace(/\/$/, '');
+    const url = `${base}/v1/wallets/${encodeURIComponent(address)}?community=${encodeURIComponent(community)}`;
+    const r = await fetch(url, { headers: { 'x-api-key': apiKey }, signal: ctrl.signal });
+    const body = await r.json().catch(() => null);
+    return { status: r.status, body };
+  } finally {
+    clearTimeout(timer);
+  }
+};

--- a/packages/adapters/coexistence/score-eligibility-checker.ts
+++ b/packages/adapters/coexistence/score-eligibility-checker.ts
@@ -71,6 +71,12 @@ export function makeScoreEligibilityChecker(
       rules: EligibilityRule[],
       walletAddress: string,
     ): Promise<ArrakisEligibilityResult> {
+      // This checker is score-backed; it cannot soundly evaluate a raw on-chain token_balance.
+      // Refuse the whole check (degrade) rather than bank a confident negative for a rule it
+      // structurally can't judge — a chain-backed checker owns token_balance. (FAGAN M-1)
+      if (rules.some((rule) => rule.ruleType === 'token_balance')) {
+        return DEGRADED;
+      }
       let res: { status: number; body: unknown };
       try {
         res = await fetcher({
@@ -107,6 +113,9 @@ export function makeScoreEligibilityChecker(
   };
 }
 
+// Assumes one community = one gating contract = one score-api profile: rule.contractAddress /
+// rule.chainId are NOT used to scope the lookup (score-api returns a single community-scoped
+// profile). A multi-contract community needs per-contract scoping — tracked follow-up (FAGAN M-3).
 function satisfies(
   rule: EligibilityRule,
   p: { tier: string | null; score: number | null; nftScore: number | null },
@@ -115,13 +124,12 @@ function satisfies(
     case 'score_threshold':
       return rule.minScore != null && p.score != null && p.score >= rule.minScore;
     case 'nft_ownership':
-      // score-api only scores holders → a present tier (or positive nft_score) = holds.
-      return p.tier !== null || (p.nftScore !== null && p.nftScore > 0);
-    case 'token_balance':
-      // raw on-chain balance is not served by the community profile; this score-backed
-      // checker cannot evaluate it — a chain-backed checker owns token_balance.
-      return false;
+      // The wallet HOLDS the gating NFT iff nft_score > 0 — NOT `tier !== null`. tier and
+      // combined_score aggregate non-NFT signals too, so a wallet can carry a tier with
+      // nft_score 0 and hold nothing; tier-presence would fail OPEN. (FAGAN H-1)
+      return p.nftScore !== null && p.nftScore > 0;
     default:
+      // token_balance is refused upstream (degrade); any unknown rule denies.
       return false;
   }
 }

--- a/packages/core/domain/verification-tiers.test.ts
+++ b/packages/core/domain/verification-tiers.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Verification Tiers — gating-ladder invariant tests
+ *
+ * Target: tier -> feature gating utilities. The shadow graduation ladder reads
+ * these to decide which Arrakis features a community may exercise. An off-by-one
+ * in tier comparison or a break in inheritance monotonicity mis-gates access
+ * (either leaks a higher-tier feature down, or fails-OPEN at a lower tier).
+ *
+ * High-value risk pinned: gating off-by-one + fail-closed inheritance.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getFeaturesForTier,
+  isFeatureAvailable,
+  getMinimumTierForFeature,
+  compareTiers,
+  type VerificationTier,
+  type Feature,
+} from './verification-tiers.js';
+
+const TIERS: VerificationTier[] = ['incumbent_only', 'arrakis_basic', 'arrakis_full'];
+
+const ALL_FEATURES: Feature[] = [
+  // tier 1 (incumbent_only)
+  'shadow_tracking',
+  'public_leaderboard_hidden_wallets',
+  'admin_shadow_digest',
+  // tier 2 (arrakis_basic)
+  'profile_view',
+  'conviction_preview',
+  'position_check',
+  'threshold_check',
+  // tier 3 (arrakis_full)
+  'full_badges',
+  'tier_progression',
+  'social_features',
+  'profile_directory',
+  'badge_showcase',
+  'conviction_alerts',
+  'role_management',
+  'channel_gating',
+];
+
+describe('getFeaturesForTier', () => {
+  it('returns exactly the tier-1 features for incumbent_only (no inheritance)', () => {
+    expect(getFeaturesForTier('incumbent_only')).toEqual([
+      'shadow_tracking',
+      'public_leaderboard_hidden_wallets',
+      'admin_shadow_digest',
+    ]);
+  });
+
+  it('accumulates own + inherited features for arrakis_basic (3 + 4 = 7)', () => {
+    const features = getFeaturesForTier('arrakis_basic');
+    expect(features).toHaveLength(7);
+    // own features first, then inherited
+    expect(features).toEqual([
+      'profile_view',
+      'conviction_preview',
+      'position_check',
+      'threshold_check',
+      'shadow_tracking',
+      'public_leaderboard_hidden_wallets',
+      'admin_shadow_digest',
+    ]);
+  });
+
+  it('accumulates the full inheritance chain for arrakis_full (3 + 4 + 8 = 15)', () => {
+    const features = getFeaturesForTier('arrakis_full');
+    expect(features).toHaveLength(15);
+    // own features come first
+    expect(features[0]).toBe('full_badges');
+    // then arrakis_basic features
+    expect(features.slice(8, 12)).toEqual([
+      'profile_view',
+      'conviction_preview',
+      'position_check',
+      'threshold_check',
+    ]);
+    // then incumbent_only features at the tail
+    expect(features.slice(12)).toEqual([
+      'shadow_tracking',
+      'public_leaderboard_hidden_wallets',
+      'admin_shadow_digest',
+    ]);
+  });
+
+  it('is monotone: each higher tier is a strict superset of every lower tier (fail-closed inheritance)', () => {
+    const inc = new Set(getFeaturesForTier('incumbent_only'));
+    const basic = new Set(getFeaturesForTier('arrakis_basic'));
+    const full = new Set(getFeaturesForTier('arrakis_full'));
+
+    for (const f of inc) expect(basic.has(f)).toBe(true);
+    for (const f of basic) expect(full.has(f)).toBe(true);
+
+    // strict: higher tiers add features
+    expect(basic.size).toBeGreaterThan(inc.size);
+    expect(full.size).toBeGreaterThan(basic.size);
+  });
+
+  it('never returns duplicate features (inheritance chain is a partition)', () => {
+    for (const tier of TIERS) {
+      const features = getFeaturesForTier(tier);
+      expect(new Set(features).size).toBe(features.length);
+    }
+  });
+});
+
+describe('isFeatureAvailable', () => {
+  it('grants inherited features at higher tiers', () => {
+    expect(isFeatureAvailable('shadow_tracking', 'arrakis_full')).toBe(true);
+    expect(isFeatureAvailable('profile_view', 'arrakis_full')).toBe(true);
+  });
+
+  it('grants a tier its own features', () => {
+    expect(isFeatureAvailable('shadow_tracking', 'incumbent_only')).toBe(true);
+    expect(isFeatureAvailable('profile_view', 'arrakis_basic')).toBe(true);
+    expect(isFeatureAvailable('full_badges', 'arrakis_full')).toBe(true);
+  });
+
+  it('FAILS CLOSED: a lower tier never sees a higher tier feature (the off-by-one guard)', () => {
+    // tier-3 feature must be blocked at tier-1 and tier-2
+    expect(isFeatureAvailable('full_badges', 'incumbent_only')).toBe(false);
+    expect(isFeatureAvailable('full_badges', 'arrakis_basic')).toBe(false);
+    expect(isFeatureAvailable('channel_gating', 'arrakis_basic')).toBe(false);
+    // tier-2 feature must be blocked at tier-1
+    expect(isFeatureAvailable('profile_view', 'incumbent_only')).toBe(false);
+    expect(isFeatureAvailable('threshold_check', 'incumbent_only')).toBe(false);
+  });
+
+  it('returns false for a feature that exists in no tier (unknown feature is denied)', () => {
+    expect(isFeatureAvailable('nonexistent_feature' as Feature, 'arrakis_full')).toBe(false);
+  });
+});
+
+describe('getMinimumTierForFeature', () => {
+  it('resolves each feature to the lowest tier that natively defines it', () => {
+    expect(getMinimumTierForFeature('shadow_tracking')).toBe('incumbent_only');
+    expect(getMinimumTierForFeature('admin_shadow_digest')).toBe('incumbent_only');
+    expect(getMinimumTierForFeature('profile_view')).toBe('arrakis_basic');
+    expect(getMinimumTierForFeature('threshold_check')).toBe('arrakis_basic');
+    expect(getMinimumTierForFeature('full_badges')).toBe('arrakis_full');
+    expect(getMinimumTierForFeature('channel_gating')).toBe('arrakis_full');
+  });
+
+  it('returns null for an unknown feature', () => {
+    expect(getMinimumTierForFeature('nonexistent_feature' as Feature)).toBeNull();
+  });
+
+  it('covers every declared feature (no feature is orphaned from the ladder)', () => {
+    for (const f of ALL_FEATURES) {
+      expect(getMinimumTierForFeature(f)).not.toBeNull();
+    }
+  });
+});
+
+describe('compareTiers', () => {
+  it('orders incumbent_only < arrakis_basic < arrakis_full', () => {
+    expect(compareTiers('incumbent_only', 'arrakis_basic')).toBeLessThan(0);
+    expect(compareTiers('arrakis_basic', 'arrakis_full')).toBeLessThan(0);
+    expect(compareTiers('incumbent_only', 'arrakis_full')).toBeLessThan(0);
+  });
+
+  it('is antisymmetric and zero on equality', () => {
+    for (const a of TIERS) {
+      expect(compareTiers(a, a)).toBe(0);
+      for (const b of TIERS) {
+        // antisymmetry: cmp(a,b) === -cmp(b,a), i.e. the pair sums to zero.
+        // Summing avoids the signed-zero (-0 vs +0) artifact of Object.is.
+        expect(compareTiers(a, b) + compareTiers(b, a)).toBe(0);
+      }
+    }
+  });
+
+  it('returns exact index distances (no off-by-one in the magnitude)', () => {
+    expect(compareTiers('incumbent_only', 'arrakis_full')).toBe(-2);
+    expect(compareTiers('arrakis_full', 'incumbent_only')).toBe(2);
+    expect(compareTiers('arrakis_basic', 'incumbent_only')).toBe(1);
+  });
+});
+
+describe('gating-ladder cross-function consistency (the load-bearing invariant)', () => {
+  // The graduation ladder relies on these three functions agreeing. A feature is
+  // available at a tier IFF that tier is at or above the feature's minimum tier.
+  it('isFeatureAvailable(f, t) === (compareTiers(t, minTier(f)) >= 0) for every feature x tier', () => {
+    for (const f of ALL_FEATURES) {
+      const min = getMinimumTierForFeature(f);
+      expect(min).not.toBeNull();
+      for (const t of TIERS) {
+        const available = isFeatureAvailable(f, t);
+        const expected = compareTiers(t, min as VerificationTier) >= 0;
+        expect(available).toBe(expected);
+      }
+    }
+  });
+
+  it('a community gains features only by moving UP the ladder, never loses one going up', () => {
+    // For each adjacent tier step, the available set only grows.
+    for (let i = 1; i < TIERS.length; i++) {
+      const lower = new Set(getFeaturesForTier(TIERS[i - 1]));
+      const higher = new Set(getFeaturesForTier(TIERS[i]));
+      for (const f of lower) expect(higher.has(f)).toBe(true);
+    }
+  });
+});

--- a/packages/core/domain/verification-tiers.test.ts
+++ b/packages/core/domain/verification-tiers.test.ts
@@ -198,8 +198,8 @@ describe('gating-ladder cross-function consistency (the load-bearing invariant)'
   it('a community gains features only by moving UP the ladder, never loses one going up', () => {
     // For each adjacent tier step, the available set only grows.
     for (let i = 1; i < TIERS.length; i++) {
-      const lower = new Set(getFeaturesForTier(TIERS[i - 1]));
-      const higher = new Set(getFeaturesForTier(TIERS[i]));
+      const lower = new Set(getFeaturesForTier(TIERS[i - 1] as VerificationTier));
+      const higher = new Set(getFeaturesForTier(TIERS[i] as VerificationTier));
       for (const f of lower) expect(higher.has(f)).toBe(true);
     }
   });


### PR DESCRIPTION
## What

Sprint item **①** of the **Shadow Mode order-counter** foundation (operator: *"foundation first"*). The S-24/S-25 coexistence layer already **is** the order-counter — incumbent detection + the `shadow → parallel → primary` graduation ladder (95% / 14 days) — but it had **no live `IEligibilityChecker`**, so it never ran. This is that keystone.

`makeScoreEligibilityChecker` routes Arrakis-eligibility through **score-api's per-community wallet profile**. Because score-api hides the chain (`svm_gateway` for Solana, `evm_bronze` for EVM), the coexistence foundation is **community- and chain-agnostic** — Pythenians (Solana) and an EVM community resolve through the identical path. The chain never leaks into the order-counter; that's *why* the foundation belongs in this repo.

## Fail-closed access boundary (11 tests pin it)

| Read | Result |
|---|---|
| 2xx + satisfied rule | `eligible: true`, `source: score_service` |
| 2xx + unsatisfied | `eligible: false`, `source: score_service` (clean) |
| 404 (not a scored holder) | `eligible: false`, `source: score_service` (real negative) |
| 403 / 429 / 5xx / timeout / transport-throw / contract-drift | `eligible: false`, **`source: native_degraded` — NEVER granted** |

- `score_threshold` → `combined_score ≥ minScore`; `nft_ownership` → score-presence (score-api only scores holders); `token_balance` deferred to a chain checker.
- community-scoped api key passed server-side only, never logged.

## Status

**Draft — surface-only.** `adapters` tsc clean; 11/11 tests green. This is a fail-closed access boundary → recommend an independent (FAGAN) review before merge. Remaining foundation items: **②** register/read a `CoexistenceConfig` order, **③** wire `syncAll()` on a 6h schedule. Then Pythenians becomes run #1 against the live foundation.

Design (local): `grimoires/loa/context/arch-brief-shadow-order-counter-convergence.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)