### PR TITLE
feat(infra): register freeside.0xhoneyjar.xyz world module

### DIFF
--- a/infrastructure/terraform/dns/honeyjar-xyz-worlds.tf
+++ b/infrastructure/terraform/dns/honeyjar-xyz-worlds.tf
@@ -17,6 +17,7 @@ locals {
   # Honey Road is an ECS-hosted world.
   world_subdomains = var.enable_production_api ? toset([
     "apdao",
+    "freeside",
     "rektdrop",
     "score-api",
   ]) : toset([])

--- a/infrastructure/terraform/world-freeside-secrets.tf
+++ b/infrastructure/terraform/world-freeside-secrets.tf
@@ -1,0 +1,33 @@
+# =============================================================================
+# Freeside Dashboard (freeside-dashboard) — AWS Secrets Manager structure
+# =============================================================================
+# Runtime secrets for the CM dashboard at freeside.0xhoneyjar.xyz.
+# Values are NOT populated by terraform — load via operator script from Vercel
+# env (bootstrap) or `vercel env pull` + `aws secretsmanager put-secret-value`.
+#
+# The key set MUST be a superset of world-freeside.tf's `secrets = {...}` map.
+# =============================================================================
+
+locals {
+  freeside_dashboard_secrets = toset([
+    "database_url",
+    "score_api_key",
+    "link_service_token",
+    "ordering_service_token",
+    "config_service_token",
+  ])
+}
+
+resource "aws_secretsmanager_secret" "freeside_dashboard" {
+  for_each = local.freeside_dashboard_secrets
+
+  name        = "arrakis/${var.environment}/worlds/freeside-dashboard/${each.key}"
+  description = "Freeside Dashboard runtime secret — loaded by operator after terraform apply"
+  kms_key_id  = aws_kms_key.secrets.arn
+
+  tags = merge(local.common_tags, {
+    World   = "freeside"
+    App     = "freeside-dashboard"
+    Purpose = each.key
+  })
+}

--- a/infrastructure/terraform/world-freeside.tf
+++ b/infrastructure/terraform/world-freeside.tf
@@ -1,0 +1,84 @@
+# =============================================================================
+# World: freeside — Freeside CM dashboard (Next.js 15, freeside-dashboard)
+# =============================================================================
+# Operator dashboard at freeside.0xhoneyjar.xyz — the sovereign Vercel replacement
+# surface for managing worlds, communities, and substrate cutovers.
+# Repo: 0xHoneyJar/freeside-dashboard
+# =============================================================================
+
+module "world_freeside" {
+  source = "./modules/world"
+
+  name        = "freeside"
+  repo        = "0xHoneyJar/freeside-dashboard"
+  environment = var.environment
+
+  cluster_id               = aws_ecs_cluster.main.id
+  cluster_name             = aws_ecs_cluster.main.name
+  vpc_id                   = module.vpc.vpc_id
+  private_subnets          = module.vpc.private_subnets
+  alb_listener_arn         = aws_lb_listener.https.arn
+  alb_security_group_id    = aws_security_group.alb.id
+  efs_file_system_id       = aws_efs_file_system.worlds.id
+  efs_security_group_id    = aws_security_group.worlds_efs.id
+  github_oidc_provider_arn = aws_iam_openid_connect_provider.github.arn
+  kms_key_arn              = aws_kms_key.secrets.arn
+  name_prefix              = local.name_prefix
+  common_tags              = local.common_tags
+  aws_region               = var.aws_region
+  account_id               = data.aws_caller_identity.current.account_id
+
+  cpu    = 512
+  memory = 1024
+
+  # Static health route — see freeside-dashboard/src/app/api/health/route.ts
+  health_check_path = "/api/health"
+
+  env_vars = {
+    APP_URL                  = "https://freeside.0xhoneyjar.xyz"
+    NEXT_PUBLIC_APP_URL      = "https://freeside.0xhoneyjar.xyz"
+    IDENTITY_API_URL         = "https://identity.0xhoneyjar.xyz"
+    IDENTITY_RESOLVE_ENABLED = "true"
+    SCORE_API_URL            = "https://score-api.0xhoneyjar.xyz"
+    TRUST_PROXY_HEADERS      = "true"
+    NODE_ENV                 = "production"
+  }
+
+  secrets = {
+    DATABASE_URL             = aws_secretsmanager_secret.freeside_dashboard["database_url"].arn
+    SCORE_API_KEY            = aws_secretsmanager_secret.freeside_dashboard["score_api_key"].arn
+    LINK_SERVICE_TOKEN       = aws_secretsmanager_secret.freeside_dashboard["link_service_token"].arn
+    ORDERING_SERVICE_TOKEN   = aws_secretsmanager_secret.freeside_dashboard["ordering_service_token"].arn
+    CONFIG_SERVICE_TOKEN     = aws_secretsmanager_secret.freeside_dashboard["config_service_token"].arn
+  }
+
+  secret_arns = [for s in aws_secretsmanager_secret.freeside_dashboard : s.arn]
+}
+
+# Dashboard calls identity-api, score-api, ordering-service, config-service, and
+# external Postgres (Neon/Vercel DB during bootstrap). Broad TCP egress matches
+# the Honey Road pattern until the world module grows an egress_mode variable.
+resource "aws_security_group_rule" "freeside_broad_tcp_outbound" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = module.world_freeside.security_group_id
+  description       = "Freeside Dashboard broad TCP outbound (Postgres + substrate APIs)."
+}
+
+output "freeside_ecr_url" {
+  value       = module.world_freeside.ecr_repository_url
+  description = "ECR repository for freeside-dashboard image pushes (set in CI as ECR_REPOSITORY)"
+}
+
+output "freeside_ci_role_arn" {
+  value       = module.world_freeside.ci_deploy_role_arn
+  description = "IAM role ARN for freeside-dashboard GitHub Actions OIDC (AWS_DEPLOY_ROLE_ARN secret)"
+}
+
+output "freeside_subdomain" {
+  value       = module.world_freeside.subdomain
+  description = "Canonical dashboard hostname (freeside.0xhoneyjar.xyz)"
+}


### PR DESCRIPTION
## Summary
- Register `freeside` world in terraform (ECS + ALB host rule + ECR + CI OIDC)
- Add Secrets Manager scaffold for dashboard runtime secrets
- Add `freeside` to honeyjar-xyz DNS world A-alias list

## Test plan
- [ ] `terraform plan` clean for world-freeside module (already applied in prod)

Made with [Cursor](https://cursor.com)