### PR TITLE
[codex] Align security audit workflow with Node 22 engine

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -40,7 +40,7 @@ jobs:
         if: steps.check-deps.outputs.has_deps == 'true'
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       # Monorepo audit (apps/ and packages/)
       - name: Audit monorepo packages


### PR DESCRIPTION
## Summary
Refs #375.

Aligns the Freeside `Security Audit` workflow's npm-audit job with the repository Node engine floor by moving `actions/setup-node` from Node 20 to Node 22.

## Why
The root `package.json` declares `engines.node: >=22`, while `.github/workflows/security-audit.yml` was still running the audit install path on Node 20. That makes the red `Security Audit` checks on #388/#389/#390 harder to interpret because the audit gate is not using the supported runtime declared by the repo.

## What changed
- `.github/workflows/security-audit.yml`: `node-version: '20'` → `node-version: '22'` for the `npm-audit` job only.

## Safety / non-claims
- No audit thresholds changed.
- No allowlists, scanner policy, lockfiles, dependencies, or PR-block behavior changed.
- This does not claim to resolve any underlying advisory; it removes a runtime mismatch so remaining audit failures are easier to classify.

## Evidence
- Root `package.json` declares `engines.node: >=22`.
- The branch was fetched after commit and verified the workflow now uses `node-version: '22'` in the audit setup step.

## Validation
- Connector-side file verification only; workflow run pending after PR creation.