### PR TITLE
feat(shadow-audit): Sprint 2 — the deployment surface (make the MVP servable for freeside-dashboard)

### DIFF
--- a/packages/services/shadow-audit/DEPLOY.md
+++ b/packages/services/shadow-audit/DEPLOY.md
@@ -10,7 +10,7 @@ code change**, only its env pointed here.
 |-----|----------|------|
 | `OPERATED_COMMUNITIES` | ✅ | comma-separated community names this deploy audits (dogfood-full eligible) |
 | `CTA_PRODUCT`, `CTA_CONVERSATION` | ✅ | the product + conversation door URLs surfaced in the audit |
-| `COLLECTION_REGISTRY` | ✅ | JSON: `{ "<chain>/<contract>": { "collection": "<belt-gateway id>", "standard": "erc721"\|"erc1155" } }` — **the 8 THJ collections** (HoneyJar1/3/4/6 + Honeycomb + crayons_factory @ 80094, HoneyJar2 @ 42161, HoneyJar5 @ 8453). Zod-validated at boot. |
+| `COLLECTION_REGISTRY` | ✅ | JSON: `{ "<chain>/<contract>": { "collection": "<belt-gateway id>", "standard": "erc721"\|"erc1155" } }`. Maps each `(chainId, contract-address)` a caller passes → the belt-gateway **collection id**. Zod-validated at boot. The 8 collection ids + their chains are live-grounded below; **the contract addresses are operator-supplied** (see the gate). |
 | `RPC_URL_<chain>` | ✅ (per registry chain) | a JSON-RPC endpoint per chain in the registry (e.g. `RPC_URL_80094`) for block-at-date resolution. Boot fails if any registry chain lacks one. |
 | `SHADOW_AUDIT_API_KEY` | optional | the `X-API-Key` the dashboard sends (when unset the k-anon aggregate is open). Set it + the dashboard's `SHADOW_AUDIT_API_KEY`. |
 | `BELT_GATEWAY_URL` | optional | sonar GraphQL endpoint (defaults to belt-gateway-production) |
@@ -20,6 +20,28 @@ code change**, only its env pointed here.
 | `PORT` | optional | bind port (Railway sets it; default 3040) |
 
 The server **fails loud at boot** on any missing/invalid required value — it never serves a half-wired audit.
+
+### Live-grounded auditable set (belt-gateway `CollectionStat`, queried 2026-06-29)
+
+The belt-gateway reconstructs ownership keyed on `(collection id, chainId)` — it stores **no contract
+address**, so the registry's contract addresses are the operator's to supply (from the deployment records).
+These are the exact `(collection, chain)` pairs that have indexed supply and are therefore auditable:
+
+| collection id | chains (chainId) | standard |
+|---|---|---|
+| `HoneyJar1` | eth (1), bera (80094) | erc721 |
+| `HoneyJar2` | **arb (42161)**, bera (80094), eth (1) | erc721 |
+| `HoneyJar3` | **zora (7777777)**, bera (80094) | erc721 |
+| `HoneyJar4` | **op (10)**, bera (80094), eth (1) | erc721 |
+| `HoneyJar5` | **base (8453)**, bera (80094), eth (1) | erc721 |
+| `HoneyJar6` | eth (1), bera (80094) | erc721 |
+| `Honeycomb` | eth (1), bera (80094) | erc721 |
+| `crayons_factory` | (in Transfer; absent from CollectionStat — confirm chain + standard) | ? |
+
+So a registry entry is `"<chainId>/<contract-address-on-that-chain>": { "collection": "HoneyJar5", "standard": "erc721" }`.
+Each generation has a canonical chain (bolded) **plus** a Berachain bridge; include only the `(chain, contract)`
+pairs the audited communities actually gate on. `crayons_factory` and per-collection token standards still need
+operator confirmation (it indexes Transfers but has no CollectionStat row).
 
 ## Railway
 

--- a/packages/services/shadow-audit/DEPLOY.md
+++ b/packages/services/shadow-audit/DEPLOY.md
@@ -1,0 +1,46 @@
+# shadow-audit-api — deploy runbook
+
+The Shadow Access Audit as its own deployable HTTP building. freeside-dashboard's
+`access-audit/client.ts` consumes it (`GET ${SHADOW_AUDIT_API_URL}/v1/audit`) — the dashboard needs **zero
+code change**, only its env pointed here.
+
+## Environment
+
+| Var | Required | What |
+|-----|----------|------|
+| `OPERATED_COMMUNITIES` | ✅ | comma-separated community names this deploy audits (dogfood-full eligible) |
+| `CTA_PRODUCT`, `CTA_CONVERSATION` | ✅ | the product + conversation door URLs surfaced in the audit |
+| `COLLECTION_REGISTRY` | ✅ | JSON: `{ "<chain>/<contract>": { "collection": "<belt-gateway id>", "standard": "erc721"\|"erc1155" } }` — **the 8 THJ collections** (HoneyJar1/3/4/6 + Honeycomb + crayons_factory @ 80094, HoneyJar2 @ 42161, HoneyJar5 @ 8453). Zod-validated at boot. |
+| `RPC_URL_<chain>` | ✅ (per registry chain) | a JSON-RPC endpoint per chain in the registry (e.g. `RPC_URL_80094`) for block-at-date resolution. Boot fails if any registry chain lacks one. |
+| `SHADOW_AUDIT_API_KEY` | optional | the `X-API-Key` the dashboard sends (when unset the k-anon aggregate is open). Set it + the dashboard's `SHADOW_AUDIT_API_KEY`. |
+| `BELT_GATEWAY_URL` | optional | sonar GraphQL endpoint (defaults to belt-gateway-production) |
+| `ROLE_SNAPSHOT_PATH` | optional | path to the Discord role-export JSON (absent → audits refuse external-mode) |
+| `CONFIRMATIONS` | optional | reorg finality depth (default 12; one source for both sonar + the "current" block) |
+| `AUDIT_K` | optional | k-anonymity threshold (default 5; **must be a positive integer** — `AUDIT_K=0` is rejected, it would disable k-anon) |
+| `PORT` | optional | bind port (Railway sets it; default 3040) |
+
+The server **fails loud at boot** on any missing/invalid required value — it never serves a half-wired audit.
+
+## Railway
+
+`railway.toml` is set (Dockerfile builder, healthcheck `/healthz`). Set in the service settings: Root Directory
+`packages/services/shadow-audit`, Build Context = repo root. The Dockerfile builds `@freeside/adapters`
+(the service resolves `@freeside/adapters/sonar` from its dist) then runs via `tsx bin/http.ts`.
+
+## 🚨 LIVE-CORRECTNESS GATE (money/ops — do this BEFORE pointing the dashboard at it)
+
+The unit suite (105 tests) proves the algorithm + assembly with injected fakes — **NOT** the live values. A
+wrong `COLLECTION_REGISTRY` mapping or RPC ⇒ a wrong holder set ⇒ a wrong audit (wrong access decisions).
+
+1. **Collection mapping** — verify each `collection` id against the live belt-gateway (a Transfer query that
+   matches nothing = a typo'd id = an empty, silently-wrong audit). `pnpm -C packages/adapters test:live`
+   exercises the real reconstruction.
+2. **RPC block-at-date** — spot-check one chain: pick a known date, confirm the resolved snapshot block's
+   timestamp is ≤ that date's UTC end and the next block's is >.
+3. **Smoke the real GET** — `curl "$URL/v1/audit?chain=80094&contract=<honeycomb>&snapshot_date=<known>&community=<thj>&owner_wallet=<addr>&threshold=1"`
+   and sanity-check the aggregate against a known holder count.
+4. **Then** set the dashboard's `SHADOW_AUDIT_API_URL` (+ `_KEY`) and the seam goes live. The dashboard
+   strict-decodes the response against the protocol `AuditOutputSchema`; the contract-parity test in
+   `src/__tests__/server.test.ts` pins that the GET output matches it.
+
+V2 (the authed `POST /v1/audit` named-output, SIWE) is fail-closed (always 401) until wired.

--- a/packages/services/shadow-audit/Dockerfile
+++ b/packages/services/shadow-audit/Dockerfile
@@ -1,33 +1,44 @@
 # shadow-audit-api — Railway-deployable Hono building (the Shadow Access Audit's HTTP surface).
 #
 # Build context: the loa-freeside repo ROOT (not this subdir) — the service consumes
-# @freeside/adapters + @freeside/shadow-audit-protocol via file: links, so both must be in
-# the build context.
+# @freeside/adapters + @freeside/shadow-audit-protocol via file: links, and @freeside/adapters in turn
+# consumes @freeside/core (file:../core), so ALL THREE must be in the build context.
 #
 # Railway: in this service's settings set
 #   Root Directory: packages/services/shadow-audit
 #   Build Context:  <repo-root>
 # OR rely on railway.toml's dockerfilePath (relative to repo root).
 #
-# tsx runs the service + protocol from source; @freeside/adapters is consumed from its built
-# dist (its package exports point to dist/), so it is the one package built here.
+# tsx runs the service + protocol from source (the protocol exports ./src). @freeside/core and
+# @freeside/adapters export dist/, so both are BUILT here (core first — adapters depends on it).
 
-FROM node:22-alpine AS base
+FROM node:22.12-alpine AS base
 WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@9.15.9 --activate
 
-# Stage the service + its file: dependencies.
+# Stage the transitive file: dependency tree: core <- adapters <- service (+ protocol).
+# (F1: packages/core was previously omitted, so the adapters install — which has file:../core — failed.)
+COPY packages/core ./packages/core
 COPY packages/adapters ./packages/adapters
 COPY packages/protocol/shadow-audit ./packages/protocol/shadow-audit
 COPY packages/services/shadow-audit ./packages/services/shadow-audit
 
-# Build @freeside/adapters so the service resolves @freeside/adapters/sonar from dist/.
+# Build @freeside/core FIRST — @freeside/adapters resolves @freeside/core from its dist/ (exports point there).
+WORKDIR /app/packages/core
+RUN pnpm install --no-frozen-lockfile && pnpm build
+
+# Then @freeside/adapters — the service resolves @freeside/adapters/sonar from its dist/.
 WORKDIR /app/packages/adapters
 RUN pnpm install --no-frozen-lockfile && pnpm build
 
-# Install the service (links the built adapters dist + the protocol src; brings tsx + hono).
+# Install the service (links the built core+adapters dist + the protocol src; brings tsx + zod + hono).
+# (F2: tsx + zod are runtime deps of bin/http.ts and now live in `dependencies`, so a production install keeps them.)
 WORKDIR /app/packages/services/shadow-audit
 RUN pnpm install --no-frozen-lockfile
+
+# loa:shortcut: --no-frozen-lockfile (F3) — the repo's npm/pnpm split means per-package lockfiles can lag the
+#   workspace; a frozen install would break the build. Upgrade trigger: once the per-package pnpm-lock.yaml
+#   files are kept in CI-verified sync, switch all three installs to --frozen-lockfile for a reproducible artifact.
 
 ENV NODE_ENV=production
 # Railway sets $PORT; bin/http.ts binds 0.0.0.0:$PORT (default 3040 in local dev).

--- a/packages/services/shadow-audit/Dockerfile
+++ b/packages/services/shadow-audit/Dockerfile
@@ -1,0 +1,35 @@
+# shadow-audit-api — Railway-deployable Hono building (the Shadow Access Audit's HTTP surface).
+#
+# Build context: the loa-freeside repo ROOT (not this subdir) — the service consumes
+# @freeside/adapters + @freeside/shadow-audit-protocol via file: links, so both must be in
+# the build context.
+#
+# Railway: in this service's settings set
+#   Root Directory: packages/services/shadow-audit
+#   Build Context:  <repo-root>
+# OR rely on railway.toml's dockerfilePath (relative to repo root).
+#
+# tsx runs the service + protocol from source; @freeside/adapters is consumed from its built
+# dist (its package exports point to dist/), so it is the one package built here.
+
+FROM node:22-alpine AS base
+WORKDIR /app
+RUN corepack enable && corepack prepare pnpm@9.15.9 --activate
+
+# Stage the service + its file: dependencies.
+COPY packages/adapters ./packages/adapters
+COPY packages/protocol/shadow-audit ./packages/protocol/shadow-audit
+COPY packages/services/shadow-audit ./packages/services/shadow-audit
+
+# Build @freeside/adapters so the service resolves @freeside/adapters/sonar from dist/.
+WORKDIR /app/packages/adapters
+RUN pnpm install --no-frozen-lockfile && pnpm build
+
+# Install the service (links the built adapters dist + the protocol src; brings tsx + hono).
+WORKDIR /app/packages/services/shadow-audit
+RUN pnpm install --no-frozen-lockfile
+
+ENV NODE_ENV=production
+# Railway sets $PORT; bin/http.ts binds 0.0.0.0:$PORT (default 3040 in local dev).
+EXPOSE 3040
+CMD ["pnpm", "start"]

--- a/packages/services/shadow-audit/bin/http.ts
+++ b/packages/services/shadow-audit/bin/http.ts
@@ -28,7 +28,10 @@ import { makeSonarOwnershipSource, registryFromMap } from '../src/ownership-sour
 import { makeRpcBlockTimeResolver } from '../src/block-time-resolver.js';
 
 process.on('unhandledRejection', (reason) => {
-  console.error('[shadow-audit-api] unhandledRejection:', reason);
+  // F9: log AND exit non-zero — a swallowed rejection can leave the process wedged (event loop alive, no
+  // longer serving correctly); Railway's healthcheck + restart policy recovers a clean crash, not a zombie.
+  console.error('[shadow-audit-api] unhandledRejection — exiting:', reason);
+  process.exit(1);
 });
 
 // the COLLECTION_REGISTRY values (collection id + token standard) are the most correctness-critical config

--- a/packages/services/shadow-audit/bin/http.ts
+++ b/packages/services/shadow-audit/bin/http.ts
@@ -1,0 +1,68 @@
+/**
+ * Sprint 2 / S2-T2 — the shadow-audit-api server entry. Constructs the real chain ownership adapter from
+ * the environment, builds the audit Hono app, and serves it via @hono/node-server (mirrors
+ * apps/freeside-operator-dash/bin/http.ts). This is the deployable surface the freeside-dashboard's
+ * already-built dormant client (`GET ${SHADOW_AUDIT_API_URL}/v1/audit`) consumes once its env is pointed
+ * here.
+ *
+ * Required env (the server FAILS LOUD at boot / first request on a missing value — never a silently
+ * half-wired audit):
+ *   OPERATED_COMMUNITIES   comma-separated community names this deploy audits (dogfood-full)
+ *   CTA_PRODUCT, CTA_CONVERSATION   the product + conversation door URLs
+ *   COLLECTION_REGISTRY    JSON: { "<chain>/<contract>": { "collection": "<belt-gateway id>", "standard": "erc721"|"erc1155" } }
+ *   RPC_URL_<chain>        a JSON-RPC endpoint per chain (e.g. RPC_URL_80094) for block-at-date resolution
+ * Optional:
+ *   SHADOW_AUDIT_API_KEY   the X-API-Key the dashboard sends (when unset the aggregate is open)
+ *   BELT_GATEWAY_URL       sonar GraphQL endpoint (defaults to belt-gateway-production)
+ *   ROLE_SNAPSHOT_PATH     path to the Discord role export JSON · AUDIT_K · PORT
+ *
+ * ⚠ LIVE CORRECTNESS is operator-gated: the COLLECTION_REGISTRY values + the RPC endpoints drive the
+ * ownership reconstruction (money/ops). Run `pnpm -C packages/adapters test:live` + a block-at-date
+ * spot-check against the configured RPC before trusting production output.
+ */
+import { serve } from '@hono/node-server';
+import { SonarClient, defaultTransferPageFetcher, type BlockTimeResolver } from '@freeside/adapters/sonar';
+import { buildAuditApp, configFromEnv } from '../src/server.js';
+import { makeSonarOwnershipSource, registryFromMap, type CollectionRef } from '../src/ownership-source.js';
+import { makeRpcBlockTimeResolver } from '../src/block-time-resolver.js';
+
+process.on('unhandledRejection', (reason) => {
+  console.error('[shadow-audit-api] unhandledRejection:', reason);
+});
+
+function loadRegistryFromEnv() {
+  const raw = process.env.COLLECTION_REGISTRY;
+  if (!raw) {
+    throw new Error('COLLECTION_REGISTRY is required (JSON map "<chain>/<contract>" → { collection, standard })');
+  }
+  let parsed: Record<string, CollectionRef>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, CollectionRef>;
+  } catch (e) {
+    throw new Error(`COLLECTION_REGISTRY is not valid JSON: ${(e as Error).message}`);
+  }
+  return registryFromMap(parsed);
+}
+
+/** Per-chain JSON-RPC resolver (the RPC endpoint differs per chain). */
+function resolverFor(chain: string): BlockTimeResolver {
+  const url = process.env[`RPC_URL_${chain}`];
+  if (!url) {
+    throw new Error(`RPC_URL_${chain} is required (JSON-RPC endpoint for chain ${chain}, for block-at-date resolution)`);
+  }
+  return makeRpcBlockTimeResolver({ url });
+}
+
+const sonar = new SonarClient(
+  process.env.BELT_GATEWAY_URL ? { endpoint: process.env.BELT_GATEWAY_URL } : {},
+  defaultTransferPageFetcher,
+);
+const ownership = makeSonarOwnershipSource({ sonar, resolverFor, registry: loadRegistryFromEnv() });
+const app = buildAuditApp(ownership, configFromEnv());
+
+const port = Number.parseInt(process.env.PORT ?? '3040', 10);
+serve({ fetch: app.fetch, port }, (info) => {
+  console.log(
+    `[shadow-audit-api] listening on http://0.0.0.0:${info.port} · operated=${process.env.OPERATED_COMMUNITIES ?? '(unset!)'} · key=${process.env.SHADOW_AUDIT_API_KEY ? 'set' : 'OPEN'}`,
+  );
+});

--- a/packages/services/shadow-audit/bin/http.ts
+++ b/packages/services/shadow-audit/bin/http.ts
@@ -21,27 +21,42 @@
  * spot-check against the configured RPC before trusting production output.
  */
 import { serve } from '@hono/node-server';
+import { z } from 'zod';
 import { SonarClient, defaultTransferPageFetcher, type BlockTimeResolver } from '@freeside/adapters/sonar';
 import { buildAuditApp, configFromEnv } from '../src/server.js';
-import { makeSonarOwnershipSource, registryFromMap, type CollectionRef } from '../src/ownership-source.js';
+import { makeSonarOwnershipSource, registryFromMap } from '../src/ownership-source.js';
 import { makeRpcBlockTimeResolver } from '../src/block-time-resolver.js';
 
 process.on('unhandledRejection', (reason) => {
   console.error('[shadow-audit-api] unhandledRejection:', reason);
 });
 
-function loadRegistryFromEnv() {
+// the COLLECTION_REGISTRY values (collection id + token standard) are the most correctness-critical config
+// in the deploy — VALIDATE them, the way role-source validates its snapshot (FAGAN MEDIUM-2). A typo'd
+// `collection` would match no Transfers → an empty, silently-wrong audit.
+const RegistrySchema = z.record(
+  z.string(),
+  z.object({ collection: z.string().min(1), standard: z.enum(['erc721', 'erc1155']) }).strict(),
+);
+
+function loadRegistryFromEnv(): { registry: ReturnType<typeof registryFromMap>; chains: Set<string> } {
   const raw = process.env.COLLECTION_REGISTRY;
   if (!raw) {
     throw new Error('COLLECTION_REGISTRY is required (JSON map "<chain>/<contract>" → { collection, standard })');
   }
-  let parsed: Record<string, CollectionRef>;
+  let parsed: unknown;
   try {
-    parsed = JSON.parse(raw) as Record<string, CollectionRef>;
+    parsed = JSON.parse(raw);
   } catch (e) {
     throw new Error(`COLLECTION_REGISTRY is not valid JSON: ${(e as Error).message}`);
   }
-  return registryFromMap(parsed);
+  const map = RegistrySchema.parse(parsed); // throws on a bad collection/standard
+  const chains = new Set<string>();
+  for (const key of Object.keys(map)) {
+    const chain = key.split('/')[0];
+    if (chain) chains.add(chain);
+  }
+  return { registry: registryFromMap(map), chains };
 }
 
 /** Per-chain JSON-RPC resolver (the RPC endpoint differs per chain). */
@@ -53,11 +68,26 @@ function resolverFor(chain: string): BlockTimeResolver {
   return makeRpcBlockTimeResolver({ url });
 }
 
+// ONE confirmations source for BOTH the SonarClient reorg guard AND the ownership-source "current" block,
+// so they can never drift apart (FAGAN MEDIUM-6: split knobs are a latent total-outage landmine).
+const confirmations = process.env.CONFIRMATIONS ? Number(process.env.CONFIRMATIONS) : 12;
+if (!Number.isInteger(confirmations) || confirmations < 0) {
+  throw new Error(`CONFIRMATIONS must be a non-negative integer (got "${process.env.CONFIRMATIONS}")`);
+}
+
+const { registry, chains } = loadRegistryFromEnv();
+// BOOT-validate an RPC URL for every registry chain — never boot /healthz-green with a chain that fails
+// every real audit at request time (FAGAN MEDIUM-3).
+const missingRpc = [...chains].filter((c) => !process.env[`RPC_URL_${c}`]);
+if (missingRpc.length > 0) {
+  throw new Error(`missing JSON-RPC endpoint(s) for registry chain(s): ${missingRpc.map((c) => `RPC_URL_${c}`).join(', ')}`);
+}
+
 const sonar = new SonarClient(
-  process.env.BELT_GATEWAY_URL ? { endpoint: process.env.BELT_GATEWAY_URL } : {},
+  process.env.BELT_GATEWAY_URL ? { endpoint: process.env.BELT_GATEWAY_URL, confirmations } : { confirmations },
   defaultTransferPageFetcher,
 );
-const ownership = makeSonarOwnershipSource({ sonar, resolverFor, registry: loadRegistryFromEnv() });
+const ownership = makeSonarOwnershipSource({ sonar, resolverFor, registry, confirmations });
 const app = buildAuditApp(ownership, configFromEnv());
 
 const port = Number.parseInt(process.env.PORT ?? '3040', 10);

--- a/packages/services/shadow-audit/package.json
+++ b/packages/services/shadow-audit/package.json
@@ -20,14 +20,14 @@
     "@freeside/adapters": "file:../../adapters",
     "@freeside/shadow-audit-protocol": "file:../../protocol/shadow-audit",
     "@hono/node-server": "^1.13.0",
-    "hono": "^4.7.0"
+    "hono": "^4.7.0",
+    "tsx": "^4.19.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "tsx": "^4.19.0",
     "typescript": "^5.7.0",
-    "vitest": "^4.0.17",
-    "zod": "^3.23.8"
+    "vitest": "^4.0.17"
   },
   "peerDependencies": {
     "zod": "^3.23.0"

--- a/packages/services/shadow-audit/package.json
+++ b/packages/services/shadow-audit/package.json
@@ -11,15 +11,20 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "start": "tsx bin/http.ts",
+    "dev": "tsx watch bin/http.ts"
   },
   "license": "AGPL-3.0",
   "dependencies": {
+    "@freeside/adapters": "file:../../adapters",
     "@freeside/shadow-audit-protocol": "file:../../protocol/shadow-audit",
+    "@hono/node-server": "^1.13.0",
     "hono": "^4.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "vitest": "^4.0.17",
     "zod": "^3.23.8"

--- a/packages/services/shadow-audit/railway.toml
+++ b/packages/services/shadow-audit/railway.toml
@@ -1,0 +1,10 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "packages/services/shadow-audit/Dockerfile"
+
+[deploy]
+healthcheckPath = "/healthz"
+healthcheckTimeout = 30
+startCommand = "pnpm start"
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3

--- a/packages/services/shadow-audit/src/__tests__/ownership-source.test.ts
+++ b/packages/services/shadow-audit/src/__tests__/ownership-source.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Sprint 2 / S2-T4 — the chain-reconstruction adapters, exercised with INJECTED fakes (no live network).
+ * The binary-search ALGORITHM + the assembly are proven here; the LIVE correctness (real RPC + belt-gateway
+ * + registry values) is a deploy gate, not a unit-suite concern (the #306 discipline).
+ */
+import { describe, it, expect } from 'vitest';
+import { makeRpcBlockTimeResolver, type JsonRpcCall } from '../block-time-resolver.js';
+import { makeSonarOwnershipSource, registryFromMap } from '../ownership-source.js';
+import type { Balances } from '../audit-service.js';
+
+const C = '0x' + 'a'.repeat(40);
+const W1 = '0x' + '1'.repeat(40);
+
+// ── BlockTimeResolver: the binary search over a fake chain ──
+
+/** A fake chain: block N has timestamp `base + N*12` (12s blocks); head = `headBlock`. */
+const fakeChain = (headBlock: number, base = 1_000_000): JsonRpcCall => async (method, params) => {
+  if (method === 'eth_blockNumber') return '0x' + headBlock.toString(16);
+  if (method === 'eth_getBlockByNumber') {
+    const n = Number.parseInt(String(params[0]), 16);
+    return { timestamp: '0x' + (base + n * 12).toString(16) };
+  }
+  throw new Error(`unexpected RPC ${method}`);
+};
+
+describe('makeRpcBlockTimeResolver — block-at-or-before via binary search', () => {
+  it('finds the highest block with timestamp <= the target', async () => {
+    const r = makeRpcBlockTimeResolver({ rpcCall: fakeChain(1000) });
+    // block N ts = 1_000_000 + 12N; target exactly on block 500's ts → 500
+    expect(await r.blockAtOrBefore(1_000_000 + 12 * 500)).toBe(500);
+    // target between block 500 and 501 → 500 (the highest <=)
+    expect(await r.blockAtOrBefore(1_000_000 + 12 * 500 + 5)).toBe(500);
+    // target before genesis ts → block 0 (the floor)
+    expect(await r.blockAtOrBefore(0)).toBe(0);
+    // target after head → head
+    expect(await r.blockAtOrBefore(10_000_000)).toBe(1000);
+  });
+  it('reports the head', async () => {
+    expect(await makeRpcBlockTimeResolver({ rpcCall: fakeChain(42) }).headBlock()).toBe(42);
+  });
+  it('rejects a non-hex RPC quantity (loud, never a silent NaN)', async () => {
+    const bad: JsonRpcCall = async () => 'not-hex';
+    await expect(makeRpcBlockTimeResolver({ rpcCall: bad }).headBlock()).rejects.toThrow(/hex quantity/);
+  });
+});
+
+// ── OwnershipSource: assembly over fakes ──
+
+const fakeResolver = (head: number) => ({
+  headBlock: async () => head,
+  blockAtOrBefore: async () => head - 100, // a deterministic snapshot block for the test
+});
+
+/** A fake sonar core: returns a fixed balance map for the requested collection. */
+const fakeSonar = (balances: Balances) => ({
+  ownershipAtBlock: async () => ({ standard: 'erc721' as const, balances } as never),
+});
+
+describe('makeSonarOwnershipSource — assembly', () => {
+  const registry = registryFromMap({ ['80094/' + C]: { collection: 'honeycomb', standard: 'erc721' } });
+
+  it('resolves a snapshot block via the resolver for a registered collection', async () => {
+    const own = makeSonarOwnershipSource({
+      sonar: fakeSonar(new Map()),
+      resolverFor: () => fakeResolver(900),
+      registry,
+    });
+    expect(await own.resolveSnapshotBlock({ chain: '80094', contract: C, snapshotDate: '2026-06-01' })).toBe(800); // 900-100
+  });
+
+  it('balancesAt returns the reconstructed holder map', async () => {
+    const bal = new Map([[W1, 2n]]);
+    const own = makeSonarOwnershipSource({ sonar: fakeSonar(bal), resolverFor: () => fakeResolver(900), registry });
+    expect(await own.balancesAt({ chain: '80094', contract: C, snapshotBlock: 500 })).toBe(bal);
+  });
+
+  it('REFUSES an unregistered collection (never reconstructs an unknown one)', async () => {
+    const own = makeSonarOwnershipSource({ sonar: fakeSonar(new Map()), resolverFor: () => fakeResolver(900), registry });
+    await expect(own.resolveSnapshotBlock({ chain: '1', contract: '0xdead', snapshotDate: '2026-06-01' })).rejects.toThrow(/no collection registry entry/);
+  });
+
+  it('registryFromMap is case-insensitive on the contract', async () => {
+    const reg = registryFromMap({ ['80094/' + C.toUpperCase()]: { collection: 'x', standard: 'erc721' } });
+    expect(reg({ chain: '80094', contract: C.toLowerCase() })?.collection).toBe('x');
+  });
+});

--- a/packages/services/shadow-audit/src/__tests__/ownership-source.test.ts
+++ b/packages/services/shadow-audit/src/__tests__/ownership-source.test.ts
@@ -30,8 +30,10 @@ describe('makeRpcBlockTimeResolver — block-at-or-before via binary search', ()
     expect(await r.blockAtOrBefore(1_000_000 + 12 * 500)).toBe(500);
     // target between block 500 and 501 → 500 (the highest <=)
     expect(await r.blockAtOrBefore(1_000_000 + 12 * 500 + 5)).toBe(500);
-    // target before genesis ts → block 0 (the floor)
-    expect(await r.blockAtOrBefore(0)).toBe(0);
+    // target before genesis ts → -1 (NO block ≤ target; the caller must refuse, not serve block 0). FAGAN HIGH-1
+    expect(await r.blockAtOrBefore(0)).toBe(-1);
+    // target exactly at genesis ts → block 0
+    expect(await r.blockAtOrBefore(1_000_000)).toBe(0);
     // target after head → head
     expect(await r.blockAtOrBefore(10_000_000)).toBe(1000);
   });
@@ -72,6 +74,12 @@ describe('makeSonarOwnershipSource — assembly', () => {
     const bal = new Map([[W1, 2n]]);
     const own = makeSonarOwnershipSource({ sonar: fakeSonar(bal), resolverFor: () => fakeResolver(900), registry });
     expect(await own.balancesAt({ chain: '80094', contract: C, snapshotBlock: 500 })).toBe(bal);
+  });
+
+  it('REFUSES a before-genesis snapshot date (resolver returns -1), never reconstructs at block 0 (FAGAN HIGH-1)', async () => {
+    const beforeGenesis = { headBlock: async () => 900, blockAtOrBefore: async () => -1 };
+    const own = makeSonarOwnershipSource({ sonar: fakeSonar(new Map()), resolverFor: () => beforeGenesis, registry });
+    await expect(own.resolveSnapshotBlock({ chain: '80094', contract: C, snapshotDate: '2000-01-01' })).rejects.toThrow(/before chain .* genesis/);
   });
 
   it('REFUSES an unregistered collection (never reconstructs an unknown one)', async () => {

--- a/packages/services/shadow-audit/src/__tests__/server.test.ts
+++ b/packages/services/shadow-audit/src/__tests__/server.test.ts
@@ -170,6 +170,14 @@ describe('configFromEnv — fail loud on missing required config', () => {
   it('throws without the CTA doors', () => {
     expect(() => configFromEnv({ OPERATED_COMMUNITIES: 'thj' } as NodeJS.ProcessEnv)).toThrow(/CTA_/);
   });
+  it('throws on AUDIT_K < 1 (k-anonymity disabled is a privacy regression — FAGAN MEDIUM-5)', () => {
+    const base = { OPERATED_COMMUNITIES: 'thj', CTA_PRODUCT: 'p', CTA_CONVERSATION: 'c' };
+    expect(() => configFromEnv({ ...base, AUDIT_K: '0' } as NodeJS.ProcessEnv)).toThrow(/AUDIT_K/);
+    expect(() => configFromEnv({ ...base, AUDIT_K: 'abc' } as NodeJS.ProcessEnv)).toThrow(/AUDIT_K/);
+    expect(() => configFromEnv({ ...base, AUDIT_K: '-3' } as NodeJS.ProcessEnv)).toThrow(/AUDIT_K/);
+    expect(configFromEnv({ ...base, AUDIT_K: '5' } as NodeJS.ProcessEnv).k).toBe(5);
+  });
+
   it('builds a valid config from a complete env', () => {
     const cfg = configFromEnv({
       OPERATED_COMMUNITIES: 'thj, other',

--- a/packages/services/shadow-audit/src/__tests__/server.test.ts
+++ b/packages/services/shadow-audit/src/__tests__/server.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { AuditOutputSchema } from '@freeside/shadow-audit-protocol';
 import { buildAuditApp, configFromEnv, type AuditServerConfig } from '../server.js';
 import { makeBalanceWhaleSource } from '../whale-source.js';
 import { makeFileRoleSource } from '../role-source.js';
@@ -115,10 +116,17 @@ describe('buildAuditApp — the deployment composition root', () => {
       const app = buildAuditApp(ownership, baseConfig({ roleSnapshotPath: path }));
       const res = await app.request(`/v1/audit?${query('thj')}`);
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { aggregate?: unknown; cta?: unknown; run_id?: string };
-      expect(body.run_id).toBeTruthy();
-      expect(body.aggregate).toBeTruthy();
-      expect(body.cta).toEqual(CTA);
+      const body = await res.json();
+      // CONTRACT PARITY (the integration's load-bearing assertion): the GET response must STRICT-parse
+      // against the protocol AuditOutputSchema — that is exactly what freeside-dashboard's client does
+      // (onExcessProperty: error). An earlier subset + excess `uncertain` made the dashboard reject every
+      // 200 and show empty. This pins the seam so the drift can never silently return.
+      expect(() => AuditOutputSchema.parse(body)).not.toThrow();
+      const parsed = AuditOutputSchema.parse(body);
+      expect(parsed.run_id).toBeTruthy();
+      expect(parsed.mode).toBe('dogfood-full');
+      expect(parsed.inputs_hash).toBeTruthy();
+      expect(parsed.cta).toEqual(CTA);
     } finally {
       cleanup();
     }

--- a/packages/services/shadow-audit/src/__tests__/server.test.ts
+++ b/packages/services/shadow-audit/src/__tests__/server.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Sprint 2 / S2-T4 — the deployment composition root, exercised with INJECTED fakes (no live network,
+ * the #306 discipline). Covers: the local adapters (whale concentration, file role-source), the
+ * X-API-Key gate, /healthz, fail-loud env config, and the GET aggregate happy-path end-to-end.
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildAuditApp, configFromEnv, type AuditServerConfig } from '../server.js';
+import { makeBalanceWhaleSource } from '../whale-source.js';
+import { makeFileRoleSource } from '../role-source.js';
+import type { OwnershipSource, Balances } from '../audit-service.js';
+
+const R1 = '0x' + '1'.repeat(40);
+const R2 = '0x' + '2'.repeat(40);
+const Y = '0x' + '5'.repeat(40);
+const CTA = { product: 'https://product', conversation: 'https://talk' };
+
+/** A fake OwnershipSource — the injection seam that keeps the suite hermetic. */
+const fakeOwnership = (snap: Balances, cur: Balances): OwnershipSource => ({
+  resolveSnapshotBlock: async () => 1000,
+  balancesAt: async () => snap,
+  currentBalances: async () => cur,
+});
+
+/** Write a valid RoleSnapshot to a temp file and return its path + a cleanup fn. */
+function tempRoleSnapshot(community: string, roleWallet: string): { path: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), 'audit-roles-'));
+  const path = join(dir, 'roles.json');
+  writeFileSync(
+    path,
+    JSON.stringify({
+      source: 'discord',
+      community,
+      captured_at: new Date(Date.now() - 60_000).toISOString(),
+      export_method: 'test-fixture',
+      owner: 'op',
+      freshness_threshold_seconds: 86_400,
+      entries: [{ discord_user_id: 'u1', wallet: roleWallet, role_ids: ['role-a'] }],
+    }),
+  );
+  return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+function query(community: string): string {
+  return new URLSearchParams({
+    chain: '80094',
+    contract: '0x' + 'a'.repeat(40),
+    snapshot_date: '2026-06-01',
+    community,
+    owner_wallet: '0x' + 'b'.repeat(40),
+    threshold: '1',
+  }).toString();
+}
+
+// ── local adapters ──
+
+describe('makeBalanceWhaleSource — top-holder concentration over the distribution', () => {
+  const whale = makeBalanceWhaleSource();
+  it('is the largest holder share of the total', async () => {
+    expect(await whale.concentration(new Map([[R1, 3n], [R2, 1n]]))).toBeCloseTo(0.75);
+  });
+  it('is 0 for an empty set (no divide-by-zero)', async () => {
+    expect(await whale.concentration(new Map())).toBe(0);
+  });
+  it('ignores zero/negative entries', async () => {
+    expect(await whale.concentration(new Map([[R1, 2n], [R2, 0n]]))).toBe(1);
+  });
+});
+
+describe('makeFileRoleSource — validated file loader', () => {
+  it('returns undefined when no path is configured', async () => {
+    expect(await makeFileRoleSource(undefined).load()).toBeUndefined();
+  });
+  it('loads + validates a real snapshot', async () => {
+    const { path, cleanup } = tempRoleSnapshot('thj', R1);
+    try {
+      const snap = await makeFileRoleSource(path).load();
+      expect(snap?.community).toBe('thj');
+      expect(snap?.entries[0]?.wallet).toBe(R1);
+    } finally {
+      cleanup();
+    }
+  });
+  it('THROWS on a missing file (fail loud, never silent-undefined)', async () => {
+    await expect(makeFileRoleSource('/no/such/roles.json').load()).rejects.toThrow();
+  });
+  it('THROWS on an invalid snapshot shape', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'audit-bad-'));
+    const path = join(dir, 'roles.json');
+    writeFileSync(path, JSON.stringify({ not: 'a snapshot' }));
+    try {
+      await expect(makeFileRoleSource(path).load()).rejects.toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── the composition root ──
+
+const baseConfig = (over: Partial<AuditServerConfig> = {}): AuditServerConfig => ({
+  operatedCommunities: ['thj'],
+  cta: CTA,
+  ...over,
+});
+
+describe('buildAuditApp — the deployment composition root', () => {
+  const ownership = fakeOwnership(new Map([[R1, 1n], [R2, 1n]]), new Map([[Y, 1n]])); // R1,R2 sold → R1 stale; Y new
+
+  it('GET /v1/audit serves the k-anon aggregate for an operated community', async () => {
+    const { path, cleanup } = tempRoleSnapshot('thj', R1);
+    try {
+      const app = buildAuditApp(ownership, baseConfig({ roleSnapshotPath: path }));
+      const res = await app.request(`/v1/audit?${query('thj')}`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { aggregate?: unknown; cta?: unknown; run_id?: string };
+      expect(body.run_id).toBeTruthy();
+      expect(body.aggregate).toBeTruthy();
+      expect(body.cta).toEqual(CTA);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('refuses an un-operated community (external-mode), never a wrong audit', async () => {
+    const app = buildAuditApp(ownership, baseConfig());
+    const res = await app.request(`/v1/audit?${query('not-ours')}`);
+    expect(res.status).toBeGreaterThanOrEqual(400);
+  });
+
+  it('/healthz is open (no key required)', async () => {
+    const app = buildAuditApp(ownership, baseConfig({ apiKey: 'secret' }));
+    const res = await app.request('/healthz');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it('X-API-Key gate: a missing/wrong key → 401', async () => {
+    const app = buildAuditApp(ownership, baseConfig({ apiKey: 'secret' }));
+    expect((await app.request(`/v1/audit?${query('thj')}`)).status).toBe(401);
+    expect(
+      (await app.request(`/v1/audit?${query('thj')}`, { headers: { 'x-api-key': 'wrong' } })).status,
+    ).toBe(401);
+  });
+
+  it('the authed POST named-output is fail-closed (V2 not wired) → 401', async () => {
+    const app = buildAuditApp(ownership, baseConfig());
+    const res = await app.request('/v1/audit', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        chain: '80094',
+        contract: '0x' + 'a'.repeat(40),
+        snapshot_date: '2026-06-01',
+        community: 'thj',
+        owner_wallet: '0x' + 'b'.repeat(40),
+        auth: { message: {}, signature: '0x', ownerWallet: '0x' + 'b'.repeat(40) },
+      }),
+    });
+    expect(res.status).toBeGreaterThanOrEqual(400); // never half-serves named records
+  });
+});
+
+describe('configFromEnv — fail loud on missing required config', () => {
+  it('throws without OPERATED_COMMUNITIES', () => {
+    expect(() => configFromEnv({ CTA_PRODUCT: 'p', CTA_CONVERSATION: 'c' } as NodeJS.ProcessEnv)).toThrow(/OPERATED_COMMUNITIES/);
+  });
+  it('throws without the CTA doors', () => {
+    expect(() => configFromEnv({ OPERATED_COMMUNITIES: 'thj' } as NodeJS.ProcessEnv)).toThrow(/CTA_/);
+  });
+  it('builds a valid config from a complete env', () => {
+    const cfg = configFromEnv({
+      OPERATED_COMMUNITIES: 'thj, other',
+      CTA_PRODUCT: 'https://p',
+      CTA_CONVERSATION: 'https://c',
+      SHADOW_AUDIT_API_KEY: 'k',
+    } as NodeJS.ProcessEnv);
+    expect(cfg.operatedCommunities).toEqual(['thj', 'other']);
+    expect(cfg.cta).toEqual({ product: 'https://p', conversation: 'https://c' });
+    expect(cfg.apiKey).toBe('k');
+  });
+});

--- a/packages/services/shadow-audit/src/block-time-resolver.ts
+++ b/packages/services/shadow-audit/src/block-time-resolver.ts
@@ -1,0 +1,93 @@
+/**
+ * Sprint 2 / S2-T1 — a real `BlockTimeResolver` (the port `date-to-block.ts` left injected + fake-only),
+ * via JSON-RPC.
+ *
+ * `resolveSnapshotBlock` needs "the highest block whose timestamp ≤ a UTC instant" + the chain head. No
+ * such adapter exists in the tree — Sprint 1 built the audit against the port but wired only a test fake.
+ * This implements it as a binary search over `eth_getBlockByNumber` (~log2(head) RPC calls per audit,
+ * deterministic). The `rpcCall` is INJECTABLE so the search ALGORITHM is unit-tested without a live node.
+ *
+ * ⚠ LIVE CORRECTNESS UNVERIFIED in this build (operator AFK; no live RPC reachable). The binary search is
+ * algorithm-tested; the real per-chain RPC URL + a live block-at-date spot-check are a DEPLOY GATE before
+ * production — a wrong snapshot block ⇒ a wrong holder set ⇒ a wrong audit (money/ops; do not trust live
+ * output until verified).
+ */
+
+import type { BlockTimeResolver } from '@freeside/adapters/sonar';
+
+/** A minimal JSON-RPC caller: (method, params) → result. Injectable for tests. */
+export type JsonRpcCall = (method: string, params: unknown[]) => Promise<unknown>;
+
+const hexToInt = (hex: unknown): number => {
+  if (typeof hex !== 'string' || !/^0x[0-9a-fA-F]+$/.test(hex)) {
+    throw new Error(`RPC: expected a hex quantity, got ${JSON.stringify(hex)}`);
+  }
+  const n = Number.parseInt(hex, 16);
+  if (!Number.isSafeInteger(n)) throw new Error(`RPC: quantity out of safe-integer range: ${hex}`);
+  return n;
+};
+
+export interface RpcBlockTimeResolverOpts {
+  /** the JSON-RPC caller; when omitted, a `fetch` POST to `url` is used. */
+  readonly rpcCall?: JsonRpcCall;
+  readonly url?: string;
+  readonly timeoutMs?: number;
+}
+
+export function makeRpcBlockTimeResolver(opts: RpcBlockTimeResolverOpts): BlockTimeResolver {
+  const rpcCall = opts.rpcCall ?? defaultRpcCall(opts.url, opts.timeoutMs ?? 15_000);
+
+  const timestampOf = async (block: number): Promise<number> => {
+    const b = await rpcCall('eth_getBlockByNumber', ['0x' + block.toString(16), false]);
+    if (!b || typeof b !== 'object') throw new Error(`RPC: block ${block} not found`);
+    return hexToInt((b as { timestamp?: unknown }).timestamp);
+  };
+  const headBlock = async (): Promise<number> => hexToInt(await rpcCall('eth_blockNumber', []));
+
+  return {
+    headBlock,
+    /** Highest block with timestamp ≤ `unixSeconds`. Binary search over [0, head]; block 0 (genesis) is the
+     *  floor, so a target before genesis resolves to 0. */
+    async blockAtOrBefore(unixSeconds: number): Promise<number> {
+      const head = await headBlock();
+      let lo = 0;
+      let hi = head;
+      let ans = 0;
+      while (lo <= hi) {
+        const mid = lo + ((hi - lo) >> 1);
+        const ts = await timestampOf(mid);
+        if (ts <= unixSeconds) {
+          ans = mid;
+          lo = mid + 1;
+        } else {
+          hi = mid - 1;
+        }
+      }
+      return ans;
+    },
+  };
+}
+
+function defaultRpcCall(url: string | undefined, timeoutMs: number): JsonRpcCall {
+  if (!url) {
+    throw new Error('makeRpcBlockTimeResolver: a JSON-RPC `url` is required when no `rpcCall` is injected');
+  }
+  return async (method, params) => {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+        signal: ctrl.signal,
+      });
+      if (!res.ok) throw new Error(`RPC ${method}: HTTP ${res.status}`);
+      const j = (await res.json()) as { result?: unknown; error?: { message?: string } };
+      if (j.error) throw new Error(`RPC ${method}: ${j.error.message ?? 'error'}`);
+      return j.result;
+    } finally {
+      clearTimeout(t);
+    }
+  };
+}

--- a/packages/services/shadow-audit/src/block-time-resolver.ts
+++ b/packages/services/shadow-audit/src/block-time-resolver.ts
@@ -46,13 +46,16 @@ export function makeRpcBlockTimeResolver(opts: RpcBlockTimeResolverOpts): BlockT
 
   return {
     headBlock,
-    /** Highest block with timestamp ≤ `unixSeconds`. Binary search over [0, head]; block 0 (genesis) is the
-     *  floor, so a target before genesis resolves to 0. */
+    /** Highest block with timestamp ≤ `unixSeconds`. Binary search over [0, head]. Returns **-1** when NO
+     *  block satisfies it — i.e. even genesis is newer than the target (a snapshot_date before the chain
+     *  existed). The caller MUST treat -1 as "no such block" and REFUSE: silently returning 0 (genesis,
+     *  whose timestamp is > target) would reconstruct an empty snapshot and serve a plausible WRONG audit
+     *  (FAGAN HIGH-1 — the one place the "refuse, never silent-wrong" invariant leaked). */
     async blockAtOrBefore(unixSeconds: number): Promise<number> {
       const head = await headBlock();
       let lo = 0;
       let hi = head;
-      let ans = 0;
+      let ans = -1; // sentinel: no block ≤ target found yet
       while (lo <= hi) {
         const mid = lo + ((hi - lo) >> 1);
         const ts = await timestampOf(mid);

--- a/packages/services/shadow-audit/src/http/audit-router.ts
+++ b/packages/services/shadow-audit/src/http/audit-router.ts
@@ -2,9 +2,19 @@
  * SDD §5/§6 — inbound HTTP adapter (AC-4, AC-6) + the thin dashboard view (T9).
  *
  * A framework-light Hono router built from injected ports, so the full request
- * path is testable in-process (app.request) with fakes — no live chain/DB. The
- * dashboard (apps/freeside-operator-dash, also Hono) mounts this router and
- * injects the real adapters at the composition root.
+ * path is testable in-process (app.request) with fakes — no live chain/DB.
+ *
+ * MOUNTED BY: the `shadow-audit-api` server entry — `../server.ts` (buildAuditApp)
+ * wires the real adapters; `bin/http.ts` constructs the chain OwnershipSource from
+ * env + serves it (Sprint 2). It is its own deployable building, NOT the inward
+ * operator-dash (an earlier docstring named operator-dash; that was aspirational +
+ * the wrong host — operator-dash is inward operator-health, this is an outward
+ * product surface).
+ *
+ * CONSUMED BY: freeside-dashboard's already-built dormant client
+ * (`src/lib/freeside-worlds/access-audit/client.ts`): `GET ${SHADOW_AUDIT_API_URL}/v1/audit`
+ * with an `X-API-Key`. The dashboard needs ZERO code change — point `SHADOW_AUDIT_API_URL`
+ * (+ `SHADOW_AUDIT_API_KEY`) at the deployed audit-api and the seam goes live.
  *
  * Routes:
  *   GET  /v1/audit          → anonymous aggregate (k-anon), rate-limited

--- a/packages/services/shadow-audit/src/http/audit-router.ts
+++ b/packages/services/shadow-audit/src/http/audit-router.ts
@@ -203,12 +203,13 @@ export function createAuditRouter(deps: AuditRouterDeps): Hono {
     const result = await audit(deps, built.order, q.data.snapshot_date, false);
     if (!result.ok) return c.json({ error: result.refusal }, refusalStatus(result.refusal));
     await recordRun(deps, result.output);
-    return c.json({
-      run_id: result.output.run_id,
-      aggregate: result.output.aggregate,
-      cta: result.output.cta,
-      uncertain: result.uncertain,
-    });
+    // Return the PROTOCOL `AuditOutput` verbatim (anonymous ⇒ no `records`). freeside-dashboard's client
+    // strict-decodes this against the protocol's AuditOutputSchema (`onExcessProperty: error`), so the
+    // earlier hand-picked subset (missing mode/inputs_hash) + the excess top-level `uncertain` made the
+    // dashboard reject every 200 and show empty — a silently-broken integration. `uncertain` (the stale-
+    // snapshot signal) stays on the HTML /view route; re-adding it to this JSON needs a protocol change
+    // on both sides (verified end-to-end by the contract-parity test).
+    return c.json(result.output);
   });
 
   // ---- POST /v1/audit — named output (authed) ----------------------------

--- a/packages/services/shadow-audit/src/ownership-source.ts
+++ b/packages/services/shadow-audit/src/ownership-source.ts
@@ -57,6 +57,11 @@ export function makeSonarOwnershipSource(opts: SonarOwnershipOpts): OwnershipSou
     async resolveSnapshotBlock({ chain, contract, snapshotDate }) {
       refOrThrow(chain, contract); // validate the collection is known BEFORE any chain work
       const { snapshotBlock } = await snapshotDateToBlock(snapshotDate, opts.resolverFor(chain), { confirmations });
+      // -1 ⇒ the resolver found NO block at-or-before the date (before chain genesis). REFUSE rather than
+      // reconstruct an empty snapshot at block 0 and serve a wrong audit (FAGAN HIGH-1).
+      if (snapshotBlock < 0) {
+        throw new Error(`shadow-audit: snapshot_date ${snapshotDate} is before chain ${chain} genesis — no block to reconstruct ownership at`);
+      }
       return snapshotBlock;
     },
 

--- a/packages/services/shadow-audit/src/ownership-source.ts
+++ b/packages/services/shadow-audit/src/ownership-source.ts
@@ -1,0 +1,88 @@
+/**
+ * Sprint 2 / S2-T1 — the real `OwnershipSource` (the audit's ownership port), assembled from the sonar
+ * adapter. THIS is the gap Sprint 1 left: the service was built against the port but only a test fake of
+ * it ever existed. It wires the three real pieces together:
+ *   - `resolveSnapshotBlock` ← `snapshotDateToBlock` (date→block, with reorg finality) + a per-chain
+ *     `BlockTimeResolver` (block-time-resolver.ts).
+ *   - `balancesAt` / `currentBalances` ← `SonarClient.ownershipAtBlock` (Transfer-replay reconstruction).
+ *   - the chain+contract → collection+standard mapping ← an injected registry (a `chain/contract` an audit
+ *     names that is NOT in the registry is REFUSED, never reconstructed as an unknown collection).
+ *
+ * Pure assembly over injected seams (sonar / resolverFor / registry), so the wiring is unit-tested with
+ * fakes (no live network — the #306 discipline). ⚠ The LIVE correctness rides on block-time-resolver.ts's
+ * RPC + the belt-gateway + the registry values — all DEPLOY config the operator must provide + verify.
+ */
+
+import type { SonarClient, BlockTimeResolver, TokenStandard } from '@freeside/adapters/sonar';
+import { snapshotDateToBlock } from '@freeside/adapters/sonar';
+import type { Balances, OwnershipSource } from './audit-service.js';
+
+/** A collection an audit can reconstruct: the belt-gateway collection id + its token standard. */
+export interface CollectionRef {
+  readonly collection: string;
+  readonly standard: TokenStandard;
+}
+
+/** Resolve a chain+contract to its belt-gateway collection, or undefined for an unknown one. */
+export type CollectionRegistry = (args: { chain: string; contract: string }) => CollectionRef | undefined;
+
+export interface SonarOwnershipOpts {
+  /** the sonar reconstruction core (only `ownershipAtBlock` is used). */
+  readonly sonar: Pick<SonarClient, 'ownershipAtBlock'>;
+  /** a `BlockTimeResolver` for a chain — the RPC differs per chain, so it is resolved by chain id. */
+  readonly resolverFor: (chain: string) => BlockTimeResolver;
+  readonly registry: CollectionRegistry;
+  /** reorg finality depth for both date→block and the "current" comparison block (default 12). */
+  readonly confirmations?: number;
+}
+
+export function makeSonarOwnershipSource(opts: SonarOwnershipOpts): OwnershipSource {
+  const confirmations = opts.confirmations ?? 12;
+
+  const refOrThrow = (chain: string, contract: string): CollectionRef => {
+    const ref = opts.registry({ chain, contract });
+    if (!ref) {
+      // refuse loudly: auditing an unknown collection would silently reconstruct garbage ownership.
+      throw new Error(`shadow-audit: no collection registry entry for ${chain}/${contract} — refusing rather than auditing an unknown collection`);
+    }
+    return ref;
+  };
+
+  const balancesAtBlock = async (chain: string, ref: CollectionRef, snapshotBlock: number, headBlock: number): Promise<Balances> => {
+    const own = await opts.sonar.ownershipAtBlock({ collection: ref.collection, snapshotBlock, standard: ref.standard, headBlock });
+    return own.balances; // HolderBalances === Map<string, bigint> === Balances
+  };
+
+  return {
+    async resolveSnapshotBlock({ chain, contract, snapshotDate }) {
+      refOrThrow(chain, contract); // validate the collection is known BEFORE any chain work
+      const { snapshotBlock } = await snapshotDateToBlock(snapshotDate, opts.resolverFor(chain), { confirmations });
+      return snapshotBlock;
+    },
+
+    async balancesAt({ chain, contract, snapshotBlock }) {
+      const ref = refOrThrow(chain, contract);
+      const head = await opts.resolverFor(chain).headBlock();
+      return balancesAtBlock(chain, ref, snapshotBlock, head);
+    },
+
+    async currentBalances({ chain, contract }) {
+      const ref = refOrThrow(chain, contract);
+      const head = await opts.resolverFor(chain).headBlock();
+      // "current" = the latest FINAL block (head − confirmations), for finality parity with the snapshot.
+      const finalBlock = Math.max(0, head - confirmations);
+      return balancesAtBlock(chain, ref, finalBlock, head);
+    },
+  };
+}
+
+/**
+ * Build a `CollectionRegistry` from a plain map keyed `"<chain>/<contract>"` (contract lowercased). The
+ * map itself is DEPLOY config — `bin/http.ts` parses it from `COLLECTION_REGISTRY` (JSON). Kept here so
+ * the lookup (case-normalization) is one tested function, not re-implemented at the composition root.
+ */
+export function registryFromMap(map: Record<string, CollectionRef>): CollectionRegistry {
+  const norm = new Map<string, CollectionRef>();
+  for (const [k, v] of Object.entries(map)) norm.set(k.toLowerCase(), v);
+  return ({ chain, contract }) => norm.get(`${chain}/${contract}`.toLowerCase());
+}

--- a/packages/services/shadow-audit/src/role-source.ts
+++ b/packages/services/shadow-audit/src/role-source.ts
@@ -1,0 +1,28 @@
+/**
+ * Sprint 2 / S2-T1 — a real `RoleSource` (the audit's role-snapshot port), file-backed.
+ *
+ * Sprint 1 built `AuditService` against the `RoleSource` port but wired only a test fake; this is the
+ * production adapter. It loads a dogfood community's Discord role export from a JSON path and
+ * strict-validates it against `RoleSnapshotSchema` BEFORE returning — a malformed snapshot must never
+ * silently serve a wrong confront-number (the audit's whole claim is the stale-access set).
+ *
+ * Two states, deliberately distinct:
+ *   - no path configured  → `undefined` (the audit then refuses with `external-mode`: dogfood-full
+ *     REQUIRES a role export; an absent one is a clean refusal, not an error).
+ *   - path set but missing/invalid → THROWS (fail loud): a misconfigured deploy must surface, never
+ *     degrade to "no snapshot" and serve a silently-wrong audit.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { RoleSnapshotSchema, type RoleSnapshot } from './role-snapshot.js';
+import type { RoleSource } from './audit-service.js';
+
+export function makeFileRoleSource(path: string | undefined): RoleSource {
+  return {
+    async load(): Promise<RoleSnapshot | undefined> {
+      if (!path) return undefined; // no export configured → external-mode refusal downstream
+      const raw = await readFile(path, 'utf8'); // missing file → throws → fail loud (misconfig surfaces)
+      return RoleSnapshotSchema.parse(JSON.parse(raw)); // invalid shape → throws → never serve wrong data
+    },
+  };
+}

--- a/packages/services/shadow-audit/src/server.ts
+++ b/packages/services/shadow-audit/src/server.ts
@@ -1,0 +1,116 @@
+/**
+ * Sprint 2 / S2-T1 — the audit's deployment composition root.
+ *
+ * Sprint 1 (#296/#300/#306) built the whole audit (schemas · AuditService · resolvers · createAuditRouter)
+ * but mounted it NOWHERE and wired only test fakes for its I/O ports. This module is the missing seam: it
+ * assembles the real adapters into the Hono app `createAuditRouter` needs, so the audit becomes a
+ * deployable HTTP building (`shadow-audit-api`) that freeside-dashboard's already-built dormant client
+ * (`GET ${SHADOW_AUDIT_API_URL}/v1/audit`) can consume.
+ *
+ * The `OwnershipSource` (the chain-reconstruction adapter) is INJECTED, NOT constructed here — it is the
+ * one correctness-critical, live-verified part (a wrong ownership reconstruction is a wrong audit), built
+ * + gated in `bin/http.ts`. That injection seam keeps this composition root fully unit-testable with a
+ * fake OwnershipSource (the #306 discipline: no live network in the unit suite). The other adapters are
+ * local + dependency-free (whale = balance concentration; roles = a validated file; rate-limit + event-
+ * store = in-memory), so they are constructed here.
+ *
+ * MVP scope = the anonymous `GET /v1/audit` k-anon aggregate. The authed `POST /v1/audit` named-output
+ * (V2, SIWE) is intentionally NOT wired — its auth is constructed fail-closed (always 401), so POST can
+ * never half-serve named records.
+ */
+
+import { Hono } from 'hono';
+import type { Cta } from '@freeside/shadow-audit-protocol';
+import { createAuditRouter, type AuditRouterDeps } from './http/audit-router.js';
+import { makeFileRoleSource } from './role-source.js';
+import { makeBalanceWhaleSource } from './whale-source.js';
+import { InMemoryEventStore } from './event-store.js';
+import { InMemoryNonceStore } from './association-verifier.js';
+import { FixedWindowRateLimiter } from './rate-limiter.js';
+import type { OwnershipSource } from './audit-service.js';
+
+export interface AuditServerConfig {
+  /** X-API-Key shared secret the dashboard sends; when set, all routes (except /healthz) require it. */
+  apiKey?: string;
+  /** community names this deploy operates (dogfood-full eligible). */
+  operatedCommunities: readonly string[];
+  cta: Cta;
+  /** path to the Discord role-export JSON; absent → audits refuse external-mode. */
+  roleSnapshotPath?: string;
+  /** k-anonymity threshold (AuditService default 5). */
+  k?: number;
+  /** per-IP rate limit (default 30 req / 60s). */
+  rateLimit?: { limit: number; windowMs: number };
+}
+
+/** Fail-closed auth for the un-wired V2 POST path: `recover` returns a wallet that can never match a real
+ *  `owner_wallet`, and `isCommunityOwner` is false, so the named-output route always 401s. */
+function failClosedAuth(): AuditRouterDeps['auth'] {
+  return {
+    recover: async () => '0x' + '0'.repeat(40),
+    nonces: new InMemoryNonceStore(),
+    isCommunityOwner: async () => false,
+    domain: 'shadow-audit',
+    chainId: 1,
+    scope: 'shadow-audit-v1',
+    maxValiditySeconds: 300,
+  };
+}
+
+/** Build the audit Hono app from an injected `OwnershipSource` + the local adapters. */
+export function buildAuditApp(ownership: OwnershipSource, config: AuditServerConfig): Hono {
+  const now = () => Date.now();
+  const rl = config.rateLimit ?? { limit: 30, windowMs: 60_000 };
+  const deps: AuditRouterDeps = {
+    ownership,
+    whale: makeBalanceWhaleSource(),
+    roles: makeFileRoleSource(config.roleSnapshotPath),
+    eventStore: new InMemoryEventStore(),
+    rateLimiter: new FixedWindowRateLimiter({ limit: rl.limit, windowMs: rl.windowMs, now }),
+    auth: failClosedAuth(),
+    isOperatedCommunity: (id) => config.operatedCommunities.includes(id),
+    cta: config.cta,
+    now,
+    clientKey: (xff) => (xff?.split(',')[0]?.trim() || 'unknown'),
+    k: config.k,
+  };
+
+  const app = new Hono();
+  // X-API-Key gate (the dashboard's access-audit client sends `X-API-Key`). /healthz stays open for
+  // deploy health checks. Defense-in-depth on top of the deploy's own network boundary.
+  if (config.apiKey) {
+    const key = config.apiKey;
+    app.use('*', async (c, next) => {
+      if (c.req.path === '/healthz') return next();
+      if (c.req.header('x-api-key') !== key) return c.json({ error: 'unauthorized' }, 401);
+      await next();
+    });
+  }
+  app.get('/healthz', (c) => c.json({ ok: true }));
+  app.route('/', createAuditRouter(deps));
+  return app;
+}
+
+/** Read the server config from the environment, FAILING LOUD on a missing required value — a half-wired
+ *  server (no operated communities, no CTA) must never boot + silently refuse every audit. */
+export function configFromEnv(env: NodeJS.ProcessEnv = process.env): AuditServerConfig {
+  const operated = (env.OPERATED_COMMUNITIES ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (operated.length === 0) {
+    throw new Error('OPERATED_COMMUNITIES is required (comma-separated community names this deploy audits)');
+  }
+  const product = env.CTA_PRODUCT;
+  const conversation = env.CTA_CONVERSATION;
+  if (!product || !conversation) {
+    throw new Error('CTA_PRODUCT and CTA_CONVERSATION are required (the product + conversation door URLs)');
+  }
+  return {
+    apiKey: env.SHADOW_AUDIT_API_KEY || undefined,
+    operatedCommunities: operated,
+    cta: { product, conversation },
+    roleSnapshotPath: env.ROLE_SNAPSHOT_PATH || undefined,
+    k: env.AUDIT_K ? Number(env.AUDIT_K) : undefined,
+  };
+}

--- a/packages/services/shadow-audit/src/server.ts
+++ b/packages/services/shadow-audit/src/server.ts
@@ -19,6 +19,7 @@
  * never half-serve named records.
  */
 
+import { timingSafeEqual } from 'node:crypto';
 import { Hono } from 'hono';
 import type { Cta } from '@freeside/shadow-audit-protocol';
 import { createAuditRouter, type AuditRouterDeps } from './http/audit-router.js';
@@ -79,10 +80,13 @@ export function buildAuditApp(ownership: OwnershipSource, config: AuditServerCon
   // X-API-Key gate (the dashboard's access-audit client sends `X-API-Key`). /healthz stays open for
   // deploy health checks. Defense-in-depth on top of the deploy's own network boundary.
   if (config.apiKey) {
-    const key = config.apiKey;
+    const keyBuf = Buffer.from(config.apiKey);
     app.use('*', async (c, next) => {
       if (c.req.path === '/healthz') return next();
-      if (c.req.header('x-api-key') !== key) return c.json({ error: 'unauthorized' }, 401);
+      const got = Buffer.from(c.req.header('x-api-key') ?? '');
+      // constant-time compare (FAGAN LOW-7: a `!==` on a shared secret is a timing oracle).
+      const ok = got.length === keyBuf.length && timingSafeEqual(got, keyBuf);
+      if (!ok) return c.json({ error: 'unauthorized' }, 401);
       await next();
     });
   }
@@ -106,11 +110,20 @@ export function configFromEnv(env: NodeJS.ProcessEnv = process.env): AuditServer
   if (!product || !conversation) {
     throw new Error('CTA_PRODUCT and CTA_CONVERSATION are required (the product + conversation door URLs)');
   }
+  // k-anonymity threshold — validate it is a POSITIVE INTEGER. `AUDIT_K=0` (or NaN) would silently disable
+  // k-anon and emit EXACT small-cohort counts, deanonymizing the stale/sold set (FAGAN MEDIUM-5).
+  let k: number | undefined;
+  if (env.AUDIT_K !== undefined && env.AUDIT_K !== '') {
+    k = Number(env.AUDIT_K);
+    if (!Number.isInteger(k) || k < 1) {
+      throw new Error(`AUDIT_K must be a positive integer (got "${env.AUDIT_K}") — k < 1 disables k-anonymity`);
+    }
+  }
   return {
     apiKey: env.SHADOW_AUDIT_API_KEY || undefined,
     operatedCommunities: operated,
     cta: { product, conversation },
     roleSnapshotPath: env.ROLE_SNAPSHOT_PATH || undefined,
-    k: env.AUDIT_K ? Number(env.AUDIT_K) : undefined,
+    k,
   };
 }

--- a/packages/services/shadow-audit/src/server.ts
+++ b/packages/services/shadow-audit/src/server.ts
@@ -66,13 +66,21 @@ export function buildAuditApp(ownership: OwnershipSource, config: AuditServerCon
     ownership,
     whale: makeBalanceWhaleSource(),
     roles: makeFileRoleSource(config.roleSnapshotPath),
+    // F4: the event store + rate limiter are IN-MEMORY (per-replica, non-durable). That is correct for the
+    // single-replica MVP — the audit is stateless read-modelling + best-effort anti-abuse, not a ledger.
+    // loa:shortcut: in-memory event/rate state; if this scales past one replica, back both with Redis (the
+    //   rate window + the nonce/event store), else limits + replay-dedup are per-replica.
     eventStore: new InMemoryEventStore(),
     rateLimiter: new FixedWindowRateLimiter({ limit: rl.limit, windowMs: rl.windowMs, now }),
     auth: failClosedAuth(),
     isOperatedCommunity: (id) => config.operatedCommunities.includes(id),
     cta: config.cta,
     now,
-    clientKey: (xff) => (xff?.split(',')[0]?.trim() || 'unknown'),
+    // F5: key the rate limit on the RIGHTMOST X-Forwarded-For hop — the one the trusted edge proxy (Railway)
+    // appends, which a client cannot forge. The leftmost hop is client-claimed and spoofable, so keying on it
+    // lets an attacker evade the limit by rotating a fake first hop. (Assumes ONE trusted proxy in front; add
+    // more from the right if the deploy fronts the service with additional trusted proxies.)
+    clientKey: (xff) => (xff?.split(',').pop()?.trim() || 'unknown'),
     k: config.k,
   };
 

--- a/packages/services/shadow-audit/src/whale-source.ts
+++ b/packages/services/shadow-audit/src/whale-source.ts
@@ -1,0 +1,32 @@
+/**
+ * Sprint 2 / S2-T1 — a real `WhaleSource` (the audit's concentration port), dependency-free.
+ *
+ * Sprint 1 built `AuditService` against the `WhaleSource` port but wired only a test fake. The SDD §3
+ * sketched a `ScoreProxy`-backed (score-api) variant, but top-holder concentration is a property of the
+ * BALANCE DISTRIBUTION itself — the share of total units held by the single largest holder, in [0,1] —
+ * so the MVP needs no score-api dependency (and `AuditService` already treats whale as best-effort,
+ * clamping + defaulting to 0 on failure). The score-api-weighted (USD-value) variant is a future
+ * enhancement, not the MVP.
+ *
+ * PURE + deterministic: no I/O, fully unit-testable. The audit clamps the result to [0,1].
+ */
+
+import type { Balances, WhaleSource } from './audit-service.js';
+
+export function makeBalanceWhaleSource(): WhaleSource {
+  return {
+    async concentration(balances: Balances): Promise<number> {
+      let total = 0n;
+      let top = 0n;
+      for (const v of balances.values()) {
+        if (v <= 0n) continue; // a zero/negative entry is not a holder
+        total += v;
+        if (v > top) top = v;
+      }
+      if (total === 0n) return 0; // no holders → no concentration (not a divide-by-zero)
+      // the reduced ratio is in [0,1]; float division after the bigint reduction is exact enough for a
+      // concentration signal (holder counts are bounded; the audit clamps the result regardless).
+      return Number(top) / Number(total);
+    },
+  };
+}

--- a/packages/services/shadow-audit/tsconfig.json
+++ b/packages/services/shadow-audit/tsconfig.json
@@ -13,6 +13,6 @@
     "verbatimModuleSyntax": false,
     "noEmit": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "bin/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Shadow Access Audit — Sprint 2: the deployment surface (make the MVP servable)

Makes the built-but-unmounted Shadow Audit (#296/#300/#306) a **deployable HTTP building** (`shadow-audit-api`) so freeside-dashboard's already-built **dormant** client (`GET ${SHADOW_AUDIT_API_URL}/v1/audit`) can consume it. The dashboard needs **zero** code change — point `SHADOW_AUDIT_API_URL` (+ `_KEY`) at the deployed audit-api and the seam goes live.

### ⚠️ The scope correction (the deeper truth)
The bead said "unmounted," but the real gap was bigger: Sprint 1 built the audit against its I/O **ports** but **only ever wired test fakes** — no real `OwnershipSource`/`WhaleSource`/`RoleSource` existed. This PR builds those real adapters + the composition root + the server entry + deploy artifacts.

### What's here (`packages/services/shadow-audit/`)
- `src/server.ts` — composition root: `buildAuditApp` + `configFromEnv` (fail-loud), X-API-Key gate, fail-closed POST (V2 not wired).
- `src/role-source.ts` · `src/whale-source.ts` — real local adapters (validated file loader · balance-distribution concentration).
- `src/ownership-source.ts` · `src/block-time-resolver.ts` — the real chain adapter: SonarClient reconstruction + date→block (RPC binary search) + a chain/contract→collection registry (an unregistered collection is **refused**, never reconstructed).
- `bin/http.ts` — the server entry (builds the chain adapter from env, serves via `@hono/node-server`). `Dockerfile` + `railway.toml`.

### Verified
- `tsc --noEmit` clean · full suite **105 tests** (fakes-injected, no live network — the #306 discipline) · `bin/http.ts` boots + `/healthz`→200 + **fails loud** on missing/invalid config.
- **Ran an adversarial FAGAN review on the diff** (generator-never-settles). It found 6 real issues my tests missed — all fixed + pinned: HIGH-1 (a before-genesis snapshot silently served block 0 → wrong audit; now refuses), MEDIUM-2 (registry now zod-validated), MEDIUM-3 (boot-validate RPC per chain), MEDIUM-5 (AUDIT_K=0 disabled k-anon; now rejected), MEDIUM-6 (one CONFIRMATIONS source), LOW-7 (timingSafeEqual). The review confirmed the security core holds (fail-closed POST, the gate, the registry refusal).

### 🚨 DEPLOY GATE (money/ops — operator must verify before merge/deploy)
**Live correctness is NOT verified** (built AFK, no live chains reachable). The unit suite proves the algorithm + assembly, NOT the live values. Before production: provide + verify the deploy config — `COLLECTION_REGISTRY` (the 8 collections' chain/contract→collection+standard map), `RPC_URL_<chain>`, `BELT_GATEWAY_URL`, `ROLE_SNAPSHOT_PATH` — and run a live block-at-date spot-check + `pnpm -C packages/adapters test:live`. A wrong collection mapping or RPC ⇒ a wrong holder set ⇒ a wrong audit.

### Scope note
The 3 leading commits (`815e90e3`, `ad7e68cc`, `9cb74470`) are the pre-existing `coord/kuang-beacon-shape-validation` base (operator-dash beacon + cheval) — **out of scope** for this review. The shadow-audit work is the 3 commits `192051b8` / `7e3dc323` / `6c710a6a`.

Closes the build half of bead `arrakis-r8n1` (the deploy + live-verification remain operator-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
