### PR TITLE
fix(platform/mcp-gateway): close SSRF/open-proxy in upstream URL resolution (arrakis-sfk5)

### DIFF
--- a/apps/mcp-gateway/package.json
+++ b/apps/mcp-gateway/package.json
@@ -17,7 +17,7 @@
     "smoke:auth": "tsx scripts/smoke-auth.ts",
     "smoke:prod": "tsx scripts/smoke-prod.ts",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test tests/credentials-resolver.test.ts tests/beacon-resolver.test.ts tests/beacon-cache.test.ts"
+    "test": "tsx --test tests/credentials-resolver.test.ts tests/beacon-resolver.test.ts tests/beacon-cache.test.ts tests/upstream-url.test.ts"
   },
   "dependencies": {
     "@0xhoneyjar/beacon-schema": "file:../../packages/beacon-schema",

--- a/apps/mcp-gateway/src/app.ts
+++ b/apps/mcp-gateway/src/app.ts
@@ -27,6 +27,7 @@ import { checkAccess, isAuthorizedOperator } from "./auth.js";
 import { refreshAllBeacons, startBeaconRefresh } from "./beacon-cache.js";
 import { resolveTenant } from "./beacon-resolver.js";
 import { resolveUpstreamCredential } from "./credentials-resolver.js";
+import { buildUpstreamUrl } from "./upstream-url.js";
 
 const app = new Hono();
 
@@ -320,15 +321,6 @@ function pruneResponseHeaders(input: Headers): Headers {
   return out;
 }
 
-/** Build the upstream URL from the gateway request, stripping the /{slug} prefix. */
-function buildUpstreamUrl(tenant: Tenant, gatewayUrl: URL): string {
-  const prefix = `/${tenant.slug}`;
-  const path = gatewayUrl.pathname.startsWith(prefix)
-    ? gatewayUrl.pathname.slice(prefix.length) || "/"
-    : gatewayUrl.pathname;
-  return new URL(path + gatewayUrl.search, tenant.upstream).toString();
-}
-
 /** Rewrite a tenant's mcp.json discovery card so transports[].url is a gateway-absolute URL. */
 function rewriteDiscoveryCard(
   tenant: Tenant,
@@ -419,7 +411,22 @@ app.all("/:slug/*", async (c) => {
   }
 
   const gatewayUrl = new URL(c.req.url);
-  const upstreamUrl = buildUpstreamUrl(tenant, gatewayUrl);
+  const built = buildUpstreamUrl(tenant, gatewayUrl);
+  if (!built.ok) {
+    // SSRF guard (fail-closed): the request path resolved to an origin other
+    // than the tenant's upstream (e.g. a protocol-relative `//evil.com` path).
+    // Reject — never forward. Diagnostic to logs; caller gets a stable code.
+    console.warn(
+      "[gateway] upstream URL rejected for tenant=%s: %s",
+      slug,
+      built.reason,
+    );
+    return c.json(
+      { error: "bad_request", code: "upstream_origin_mismatch", slug },
+      400,
+    );
+  }
+  const upstreamUrl = built.url;
   const isDiscovery = gatewayUrl.pathname.endsWith("/.well-known/mcp.json");
 
   const headers = pruneRequestHeaders(c.req.raw.headers);

--- a/apps/mcp-gateway/src/upstream-url.ts
+++ b/apps/mcp-gateway/src/upstream-url.ts
@@ -1,0 +1,54 @@
+/**
+ * upstream-url.ts — pure resolution of a gateway request path to its tenant's
+ * upstream URL, carrying the SSRF origin guard.
+ *
+ * Kept separate from app.ts (the Hono execution surface) so this
+ * security-critical logic is unit-testable in isolation: a pure decision
+ * (Construct plane), not I/O (Execution plane). app.ts imports it; the proxy
+ * handler checks the result and fails closed on an escape.
+ */
+import type { Tenant } from "./tenants.js";
+
+/** Result of resolving an upstream URL — fails CLOSED on an origin escape (SSRF guard). */
+export type UpstreamUrlResult =
+  | { readonly ok: true; readonly url: string }
+  | { readonly ok: false; readonly reason: string };
+
+/**
+ * Build the upstream URL from a gateway request, stripping the `/{slug}` prefix.
+ *
+ * SSRF guard (fail-closed): the request path is caller-controlled. A
+ * protocol-relative component such as `/{slug}//evil.com/x` slices to
+ * `//evil.com/x`, which `new URL(path, upstream)` resolves to a DIFFERENT
+ * origin (`https://evil.com/x`) — turning the gateway into an open proxy that
+ * forwards the caller (and, for a credentialed tenant, the upstream key) to an
+ * attacker host. We resolve, then assert the result's origin equals the
+ * tenant's own upstream origin — the same host-allowlist discipline the
+ * Network Firewall already applies (see
+ * packages/adapters/agent/byok-provider-endpoints.ts). Any origin escape is
+ * rejected, never forwarded.
+ *
+ * Note: dot-segment traversal (`/{slug}/../../x`) is NOT an escape — `new URL`
+ * normalizes it within the upstream origin, so it passes the guard and forwards
+ * to a normalized on-origin path. Only an origin change is rejected.
+ *
+ * The check compares `.origin` (scheme+host+port), which is path-independent, so
+ * it stays sound regardless of whether `tenant.upstream` is origin-only (the
+ * UpstreamUrlSchema intent) or ever carried a base path — a base path would be
+ * stripped by resolution (pre-existing behavior), never used to bypass the guard.
+ */
+export function buildUpstreamUrl(tenant: Tenant, gatewayUrl: URL): UpstreamUrlResult {
+  const prefix = `/${tenant.slug}`;
+  const path = gatewayUrl.pathname.startsWith(prefix)
+    ? gatewayUrl.pathname.slice(prefix.length) || "/"
+    : gatewayUrl.pathname;
+  const upstream = new URL(tenant.upstream);
+  const resolved = new URL(path + gatewayUrl.search, upstream);
+  if (resolved.origin !== upstream.origin) {
+    return {
+      ok: false,
+      reason: `resolved origin ${resolved.origin} does not match tenant upstream origin ${upstream.origin}`,
+    };
+  }
+  return { ok: true, url: resolved.toString() };
+}

--- a/apps/mcp-gateway/tests/upstream-url.test.ts
+++ b/apps/mcp-gateway/tests/upstream-url.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { buildUpstreamUrl } from "../src/upstream-url.js";
+import type { Tenant } from "../src/tenants.js";
+
+// A codex-shaped fixture. The guard's property is tenant-independent — it
+// asserts the resolved origin equals THIS tenant's upstream origin — so the
+// test is hermetic (no coupling to the live tenant table). buildUpstreamUrl
+// reads only `slug` and `upstream`; the cast supplies the rest of the shape.
+const codex = {
+  slug: "codex",
+  upstream: "https://codex-mcp-production.up.railway.app",
+} as unknown as Tenant;
+const upstreamOrigin = new URL(codex.upstream).origin;
+const gw = (path: string) => new URL("https://gateway.test" + path);
+
+test("forwards a normal path to the tenant's own upstream origin", () => {
+  const r = buildUpstreamUrl(codex, gw("/codex/v1/tools"));
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(new URL(r.url).origin, upstreamOrigin);
+    assert.equal(new URL(r.url).pathname, "/v1/tools");
+  }
+});
+
+test("SSRF: a protocol-relative path escaping the upstream origin is REJECTED (fail-closed)", () => {
+  // `/codex//evil.com/x` slices to `//evil.com/x` → new URL(...) ⇒ https://evil.com/x.
+  // The unfixed code returned that string and the gateway forwarded to evil.com.
+  // The guard now rejects: resolved origin != the tenant's upstream origin.
+  const r = buildUpstreamUrl(codex, gw("/codex//evil.com/x"));
+  assert.equal(r.ok, false);
+  if (!r.ok) assert.match(r.reason, /does not match tenant upstream origin/);
+});
+
+test("SSRF: a userinfo @-authority pointing at a foreign host is REJECTED", () => {
+  // `//user@evil.com/x` → the authority host is `evil.com` (userinfo before @ is
+  // discarded) → foreign origin → rejected. Deterministic (F1: no branchless skip).
+  const r = buildUpstreamUrl(codex, gw("/codex//user@evil.com/x"));
+  assert.equal(r.ok, false);
+  if (!r.ok) assert.match(r.reason, /does not match tenant upstream origin/);
+});
+
+test("SSRF: a backslash-smuggled authority is REJECTED (WHATWG normalizes \\ to /)", () => {
+  // `/codex/\\evil.com` — the classic WAF/parser-differential vector. WHATWG
+  // converts `\` to `/` for https, yielding `//evil.com` → foreign origin.
+  const r = buildUpstreamUrl(codex, gw("/codex/\\evil.com/x"));
+  assert.equal(r.ok, false);
+});
+
+test("encoded slashes are NOT decoded — path stays ON the upstream origin (F2: locks vs a future decode refactor)", () => {
+  // `%2F%2Fevil.com` must remain a literal path segment on the upstream origin,
+  // never decoded into `//evil.com`. Pins the invariant if anyone later decodes
+  // the path before new URL(...).
+  const r = buildUpstreamUrl(codex, gw("/codex/%2F%2Fevil.com"));
+  assert.equal(r.ok, true);
+  if (r.ok) assert.equal(new URL(r.url).origin, upstreamOrigin);
+});
+
+test("dot-segment traversal that normalizes ON-origin is allowed (not an escape)", () => {
+  const r = buildUpstreamUrl(codex, gw("/codex/../../evil.com"));
+  assert.equal(r.ok, true);
+  if (r.ok) assert.equal(new URL(r.url).origin, upstreamOrigin);
+});
+
+test("query string is preserved through resolution", () => {
+  const r = buildUpstreamUrl(codex, gw("/codex/search?q=mibera&n=3"));
+  assert.equal(r.ok, true);
+  if (r.ok) assert.equal(new URL(r.url).search, "?q=mibera&n=3");
+});


### PR DESCRIPTION
## SSRF / open-proxy fix — mcp-gateway upstream URL resolution

Closes the critical SSRF in the MCP federation gateway (bead `arrakis-sfk5`). Built and verified through the icebreaker gates; **your merge is the final gate** — it mints the signed custody this autonomous run cannot.

### The vulnerability
`/{slug}/*` proxy paths are caller-controlled. `/codex//evil.com/x` slices to `//evil.com/x` — a protocol-relative URL that **replaces the host** — so `new URL(path, tenant.upstream)` resolved to `https://evil.com/x`. The gateway then forwarded the request (and, for a credentialed tenant, the upstream API key in headers) to the attacker host. Backslash (`\`→`/`), userinfo `@`, control-char, and IP/port variants reach the same escape.

### The fix
- Extract `buildUpstreamUrl` → pure `upstream-url.ts` (Construct-plane, unit-testable in isolation), returning `{ok,url} | {ok:false,reason}`.
- Assert `resolved.origin === new URL(tenant.upstream).origin` — the same host-allowlist discipline the Network Firewall applies (`packages/adapters/agent/byok-provider-endpoints.ts`). Origin-equality (scheme+host+**port**) is strictly safer than host-only (rejects `//upstream:8443`).
- Call site fails **closed**: `400`, credential never attached on the reject path, foreign-origin diagnostic to **logs only** (caller gets stable `{error,code,slug}`). Dot-segment traversal that normalizes on-origin and encoded slashes (kept literal) are unaffected.

### Gates — the icebreaker loop
| Gate | Verdict |
|---|---|
| **meter** — `tests/upstream-url.test.ts` | **7/7** ✅ · proven RED when the guard is removed (teeth) · covers protocol-relative, userinfo, backslash, encoded-slash |
| **reviewGate** — FAGAN (cross-model, codex) | **CONVERGED, 0 blockers** · 21 bypass vectors empirically rejected · 4 LOW findings addressed in-diff |
| **laplasGate** — legba ed25519 | gate `pass` (chain/cas/artifact_shape sound) · `anchored:false` (no operator trust-store in an autonomous session — by design) |

### Anchor (reproducible custody record)
```
run_id:       arrakis-sfk5-553ade3d
record_hash:  5fbb9989c710ac25df294d33662786b10a284b276f8993a490fca0cee2c1d553
gate:         pass    (integrity validated)
anchored:     false   → your merge mints the signed custody
```

> Built autonomously through the icebreaker gates (the *cut-new-ICE* loop): GROUND → ACT → meter → reviewGate → laplasGate → ship. The generator never settled its own verdict — FAGAN did; Laplas holds custody.

🤖 Generated with [Claude Code](https://claude.com/claude-code)