### PR TITLE
fix(dns): freeside dashboard stays on Vercel wildcard

### DIFF
--- a/infrastructure/terraform/dns/honeyjar-xyz-worlds.tf
+++ b/infrastructure/terraform/dns/honeyjar-xyz-worlds.tf
@@ -15,9 +15,10 @@ locals {
   # 2026-04-16: "mibera" temporarily removed to restore Honey Road (Vercel) at
   # mibera.0xhoneyjar.xyz while we migrate Honey Road onto Freeside. Re-add once
   # Honey Road is an ECS-hosted world.
+  # 2026-07-01: "freeside" stays on Vercel (freeside-dashboard) until Freeside ECS
+  # DX beats Vercel; wildcard *.0xhoneyjar.xyz → cname.vercel-dns.com serves it.
   world_subdomains = var.enable_production_api ? toset([
     "apdao",
-    "freeside",
     "rektdrop",
     "score-api",
   ]) : toset([])


### PR DESCRIPTION
Remove freeside from ALB world_subdomains — dashboard hosts on Vercel until ECS DX is ready.