### PR TITLE
Run Mode: Community onboarding kitchen (K0-K2)

### DIFF
--- a/packages/services/ordering/DEPLOY.md
+++ b/packages/services/ordering/DEPLOY.md
@@ -22,9 +22,18 @@ adapter consumes it when `ORDERING_SERVICE_URL` is set.
 | `SCORE_API_URL` | optional | capability resolver hint |
 | `WORLDS_API_URL` | optional | capability resolver hint |
 | `CTA_PRODUCT`, `CTA_CONVERSATION` | optional | CTA URLs in lifecycle metadata (defaults freeside.app) |
-| `ORDER_OPS_WEBHOOK_URL` | optional | Fire-and-forget POST when a `community-onboarding` order is placed. JSON body includes `text` for Slack incoming webhooks plus structured fields (`order_id`, `contact_email`, `contract_address`, `chain_id`, etc.). Failures are logged only; never blocks the 200. |
+| `ORDER_OPS_WEBHOOK_URL` | optional | Fire-and-forget POST when a `community-onboarding` order is placed. Second POST when triage issues are filed (`community_onboarding.ingredients_enqueued`). |
+| `DATABASE_URL` | recommended (kitchen K0) | Postgres store — orders survive restart |
+| `RUN_MIGRATIONS` | optional | Set `true` on deploy to apply `migrations/001_orders.sql` |
+| `GITHUB_TOKEN` | required for kitchen K1 | PAT with `issues:write` on kitchen repos |
+| `KITCHEN_ISSUE_REPO_SONAR` | optional | Default `0xHoneyJar/sonar-api` |
+| `KITCHEN_ISSUE_REPO_SCORE` | optional | Default `0xHoneyJar/score-api` |
+| `KITCHEN_ISSUE_REPO_WORLDS` | optional | Default `0xHoneyJar/worlds-api` |
+| `KITCHEN_ENQUEUE_ENABLED` | optional | Default `true`; set `false` to disable issue fan-out |
+| `ENABLE_REPROBE` | optional | Set `true` on http service to run reprobe loop in-process |
+| `KITCHEN_REPROBE_INTERVAL_SEC` | optional | Default `900` (15 min) |
 
-**Store:** in-memory for internal demo. Restarts drop orders. Postgres `OrderStore` is Sprint 4.
+**Store:** Postgres when `DATABASE_URL` set; otherwise in-memory (local dev only).
 
 ### Operator webhook payload (example)
 

--- a/packages/services/ordering/bin/http.ts
+++ b/packages/services/ordering/bin/http.ts
@@ -1,63 +1,15 @@
 /**
  * order-intake composition root — deployable HTTP edge for internal demo + dashboard consumer.
- *
- * Wires intake + CommunityOnboardingOrchestrator in-process (NATS consumer is prod hardening).
- * Dashboard: ORDERING_SERVICE_URL → POST/GET /v1/orders, advance-ingredient for operator triage.
  */
 import { serve } from '@hono/node-server';
-import type { Cta } from '@freeside/shadow-audit-protocol';
-import type { AuditServiceResult } from '@freeside/shadow-audit-service';
-import {
-  ConfigCapabilityResolver,
-  createIntakeApp,
-  InMemoryOrderStore,
-  OrderOrchestrator,
-  StubTriagePorts,
-  type AuditPort,
-  type CapabilityConfig,
-} from '../src/index.js';
 
-class NoopAudit implements AuditPort {
-  async invoke(): Promise<AuditServiceResult> {
-    throw new Error('audit port unused for community-onboarding intake');
-  }
-}
+import { createIntakeApp } from '../src/intake.js';
+import { createOrderingComposition, serviceTokenFromEnv } from '../src/composition.js';
+import { ReProbeWorker } from '../src/reprobe-worker.js';
 
-function triageCapabilityConfig(): CapabilityConfig {
-  return {
-    'collection-index': {
-      building: 'sonar-api',
-      endpoint: process.env.SONAR_API_URL?.trim() || 'http://sonar.internal',
-    },
-    'community-register': {
-      building: 'score-api',
-      endpoint: process.env.SCORE_API_URL?.trim() || 'http://score.internal',
-    },
-    'world-manifest': {
-      building: 'worlds-api',
-      endpoint: process.env.WORLDS_API_URL?.trim() || 'http://worlds.internal',
-    },
-  };
-}
+const { store, orchestrator, enqueue } = await createOrderingComposition();
 
-function ctaFromEnv(): Cta {
-  const product = process.env.CTA_PRODUCT?.trim() || 'https://freeside.app';
-  const conversation = process.env.CTA_CONVERSATION?.trim() || 'https://freeside.app';
-  return { product, conversation };
-}
-
-const store = new InMemoryOrderStore();
-const orchestrator = new OrderOrchestrator({
-  store,
-  resolver: new ConfigCapabilityResolver(triageCapabilityConfig()),
-  audit: new NoopAudit(),
-  communities: () => undefined,
-  cta: ctaFromEnv(),
-  now: () => Date.now(),
-  triage: new StubTriagePorts(),
-});
-
-const serviceToken = process.env.SERVICE_TOKEN?.trim() || process.env.ORDERING_SERVICE_TOKEN?.trim();
+const serviceToken = serviceTokenFromEnv();
 
 const app = createIntakeApp({
   store,
@@ -66,10 +18,22 @@ const app = createIntakeApp({
     void orchestrator.process(orderId);
   },
   orchestrator,
-  serviceToken: serviceToken || undefined,
+  serviceToken,
 });
 
-app.get('/healthz', (c) => c.json({ ok: true, service: 'ordering-service' }));
+app.get('/healthz', (c) =>
+  c.json({
+    ok: true,
+    service: 'ordering-service',
+    store: process.env.DATABASE_URL ? 'postgres' : 'memory',
+    kitchen_enqueue: Boolean(enqueue),
+  }),
+);
+
+if (process.env.ENABLE_REPROBE === 'true') {
+  const worker = new ReProbeWorker(store, orchestrator);
+  worker.start();
+}
 
 const port = Number(process.env.PORT ?? 8090);
 serve({ fetch: app.fetch, port });

--- a/packages/services/ordering/bin/worker.ts
+++ b/packages/services/ordering/bin/worker.ts
@@ -1,0 +1,15 @@
+/**
+ * Kitchen re-probe worker — scans producing orders on an interval.
+ */
+import { createOrderingComposition } from '../src/composition.js';
+import { ReProbeWorker } from '../src/reprobe-worker.js';
+
+const { store, orchestrator } = await createOrderingComposition();
+const worker = new ReProbeWorker(store, orchestrator);
+worker.start();
+
+// eslint-disable-next-line no-console
+console.log(`ordering-service worker started (interval ${process.env.KITCHEN_REPROBE_INTERVAL_SEC ?? 900}s)`);
+
+process.on('SIGTERM', () => worker.stop());
+process.on('SIGINT', () => worker.stop());

--- a/packages/services/ordering/migrations/001_orders.sql
+++ b/packages/services/ordering/migrations/001_orders.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS orders (
+  order_id            TEXT PRIMARY KEY,
+  product             TEXT NOT NULL,
+  placed_by           TEXT NOT NULL,
+  inputs              JSONB NOT NULL,
+  inputs_digest       TEXT NOT NULL,
+  state               TEXT NOT NULL,
+  placed_at_unix      BIGINT NOT NULL,
+  created_at_unix     BIGINT NOT NULL,
+  updated_at_unix     BIGINT NOT NULL,
+  recipe_id           TEXT,
+  resolved_buildings  JSONB,
+  result_ref          TEXT,
+  output              JSONB,
+  output_digest       TEXT,
+  refusal             JSONB,
+  ingredients         JSONB,
+  fulfillment         JSONB,
+  ingredient_jobs     JSONB NOT NULL DEFAULT '[]'::jsonb,
+  operator_audit      JSONB NOT NULL DEFAULT '[]'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS orders_producing_idx ON orders (state) WHERE state = 'producing';
+
+CREATE TABLE IF NOT EXISTS order_outbox (
+  seq         BIGSERIAL PRIMARY KEY,
+  order_id    TEXT NOT NULL REFERENCES orders(order_id) ON DELETE CASCADE,
+  subject     TEXT NOT NULL,
+  payload     JSONB NOT NULL,
+  published   BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+CREATE INDEX IF NOT EXISTS order_outbox_pending_idx ON order_outbox (published) WHERE published = FALSE;

--- a/packages/services/ordering/package.json
+++ b/packages/services/ordering/package.json
@@ -13,7 +13,8 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "start": "tsx bin/http.ts",
-    "dev": "tsx watch bin/http.ts"
+    "dev": "tsx watch bin/http.ts",
+    "worker": "tsx bin/worker.ts"
   },
   "license": "AGPL-3.0",
   "dependencies": {
@@ -22,11 +23,13 @@
     "@freeside/shadow-audit-service": "file:../shadow-audit",
     "@hono/node-server": "^1.13.0",
     "hono": "^4.7.0",
+    "pg": "^8.16.0",
     "tsx": "^4.19.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "@types/pg": "^8.15.2",
     "typescript": "^5.7.0",
     "vitest": "^4.0.17"
   },

--- a/packages/services/ordering/pnpm-lock.yaml
+++ b/packages/services/ordering/pnpm-lock.yaml
@@ -16,13 +16,16 @@ importers:
         version: file:../../protocol/shadow-audit(zod@3.25.76)
       '@freeside/shadow-audit-service':
         specifier: file:../shadow-audit
-        version: file:../shadow-audit(pino@10.3.1)(typescript@5.9.3)(zod@3.25.76)
+        version: file:../shadow-audit(@types/pg@8.20.0)(pg@8.22.0)(pino@10.3.1)(typescript@5.9.3)(zod@3.25.76)
       '@hono/node-server':
         specifier: ^1.13.0
         version: 1.19.14(hono@4.12.27)
       hono:
         specifier: ^4.7.0
         version: 4.12.27
+      pg:
+        specifier: ^8.16.0
+        version: 8.22.0
       tsx:
         specifier: ^4.19.0
         version: 4.22.4
@@ -33,6 +36,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.0
+      '@types/pg':
+        specifier: ^8.15.2
+        version: 8.20.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -522,6 +528,9 @@ packages:
   '@types/node@22.20.0':
     resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
 
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
   '@vitest/expect@4.1.9':
     resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
 
@@ -853,6 +862,40 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.15.0:
+    resolution: {integrity: sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.22.0:
+    resolution: {integrity: sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -873,6 +916,22 @@ packages:
   postcss@8.5.16:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   postgres@3.4.9:
     resolution: {integrity: sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==}
@@ -1078,6 +1137,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -1368,13 +1431,13 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@freeside/adapters@file:../../adapters(pino@10.3.1)(typescript@5.9.3)':
+  '@freeside/adapters@file:../../adapters(@types/pg@8.20.0)(pg@8.22.0)(pino@10.3.1)(typescript@5.9.3)':
     dependencies:
       '@0xhoneyjar/loa-hounfour': https://codeload.github.com/0xHoneyJar/loa-hounfour/tar.gz/aed755f7fea8d2739cf9c755b45aaa580b6af6a9
       '@aws-sdk/client-secrets-manager': 3.1076.0
       '@freeside/core': file:../../core
       aws-embedded-metrics: 4.2.1
-      drizzle-orm: 0.33.0(postgres@3.4.9)
+      drizzle-orm: 0.33.0(@types/pg@8.20.0)(pg@8.22.0)(postgres@3.4.9)
       ioredis: 5.11.1
       jose: 5.10.0
       opossum: 8.5.0
@@ -1428,9 +1491,9 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@freeside/shadow-audit-service@file:../shadow-audit(pino@10.3.1)(typescript@5.9.3)(zod@3.25.76)':
+  '@freeside/shadow-audit-service@file:../shadow-audit(@types/pg@8.20.0)(pg@8.22.0)(pino@10.3.1)(typescript@5.9.3)(zod@3.25.76)':
     dependencies:
-      '@freeside/adapters': file:../../adapters(pino@10.3.1)(typescript@5.9.3)
+      '@freeside/adapters': file:../../adapters(@types/pg@8.20.0)(pg@8.22.0)(pino@10.3.1)(typescript@5.9.3)
       '@freeside/shadow-audit-protocol': file:../../protocol/shadow-audit(zod@3.25.76)
       '@hono/node-server': 1.19.14(hono@4.12.27)
       hono: 4.12.27
@@ -1632,6 +1695,12 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 22.20.0
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
+
   '@vitest/expect@4.1.9':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -1704,8 +1773,10 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  drizzle-orm@0.33.0(postgres@3.4.9):
+  drizzle-orm@0.33.0(@types/pg@8.20.0)(pg@8.22.0)(postgres@3.4.9):
     optionalDependencies:
+      '@types/pg': 8.20.0
+      pg: 8.22.0
       postgres: 3.4.9
 
   es-module-lexer@2.2.0: {}
@@ -1856,6 +1927,41 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.22.0):
+    dependencies:
+      pg: 8.22.0
+
+  pg-protocol@1.15.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.22.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.22.0)
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
@@ -1885,6 +1991,16 @@ snapshots:
       nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   postgres@3.4.9: {}
 
@@ -2033,5 +2149,7 @@ snapshots:
       stackback: 0.0.2
 
   ws@8.20.1: {}
+
+  xtend@4.0.2: {}
 
   zod@3.25.76: {}

--- a/packages/services/ordering/src/__tests__/ingredient-enqueue.test.ts
+++ b/packages/services/ordering/src/__tests__/ingredient-enqueue.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { INITIAL_COMMUNITY_ONBOARDING_INGREDIENTS, ORDER_LIFECYCLE_SUBJECTS } from '@freeside/ordering-protocol';
+
+import { RecordingGitHubIssuePort } from '../github-issue-port.js';
+import { IngredientEnqueueService } from '../ingredient-enqueue.js';
+import { InMemoryOrderStore, type NewOrder } from '../store.js';
+
+function communityOrder(orderId = 'ord_kitchen_1'): NewOrder {
+  return {
+    order_id: orderId,
+    product: 'community-onboarding',
+    placed_by: 'dashboard_onboarding',
+    placed_at_unix: 1_700_000_000,
+    inputs_digest: 'a'.repeat(64),
+    inputs: {
+      chain_id: '1',
+      contract_address: '0xabc',
+      contact_email: 'cm@example.com',
+      community_name: 'Test',
+      source: 'dashboard_onboarding',
+    },
+    ingredients: { ...INITIAL_COMMUNITY_ONBOARDING_INGREDIENTS },
+  };
+}
+
+describe('IngredientEnqueueService', () => {
+  it('files github issues for pending sonar/score/worlds_manifest and marks in_progress', async () => {
+    const store = new InMemoryOrderStore({ now: () => 1_700_000_000 });
+    const github = new RecordingGitHubIssuePort();
+    const enqueue = new IngredientEnqueueService(store, github);
+
+    await store.placeOrder(communityOrder(), {
+      subject: ORDER_LIFECYCLE_SUBJECTS.placed,
+      payload: { order_id: 'ord_kitchen_1', product: 'community-onboarding', inputs_digest: 'a'.repeat(64) },
+    });
+    await store.transition('ord_kitchen_1', 'placed', 'routing');
+    await store.transition('ord_kitchen_1', 'routing', 'producing', {
+      patch: { ingredients: { ...INITIAL_COMMUNITY_ONBOARDING_INGREDIENTS } },
+    });
+
+    await enqueue.enqueueMissing('ord_kitchen_1');
+
+    expect(github.issues).toHaveLength(3);
+    const record = await store.get('ord_kitchen_1');
+    expect(record?.ingredient_jobs).toHaveLength(3);
+    expect(record?.ingredients?.sonar).toBe('in_progress');
+    expect(record?.ingredients?.score).toBe('in_progress');
+    expect(record?.ingredients?.worlds_manifest).toBe('in_progress');
+  });
+
+  it('does not duplicate issues on second enqueue', async () => {
+    const store = new InMemoryOrderStore({ now: () => 1_700_000_000 });
+    const github = new RecordingGitHubIssuePort();
+    const enqueue = new IngredientEnqueueService(store, github);
+
+    await store.placeOrder(communityOrder('ord_kitchen_2'), {
+      subject: ORDER_LIFECYCLE_SUBJECTS.placed,
+      payload: { order_id: 'ord_kitchen_2', product: 'community-onboarding', inputs_digest: 'a'.repeat(64) },
+    });
+    await store.transition('ord_kitchen_2', 'placed', 'routing');
+    await store.transition('ord_kitchen_2', 'routing', 'producing');
+
+    await enqueue.enqueueMissing('ord_kitchen_2');
+    await enqueue.enqueueMissing('ord_kitchen_2');
+
+    expect(github.issues).toHaveLength(3);
+    expect((await store.get('ord_kitchen_2'))?.ingredient_jobs).toHaveLength(3);
+  });
+});

--- a/packages/services/ordering/src/community-onboarding-orchestrator.ts
+++ b/packages/services/ordering/src/community-onboarding-orchestrator.ts
@@ -19,6 +19,9 @@ import { type CapabilityResolver, type ResolvedEndpoint, CapabilityUnresolvedErr
 import type { PrivateOpsPublisher } from './private-ops.js';
 import type { ProcessResult } from './orchestrator.js';
 import type { TriagePorts } from './triage-ports.js';
+import type { IngredientEnqueueService } from './ingredient-enqueue.js';
+import { fireEnqueue } from './ingredient-enqueue.js';
+import type { OperatorAuditEntry } from './kitchen-types.js';
 
 export interface CommunityOnboardingOrchestratorDeps {
   store: OrderStore;
@@ -26,6 +29,7 @@ export interface CommunityOnboardingOrchestratorDeps {
   triage: TriagePorts;
   now: () => number;
   opsChannel?: PrivateOpsPublisher;
+  enqueue?: IngredientEnqueueService;
 }
 
 type IngredientKey = keyof CommunityOnboardingIngredients;
@@ -123,6 +127,8 @@ export class CommunityOnboardingOrchestrator {
         });
         step++;
       }
+
+      fireEnqueue(orderId, this.deps.enqueue);
     }
 
     if (record.state === 'producing') {
@@ -177,7 +183,16 @@ export class CommunityOnboardingOrchestrator {
       fulfillment = this.buildFulfillment(parsedInputs.data, ingredients, worldSlug);
     }
 
-    const updated = await this.deps.store.patchRecord(orderId, { ingredients, fulfillment });
+    const auditEntry: OperatorAuditEntry = {
+      event: 'operator.advance',
+      ingredient,
+      status,
+      world_slug: worldSlug,
+      at_unix: Math.floor(this.deps.now() / 1000),
+    };
+    const operator_audit = [...(record.operator_audit ?? []), auditEntry];
+
+    const updated = await this.deps.store.patchRecord(orderId, { ingredients, fulfillment, operator_audit });
 
     if (updated.state === 'placed') {
       await this.process(orderId, updated);

--- a/packages/services/ordering/src/composition.ts
+++ b/packages/services/ordering/src/composition.ts
@@ -1,0 +1,74 @@
+import type { Cta } from '@freeside/shadow-audit-protocol';
+import type { AuditServiceResult } from '@freeside/shadow-audit-service';
+
+import {
+  ConfigCapabilityResolver,
+  type CapabilityConfig,
+} from './resolver.js';
+import { OrderOrchestrator } from './orchestrator.js';
+import type { AuditPort } from './audit-acl.js';
+import type { OrderStore } from './store.js';
+import { createGitHubIssuePort } from './github-issue-port.js';
+import { IngredientEnqueueService } from './ingredient-enqueue.js';
+import { createKitchenTriagePorts } from './kitchen-triage-ports.js';
+import { createOrderStore } from './store-factory.js';
+
+class NoopAudit implements AuditPort {
+  async invoke(): Promise<AuditServiceResult> {
+    throw new Error('audit port unused for community-onboarding intake');
+  }
+}
+
+function triageCapabilityConfig(): CapabilityConfig {
+  return {
+    'collection-index': {
+      building: 'sonar-api',
+      endpoint: process.env.SONAR_API_URL?.trim() || 'http://sonar.internal',
+    },
+    'community-register': {
+      building: 'score-api',
+      endpoint: process.env.SCORE_API_URL?.trim() || 'http://score.internal',
+    },
+    'world-manifest': {
+      building: 'worlds-api',
+      endpoint: process.env.WORLDS_API_URL?.trim() || 'http://worlds.internal',
+    },
+  };
+}
+
+export function ctaFromEnv(): Cta {
+  const product = process.env.CTA_PRODUCT?.trim() || 'https://freeside.app';
+  const conversation = process.env.CTA_CONVERSATION?.trim() || 'https://freeside.app';
+  return { product, conversation };
+}
+
+export interface OrderingComposition {
+  store: OrderStore;
+  orchestrator: OrderOrchestrator;
+  enqueue: IngredientEnqueueService | undefined;
+}
+
+export async function createOrderingComposition(): Promise<OrderingComposition> {
+  const store = await createOrderStore();
+  const triage = createKitchenTriagePorts();
+  const github = createGitHubIssuePort();
+  const enqueue = github ? new IngredientEnqueueService(store, github) : undefined;
+
+  const orchestrator = new OrderOrchestrator({
+    store,
+    resolver: new ConfigCapabilityResolver(triageCapabilityConfig()),
+    audit: new NoopAudit(),
+    communities: () => undefined,
+    cta: ctaFromEnv(),
+    now: () => Date.now(),
+    triage,
+    enqueue,
+  });
+
+  return { store, orchestrator, enqueue };
+}
+
+export function serviceTokenFromEnv(): string | undefined {
+  const token = process.env.SERVICE_TOKEN?.trim() || process.env.ORDERING_SERVICE_TOKEN?.trim();
+  return token || undefined;
+}

--- a/packages/services/ordering/src/github-issue-port.ts
+++ b/packages/services/ordering/src/github-issue-port.ts
@@ -1,0 +1,149 @@
+import type { EnqueueIngredientKey } from './kitchen-types.js';
+
+export interface GitHubIssueResult {
+  url: string;
+  number: number;
+}
+
+export interface GitHubIssuePort {
+  ensureIssue(args: {
+    repo: string;
+    title: string;
+    body: string;
+    labels: string[];
+    idempotencyKey: string;
+  }): Promise<GitHubIssueResult>;
+}
+
+export class RecordingGitHubIssuePort implements GitHubIssuePort {
+  readonly issues: Array<{ repo: string; title: string; body: string; labels: string[]; idempotencyKey: string }> = [];
+  private seq = 1;
+  private readonly byKey = new Map<string, GitHubIssueResult>();
+
+  async ensureIssue(args: {
+    repo: string;
+    title: string;
+    body: string;
+    labels: string[];
+    idempotencyKey: string;
+  }): Promise<GitHubIssueResult> {
+    const existing = this.byKey.get(args.idempotencyKey);
+    if (existing) return existing;
+
+    this.issues.push(args);
+    const number = this.seq++;
+    const result = { url: `https://github.com/${args.repo}/issues/${number}`, number };
+    this.byKey.set(args.idempotencyKey, result);
+    return result;
+  }
+}
+
+export class FetchGitHubIssuePort implements GitHubIssuePort {
+  constructor(
+    private readonly token: string,
+    private readonly fetchImpl: typeof fetch = fetch,
+  ) {}
+
+  async ensureIssue(args: {
+    repo: string;
+    title: string;
+    body: string;
+    labels: string[];
+    idempotencyKey: string;
+  }): Promise<GitHubIssueResult> {
+    const [owner, repo] = args.repo.split('/');
+    if (!owner || !repo) throw new Error(`invalid repo: ${args.repo}`);
+
+    const searchTitle = encodeURIComponent(`[order] ${args.idempotencyKey}`);
+    const searchRes = await this.fetchImpl(
+      `https://api.github.com/search/issues?q=repo:${owner}/${repo}+in:title+${searchTitle}&per_page=1`,
+      { headers: this.headers() },
+    );
+    if (searchRes.ok) {
+      const searchJson = (await searchRes.json()) as { items?: { html_url: string; number: number }[] };
+      const hit = searchJson.items?.[0];
+      if (hit) return { url: hit.html_url, number: hit.number };
+    }
+
+    const createRes = await this.fetchImpl(`https://api.github.com/repos/${owner}/${repo}/issues`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify({
+        title: args.title,
+        body: args.body,
+        labels: args.labels,
+      }),
+    });
+    if (!createRes.ok) {
+      const text = await createRes.text();
+      throw new Error(`GitHub issue create failed: ${createRes.status} ${text}`);
+    }
+    const created = (await createRes.json()) as { html_url: string; number: number };
+    return { url: created.html_url, number: created.number };
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.token}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    };
+  }
+}
+
+export function createGitHubIssuePort(): GitHubIssuePort | null {
+  const token = process.env.GITHUB_TOKEN?.trim();
+  if (!token) return null;
+  return new FetchGitHubIssuePort(token);
+}
+
+export function repoForIngredient(ingredient: EnqueueIngredientKey): string | null {
+  switch (ingredient) {
+    case 'sonar':
+      return process.env.KITCHEN_ISSUE_REPO_SONAR?.trim() ?? '0xHoneyJar/sonar-api';
+    case 'score':
+      return process.env.KITCHEN_ISSUE_REPO_SCORE?.trim() ?? '0xHoneyJar/score-api';
+    case 'worlds_manifest':
+      return process.env.KITCHEN_ISSUE_REPO_WORLDS?.trim() ?? '0xHoneyJar/worlds-api';
+  }
+}
+
+export function buildIssueBody(args: {
+  ingredient: EnqueueIngredientKey;
+  orderId: string;
+  contactEmail: string;
+  chainId: string;
+  contractAddress: string;
+  communityName?: string;
+  placedAtIso: string;
+}): string {
+  const name = args.communityName ? ` (${args.communityName})` : '';
+  const base = [
+    `## Community onboarding — ${args.ingredient}`,
+    '',
+    `**Order:** \`${args.orderId}\``,
+    `**Placed:** ${args.placedAtIso}`,
+    `**Contact:** ${args.contactEmail}${name}`,
+    `**Chain:** ${args.chainId}`,
+    `**Contract:** \`${args.contractAddress}\``,
+    '',
+  ];
+
+  const advance = `\`\`\`bash
+curl -X POST "$ORDERING_SERVICE_URL/v1/orders/${args.orderId}/advance-ingredient" \\
+  -H "Authorization: Bearer $SERVICE_TOKEN" \\
+  -H 'Content-Type: application/json' \\
+  -d '{"ingredient":"${args.ingredient}","status":"complete"${args.ingredient === 'worlds_manifest' ? ',"world_slug":"YOUR_SLUG"' : ''}}'
+\`\`\``;
+
+  return [...base, '### Operator checklist', '', `- [ ] Complete ${args.ingredient} triage`, '- [ ] Run advance curl when done', '', advance].join('\n');
+}
+
+export function issueTitle(orderId: string, ingredient: EnqueueIngredientKey): string {
+  return `[community-onboarding] ${ingredient} · order ${orderId.slice(0, 8)}`;
+}
+
+export function issueLabels(orderId: string, ingredient: EnqueueIngredientKey): string[] {
+  return ['community-onboarding', `ingredient/${ingredient}`, `order/${orderId}`];
+}

--- a/packages/services/ordering/src/index.ts
+++ b/packages/services/ordering/src/index.ts
@@ -77,8 +77,37 @@ export {
   type CommunityOnboardingOpsNotice,
   buildCommunityOnboardingOpsNotice,
   fireCommunityOnboardingOpsWebhook,
+  fireCommunityOnboardingIssueLinks,
   opsWebhookUrl,
 } from './order-ops-webhook.js';
+
+export {
+  type EnqueueIngredientKey,
+  type IngredientJob,
+  type OperatorAuditEntry,
+  ingredientJobIdempotencyKey,
+} from './kitchen-types.js';
+
+export {
+  type GitHubIssuePort,
+  type GitHubIssueResult,
+  RecordingGitHubIssuePort,
+  FetchGitHubIssuePort,
+  createGitHubIssuePort,
+  repoForIngredient,
+} from './github-issue-port.js';
+
+export {
+  IngredientEnqueueService,
+  kitchenEnqueueEnabled,
+  fireEnqueue,
+} from './ingredient-enqueue.js';
+
+export { PostgresOrderStore } from './store-postgres.js';
+export { createOrderStore } from './store-factory.js';
+export { KitchenTriagePorts, createKitchenTriagePorts } from './kitchen-triage-ports.js';
+export { ReProbeWorker, reprobeIntervalMs } from './reprobe-worker.js';
+export { createOrderingComposition, serviceTokenFromEnv, ctaFromEnv } from './composition.js';
 
 export { createFrontendApp } from './frontend.js';
 

--- a/packages/services/ordering/src/ingredient-enqueue.ts
+++ b/packages/services/ordering/src/ingredient-enqueue.ts
@@ -1,0 +1,123 @@
+import { CommunityOnboardingInputs, INITIAL_COMMUNITY_ONBOARDING_INGREDIENTS } from '@freeside/ordering-protocol';
+
+import {
+  buildIssueBody,
+  issueLabels,
+  issueTitle,
+  repoForIngredient,
+  type GitHubIssuePort,
+} from './github-issue-port.js';
+import {
+  type EnqueueIngredientKey,
+  type IngredientJob,
+  ingredientJobIdempotencyKey,
+} from './kitchen-types.js';
+import { fireCommunityOnboardingIssueLinks } from './order-ops-webhook.js';
+import type { OrderStore } from './store.js';
+
+const ENQUEUE_INGREDIENTS: EnqueueIngredientKey[] = ['sonar', 'score', 'worlds_manifest'];
+
+export function kitchenEnqueueEnabled(): boolean {
+  const raw = process.env.KITCHEN_ENQUEUE_ENABLED?.trim();
+  if (raw === 'false') return false;
+  return true;
+}
+
+export class IngredientEnqueueService {
+  constructor(
+    private readonly store: OrderStore,
+    private readonly github: GitHubIssuePort | null,
+    private readonly now: () => number = () => Math.floor(Date.now() / 1000),
+  ) {}
+
+  async enqueueMissing(orderId: string): Promise<void> {
+    if (!kitchenEnqueueEnabled() || !this.github) return;
+
+    const record = await this.store.get(orderId);
+    if (!record || record.product !== 'community-onboarding') return;
+
+    const parsed = CommunityOnboardingInputs.safeParse(record.inputs);
+    if (!parsed.success) return;
+
+    const inputs = parsed.data;
+    const ingredients = record.ingredients ?? INITIAL_COMMUNITY_ONBOARDING_INGREDIENTS;
+    const existingJobs = record.ingredient_jobs ?? [];
+    const jobsByIngredient = new Map(existingJobs.map((j) => [j.ingredient, j]));
+
+    let jobs = [...existingJobs];
+    let dirty = false;
+    const newJobs: IngredientJob[] = [];
+    const nextIngredients = { ...ingredients };
+
+    for (const ingredient of ENQUEUE_INGREDIENTS) {
+      if (ingredients[ingredient] !== 'pending') continue;
+      if (jobsByIngredient.has(ingredient)) continue;
+
+      const repo = repoForIngredient(ingredient);
+      if (!repo) continue;
+
+      const idempotencyKey = ingredientJobIdempotencyKey(orderId, ingredient);
+      const placedAtIso = new Date(record.placed_at_unix * 1000).toISOString();
+
+      try {
+        const issue = await this.github.ensureIssue({
+          repo,
+          title: issueTitle(orderId, ingredient),
+          body: buildIssueBody({
+            ingredient,
+            orderId,
+            contactEmail: inputs.contact_email,
+            chainId: inputs.chain_id,
+            contractAddress: inputs.contract_address,
+            communityName: inputs.community_name,
+            placedAtIso,
+          }),
+          labels: issueLabels(orderId, ingredient),
+          idempotencyKey,
+        });
+
+        const job: IngredientJob = {
+          ingredient,
+          kind: 'github_issue',
+          external_ref: issue.url,
+          external_id: String(issue.number),
+          repo,
+          idempotency_key: idempotencyKey,
+          enqueued_at_unix: this.now(),
+        };
+        jobs = [...jobs, job];
+        newJobs.push(job);
+        jobsByIngredient.set(ingredient, job);
+        nextIngredients[ingredient] = 'in_progress';
+        dirty = true;
+      } catch (e) {
+        console.error(
+          '[ordering-service] ingredient enqueue failed:',
+          ingredient,
+          e instanceof Error ? e.message : e,
+        );
+      }
+    }
+
+    if (dirty) {
+      await this.store.patchRecord(orderId, {
+        ingredient_jobs: jobs,
+        ingredients: nextIngredients,
+      });
+      fireCommunityOnboardingIssueLinks({
+        order_id: orderId,
+        contact_email: inputs.contact_email,
+        contract_address: inputs.contract_address,
+        chain_id: inputs.chain_id,
+        jobs: newJobs,
+      });
+    }
+  }
+}
+
+export function fireEnqueue(orderId: string, service: IngredientEnqueueService | undefined): void {
+  if (!service) return;
+  void service.enqueueMissing(orderId).catch((e) => {
+    console.error('[ordering-service] enqueueMissing failed:', e instanceof Error ? e.message : e);
+  });
+}

--- a/packages/services/ordering/src/intake.ts
+++ b/packages/services/ordering/src/intake.ts
@@ -138,6 +138,8 @@ export function createIntakeApp(deps: IntakeDeps): Hono {
         refusal: record.refusal,
         ingredients: record.ingredients,
         fulfillment: record.fulfillment,
+        ingredient_jobs: record.ingredient_jobs,
+        operator_audit: record.operator_audit,
       },
       200,
     );
@@ -183,6 +185,8 @@ export function createIntakeApp(deps: IntakeDeps): Hono {
           state: record.state,
           ingredients: record.ingredients,
           fulfillment: record.fulfillment,
+          ingredient_jobs: record.ingredient_jobs,
+          operator_audit: record.operator_audit,
         },
         200,
       );

--- a/packages/services/ordering/src/kitchen-triage-ports.ts
+++ b/packages/services/ordering/src/kitchen-triage-ports.ts
@@ -1,0 +1,31 @@
+import { StubTriagePorts, type TriagePorts } from './triage-ports.js';
+
+/** Delegates to stub probes until KITCHEN_PROBE_HTTP_ENABLED wires building HTTP clients. */
+export class KitchenTriagePorts implements TriagePorts {
+  private readonly fallback = new StubTriagePorts();
+
+  sonar = {
+    probe: (chainId: string, contract: string) => this.fallback.sonar.probe(chainId, contract),
+  };
+  score = {
+    probe: (chainId: string, contract: string) => this.fallback.score.probe(chainId, contract),
+  };
+  worlds = {
+    probe: (chainId: string, contract: string) => this.fallback.worlds.probe(chainId, contract),
+  };
+  discord = {
+    probe: (chainId: string, contract: string) =>
+      this.fallback.discord?.probe(chainId, contract) ?? Promise.resolve('optional' as const),
+  };
+  shadow = {
+    probe: (chainId: string, contract: string) => this.fallback.shadow.probe(chainId, contract),
+  };
+}
+
+export function createKitchenTriagePorts(): TriagePorts {
+  if (process.env.KITCHEN_PROBE_HTTP_ENABLED === 'true') {
+    // K3: swap HttpBuildingProbes when upstream APIs ship.
+    return new KitchenTriagePorts();
+  }
+  return new KitchenTriagePorts();
+}

--- a/packages/services/ordering/src/kitchen-types.ts
+++ b/packages/services/ordering/src/kitchen-types.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+export const EnqueueIngredientKey = z.enum(['sonar', 'score', 'worlds_manifest']);
+export type EnqueueIngredientKey = z.infer<typeof EnqueueIngredientKey>;
+
+export const IngredientJob = z.object({
+  ingredient: EnqueueIngredientKey,
+  kind: z.literal('github_issue'),
+  external_ref: z.string().url(),
+  external_id: z.string(),
+  repo: z.string(),
+  idempotency_key: z.string(),
+  enqueued_at_unix: z.number().int(),
+});
+export type IngredientJob = z.infer<typeof IngredientJob>;
+
+export const OperatorAuditEntry = z.object({
+  event: z.literal('operator.advance'),
+  ingredient: z.string(),
+  status: z.string(),
+  world_slug: z.string().optional(),
+  at_unix: z.number().int(),
+});
+export type OperatorAuditEntry = z.infer<typeof OperatorAuditEntry>;
+
+export function ingredientJobIdempotencyKey(orderId: string, ingredient: EnqueueIngredientKey): string {
+  return `${orderId}:${ingredient}`;
+}

--- a/packages/services/ordering/src/orchestrator.ts
+++ b/packages/services/ordering/src/orchestrator.ts
@@ -8,6 +8,7 @@ import { AccessRiskAuditOrchestrator } from './access-risk-audit-orchestrator.js
 import { CommunityOnboardingOrchestrator } from './community-onboarding-orchestrator.js';
 import type { TriagePorts } from './triage-ports.js';
 import { StubTriagePorts } from './triage-ports.js';
+import type { IngredientEnqueueService } from './ingredient-enqueue.js';
 
 /**
  * The thin orchestrator (SDD §6) — dispatches by product to preset-specific handlers.
@@ -32,6 +33,8 @@ export interface OrchestratorDeps {
   now: () => number;
   /** Preset #2 ingredient probes — defaults to stub (operator advance MVP). */
   triage?: TriagePorts;
+  /** Kitchen V1 — GitHub issue fan-out per ingredient. */
+  enqueue?: IngredientEnqueueService;
   /** Optional private ops channel (SDD §13 M-8). */
   opsChannel?: PrivateOpsPublisher;
 }
@@ -56,6 +59,7 @@ export class OrderOrchestrator {
     this.communityOnboarding = new CommunityOnboardingOrchestrator({
       ...shared,
       triage: deps.triage ?? new StubTriagePorts(),
+      enqueue: deps.enqueue,
     });
   }
 

--- a/packages/services/ordering/src/order-ops-webhook.ts
+++ b/packages/services/ordering/src/order-ops-webhook.ts
@@ -1,8 +1,10 @@
 import { CommunityOnboardingInputs } from '@freeside/ordering-protocol';
 
+import type { IngredientJob } from './kitchen-types.js';
+
 /** Sanitized operator notice for a newly placed community-onboarding order. */
 export type CommunityOnboardingOpsNotice = {
-  event: 'community_onboarding.placed';
+  event: 'community_onboarding.placed' | 'community_onboarding.ingredients_enqueued';
   order_id: string;
   placed_by: string;
   contact_email: string;
@@ -12,6 +14,7 @@ export type CommunityOnboardingOpsNotice = {
   placed_at: string;
   /** One-line summary for Slack incoming webhooks (unknown fields are ignored). */
   text: string;
+  ingredient_jobs?: Pick<IngredientJob, 'ingredient' | 'external_ref'>[];
 };
 
 export function opsWebhookUrl(): string | null {
@@ -61,4 +64,30 @@ export function fireCommunityOnboardingOpsWebhook(
       err instanceof Error ? err.message : err,
     );
   });
+}
+
+export function fireCommunityOnboardingIssueLinks(args: {
+  order_id: string;
+  contact_email: string;
+  contract_address: string;
+  chain_id: string;
+  jobs: IngredientJob[];
+  webhookUrl?: string | null;
+}): void {
+  if (args.jobs.length === 0) return;
+  const links = args.jobs.map((j) => `${j.ingredient}: ${j.external_ref}`).join('\n');
+  fireCommunityOnboardingOpsWebhook(
+    {
+      event: 'community_onboarding.ingredients_enqueued',
+      order_id: args.order_id,
+      placed_by: 'ordering-service',
+      contact_email: args.contact_email,
+      contract_address: args.contract_address,
+      chain_id: args.chain_id,
+      placed_at: new Date().toISOString(),
+      text: `Triage issues filed for order ${args.order_id}:\n${links}`,
+      ingredient_jobs: args.jobs.map((j) => ({ ingredient: j.ingredient, external_ref: j.external_ref })),
+    },
+    args.webhookUrl,
+  );
 }

--- a/packages/services/ordering/src/reprobe-worker.ts
+++ b/packages/services/ordering/src/reprobe-worker.ts
@@ -1,0 +1,45 @@
+import type { OrderOrchestrator } from './orchestrator.js';
+import type { OrderStore } from './store.js';
+
+export function reprobeIntervalMs(): number {
+  const sec = Number(process.env.KITCHEN_REPROBE_INTERVAL_SEC ?? 900);
+  return Number.isFinite(sec) && sec > 0 ? sec * 1000 : 900_000;
+}
+
+export class ReProbeWorker {
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private readonly store: OrderStore,
+    private readonly orchestrator: OrderOrchestrator,
+    private readonly intervalMs: number = reprobeIntervalMs(),
+  ) {}
+
+  start(): void {
+    if (this.timer) return;
+    void this.tick();
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, this.intervalMs);
+  }
+
+  stop(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  async tick(): Promise<void> {
+    const orders = await this.store.listByState('producing');
+    for (const order of orders) {
+      try {
+        await this.orchestrator.process(order.order_id);
+      } catch (e) {
+        console.error(
+          '[ordering-service] reprobe tick failed:',
+          order.order_id,
+          e instanceof Error ? e.message : e,
+        );
+      }
+    }
+  }
+}

--- a/packages/services/ordering/src/store-factory.ts
+++ b/packages/services/ordering/src/store-factory.ts
@@ -1,0 +1,11 @@
+import type { OrderStore } from './store.js';
+import { InMemoryOrderStore } from './store.js';
+import { PostgresOrderStore } from './store-postgres.js';
+
+export async function createOrderStore(): Promise<OrderStore> {
+  const url = process.env.DATABASE_URL?.trim();
+  if (url) {
+    return PostgresOrderStore.connect(url, { migrate: process.env.RUN_MIGRATIONS === 'true' });
+  }
+  return new InMemoryOrderStore();
+}

--- a/packages/services/ordering/src/store-postgres.ts
+++ b/packages/services/ordering/src/store-postgres.ts
@@ -1,0 +1,265 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import pg from 'pg';
+
+import type { OrderState } from './order-state.js';
+import {
+  OrderNotFoundError,
+  type NewOrder,
+  type OrderPatch,
+  type OrderRecord,
+  type OrderStore,
+  type OutboxEntry,
+  type OutboxEvent,
+  type TransitionOpts,
+} from './store.js';
+import { assertTransition } from './order-state.js';
+import type { IngredientJob, OperatorAuditEntry } from './kitchen-types.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function rowToRecord(row: pg.QueryResultRow): OrderRecord {
+  return {
+    order_id: row.order_id,
+    product: row.product,
+    placed_by: row.placed_by,
+    inputs: row.inputs,
+    placed_at_unix: Number(row.placed_at_unix),
+    state: row.state as OrderState,
+    inputs_digest: row.inputs_digest,
+    recipe_id: row.recipe_id ?? undefined,
+    resolved_buildings: row.resolved_buildings ?? undefined,
+    result_ref: row.result_ref ?? undefined,
+    output: row.output ?? undefined,
+    output_digest: row.output_digest ?? undefined,
+    refusal: row.refusal ?? undefined,
+    ingredients: row.ingredients ?? undefined,
+    fulfillment: row.fulfillment ?? undefined,
+    ingredient_jobs: (row.ingredient_jobs ?? []) as IngredientJob[],
+    operator_audit: (row.operator_audit ?? []) as OperatorAuditEntry[],
+    created_at_unix: Number(row.created_at_unix),
+    updated_at_unix: Number(row.updated_at_unix),
+  };
+}
+
+export interface PostgresOrderStoreOptions {
+  pool: pg.Pool;
+  now?: () => number;
+}
+
+export class PostgresOrderStore implements OrderStore {
+  private readonly pool: pg.Pool;
+  private readonly now: () => number;
+
+  constructor(opts: PostgresOrderStoreOptions) {
+    this.pool = opts.pool;
+    this.now = opts.now ?? (() => Math.floor(Date.now() / 1000));
+  }
+
+  static async connect(connectionString: string, opts: { migrate?: boolean } = {}): Promise<PostgresOrderStore> {
+    const pool = new pg.Pool({ connectionString, max: 5 });
+    const store = new PostgresOrderStore({ pool });
+    if (opts.migrate ?? process.env.RUN_MIGRATIONS === 'true') {
+      await store.runMigrations();
+    }
+    return store;
+  }
+
+  async runMigrations(): Promise<void> {
+    const sql = readFileSync(join(__dirname, '../migrations/001_orders.sql'), 'utf8');
+    await this.pool.query(sql);
+  }
+
+  async close(): Promise<void> {
+    await this.pool.end();
+  }
+
+  async placeOrder(order: NewOrder, placedEvent: OutboxEvent): Promise<{ created: boolean; record: OrderRecord }> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      const existing = await client.query('SELECT * FROM orders WHERE order_id = $1', [order.order_id]);
+      if (existing.rows.length > 0) {
+        await client.query('COMMIT');
+        return { created: false, record: rowToRecord(existing.rows[0]) };
+      }
+
+      const ts = this.now();
+      const insert = await client.query(
+        `INSERT INTO orders (
+          order_id, product, placed_by, inputs, inputs_digest, state,
+          placed_at_unix, created_at_unix, updated_at_unix, ingredients,
+          ingredient_jobs, operator_audit
+        ) VALUES ($1,$2,$3,$4,$5,'placed',$6,$7,$7,$8,'[]'::jsonb,'[]'::jsonb)
+        RETURNING *`,
+        [
+          order.order_id,
+          order.product,
+          order.placed_by,
+          JSON.stringify(order.inputs),
+          order.inputs_digest,
+          order.placed_at_unix,
+          ts,
+          order.ingredients ? JSON.stringify(order.ingredients) : null,
+        ],
+      );
+      await client.query(
+        'INSERT INTO order_outbox (order_id, subject, payload) VALUES ($1,$2,$3)',
+        [order.order_id, placedEvent.subject, JSON.stringify(placedEvent.payload)],
+      );
+      await client.query('COMMIT');
+      return { created: true, record: rowToRecord(insert.rows[0]) };
+    } catch (e) {
+      await client.query('ROLLBACK');
+      throw e;
+    } finally {
+      client.release();
+    }
+  }
+
+  async get(orderId: string): Promise<OrderRecord | undefined> {
+    const res = await this.pool.query('SELECT * FROM orders WHERE order_id = $1', [orderId]);
+    if (res.rows.length === 0) return undefined;
+    return rowToRecord(res.rows[0]);
+  }
+
+  async transition(
+    orderId: string,
+    expectedFrom: OrderState,
+    to: OrderState,
+    opts: TransitionOpts = {},
+  ): Promise<{ ok: boolean; record?: OrderRecord }> {
+    assertTransition(expectedFrom, to);
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      const res = await client.query('SELECT * FROM orders WHERE order_id = $1 FOR UPDATE', [orderId]);
+      if (res.rows.length === 0) throw new OrderNotFoundError(orderId);
+      const current = rowToRecord(res.rows[0]);
+      if (current.state !== expectedFrom) {
+        await client.query('COMMIT');
+        return { ok: false, record: current };
+      }
+
+      const patch = opts.patch ?? {};
+      const ts = this.now();
+      const updated = await client.query(
+        `UPDATE orders SET
+          state = $2,
+          updated_at_unix = $3,
+          recipe_id = COALESCE($4, recipe_id),
+          resolved_buildings = COALESCE($5, resolved_buildings),
+          result_ref = COALESCE($6, result_ref),
+          output = COALESCE($7, output),
+          output_digest = COALESCE($8, output_digest),
+          refusal = COALESCE($9, refusal),
+          ingredients = COALESCE($10, ingredients),
+          fulfillment = COALESCE($11, fulfillment),
+          ingredient_jobs = COALESCE($12, ingredient_jobs),
+          operator_audit = COALESCE($13, operator_audit)
+        WHERE order_id = $1
+        RETURNING *`,
+        [
+          orderId,
+          to,
+          ts,
+          patch.recipe_id ?? null,
+          patch.resolved_buildings ? JSON.stringify(patch.resolved_buildings) : null,
+          patch.result_ref ?? null,
+          patch.output ? JSON.stringify(patch.output) : null,
+          patch.output_digest ?? null,
+          patch.refusal ? JSON.stringify(patch.refusal) : null,
+          patch.ingredients ? JSON.stringify(patch.ingredients) : null,
+          patch.fulfillment ? JSON.stringify(patch.fulfillment) : null,
+          patch.ingredient_jobs ? JSON.stringify(patch.ingredient_jobs) : null,
+          patch.operator_audit ? JSON.stringify(patch.operator_audit) : null,
+        ],
+      );
+
+      if (opts.event) {
+        await client.query('INSERT INTO order_outbox (order_id, subject, payload) VALUES ($1,$2,$3)', [
+          orderId,
+          opts.event.subject,
+          JSON.stringify(opts.event.payload),
+        ]);
+      }
+      await client.query('COMMIT');
+      return { ok: true, record: rowToRecord(updated.rows[0]) };
+    } catch (e) {
+      await client.query('ROLLBACK');
+      throw e;
+    } finally {
+      client.release();
+    }
+  }
+
+  async appendEvent(orderId: string, event: OutboxEvent): Promise<void> {
+    const exists = await this.pool.query('SELECT 1 FROM orders WHERE order_id = $1', [orderId]);
+    if (exists.rows.length === 0) throw new OrderNotFoundError(orderId);
+    await this.pool.query('INSERT INTO order_outbox (order_id, subject, payload) VALUES ($1,$2,$3)', [
+      orderId,
+      event.subject,
+      JSON.stringify(event.payload),
+    ]);
+  }
+
+  async patchRecord(orderId: string, patch: OrderPatch): Promise<OrderRecord> {
+    const current = await this.get(orderId);
+    if (!current) throw new OrderNotFoundError(orderId);
+    const ts = this.now();
+    const res = await this.pool.query(
+      `UPDATE orders SET
+        updated_at_unix = $2,
+        recipe_id = COALESCE($3, recipe_id),
+        resolved_buildings = COALESCE($4, resolved_buildings),
+        result_ref = COALESCE($5, result_ref),
+        output = COALESCE($6, output),
+        output_digest = COALESCE($7, output_digest),
+        refusal = COALESCE($8, refusal),
+        ingredients = COALESCE($9, ingredients),
+        fulfillment = COALESCE($10, fulfillment),
+        ingredient_jobs = COALESCE($11, ingredient_jobs),
+        operator_audit = COALESCE($12, operator_audit)
+      WHERE order_id = $1
+      RETURNING *`,
+      [
+        orderId,
+        ts,
+        patch.recipe_id ?? null,
+        patch.resolved_buildings ? JSON.stringify(patch.resolved_buildings) : null,
+        patch.result_ref ?? null,
+        patch.output ? JSON.stringify(patch.output) : null,
+        patch.output_digest ?? null,
+        patch.refusal ? JSON.stringify(patch.refusal) : null,
+        patch.ingredients ? JSON.stringify(patch.ingredients) : null,
+        patch.fulfillment ? JSON.stringify(patch.fulfillment) : null,
+        patch.ingredient_jobs ? JSON.stringify(patch.ingredient_jobs) : null,
+        patch.operator_audit ? JSON.stringify(patch.operator_audit) : null,
+      ],
+    );
+    return rowToRecord(res.rows[0]);
+  }
+
+  async pendingOutbox(): Promise<OutboxEntry[]> {
+    const res = await this.pool.query(
+      'SELECT seq, order_id, subject, payload, published FROM order_outbox WHERE published = FALSE ORDER BY seq',
+    );
+    return res.rows.map((row) => ({
+      seq: Number(row.seq),
+      order_id: row.order_id,
+      subject: row.subject,
+      payload: row.payload,
+      published: row.published,
+    }));
+  }
+
+  async markPublished(seq: number): Promise<void> {
+    await this.pool.query('UPDATE order_outbox SET published = TRUE WHERE seq = $1', [seq]);
+  }
+
+  async listByState(state: OrderState): Promise<OrderRecord[]> {
+    const res = await this.pool.query('SELECT * FROM orders WHERE state = $1', [state]);
+    return res.rows.map(rowToRecord);
+  }
+}

--- a/packages/services/ordering/src/store.ts
+++ b/packages/services/ordering/src/store.ts
@@ -6,6 +6,7 @@ import type {
   CommunityOnboardingOutput,
 } from '@freeside/ordering-protocol';
 import { assertTransition, type OrderState } from './order-state.js';
+import type { IngredientJob, OperatorAuditEntry } from './kitchen-types.js';
 
 /**
  * Durable order-state store + transactional outbox (SDD §13 H-3 / H-4).
@@ -66,6 +67,10 @@ export interface OrderRecord {
   ingredients?: CommunityOnboardingIngredients;
   /** Preset #2 terminal output — worlds-api canonical slug. */
   fulfillment?: CommunityOnboardingOutput;
+  /** Kitchen V1 — GitHub triage issues filed per ingredient. */
+  ingredient_jobs?: IngredientJob[];
+  /** Kitchen V2 — operator advance-ingredient audit trail. */
+  operator_audit?: OperatorAuditEntry[];
   created_at_unix: number;
   updated_at_unix: number;
 }
@@ -82,6 +87,8 @@ export type OrderPatch = Partial<
     | 'refusal'
     | 'ingredients'
     | 'fulfillment'
+    | 'ingredient_jobs'
+    | 'operator_audit'
   >
 >;
 
@@ -108,6 +115,8 @@ export interface OrderStore {
   patchRecord(orderId: string, patch: OrderPatch): Promise<OrderRecord>;
   pendingOutbox(): Promise<OutboxEntry[]>;
   markPublished(seq: number): Promise<void>;
+  /** Kitchen worker — orders in a given lifecycle state. */
+  listByState(state: OrderState): Promise<OrderRecord[]>;
 }
 
 export class OrderNotFoundError extends Error {
@@ -154,6 +163,8 @@ export class InMemoryOrderStore implements OrderStore {
       state: 'placed',
       inputs_digest: order.inputs_digest,
       ingredients: order.ingredients,
+      ingredient_jobs: [],
+      operator_audit: [],
       created_at_unix: ts,
       updated_at_unix: ts,
     };
@@ -209,5 +220,9 @@ export class InMemoryOrderStore implements OrderStore {
   async markPublished(seq: number): Promise<void> {
     const entry = this.outbox.find((e) => e.seq === seq);
     if (entry) entry.published = true;
+  }
+
+  async listByState(state: OrderState): Promise<OrderRecord[]> {
+    return [...this.orders.values()].filter((r) => r.state === state);
   }
 }

--- a/packages/services/ordering/src/triage-ports.ts
+++ b/packages/services/ordering/src/triage-ports.ts
@@ -24,9 +24,9 @@ export interface TriagePorts {
 
 /** MVP default: all probes return pending until operator advance. */
 export class StubTriagePorts implements TriagePorts {
-  sonar = { probe: async () => 'pending' as const };
-  score = { probe: async () => 'pending' as const };
-  worlds = { probe: async () => 'pending' as const };
-  discord = { probe: async () => 'optional' as const };
-  shadow = { probe: async () => 'blocked' as const };
+  sonar = { probe: async (_chainId: string, _contract: string) => 'pending' as const };
+  score = { probe: async (_chainId: string, _contract: string) => 'pending' as const };
+  worlds = { probe: async (_chainId: string, _contract: string) => 'pending' as const };
+  discord = { probe: async (_chainId: string, _contract: string) => 'optional' as const };
+  shadow = { probe: async (_chainId: string, _contract: string) => 'blocked' as const };
 }


### PR DESCRIPTION
## Summary

Implements kitchen fulfillment sprints K0–K2 for `community-onboarding` orders in ordering-service.

| Sprint | Deliverable |
|--------|-------------|
| K0 | `PostgresOrderStore` + migration; `DATABASE_URL` store factory |
| K1 | `GitHubIssuePort` + `IngredientEnqueueService` — 3 triage issues per order |
| K2 | `ReProbeWorker`, operator advance audit log, Discord issue-link webhook |

Dashboard unchanged. Operators still complete work via GitHub issues + `advance-ingredient` until upstream APIs land (K3).

## Test plan

- [x] `pnpm test` in `packages/services/ordering` (66 tests)
- [ ] Railway: add Postgres + `DATABASE_URL`, `RUN_MIGRATIONS=true`, redeploy http service
- [ ] Railway: set `GITHUB_TOKEN`, verify place order files 3 issues
- [ ] Optional: deploy `bin/worker.ts` or `ENABLE_REPROBE=true`
- [ ] Dashboard E2E: place order → issues in sonar-api/score-api/worlds-api → advance → `ready`

## Ops env (new)

```
DATABASE_URL=
RUN_MIGRATIONS=true
GITHUB_TOKEN=
KITCHEN_ISSUE_REPO_SONAR=0xHoneyJar/sonar-api
KITCHEN_ISSUE_REPO_SCORE=0xHoneyJar/score-api
KITCHEN_ISSUE_REPO_WORLDS=0xHoneyJar/worlds-api
KITCHEN_ENQUEUE_ENABLED=true
ENABLE_REPROBE=true
KITCHEN_REPROBE_INTERVAL_SEC=900
```

## Related

- freeside-dashboard SDD: `grimoires/loa/sdd.community-onboarding-kitchen.md`
- Upstream: sonar-api #107, score-api #378, worlds-api #11


Made with [Cursor](https://cursor.com)