### PR TITLE
[codex] Align PR validation workflow with Node 22 engine

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -28,7 +28,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
   WORKING_DIR: './themes/sietch'
 
 jobs:


### PR DESCRIPTION
## Summary
Refs #375.

Aligns `.github/workflows/pr-validation.yml` with the repository Node engine floor by moving the workflow-level `NODE_VERSION` from Node 20 to Node 22.

## Why
The root `package.json` declares `engines.node: >=22`, while `PR Validation` still ran build/test/lint/security jobs through `env.NODE_VERSION: '20'`. That makes red PR Validation runs on #389/#390 harder to interpret because the workflow is exercising an unsupported runtime before any package/test failure can be classified.

## What changed
- `.github/workflows/pr-validation.yml`: `NODE_VERSION: '20'` -> `NODE_VERSION: '22'`.

## Safety / non-claims
- No job names, gates, thresholds, audit filters, allowlists, secrets handling, dependencies, lockfiles, or PR-block behavior changed.
- This does not claim to resolve any underlying advisory or test failure; it removes an engine mismatch so remaining failures are easier to classify.

## Evidence
- Root `package.json` declares `engines.node: >=22`.
- Post-commit fetch verified `.github/workflows/pr-validation.yml` now has `NODE_VERSION: '22'`.
- Carry-forward issue #375 tracks repeated Freeside CI/security red gates and local log classification commands.

## Validation
- Connector-side file verification only; waiting for GitHub Actions on this PR.