### PR TITLE
fix(platform/coexistence): minimum-sample-size floor on the live cutover graduation gate (arrakis-dkf9)

### DIFF
--- a/themes/sietch/src/discord/commands/admin-migrate.ts
+++ b/themes/sietch/src/discord/commands/admin-migrate.ts
@@ -410,6 +410,11 @@ function buildReadinessEmbed(readiness: ReadinessCheckResult): EmbedBuilder {
         inline: true,
       },
       {
+        name: 'Sample Size',
+        value: `${readiness.sampleSize} / ${readiness.requiredSampleSize} ${readiness.checks.sampleSizeCheck ? '✅' : '❌'}`,
+        inline: true,
+      },
+      {
         name: 'Incumbent Configured',
         value: readiness.checks.incumbentConfigured ? '✅ Yes' : '❌ No',
         inline: true,

--- a/themes/sietch/src/packages/adapters/coexistence/MigrationEngine.ts
+++ b/themes/sietch/src/packages/adapters/coexistence/MigrationEngine.ts
@@ -34,6 +34,7 @@ import {
   type TakeoverStep,
   type TakeoverConfirmationState,
 } from './takeover-confirmation.js';
+import { evaluateCutoverReadiness } from './cutover-readiness.js';
 import { createLogger, type ILogger } from '../../infrastructure/logging/index.js';
 
 // =============================================================================
@@ -45,6 +46,18 @@ export const MIN_SHADOW_DAYS = 14;
 
 /** Minimum accuracy percentage required before migration (Sprint 62 requirement) */
 export const MIN_ACCURACY_PERCENT = 95;
+
+/**
+ * Minimum number of compared members the accuracy % must be computed over before a
+ * cutover may graduate (arrakis-dkf9). Without a floor a tiny sample (3/3 = 100%)
+ * clears the 95% accuracy gate and grants real access on meaningless data.
+ */
+// loa:shortcut: MIN_SAMPLE_SIZE=30 (conventional small-sample floor for a proportion).
+// CEILING: n=30 at 95% still admits a community whose TRUE accuracy is ~80% by sampling luck
+// (Wilson 95% lower bound). UPGRADE TRIGGER: before cutting over any community where a wrongful
+// role grant is costly, raise toward n>=100, or replace this flat floor with a Wilson-lower-bound
+// gate (require the 95% CI lower bound — not the point estimate — to clear MIN_ACCURACY_PERCENT).
+export const MIN_SAMPLE_SIZE = 30;
 
 /** Default batch size for gradual migration */
 export const DEFAULT_BATCH_SIZE = 100;
@@ -89,10 +102,15 @@ export interface ReadinessCheckResult {
   accuracyPercent: number;
   /** Required accuracy percentage */
   requiredAccuracyPercent: number;
+  /** Number of compared members the accuracy was computed over (the sample size) */
+  sampleSize: number;
+  /** Required minimum sample size before the accuracy gate counts (arrakis-dkf9) */
+  requiredSampleSize: number;
   /** Individual check results */
   checks: {
     shadowDaysCheck: boolean;
     accuracyCheck: boolean;
+    sampleSizeCheck: boolean;
     incumbentConfigured: boolean;
     modeCheck: boolean;
   };
@@ -394,9 +412,12 @@ export class MigrationEngine {
         requiredShadowDays: MIN_SHADOW_DAYS,
         accuracyPercent: 0,
         requiredAccuracyPercent: MIN_ACCURACY_PERCENT,
+        sampleSize: 0,
+        requiredSampleSize: MIN_SAMPLE_SIZE,
         checks: {
           shadowDaysCheck: false,
           accuracyCheck: false,
+          sampleSizeCheck: false,
           incumbentConfigured: false,
           modeCheck: false,
         },
@@ -414,31 +435,23 @@ export class MigrationEngine {
     // Calculate shadow days
     const shadowDays = this.calculateShadowDays(state);
 
-    // Perform checks
-    const shadowDaysCheck = shadowDays >= MIN_SHADOW_DAYS;
-    const accuracyCheck = divergenceSummary.accuracyPercent >= MIN_ACCURACY_PERCENT;
-    const modeCheck = state.currentMode === 'shadow' || state.currentMode === 'parallel';
-
-    const ready = shadowDaysCheck && accuracyCheck && incumbentConfigured && modeCheck;
-
-    // Build reason if not ready
-    let reason: string | undefined;
-    if (!ready) {
-      const reasons: string[] = [];
-      if (!incumbentConfigured) {
-        reasons.push('No incumbent bot configured');
-      }
-      if (!modeCheck) {
-        reasons.push(`Invalid mode for migration: ${state.currentMode} (must be shadow or parallel)`);
-      }
-      if (!shadowDaysCheck) {
-        reasons.push(`Insufficient shadow days: ${shadowDays}/${MIN_SHADOW_DAYS}`);
-      }
-      if (!accuracyCheck) {
-        reasons.push(`Insufficient accuracy: ${divergenceSummary.accuracyPercent.toFixed(1)}%/${MIN_ACCURACY_PERCENT}%`);
-      }
-      reason = reasons.join('; ');
-    }
+    // Perform checks. The cutover-graduation DECISION is a pure, typed function
+    // (cutover-readiness.ts), extracted so this highest-stakes gate is type-checked
+    // and unit-tested despite this file being @ts-nocheck. It adds the
+    // minimum-sample-size floor (arrakis-dkf9): a tiny sample (e.g. 3/3 = 100%) must
+    // NOT clear the 95% accuracy gate and grant real access on meaningless data.
+    const modeValid = state.currentMode === 'shadow' || state.currentMode === 'parallel';
+    const { ready, checks, reason } = evaluateCutoverReadiness({
+      shadowDays,
+      minShadowDays: MIN_SHADOW_DAYS,
+      accuracyPercent: divergenceSummary.accuracyPercent,
+      minAccuracyPercent: MIN_ACCURACY_PERCENT,
+      sampleSize: divergenceSummary.totalMembers,
+      minSampleSize: MIN_SAMPLE_SIZE,
+      incumbentConfigured,
+      modeValid,
+      currentMode: state.currentMode,
+    });
 
     const result: ReadinessCheckResult = {
       ready,
@@ -446,12 +459,9 @@ export class MigrationEngine {
       requiredShadowDays: MIN_SHADOW_DAYS,
       accuracyPercent: divergenceSummary.accuracyPercent,
       requiredAccuracyPercent: MIN_ACCURACY_PERCENT,
-      checks: {
-        shadowDaysCheck,
-        accuracyCheck,
-        incumbentConfigured,
-        modeCheck,
-      },
+      sampleSize: divergenceSummary.totalMembers,
+      requiredSampleSize: MIN_SAMPLE_SIZE,
+      checks,
       reason,
     };
 

--- a/themes/sietch/src/packages/adapters/coexistence/cutover-readiness.ts
+++ b/themes/sietch/src/packages/adapters/coexistence/cutover-readiness.ts
@@ -1,0 +1,104 @@
+/**
+ * cutover-readiness.ts — the pure decision for whether a coexistence migration may
+ * graduate to a PRIMARY cutover (which grants real community-access roles).
+ *
+ * Extracted from MigrationEngine.checkReadiness (that file is `// @ts-nocheck`) so
+ * the highest-stakes gate in the system is TYPE-CHECKED and unit-testable in
+ * isolation: a pure decision (Construct plane), no I/O (Execution plane). The host
+ * gathers the inputs (migration state, divergence summary) and delegates the verdict
+ * here.
+ *
+ * It carries the minimum-sample-size FLOOR (arrakis-dkf9): an accuracy percentage is
+ * only meaningful over a sufficient sample, so a tiny sample (e.g. 3 compared members
+ * at 3/3 = 100%) must NOT clear the 95% accuracy gate and grant real access on
+ * statistically meaningless data. The floor is an INPUT (`minSampleSize`), so the
+ * threshold policy stays co-located with the other thresholds in the host.
+ */
+
+export interface CutoverReadinessInput {
+  readonly shadowDays: number;
+  readonly minShadowDays: number;
+  readonly accuracyPercent: number;
+  readonly minAccuracyPercent: number;
+  /**
+   * The number of compared members the accuracy % is computed over — the accuracy
+   * DENOMINATOR (`divergenceSummary.totalMembers`). This is the signal dkf9 ignored.
+   */
+  readonly sampleSize: number;
+  readonly minSampleSize: number;
+  readonly incumbentConfigured: boolean;
+  readonly modeValid: boolean;
+  /** Current mode label — used only for the human-readable reason, not the decision. */
+  readonly currentMode?: string;
+}
+
+export interface CutoverReadinessChecks {
+  readonly shadowDaysCheck: boolean;
+  readonly accuracyCheck: boolean;
+  readonly sampleSizeCheck: boolean;
+  readonly incumbentConfigured: boolean;
+  readonly modeCheck: boolean;
+}
+
+export interface CutoverReadinessDecision {
+  readonly ready: boolean;
+  readonly checks: CutoverReadinessChecks;
+  readonly reason?: string;
+}
+
+/**
+ * Pure cutover-graduation verdict. `ready` is the conjunction of ALL gates — shadow
+ * days, accuracy, SAMPLE SIZE, incumbent configured, and a valid mode — so any
+ * failing gate (including an under-sized accuracy sample) fails CLOSED to not-ready.
+ */
+export function evaluateCutoverReadiness(
+  input: CutoverReadinessInput,
+): CutoverReadinessDecision {
+  const shadowDaysCheck = input.shadowDays >= input.minShadowDays;
+  const accuracyCheck = input.accuracyPercent >= input.minAccuracyPercent;
+  // SAMPLE-SIZE FLOOR (arrakis-dkf9): a high accuracy % over too few comparisons is
+  // not yet trustworthy — require a minimum sample before the accuracy gate counts.
+  const sampleSizeCheck = input.sampleSize >= input.minSampleSize;
+  const incumbentConfigured = input.incumbentConfigured;
+  const modeCheck = input.modeValid;
+
+  const ready =
+    shadowDaysCheck &&
+    accuracyCheck &&
+    sampleSizeCheck &&
+    incumbentConfigured &&
+    modeCheck;
+
+  let reason: string | undefined;
+  if (!ready) {
+    const reasons: string[] = [];
+    if (!incumbentConfigured) {
+      reasons.push('No incumbent bot configured');
+    }
+    if (!modeCheck) {
+      reasons.push(
+        `Invalid mode for migration: ${input.currentMode ?? 'unknown'} (must be shadow or parallel)`,
+      );
+    }
+    if (!shadowDaysCheck) {
+      reasons.push(`Insufficient shadow days: ${input.shadowDays}/${input.minShadowDays}`);
+    }
+    if (!sampleSizeCheck) {
+      reasons.push(
+        `Insufficient sample size: ${input.sampleSize}/${input.minSampleSize} compared members (accuracy not yet statistically meaningful)`,
+      );
+    }
+    if (!accuracyCheck) {
+      reasons.push(
+        `Insufficient accuracy: ${input.accuracyPercent.toFixed(1)}%/${input.minAccuracyPercent}%`,
+      );
+    }
+    reason = reasons.join('; ');
+  }
+
+  return {
+    ready,
+    checks: { shadowDaysCheck, accuracyCheck, sampleSizeCheck, incumbentConfigured, modeCheck },
+    reason,
+  };
+}

--- a/themes/sietch/tests/unit/packages/adapters/coexistence/cutover-readiness.test.ts
+++ b/themes/sietch/tests/unit/packages/adapters/coexistence/cutover-readiness.test.ts
@@ -1,0 +1,90 @@
+/**
+ * cutover-readiness Unit Tests
+ *
+ * The pure cutover-graduation decision (extracted from MigrationEngine.checkReadiness).
+ * CRITICAL TEST (arrakis-dkf9): a high accuracy % over a tiny sample must NOT graduate
+ * a cutover — that would grant real community-access roles on statistically
+ * meaningless data. A 3-member 3/3 = 100% sample is the canonical bug case.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateCutoverReadiness,
+  type CutoverReadinessInput,
+} from '../../../../../src/packages/adapters/coexistence/cutover-readiness.js';
+
+// A baseline input that PASSES every gate — each test perturbs one dimension.
+const ok = (over: Partial<CutoverReadinessInput> = {}): CutoverReadinessInput => ({
+  shadowDays: 14,
+  minShadowDays: 14,
+  accuracyPercent: 100,
+  minAccuracyPercent: 95,
+  sampleSize: 50,
+  minSampleSize: 30,
+  incumbentConfigured: true,
+  modeValid: true,
+  currentMode: 'parallel',
+  ...over,
+});
+
+describe('evaluateCutoverReadiness', () => {
+  it('graduates when shadow days, accuracy, sample size, incumbent, and mode all clear', () => {
+    const d = evaluateCutoverReadiness(ok());
+    expect(d.ready).toBe(true);
+    expect(d.reason).toBeUndefined();
+    expect(d.checks).toEqual({
+      shadowDaysCheck: true,
+      accuracyCheck: true,
+      sampleSizeCheck: true,
+      incumbentConfigured: true,
+      modeCheck: true,
+    });
+  });
+
+  it('arrakis-dkf9: a tiny 3/3 = 100% sample does NOT graduate (sample-size floor)', () => {
+    // The bug: 100% accuracy over 3 compared members cleared the 95% gate.
+    const d = evaluateCutoverReadiness(ok({ accuracyPercent: 100, sampleSize: 3 }));
+    expect(d.ready).toBe(false);
+    expect(d.checks.accuracyCheck).toBe(true); // accuracy alone still "passes"...
+    expect(d.checks.sampleSizeCheck).toBe(false); // ...but the sample floor blocks it
+    expect(d.reason).toMatch(/Insufficient sample size: 3\/30/);
+  });
+
+  it('sample-size floor is inclusive at the boundary', () => {
+    expect(evaluateCutoverReadiness(ok({ sampleSize: 30 })).ready).toBe(true);
+    expect(evaluateCutoverReadiness(ok({ sampleSize: 29 })).ready).toBe(false);
+  });
+
+  it('a zero sample (no comparisons at all) does NOT graduate', () => {
+    const d = evaluateCutoverReadiness(ok({ sampleSize: 0 }));
+    expect(d.ready).toBe(false);
+    expect(d.checks.sampleSizeCheck).toBe(false);
+  });
+
+  it('both gates exactly at their floor (95% over 30 members) graduates', () => {
+    const d = evaluateCutoverReadiness(ok({ accuracyPercent: 95, sampleSize: 30 }));
+    expect(d.ready).toBe(true);
+  });
+
+  it('still enforces the pre-existing gates — the floor is additive, not a replacement', () => {
+    expect(evaluateCutoverReadiness(ok({ accuracyPercent: 94 })).ready).toBe(false);
+    expect(evaluateCutoverReadiness(ok({ shadowDays: 13 })).ready).toBe(false);
+    expect(evaluateCutoverReadiness(ok({ incumbentConfigured: false })).ready).toBe(false);
+    expect(evaluateCutoverReadiness(ok({ modeValid: false })).ready).toBe(false);
+  });
+
+  it('the reason names every failing gate, including the sample floor', () => {
+    const d = evaluateCutoverReadiness(
+      ok({ accuracyPercent: 80, sampleSize: 5, shadowDays: 2 }),
+    );
+    expect(d.ready).toBe(false);
+    expect(d.reason).toMatch(/Insufficient shadow days: 2\/14/);
+    expect(d.reason).toMatch(/Insufficient sample size: 5\/30/);
+    expect(d.reason).toMatch(/Insufficient accuracy: 80\.0%\/95%/);
+  });
+
+  it('preserves the exact mode-failure diagnostic (includes the offending mode)', () => {
+    const d = evaluateCutoverReadiness(ok({ modeValid: false, currentMode: 'primary' }));
+    expect(d.reason).toMatch(/Invalid mode for migration: primary \(must be shadow or parallel\)/);
+  });
+});


### PR DESCRIPTION
## Cutover graduation gate — minimum-sample-size floor (arrakis-dkf9)

`MigrationEngine.checkReadiness` gates the coexistence→**PRIMARY** cutover that grants **real Discord community-access roles**. The gate required `shadowDays>=14 && accuracyPercent>=95` — with **no minimum-sample-size floor**. Since `accuracyPercent = (matchCount / totalMembers) * 100` ([CoexistenceStorage.ts:719](../blob/main/themes/sietch/src/packages/adapters/coexistence/CoexistenceStorage.ts)), a tiny sample (`totalMembers=3, matchCount=3` → 100%) **cleared the 95% gate** — firing the cutover on statistically meaningless data and granting real access. This is the **LIVE mounted executor** (the `packages/` coexistence copy is unmounted dead code — per arrakis-oaxr, audit the mounted one).

> Built and verified through the icebreaker gates; **your merge is the final gate** — it mints the signed custody this autonomous run cannot.

### The fix
- Extract the graduation **decision** from `checkReadiness` (host file is `// @ts-nocheck`) into a new **pure, type-checked** module `cutover-readiness.ts` — `evaluateCutoverReadiness()`. The highest-stakes decision is now typed + unit-testable (also chips at **arrakis-s8hf**).
- Add a sample-size floor: `sampleSize >= MIN_SAMPLE_SIZE` ANDed into `ready` (**fail-closed**). `checkReadiness` passes `divergenceSummary.totalMembers` (the accuracy denominator).
- Additive: `ReadinessCheckResult` gains `sampleSize` / `requiredSampleSize` / `checks.sampleSizeCheck`; the admin readiness panel shows a **Sample Size** row.

### Gates — the icebreaker loop
| Gate | Verdict |
|---|---|
| **meter** — `cutover-readiness.test.ts` | **8/8** ✅ · proven RED when the floor is removed · fails closed on `0/NaN/undefined/negative` |
| **reviewGate** — FAGAN (cross-model, codex) | **CONVERGED, 0 blockers** · 15-case verbatim port confirmed fail-closed + behavior-preserving + genuinely wired to the live grant (`executeMigration:519-535` re-checks `ready`) |
| **laplasGate** — legba ed25519 | gate `pass` (integrity) · `anchored:false` (no operator trust-store in an autonomous session — by design) |

### ⚠️ Policy call for you (FAGAN F1)
`MIN_SAMPLE_SIZE = 30` closes the unbounded n=3 hole and is fail-closed + operator-tunable — but it's statistically thin: at n=30, a community whose **true** accuracy is ~80% can still graduate by sampling luck (Wilson 95% lower bound). The constant carries a marker with a concrete upgrade path (raise toward n≥100, or a Wilson-lower-bound gate). **The value is yours to set on merge** — the mechanism (the floor + the right denominator) is what this PR lands.

### Anchor (reproducible custody record)
```
run_id:       arrakis-dkf9-92e77cd3
record_hash:  e358e693a19eb0154f500bf27e551f3c76e95ea3905ebcccebf0fc65b4c75ae8
gate:         pass    (integrity validated)
anchored:     false   → your merge mints the signed custody
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)