### PR TITLE
[codex] Align CI validation jobs with Node 22 engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Validate JSON files
         run: |
@@ -156,7 +156,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install markdownlint-cli
         run: npm install -g markdownlint-cli


### PR DESCRIPTION
## Summary
Refs #375.

Aligns the remaining Freeside CI validation jobs that explicitly set Node 20 with the repository Node engine floor.

## Why
The root `package.json` declares `engines.node: >=22`, but `.github/workflows/ci.yml` still used Node 20 for:

- `validate` / `Setup Node.js`
- `markdown-lint` / `Setup Node.js`

The unit and integration test jobs already use Node 22. This mismatch makes red CI runs harder to classify because part of the workflow is exercising an unsupported runtime.

## What changed
- `.github/workflows/ci.yml`: `validate` setup-node `node-version: '20'` -> `node-version: '22'`.
- `.github/workflows/ci.yml`: `markdown-lint` setup-node `node-version: '20'` -> `node-version: '22'`.

## Safety / non-claims
- No CI job names, gates, thresholds, test commands, dependencies, lockfiles, allowlists, or scanner policy changed.
- This does not claim to resolve the inherited Unit/Integration red gates on #388/#389/#390; it removes an engine mismatch so remaining failures are easier to classify.

## Evidence
- Root `package.json` declares `engines.node: >=22`.
- Post-commit fetch verified both changed setup-node entries now use `node-version: '22'`.

## Validation
- Connector-side file verification only; waiting for GitHub Actions on this PR.