### PR TITLE
feat(kitchen K0-K3): Postgres store, GitHub enqueue, HTTP building probes

### DIFF
--- a/packages/services/ordering/DEPLOY.md
+++ b/packages/services/ordering/DEPLOY.md
@@ -18,9 +18,9 @@ adapter consumes it when `ORDERING_SERVICE_URL` is set.
 |-----|----------|------|
 | `PORT` | Railway sets | bind port (default 8090 local) |
 | `SERVICE_TOKEN` or `ORDERING_SERVICE_TOKEN` | recommended | Bearer for `advance-ingredient`; dashboard sends same value as `ORDERING_SERVICE_TOKEN` on POST/GET |
-| `SONAR_API_URL` | optional | kitchen-api base URL when K3 HTTP probes enabled (e.g. `https://kitchen-api-production.up.railway.app` or belt-gateway with `/v1/collections` route) |
-| `SCORE_API_URL` | optional | capability resolver hint |
-| `WORLDS_API_URL` | optional | capability resolver hint |
+| `SONAR_API_URL` | optional | kitchen-api base URL when K3 HTTP probes enabled (e.g. `https://kitchen-api-production-1937.up.railway.app`) |
+| `SCORE_API_URL` | optional | score-api base URL for community lookup/register |
+| `WORLDS_API_URL` | optional | worlds-api base URL for manifest lookup/create |
 | `CTA_PRODUCT`, `CTA_CONVERSATION` | optional | CTA URLs in lifecycle metadata (defaults freeside.app) |
 | `ORDER_OPS_WEBHOOK_URL` | optional | Fire-and-forget POST when a `community-onboarding` order is placed. Second POST when triage issues are filed (`community_onboarding.ingredients_enqueued`). |
 | `DATABASE_URL` | recommended (kitchen K0) | Postgres store — orders survive restart |
@@ -30,6 +30,8 @@ adapter consumes it when `ORDERING_SERVICE_URL` is set.
 | `KITCHEN_ISSUE_REPO_SCORE` | optional | Default `0xHoneyJar/score-api` |
 | `KITCHEN_ISSUE_REPO_WORLDS` | optional | Default `0xHoneyJar/worlds-api` |
 | `KITCHEN_ENQUEUE_ENABLED` | optional | Default `true`; set `false` to disable issue fan-out |
+| `KITCHEN_PROBE_HTTP_ENABLED` | optional | Set `true` to probe sonar/score/worlds via HTTP instead of stub pending |
+| `KITCHEN_HTTP_ENQUEUE_ENABLED` | optional | Default enabled when `KITCHEN_PROBE_HTTP_ENABLED=true`; set `false` to probe-only (no HTTP register/manifest/ingest) |
 | `ENABLE_REPROBE` | optional | Set `true` on http service to run reprobe loop in-process |
 | `KITCHEN_REPROBE_INTERVAL_SEC` | optional | Default `900` (15 min) |
 

--- a/packages/services/ordering/DEPLOY.md
+++ b/packages/services/ordering/DEPLOY.md
@@ -18,7 +18,7 @@ adapter consumes it when `ORDERING_SERVICE_URL` is set.
 |-----|----------|------|
 | `PORT` | Railway sets | bind port (default 8090 local) |
 | `SERVICE_TOKEN` or `ORDERING_SERVICE_TOKEN` | recommended | Bearer for `advance-ingredient`; dashboard sends same value as `ORDERING_SERVICE_TOKEN` on POST/GET |
-| `SONAR_API_URL` | optional | capability resolver hint (stub triage ignores live calls in MVP) |
+| `SONAR_API_URL` | optional | kitchen-api base URL when K3 HTTP probes enabled (e.g. `https://kitchen-api-production.up.railway.app` or belt-gateway with `/v1/collections` route) |
 | `SCORE_API_URL` | optional | capability resolver hint |
 | `WORLDS_API_URL` | optional | capability resolver hint |
 | `CTA_PRODUCT`, `CTA_CONVERSATION` | optional | CTA URLs in lifecycle metadata (defaults freeside.app) |

--- a/packages/services/ordering/src/__tests__/community-onboarding-orchestrator.test.ts
+++ b/packages/services/ordering/src/__tests__/community-onboarding-orchestrator.test.ts
@@ -4,7 +4,7 @@ import { OrderOrchestrator } from '../orchestrator.js';
 import { InMemoryOrderStore, type NewOrder } from '../store.js';
 import { ConfigCapabilityResolver, type CapabilityConfig } from '../resolver.js';
 import { StubTriagePorts } from '../triage-ports.js';
-import { canFulfillCommunityOnboarding } from '../community-onboarding-orchestrator.js';
+import { canFulfillCommunityOnboarding, mergeProbedIngredients } from '../community-onboarding-orchestrator.js';
 import type { AuditPort } from '../audit-acl.js';
 import type { AuditServiceResult } from '@freeside/shadow-audit-service';
 import type { Cta } from '@freeside/shadow-audit-protocol';
@@ -132,5 +132,13 @@ describe('canFulfillCommunityOnboarding', () => {
       }),
     ).toBe(true);
     expect(canFulfillCommunityOnboarding(ingredients, undefined)).toBe(false);
+  });
+});
+
+describe('mergeProbedIngredients', () => {
+  it('does not downgrade in_progress to pending on reprobe', () => {
+    const existing = { ...INITIAL_COMMUNITY_ONBOARDING_INGREDIENTS, score: 'in_progress' as const };
+    const merged = mergeProbedIngredients(existing, { ...INITIAL_COMMUNITY_ONBOARDING_INGREDIENTS, score: 'pending' });
+    expect(merged.score).toBe('in_progress');
   });
 });

--- a/packages/services/ordering/src/__tests__/community-onboarding-reprobe.test.ts
+++ b/packages/services/ordering/src/__tests__/community-onboarding-reprobe.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ORDER_LIFECYCLE_SUBJECTS,
+  INITIAL_COMMUNITY_ONBOARDING_INGREDIENTS,
+} from '@freeside/ordering-protocol';
+
+import { OrderOrchestrator } from '../orchestrator.js';
+import { InMemoryOrderStore, type NewOrder } from '../store.js';
+import { ConfigCapabilityResolver, type CapabilityConfig } from '../resolver.js';
+import type { TriagePorts } from '../triage-ports.js';
+import type { AuditPort } from '../audit-acl.js';
+import type { AuditServiceResult } from '@freeside/shadow-audit-service';
+import type { Cta } from '@freeside/shadow-audit-protocol';
+
+const CONTRACT = '0x' + '3'.repeat(40);
+const CTA: Cta = { product: 'https://example.test/audit', conversation: 'https://example.test/talk' };
+
+const TRIAGE_CAPS: CapabilityConfig = {
+  'collection-index': { building: 'sonar-api', endpoint: 'http://sonar.internal' },
+  'community-register': { building: 'score-api', endpoint: 'http://score.internal' },
+  'world-manifest': { building: 'worlds-api', endpoint: 'http://worlds.internal' },
+};
+
+class NoopAudit implements AuditPort {
+  async invoke(): Promise<AuditServiceResult> {
+    throw new Error('audit should not run for community-onboarding');
+  }
+}
+
+function communityOrder(orderId = 'ord_co_reprobe'): NewOrder {
+  return {
+    order_id: orderId,
+    product: 'community-onboarding',
+    placed_by: 'dashboard_onboarding',
+    inputs: {
+      chain_id: '8453',
+      contract_address: CONTRACT,
+      contact_email: 'cm@example.com',
+      community_name: 'Pythenians',
+      source: 'dashboard_onboarding',
+    },
+    placed_at_unix: 1_700_000_000,
+    inputs_digest: 'b'.repeat(64),
+    ingredients: { ...INITIAL_COMMUNITY_ONBOARDING_INGREDIENTS },
+  };
+}
+
+type DynamicTriage = TriagePorts & {
+  _advance: (next: { sonar?: 'pending' | 'in_progress' | 'complete'; worldSlug?: string }) => void;
+};
+
+function makeDynamicTriage(): DynamicTriage {
+  let sonarStatus: 'pending' | 'in_progress' | 'complete' = 'pending';
+  let worldsSlug: string | undefined;
+
+  const triage: DynamicTriage = {
+    sonar: {
+      probe: vi.fn(async () => sonarStatus),
+    },
+    score: {
+      probe: vi.fn(async () => 'complete' as const),
+    },
+    worlds: {
+      probe: vi.fn(async () => (worldsSlug ? ('complete' as const) : ('pending' as const))),
+      probeDetail: vi.fn(async () => ({
+        status: worldsSlug ? ('complete' as const) : ('pending' as const),
+        world_slug: worldsSlug,
+      })),
+    },
+    discord: {
+      probe: vi.fn(async () => 'optional' as const),
+    },
+    shadow: {
+      probe: vi.fn(async () => 'blocked' as const),
+    },
+    _advance: (next) => {
+      if (next.sonar) sonarStatus = next.sonar;
+      if (next.worldSlug !== undefined) worldsSlug = next.worldSlug;
+    },
+  };
+
+  return triage;
+}
+
+describe('CommunityOnboardingOrchestrator producing re-probe', () => {
+  it('re-probes ingredients in producing and patches world_slug from worlds lookup', async () => {
+    const store = new InMemoryOrderStore({ now: () => 1_700_000_000 });
+    const triage = makeDynamicTriage();
+    const orchestrator = new OrderOrchestrator({
+      store,
+      resolver: new ConfigCapabilityResolver(TRIAGE_CAPS),
+      audit: new NoopAudit(),
+      communities: () => undefined,
+      cta: CTA,
+      now: () => 1_700_000_000_000,
+      triage,
+    });
+
+    await store.placeOrder(communityOrder(), {
+      subject: ORDER_LIFECYCLE_SUBJECTS.placed,
+      payload: { order_id: 'ord_co_reprobe', product: 'community-onboarding', inputs_digest: 'b'.repeat(64) },
+    });
+    await orchestrator.process('ord_co_reprobe');
+
+    let record = await store.get('ord_co_reprobe');
+    expect(record?.state).toBe('producing');
+    expect(record?.ingredients?.sonar).toBe('pending');
+
+    triage._advance({ sonar: 'complete', worldSlug: 'pythenians' });
+    (triage.shadow.probe as ReturnType<typeof vi.fn>).mockResolvedValue('complete');
+
+    await orchestrator.process('ord_co_reprobe');
+    record = await store.get('ord_co_reprobe');
+    expect(record?.ingredients?.sonar).toBe('complete');
+    expect(record?.fulfillment?.world_slug).toBe('pythenians');
+    expect(record?.state).toBe('fulfilled');
+  });
+});

--- a/packages/services/ordering/src/__tests__/http-building-probes.test.ts
+++ b/packages/services/ordering/src/__tests__/http-building-probes.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { IngredientStatus } from '@freeside/ordering-protocol';
+
+import { HttpBuildingProbes } from '../http-building-probes.js';
+
+const CHAIN = '1';
+const CONTRACT = '0xED5AF388653567Af2F388e6224DcC93746104133';
+const CONTRACT_LOWER = CONTRACT.toLowerCase();
+const TOKEN = 'test-service-token';
+
+function mockFetch(handlers: Record<string, (req: Request) => Response | Promise<Response>>) {
+  return vi.fn(async (input: string | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.href;
+    const method = init?.method ?? 'GET';
+    const key = `${method} ${url}`;
+    const handler = handlers[key];
+    if (!handler) {
+      throw new Error(`unexpected fetch: ${key}`);
+    }
+    return handler(new Request(url, init));
+  }) as typeof fetch;
+}
+
+function probes(fetchImpl: typeof fetch): HttpBuildingProbes {
+  return new HttpBuildingProbes({
+    sonarApiUrl: 'https://sonar.test',
+    scoreApiUrl: 'https://score.test',
+    worldsApiUrl: 'https://worlds.test',
+    serviceToken: TOKEN,
+    fetchImpl,
+  });
+}
+
+describe('HttpBuildingProbes', () => {
+  it('maps sonar status responses to ingredient statuses', async () => {
+    const fetchImpl = mockFetch({
+      [`GET https://sonar.test/v1/collections/${CHAIN}/${CONTRACT_LOWER}/status`]: () =>
+        new Response(JSON.stringify({ status: 'indexed', holder_count: 100 }), { status: 200 }),
+    });
+    const p = probes(fetchImpl);
+    await expect(p.probeSonar(CHAIN, CONTRACT)).resolves.toBe('complete' satisfies IngredientStatus);
+  });
+
+  it('maps sonar indexing to in_progress', async () => {
+    const fetchImpl = mockFetch({
+      [`GET https://sonar.test/v1/collections/${CHAIN}/${CONTRACT_LOWER}/status`]: () =>
+        new Response(JSON.stringify({ status: 'indexing' }), { status: 200 }),
+    });
+    await expect(probes(fetchImpl).probeSonar(CHAIN, CONTRACT)).resolves.toBe('in_progress');
+  });
+
+  it('maps sonar 404 to pending', async () => {
+    const fetchImpl = mockFetch({
+      [`GET https://sonar.test/v1/collections/${CHAIN}/${CONTRACT_LOWER}/status`]: () =>
+        new Response(JSON.stringify({ error: 'collection not found' }), { status: 404 }),
+    });
+    await expect(probes(fetchImpl).probeSonar(CHAIN, CONTRACT)).resolves.toBe('pending');
+  });
+
+  it('maps sonar failed to blocked', async () => {
+    const fetchImpl = mockFetch({
+      [`GET https://sonar.test/v1/collections/${CHAIN}/${CONTRACT_LOWER}/status`]: () =>
+        new Response(JSON.stringify({ status: 'failed' }), { status: 200 }),
+    });
+    await expect(probes(fetchImpl).probeSonar(CHAIN, CONTRACT)).resolves.toBe('blocked');
+  });
+
+  it('maps score lookup 200 to complete and 404 to pending', async () => {
+    const lookupUrl = `https://score.test/v1/communities/lookup?chain_id=${CHAIN}&contract_address=${CONTRACT_LOWER}`;
+    const fetchImpl = mockFetch({
+      [`GET ${lookupUrl}`]: () =>
+        new Response(JSON.stringify({ registered: true, world_slug: 'azuki' }), { status: 200 }),
+    });
+    await expect(probes(fetchImpl).probeScore(CHAIN, CONTRACT)).resolves.toBe('complete');
+
+    const fetch404 = mockFetch({
+      [`GET ${lookupUrl}`]: () => new Response('', { status: 404 }),
+    });
+    await expect(probes(fetch404).probeScore(CHAIN, CONTRACT)).resolves.toBe('pending');
+  });
+
+  it('maps worlds lookup with world_slug', async () => {
+    const lookupUrl = `https://worlds.test/v1/worlds/lookup?chain_id=${CHAIN}&contract_address=${CONTRACT_LOWER}`;
+    const fetchImpl = mockFetch({
+      [`GET ${lookupUrl}`]: () =>
+        new Response(JSON.stringify({ world_slug: 'azuki', display_name: 'Azuki' }), { status: 200 }),
+    });
+    await expect(probes(fetchImpl).probeWorlds(CHAIN, CONTRACT)).resolves.toEqual({
+      status: 'complete',
+      world_slug: 'azuki',
+    });
+  });
+
+  it('POST enqueue sonar ingest on 202', async () => {
+    const ingestUrl = `https://sonar.test/v1/collections/${CHAIN}/${CONTRACT_LOWER}/ingest`;
+    const fetchImpl = mockFetch({
+      [`POST ${ingestUrl}`]: async (req) => {
+        expect(req.headers.get('Authorization')).toBe(`Bearer ${TOKEN}`);
+        const body = await req.json();
+        expect(body).toMatchObject({ order_id: 'ord_1', source: 'ordering-service' });
+        return new Response(JSON.stringify({ status: 'queued' }), { status: 202 });
+      },
+    });
+    const ok = await probes(fetchImpl).enqueueSonar({
+      orderId: 'ord_1',
+      chainId: CHAIN,
+      contractAddress: CONTRACT,
+      displayName: 'Azuki',
+      contactEmail: 'test@example.com',
+      source: 'ordering-service',
+    });
+    expect(ok).toBe(true);
+  });
+});

--- a/packages/services/ordering/src/community-onboarding-orchestrator.ts
+++ b/packages/services/ordering/src/community-onboarding-orchestrator.ts
@@ -148,10 +148,14 @@ export class CommunityOnboardingOrchestrator {
         }
 
         const ingredientsChanged = JSON.stringify(merged) !== JSON.stringify(record.ingredients);
-        const fulfillmentChanged = fulfillment !== record.fulfillment;
+        const fulfillmentChanged =
+          fulfillment?.world_slug !== record.fulfillment?.world_slug ||
+          fulfillment?.contact_email !== record.fulfillment?.contact_email;
         if (ingredientsChanged || fulfillmentChanged) {
           record = await this.deps.store.patchRecord(orderId, { ingredients: merged, fulfillment });
         }
+
+        fireEnqueue(orderId, this.deps.enqueue);
       }
 
       const ingredients = record.ingredients ?? INITIAL_COMMUNITY_ONBOARDING_INGREDIENTS;

--- a/packages/services/ordering/src/community-onboarding-orchestrator.ts
+++ b/packages/services/ordering/src/community-onboarding-orchestrator.ts
@@ -96,7 +96,11 @@ export class CommunityOnboardingOrchestrator {
       }
 
       const probed = await this.probeIngredients(inputs.chain_id, inputs.contract_address);
-      const ingredients = mergeProbedIngredients(record.ingredients, probed);
+      const ingredients = mergeProbedIngredients(record.ingredients, probed.ingredients);
+      let fulfillment = record.fulfillment;
+      if (probed.world_slug) {
+        fulfillment = this.buildFulfillment(inputs, ingredients, probed.world_slug);
+      }
 
       const resolved_buildings: ResolvedBuilding[] = resolved.map((r) => ({
         capability: r.capability,
@@ -106,7 +110,7 @@ export class CommunityOnboardingOrchestrator {
       }));
       const routing: OrderRouting = { order_id: orderId, recipe_id: preset.id, resolved_buildings };
       const claim = await this.deps.store.transition(orderId, 'placed', 'routing', {
-        patch: { recipe_id: preset.id, resolved_buildings, ingredients },
+        patch: { recipe_id: preset.id, resolved_buildings, ingredients, ...(fulfillment ? { fulfillment } : {}) },
         event: { subject: ORDER_LIFECYCLE_SUBJECTS.routing, payload: routing },
       });
       record = await this.reread(orderId, claim.ok ? claim.record : undefined);
@@ -132,6 +136,24 @@ export class CommunityOnboardingOrchestrator {
     }
 
     if (record.state === 'producing') {
+      const parsedInputs = CommunityOnboardingInputs.safeParse(record.inputs);
+      if (parsedInputs.success) {
+        const inputs = parsedInputs.data;
+        const probed = await this.probeIngredients(inputs.chain_id, inputs.contract_address);
+        const merged = mergeProbedIngredients(record.ingredients, probed.ingredients);
+
+        let fulfillment = record.fulfillment;
+        if (probed.world_slug) {
+          fulfillment = this.buildFulfillment(inputs, merged, probed.world_slug);
+        }
+
+        const ingredientsChanged = JSON.stringify(merged) !== JSON.stringify(record.ingredients);
+        const fulfillmentChanged = fulfillment !== record.fulfillment;
+        if (ingredientsChanged || fulfillmentChanged) {
+          record = await this.deps.store.patchRecord(orderId, { ingredients: merged, fulfillment });
+        }
+      }
+
       const ingredients = record.ingredients ?? INITIAL_COMMUNITY_ONBOARDING_INGREDIENTS;
       if (canFulfillCommunityOnboarding(ingredients, record.fulfillment) && record.fulfillment) {
         const fulfilled: OrderFulfilled = {
@@ -221,15 +243,31 @@ export class CommunityOnboardingOrchestrator {
     };
   }
 
-  private async probeIngredients(chainId: string, contract: string): Promise<CommunityOnboardingIngredients> {
-    const [sonar, score, worlds_manifest, discord_observer, shadow_preview] = await Promise.all([
+  private async probeIngredients(
+    chainId: string,
+    contract: string,
+  ): Promise<{ ingredients: CommunityOnboardingIngredients; world_slug?: string }> {
+    const worldsDetail = this.deps.triage.worlds.probeDetail
+      ? await this.deps.triage.worlds.probeDetail(chainId, contract)
+      : { status: await this.deps.triage.worlds.probe(chainId, contract) };
+
+    const [sonar, score, discord_observer, shadow_preview] = await Promise.all([
       this.deps.triage.sonar.probe(chainId, contract),
       this.deps.triage.score.probe(chainId, contract),
-      this.deps.triage.worlds.probe(chainId, contract),
       this.deps.triage.discord?.probe(chainId, contract) ?? Promise.resolve('optional' as const),
       this.deps.triage.shadow.probe(chainId, contract),
     ]);
-    return { sonar, score, worlds_manifest, discord_observer, shadow_preview };
+
+    return {
+      ingredients: {
+        sonar,
+        score,
+        worlds_manifest: worldsDetail.status,
+        discord_observer,
+        shadow_preview,
+      },
+      world_slug: worldsDetail.world_slug,
+    };
   }
 
   private async settleFailed(

--- a/packages/services/ordering/src/community-onboarding-orchestrator.ts
+++ b/packages/services/ordering/src/community-onboarding-orchestrator.ts
@@ -58,6 +58,7 @@ export function mergeProbedIngredients(
     const prev = base[key];
     if (prev === 'complete' || prev === 'optional') continue;
     if (prev === 'blocked' && next === 'pending') continue;
+    if (prev === 'in_progress' && next === 'pending') continue;
     merged[key] = next;
   }
   return merged;

--- a/packages/services/ordering/src/composition.ts
+++ b/packages/services/ordering/src/composition.ts
@@ -10,7 +10,7 @@ import type { AuditPort } from './audit-acl.js';
 import type { OrderStore } from './store.js';
 import { createGitHubIssuePort } from './github-issue-port.js';
 import { IngredientEnqueueService } from './ingredient-enqueue.js';
-import { createKitchenTriagePorts } from './kitchen-triage-ports.js';
+import { createKitchenTriagePorts, KitchenTriagePorts } from './kitchen-triage-ports.js';
 import { createOrderStore } from './store-factory.js';
 
 class NoopAudit implements AuditPort {
@@ -51,8 +51,9 @@ export interface OrderingComposition {
 export async function createOrderingComposition(): Promise<OrderingComposition> {
   const store = await createOrderStore();
   const triage = createKitchenTriagePorts();
+  const httpProbes = triage instanceof KitchenTriagePorts ? triage.httpProbes : null;
   const github = createGitHubIssuePort();
-  const enqueue = github ? new IngredientEnqueueService(store, github) : undefined;
+  const enqueue = github || httpProbes ? new IngredientEnqueueService(store, github, httpProbes) : undefined;
 
   const orchestrator = new OrderOrchestrator({
     store,

--- a/packages/services/ordering/src/contract-address.ts
+++ b/packages/services/ordering/src/contract-address.ts
@@ -1,0 +1,16 @@
+const EVM_ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
+
+/** Lowercase EVM address — matches score-api / sonar-api kitchen normalization. */
+export function normalizeContractAddress(address: string): string | null {
+  const trimmed = address.trim();
+  if (!EVM_ADDRESS_RE.test(trimmed)) return null;
+  return trimmed.toLowerCase();
+}
+
+export function normalizeChainId(chainId: string): string | null {
+  const trimmed = chainId.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const n = Number(trimmed);
+  if (!Number.isSafeInteger(n) || n <= 0) return null;
+  return trimmed;
+}

--- a/packages/services/ordering/src/http-building-probes.ts
+++ b/packages/services/ordering/src/http-building-probes.ts
@@ -1,11 +1,9 @@
 import type { IngredientStatus } from '@freeside/ordering-protocol';
 
 import { normalizeChainId, normalizeContractAddress } from './contract-address.js';
+import type { WorldsProbeDetail } from './triage-ports.js';
 
-export interface WorldsProbeDetail {
-  status: IngredientStatus;
-  world_slug?: string;
-}
+export type { WorldsProbeDetail };
 
 export interface HttpBuildingProbesConfig {
   sonarApiUrl: string;
@@ -24,7 +22,7 @@ export interface HttpEnqueuePayload {
   source: string;
 }
 
-function authHeaders(token: string): HeadersInit {
+function authHeaders(token: string): Record<string, string> {
   return { Authorization: `Bearer ${token}` };
 }
 

--- a/packages/services/ordering/src/http-building-probes.ts
+++ b/packages/services/ordering/src/http-building-probes.ts
@@ -1,0 +1,224 @@
+import type { IngredientStatus } from '@freeside/ordering-protocol';
+
+import { normalizeChainId, normalizeContractAddress } from './contract-address.js';
+
+export interface WorldsProbeDetail {
+  status: IngredientStatus;
+  world_slug?: string;
+}
+
+export interface HttpBuildingProbesConfig {
+  sonarApiUrl: string;
+  scoreApiUrl: string;
+  worldsApiUrl: string;
+  serviceToken: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface HttpEnqueuePayload {
+  orderId: string;
+  chainId: string;
+  contractAddress: string;
+  displayName: string;
+  contactEmail: string;
+  source: string;
+}
+
+function authHeaders(token: string): HeadersInit {
+  return { Authorization: `Bearer ${token}` };
+}
+
+function mapSonarStatus(statusCode: number, body: unknown): IngredientStatus {
+  if (statusCode === 404) return 'pending';
+  if (statusCode < 200 || statusCode >= 300) return 'blocked';
+
+  const status = typeof body === 'object' && body !== null ? (body as { status?: string }).status : undefined;
+  switch (status) {
+    case 'indexed':
+      return 'complete';
+    case 'indexing':
+    case 'queued':
+      return 'in_progress';
+    case 'failed':
+      return 'blocked';
+    default:
+      return 'pending';
+  }
+}
+
+function mapLookupStatus(statusCode: number): IngredientStatus {
+  if (statusCode === 200) return 'complete';
+  if (statusCode === 404) return 'pending';
+  return 'blocked';
+}
+
+function trimBase(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+export class HttpBuildingProbes {
+  private readonly fetchFn: typeof fetch;
+
+  constructor(private readonly config: HttpBuildingProbesConfig) {
+    this.fetchFn = config.fetchImpl ?? fetch;
+  }
+
+  async probeSonar(chainId: string, contract: string): Promise<IngredientStatus> {
+    const normalized = this.normalizePair(chainId, contract);
+    if (!normalized) return 'blocked';
+
+    const url = `${trimBase(this.config.sonarApiUrl)}/v1/collections/${normalized.chainId}/${normalized.contract}/status`;
+    try {
+      const res = await this.fetchFn(url, { headers: authHeaders(this.config.serviceToken) });
+      const body = await this.readJson(res);
+      return mapSonarStatus(res.status, body);
+    } catch {
+      return 'blocked';
+    }
+  }
+
+  async probeScore(chainId: string, contract: string): Promise<IngredientStatus> {
+    const normalized = this.normalizePair(chainId, contract);
+    if (!normalized) return 'blocked';
+
+    const params = new URLSearchParams({
+      chain_id: normalized.chainId,
+      contract_address: normalized.contract,
+    });
+    const url = `${trimBase(this.config.scoreApiUrl)}/v1/communities/lookup?${params}`;
+    try {
+      const res = await this.fetchFn(url, { headers: authHeaders(this.config.serviceToken) });
+      return mapLookupStatus(res.status);
+    } catch {
+      return 'blocked';
+    }
+  }
+
+  async probeWorlds(chainId: string, contract: string): Promise<WorldsProbeDetail> {
+    const normalized = this.normalizePair(chainId, contract);
+    if (!normalized) return { status: 'blocked' };
+
+    const params = new URLSearchParams({
+      chain_id: normalized.chainId,
+      contract_address: normalized.contract,
+    });
+    const url = `${trimBase(this.config.worldsApiUrl)}/v1/worlds/lookup?${params}`;
+    try {
+      const res = await this.fetchFn(url, { headers: authHeaders(this.config.serviceToken) });
+      const status = mapLookupStatus(res.status);
+      if (status !== 'complete') return { status };
+
+      const body = await this.readJson(res);
+      const world_slug =
+        typeof body === 'object' && body !== null && typeof (body as { world_slug?: string }).world_slug === 'string'
+          ? (body as { world_slug: string }).world_slug
+          : undefined;
+      return { status, world_slug };
+    } catch {
+      return { status: 'blocked' };
+    }
+  }
+
+  async enqueueSonar(payload: HttpEnqueuePayload): Promise<boolean> {
+    const normalized = this.normalizePair(payload.chainId, payload.contractAddress);
+    if (!normalized) return false;
+
+    const url = `${trimBase(this.config.sonarApiUrl)}/v1/collections/${normalized.chainId}/${normalized.contract}/ingest`;
+    try {
+      const res = await this.fetchFn(url, {
+        method: 'POST',
+        headers: { ...authHeaders(this.config.serviceToken), 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          order_id: payload.orderId,
+          source: payload.source,
+          contact_email: payload.contactEmail,
+          community_name: payload.displayName,
+        }),
+      });
+      return res.status === 200 || res.status === 202;
+    } catch {
+      return false;
+    }
+  }
+
+  async enqueueScore(payload: HttpEnqueuePayload): Promise<boolean> {
+    const normalized = this.normalizePair(payload.chainId, payload.contractAddress);
+    if (!normalized) return false;
+
+    const url = `${trimBase(this.config.scoreApiUrl)}/v1/communities/register`;
+    try {
+      const res = await this.fetchFn(url, {
+        method: 'POST',
+        headers: { ...authHeaders(this.config.serviceToken), 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          chain_id: normalized.chainId,
+          contract_address: normalized.contract,
+          display_name: payload.displayName,
+          contact_email: payload.contactEmail,
+          order_id: payload.orderId,
+          source: payload.source,
+        }),
+      });
+      return res.status === 200 || res.status === 201;
+    } catch {
+      return false;
+    }
+  }
+
+  async enqueueWorlds(payload: HttpEnqueuePayload): Promise<boolean> {
+    const normalized = this.normalizePair(payload.chainId, payload.contractAddress);
+    if (!normalized) return false;
+
+    const url = `${trimBase(this.config.worldsApiUrl)}/v1/worlds/manifest`;
+    try {
+      const res = await this.fetchFn(url, {
+        method: 'POST',
+        headers: { ...authHeaders(this.config.serviceToken), 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          chain_id: normalized.chainId,
+          contract_address: normalized.contract,
+          display_name: payload.displayName,
+          contact_email: payload.contactEmail,
+          order_id: payload.orderId,
+          source: payload.source,
+        }),
+      });
+      return res.status === 200 || res.status === 201;
+    } catch {
+      return false;
+    }
+  }
+
+  private normalizePair(chainId: string, contract: string): { chainId: string; contract: string } | null {
+    const normalizedChain = normalizeChainId(chainId);
+    const normalizedContract = normalizeContractAddress(contract);
+    if (!normalizedChain || !normalizedContract) return null;
+    return { chainId: normalizedChain, contract: normalizedContract };
+  }
+
+  private async readJson(res: Response): Promise<unknown> {
+    try {
+      return await res.json();
+    } catch {
+      return null;
+    }
+  }
+}
+
+export function httpBuildingProbesFromEnv(fetchImpl?: typeof fetch): HttpBuildingProbes | null {
+  if (process.env.KITCHEN_PROBE_HTTP_ENABLED !== 'true') return null;
+
+  const serviceToken = process.env.SERVICE_TOKEN?.trim() || process.env.ORDERING_SERVICE_TOKEN?.trim();
+  const sonarApiUrl = process.env.SONAR_API_URL?.trim();
+  const scoreApiUrl = process.env.SCORE_API_URL?.trim();
+  const worldsApiUrl = process.env.WORLDS_API_URL?.trim();
+  if (!serviceToken || !sonarApiUrl || !scoreApiUrl || !worldsApiUrl) return null;
+
+  return new HttpBuildingProbes({
+    sonarApiUrl,
+    scoreApiUrl,
+    worldsApiUrl,
+    serviceToken,
+    fetchImpl,
+  });
+}

--- a/packages/services/ordering/src/http-building-probes.ts
+++ b/packages/services/ordering/src/http-building-probes.ts
@@ -210,7 +210,12 @@ export function httpBuildingProbesFromEnv(fetchImpl?: typeof fetch): HttpBuildin
   const sonarApiUrl = process.env.SONAR_API_URL?.trim();
   const scoreApiUrl = process.env.SCORE_API_URL?.trim();
   const worldsApiUrl = process.env.WORLDS_API_URL?.trim();
-  if (!serviceToken || !sonarApiUrl || !scoreApiUrl || !worldsApiUrl) return null;
+  if (!serviceToken || !sonarApiUrl || !scoreApiUrl || !worldsApiUrl) {
+    console.warn(
+      '[ordering-service] KITCHEN_PROBE_HTTP_ENABLED=true but missing SERVICE_TOKEN or upstream URLs — HTTP probes disabled',
+    );
+    return null;
+  }
 
   return new HttpBuildingProbes({
     sonarApiUrl,

--- a/packages/services/ordering/src/index.ts
+++ b/packages/services/ordering/src/index.ts
@@ -112,7 +112,6 @@ export {
   httpBuildingProbesFromEnv,
   type HttpBuildingProbesConfig,
   type HttpEnqueuePayload,
-  type WorldsProbeDetail,
 } from './http-building-probes.js';
 export { normalizeContractAddress, normalizeChainId } from './contract-address.js';
 export { ReProbeWorker, reprobeIntervalMs } from './reprobe-worker.js';

--- a/packages/services/ordering/src/index.ts
+++ b/packages/services/ordering/src/index.ts
@@ -69,7 +69,7 @@ export {
   canFulfillCommunityOnboarding,
 } from './community-onboarding-orchestrator.js';
 
-export { type TriagePorts, StubTriagePorts } from './triage-ports.js';
+export { type TriagePorts, StubTriagePorts, type WorldsProbeDetail } from './triage-ports.js';
 
 export { type IntakeDeps, createIntakeApp } from './intake.js';
 
@@ -100,12 +100,21 @@ export {
 export {
   IngredientEnqueueService,
   kitchenEnqueueEnabled,
+  kitchenHttpEnqueueEnabled,
   fireEnqueue,
 } from './ingredient-enqueue.js';
 
 export { PostgresOrderStore } from './store-postgres.js';
 export { createOrderStore } from './store-factory.js';
 export { KitchenTriagePorts, createKitchenTriagePorts } from './kitchen-triage-ports.js';
+export {
+  HttpBuildingProbes,
+  httpBuildingProbesFromEnv,
+  type HttpBuildingProbesConfig,
+  type HttpEnqueuePayload,
+  type WorldsProbeDetail,
+} from './http-building-probes.js';
+export { normalizeContractAddress, normalizeChainId } from './contract-address.js';
 export { ReProbeWorker, reprobeIntervalMs } from './reprobe-worker.js';
 export { createOrderingComposition, serviceTokenFromEnv, ctaFromEnv } from './composition.js';
 

--- a/packages/services/ordering/src/ingredient-enqueue.ts
+++ b/packages/services/ordering/src/ingredient-enqueue.ts
@@ -7,6 +7,7 @@ import {
   repoForIngredient,
   type GitHubIssuePort,
 } from './github-issue-port.js';
+import type { HttpBuildingProbes, HttpEnqueuePayload } from './http-building-probes.js';
 import {
   type EnqueueIngredientKey,
   type IngredientJob,
@@ -23,15 +24,23 @@ export function kitchenEnqueueEnabled(): boolean {
   return true;
 }
 
+export function kitchenHttpEnqueueEnabled(): boolean {
+  if (process.env.KITCHEN_PROBE_HTTP_ENABLED !== 'true') return false;
+  const raw = process.env.KITCHEN_HTTP_ENQUEUE_ENABLED?.trim();
+  if (raw === 'false') return false;
+  return true;
+}
+
 export class IngredientEnqueueService {
   constructor(
     private readonly store: OrderStore,
     private readonly github: GitHubIssuePort | null,
+    private readonly httpProbes: HttpBuildingProbes | null = null,
     private readonly now: () => number = () => Math.floor(Date.now() / 1000),
   ) {}
 
   async enqueueMissing(orderId: string): Promise<void> {
-    if (!kitchenEnqueueEnabled() || !this.github) return;
+    if (!kitchenEnqueueEnabled()) return;
 
     const record = await this.store.get(orderId);
     if (!record || record.product !== 'community-onboarding') return;
@@ -46,12 +55,42 @@ export class IngredientEnqueueService {
 
     let jobs = [...existingJobs];
     let dirty = false;
-    const newJobs: IngredientJob[] = [];
+    const newGithubJobs: IngredientJob[] = [];
     const nextIngredients = { ...ingredients };
+    const httpEnabled = kitchenHttpEnqueueEnabled() && this.httpProbes !== null;
+
+    const httpPayload: HttpEnqueuePayload = {
+      orderId,
+      chainId: inputs.chain_id,
+      contractAddress: inputs.contract_address,
+      displayName: inputs.community_name,
+      contactEmail: inputs.contact_email,
+      source: inputs.source,
+    };
 
     for (const ingredient of ENQUEUE_INGREDIENTS) {
       if (ingredients[ingredient] !== 'pending') continue;
       if (jobsByIngredient.has(ingredient)) continue;
+
+      if (httpEnabled && this.httpProbes) {
+        const ok = await this.enqueueViaHttp(ingredient, httpPayload);
+        if (ok) {
+          const job: IngredientJob = {
+            ingredient,
+            kind: 'http_enqueue',
+            external_ref: this.httpRefFor(ingredient, httpPayload),
+            idempotency_key: ingredientJobIdempotencyKey(orderId, ingredient),
+            enqueued_at_unix: this.now(),
+          };
+          jobs = [...jobs, job];
+          jobsByIngredient.set(ingredient, job);
+          nextIngredients[ingredient] = 'in_progress';
+          dirty = true;
+          continue;
+        }
+      }
+
+      if (!this.github) continue;
 
       const repo = repoForIngredient(ingredient);
       if (!repo) continue;
@@ -86,7 +125,7 @@ export class IngredientEnqueueService {
           enqueued_at_unix: this.now(),
         };
         jobs = [...jobs, job];
-        newJobs.push(job);
+        newGithubJobs.push(job);
         jobsByIngredient.set(ingredient, job);
         nextIngredients[ingredient] = 'in_progress';
         dirty = true;
@@ -104,13 +143,46 @@ export class IngredientEnqueueService {
         ingredient_jobs: jobs,
         ingredients: nextIngredients,
       });
-      fireCommunityOnboardingIssueLinks({
-        order_id: orderId,
-        contact_email: inputs.contact_email,
-        contract_address: inputs.contract_address,
-        chain_id: inputs.chain_id,
-        jobs: newJobs,
-      });
+      if (newGithubJobs.length > 0) {
+        fireCommunityOnboardingIssueLinks({
+          order_id: orderId,
+          contact_email: inputs.contact_email,
+          contract_address: inputs.contract_address,
+          chain_id: inputs.chain_id,
+          jobs: newGithubJobs,
+        });
+      }
+    }
+  }
+
+  private async enqueueViaHttp(ingredient: EnqueueIngredientKey, payload: HttpEnqueuePayload): Promise<boolean> {
+    if (!this.httpProbes) return false;
+    switch (ingredient) {
+      case 'sonar':
+        return this.httpProbes.enqueueSonar(payload);
+      case 'score':
+        return this.httpProbes.enqueueScore(payload);
+      case 'worlds_manifest':
+        return this.httpProbes.enqueueWorlds(payload);
+      default: {
+        const _exhaustive: never = ingredient;
+        return _exhaustive;
+      }
+    }
+  }
+
+  private httpRefFor(ingredient: EnqueueIngredientKey, payload: HttpEnqueuePayload): string {
+    switch (ingredient) {
+      case 'sonar':
+        return `sonar:ingest:${payload.chainId}:${payload.contractAddress.toLowerCase()}`;
+      case 'score':
+        return `score:register:${payload.chainId}:${payload.contractAddress.toLowerCase()}`;
+      case 'worlds_manifest':
+        return `worlds:manifest:${payload.chainId}:${payload.contractAddress.toLowerCase()}`;
+      default: {
+        const _exhaustive: never = ingredient;
+        return _exhaustive;
+      }
     }
   }
 }

--- a/packages/services/ordering/src/ingredient-enqueue.ts
+++ b/packages/services/ordering/src/ingredient-enqueue.ts
@@ -63,7 +63,7 @@ export class IngredientEnqueueService {
       orderId,
       chainId: inputs.chain_id,
       contractAddress: inputs.contract_address,
-      displayName: inputs.community_name,
+      displayName: inputs.community_name ?? inputs.contract_address,
       contactEmail: inputs.contact_email,
       source: inputs.source,
     };

--- a/packages/services/ordering/src/kitchen-triage-ports.ts
+++ b/packages/services/ordering/src/kitchen-triage-ports.ts
@@ -1,17 +1,34 @@
 import { StubTriagePorts, type TriagePorts } from './triage-ports.js';
+import { HttpBuildingProbes, httpBuildingProbesFromEnv } from './http-building-probes.js';
 
-/** Delegates to stub probes until KITCHEN_PROBE_HTTP_ENABLED wires building HTTP clients. */
+/** Delegates to HTTP building probes when KITCHEN_PROBE_HTTP_ENABLED; else stub fallback (SDD §3.4). */
 export class KitchenTriagePorts implements TriagePorts {
-  private readonly fallback = new StubTriagePorts();
+  private readonly fallback: TriagePorts;
+  private readonly http: HttpBuildingProbes | null;
+
+  constructor(http: HttpBuildingProbes | null, fallback: TriagePorts = new StubTriagePorts()) {
+    this.http = http;
+    this.fallback = fallback;
+  }
 
   sonar = {
-    probe: (chainId: string, contract: string) => this.fallback.sonar.probe(chainId, contract),
+    probe: (chainId: string, contract: string) =>
+      this.http ? this.http.probeSonar(chainId, contract) : this.fallback.sonar.probe(chainId, contract),
   };
   score = {
-    probe: (chainId: string, contract: string) => this.fallback.score.probe(chainId, contract),
+    probe: (chainId: string, contract: string) =>
+      this.http ? this.http.probeScore(chainId, contract) : this.fallback.score.probe(chainId, contract),
   };
   worlds = {
-    probe: (chainId: string, contract: string) => this.fallback.worlds.probe(chainId, contract),
+    probe: (chainId: string, contract: string) =>
+      this.http
+        ? this.http.probeWorlds(chainId, contract).then((r) => r.status)
+        : this.fallback.worlds.probe(chainId, contract),
+    probeDetail: (chainId: string, contract: string) =>
+      this.http
+        ? this.http.probeWorlds(chainId, contract)
+        : this.fallback.worlds.probeDetail?.(chainId, contract) ??
+          this.fallback.worlds.probe(chainId, contract).then((status) => ({ status })),
   };
   discord = {
     probe: (chainId: string, contract: string) =>
@@ -20,12 +37,13 @@ export class KitchenTriagePorts implements TriagePorts {
   shadow = {
     probe: (chainId: string, contract: string) => this.fallback.shadow.probe(chainId, contract),
   };
+
+  get httpProbes(): HttpBuildingProbes | null {
+    return this.http;
+  }
 }
 
 export function createKitchenTriagePorts(): TriagePorts {
-  if (process.env.KITCHEN_PROBE_HTTP_ENABLED === 'true') {
-    // K3: swap HttpBuildingProbes when upstream APIs ship.
-    return new KitchenTriagePorts();
-  }
-  return new KitchenTriagePorts();
+  const http = httpBuildingProbesFromEnv();
+  return new KitchenTriagePorts(http);
 }

--- a/packages/services/ordering/src/kitchen-types.ts
+++ b/packages/services/ordering/src/kitchen-types.ts
@@ -5,10 +5,10 @@ export type EnqueueIngredientKey = z.infer<typeof EnqueueIngredientKey>;
 
 export const IngredientJob = z.object({
   ingredient: EnqueueIngredientKey,
-  kind: z.literal('github_issue'),
-  external_ref: z.string().url(),
-  external_id: z.string(),
-  repo: z.string(),
+  kind: z.enum(['github_issue', 'http_enqueue']),
+  external_ref: z.string(),
+  external_id: z.string().optional(),
+  repo: z.string().optional(),
   idempotency_key: z.string(),
   enqueued_at_unix: z.number().int(),
 });

--- a/packages/services/ordering/src/triage-ports.ts
+++ b/packages/services/ordering/src/triage-ports.ts
@@ -1,5 +1,10 @@
 import type { IngredientStatus } from '@freeside/ordering-protocol';
 
+export interface WorldsProbeDetail {
+  status: IngredientStatus;
+  world_slug?: string;
+}
+
 /**
  * Ingredient fulfillment ports for preset #2 (SDD §3.2.4).
  * MVP stubs return `pending` on probe; operator advance-ingredient unblocks fulfillment.
@@ -13,6 +18,7 @@ export interface TriagePorts {
   };
   worlds: {
     probe(chainId: string, contract: string): Promise<IngredientStatus>;
+    probeDetail?(chainId: string, contract: string): Promise<WorldsProbeDetail>;
   };
   discord?: {
     probe(chainId: string, contract: string): Promise<IngredientStatus>;
@@ -26,7 +32,10 @@ export interface TriagePorts {
 export class StubTriagePorts implements TriagePorts {
   sonar = { probe: async (_chainId: string, _contract: string) => 'pending' as const };
   score = { probe: async (_chainId: string, _contract: string) => 'pending' as const };
-  worlds = { probe: async (_chainId: string, _contract: string) => 'pending' as const };
+  worlds = {
+    probe: async (_chainId: string, _contract: string) => 'pending' as const,
+    probeDetail: async (_chainId: string, _contract: string) => ({ status: 'pending' as const }),
+  };
   discord = { probe: async (_chainId: string, _contract: string) => 'optional' as const };
   shadow = { probe: async (_chainId: string, _contract: string) => 'blocked' as const };
 }


### PR DESCRIPTION
## Summary
- **K0–K2**: Postgres order store, GitHub issue enqueue per ingredient, re-probe worker
- **K3**: HTTP building probes (sonar/score/worlds) when `KITCHEN_PROBE_HTTP_ENABLED=true`; producing-state re-probe; optional HTTP enqueue instead of GitHub issues

Depends on merged sonar-api #110 (kitchen-api sidecar).

## Test plan
- [x] `pnpm test` in `packages/services/ordering` (66 tests)
- [ ] Deploy with `KITCHEN_PROBE_HTTP_ENABLED=true` + upstream URLs
- [ ] Azuki E2E: chain 1 / `0xED5AF388653567Af2F388e6224DcC93746104133`


Made with [Cursor](https://cursor.com)