### PR TITLE
fix(.claude): Fable outage fallback for Bridgebuilder (loa#402)

### DIFF
--- a/.claude/adapters/loa_cheval/providers/claude_headless_adapter.py
+++ b/.claude/adapters/loa_cheval/providers/claude_headless_adapter.py
@@ -120,7 +120,46 @@ class ClaudeHeadlessAdapter(ProviderAdapter):
         enforce_context_window(request, model_config)
 
         prompt = self._build_prompt(request.messages)
-        cmd = self._build_command(request, model_config, prompt)
+        configured_cli_model = (model_config.extra or {}).get("cli_model") or request.model
+        try:
+            return self._invoke_claude_p(
+                request, model_config, prompt, configured_cli_model,
+            )
+        except ProviderUnavailableError as exc:
+            # loa#402: when the headless terminal is pinned to fable (model-config
+            # claude-headless.extra.cli_model) and the CLI reports Fable outage,
+            # retry once with opus so BB completes when Opus subscription works.
+            if (
+                configured_cli_model == "fable"
+                and self._should_retry_fable_to_opus(exc)
+            ):
+                logger.warning(
+                    "claude-headless: fable CLI unavailable; retrying with cli_model=opus"
+                )
+                return self._invoke_claude_p(
+                    request, model_config, prompt, "opus",
+                )
+            raise
+
+    def _should_retry_fable_to_opus(self, exc: ProviderUnavailableError) -> bool:
+        msg = str(exc).lower()
+        return "fable" in msg and (
+            "unavailable" in msg
+            or "retries_exhausted" in msg
+            or "currently unavailable" in msg
+        )
+
+    def _invoke_claude_p(
+        self,
+        request: CompletionRequest,
+        model_config,
+        prompt: str,
+        cli_model: str,
+    ) -> CompletionResult:
+        """Run a single claude -p invocation with an explicit CLI model id."""
+        cmd = self._build_command(
+            request, model_config, prompt, cli_model_override=cli_model,
+        )
         timeout_s = self._compute_timeout()
         # Cycle-110 sprint-2b2b1 BB iter-2 F-001 closure: read per-model
         # headless_concurrency_limit (cycle-110 ModelConfig field). Default 50
@@ -128,8 +167,9 @@ class ClaudeHeadlessAdapter(ProviderAdapter):
         n_slots = getattr(model_config, "headless_concurrency_limit", None) or 50
 
         logger.debug(
-            "claude-headless invoking: model=%s timeout=%.0fs prompt_chars=%d slots=%d",
+            "claude-headless invoking: model=%s cli_model=%s timeout=%.0fs prompt_chars=%d slots=%d",
             request.model,
+            cli_model,
             timeout_s,
             len(prompt),
             n_slots,
@@ -274,6 +314,8 @@ class ClaudeHeadlessAdapter(ProviderAdapter):
         request: CompletionRequest,
         model_config,
         prompt: str,
+        *,
+        cli_model_override: Optional[str] = None,
     ) -> List[str]:
         """Build the claude argv. Headless, plan-mode (read-only), no tools."""
         # cycle-104 sprint-2 T2.11 amendment: when the chain entry is a
@@ -281,7 +323,11 @@ class ClaudeHeadlessAdapter(ProviderAdapter):
         # recognize the Loa alias as a model name. Honor `extra.cli_model`
         # if declared so the operator can map the alias to a real CLI
         # model identifier (e.g. `sonnet`, `opus`).
-        cli_model = (model_config.extra or {}).get("cli_model") or request.model
+        cli_model = (
+            cli_model_override
+            or (model_config.extra or {}).get("cli_model")
+            or request.model
+        )
         cmd: List[str] = [
             self._claude_bin(),
             "-p",

--- a/.claude/skills/bridgebuilder-review/resources/__tests__/cheval-delegate.test.ts
+++ b/.claude/skills/bridgebuilder-review/resources/__tests__/cheval-delegate.test.ts
@@ -83,7 +83,16 @@ function makeFakeSpawn(script: FakeProcessScript, calls: SpawnCall[]) {
   }) as unknown as typeof import("node:child_process").spawn;
 }
 
-function makeAdapter(script: FakeProcessScript, calls: SpawnCall[], overrides: Partial<Parameters<typeof ChevalDelegateAdapter.prototype.generateReview>[0]> & Record<string, unknown> = {}) {
+function makeSequentialSpawn(scripts: FakeProcessScript[], calls: SpawnCall[]) {
+  let idx = 0;
+  return ((command: string, args: readonly string[], opts: { env?: NodeJS.ProcessEnv } = {}) => {
+    const script = scripts[Math.min(idx, scripts.length - 1)];
+    idx += 1;
+    return makeFakeSpawn(script, calls)(command, args, opts);
+  }) as unknown as typeof import("node:child_process").spawn;
+}
+
+function makeAdapter(script: FakeProcessScript, calls: SpawnCall[], overrides: Record<string, unknown> = {}) {
   return new ChevalDelegateAdapter({
     model: "anthropic:claude-sonnet-4-5-20250929",
     timeoutMs: 5_000,
@@ -268,6 +277,43 @@ describe("ChevalDelegateAdapter — success path", () => {
     );
     const result = await adapter.generateReview(baseRequest);
     assert.equal(result.model, "anthropic:claude-sonnet-4-5-20250929");
+  });
+
+  it("retries with opus when fable chain exhausts (loa#402)", async () => {
+    const calls: SpawnCall[] = [];
+    const adapter = new ChevalDelegateAdapter({
+      model: "anthropic:claude-fable-5",
+      timeoutMs: 5_000,
+      chevalScript: "/tmp/fake-cheval.py",
+      pythonBin: "/tmp/fake-python3",
+      spawnFn: makeSequentialSpawn(
+        [
+          {
+            stderr: JSON.stringify({
+              code: "RETRIES_EXHAUSTED",
+              message: "Claude Fable 5 is currently unavailable",
+            }),
+            exitCode: 1,
+          },
+          {
+            stdout: JSON.stringify({
+              content: "fallback review",
+              model: "claude-opus-4-8",
+              provider: "anthropic",
+              usage: { input_tokens: 10, output_tokens: 20 },
+            }),
+            exitCode: 0,
+          },
+        ],
+        calls,
+      ),
+    });
+
+    const result = await adapter.generateReview(baseRequest);
+    assert.equal(result.content, "fallback review");
+    assert.equal(calls.length, 2);
+    assert.ok(calls[0]!.args.includes("anthropic:claude-fable-5"));
+    assert.ok(calls[1]!.args.includes("anthropic:claude-opus-4-8"));
   });
 });
 

--- a/.claude/skills/bridgebuilder-review/resources/adapters/cheval-delegate.ts
+++ b/.claude/skills/bridgebuilder-review/resources/adapters/cheval-delegate.ts
@@ -27,6 +27,8 @@ import type {
 const DEFAULT_TIMEOUT_MS = 120_000;
 const SIGKILL_GRACE_MS = 5_000;
 const DEFAULT_AGENT = "reviewing-code";
+/** loa#402 — explicit Opus fallback when Fable tier exhausts cheval chain. */
+const FABLE_FALLBACK_MODEL = "anthropic:claude-opus-4-8";
 
 const CHEVAL_SCRIPT_REL = ".claude/adapters/cheval.py";
 
@@ -113,6 +115,26 @@ export class ChevalDelegateAdapter implements ILLMProvider {
       );
     }
 
+    try {
+      return await this.invokeChevalOnce(request, this.opts.model);
+    } catch (err) {
+      if (
+        err instanceof LLMProviderError
+        && err.code === "PROVIDER_ERROR"
+        && isFableTierModel(this.opts.model)
+        && isFableChainExhaustion(err.message)
+      ) {
+        return this.invokeChevalOnce(request, FABLE_FALLBACK_MODEL);
+      }
+      throw err;
+    }
+  }
+
+  /** Spawn cheval once for the given provider:model binding. */
+  private async invokeChevalOnce(
+    request: ReviewRequest,
+    model: string,
+  ): Promise<ReviewResponse> {
     const scriptPath =
       this.opts.chevalScript ?? join(process.cwd(), CHEVAL_SCRIPT_REL);
 
@@ -144,7 +166,7 @@ export class ChevalDelegateAdapter implements ILLMProvider {
         "--agent",
         this.opts.agent,
         "--model",
-        this.opts.model,
+        model,
         "--system",
         systemPath,
         "--input",
@@ -258,7 +280,7 @@ export class ChevalDelegateAdapter implements ILLMProvider {
         content: parsed.content,
         inputTokens,
         outputTokens,
-        model: parsed.model ?? this.opts.model,
+        model: parsed.model ?? model,
         provider: parsed.provider,
         // Prefer cheval's reported provider-call latency. Fall back to our wall
         // clock (which includes Python startup) when cheval doesn't report.
@@ -274,6 +296,21 @@ export class ChevalDelegateAdapter implements ILLMProvider {
       }
     }
   }
+}
+
+function isFableTierModel(model: string): boolean {
+  const normalized = model.toLowerCase();
+  return normalized.includes("fable") || normalized.endsWith(":fable");
+}
+
+/** True when cheval exhausted the within-company chain on a Fable outage. */
+function isFableChainExhaustion(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes("retries_exhausted")
+    || lower.includes("chain_exhausted")
+    || lower.includes("provider_unavailable")
+  ) && (lower.includes("fable") || lower.includes("unavailable"));
 }
 
 /**


### PR DESCRIPTION
## Summary
- **claude-headless**: when `cli_model=fable` and the CLI reports Fable unavailable, retry once with `opus`
- **ChevalDelegateAdapter**: when Fable tier exhausts cheval chain (`RETRIES_EXHAUSTED`), retry once with `anthropic:claude-opus-4-8`
- Unit test covers delegate retry path

Fixes #402

## Test plan
- [x] `node --import tsx --test resources/__tests__/cheval-delegate.test.ts`
- [x] `pytest tests/test_claude_headless_adapter.py`
- [ ] Operator `/bridgebuilder --pr N` when Fable down, Opus available


Made with [Cursor](https://cursor.com)