### PR TITLE
docs(registry): score-api DORMANT ECS notes (#417 network slice)

### DIFF
--- a/packages/freeside-registry/registry.yaml
+++ b/packages/freeside-registry/registry.yaml
@@ -218,6 +218,9 @@ modules:
       with full health response at `/` (NOT `/healthz`):
         {status:"ok", service:"score-api", db:"connected", scoring_version:"v0.7",
          last_run_id:5903, last_run_at:"2026-05-26 03:35:21+00"}
+      Canonical public URL: https://score.0xhoneyjar.xyz (DNS CNAME → Railway).
+      ECS module.world_score_api + score-api.0xhoneyjar.xyz ALB path is DORMANT
+      (loa-freeside#417) — do not treat as production compute.
       mcp-gateway's probeTenant() calls `/healthz` which 404s — the gateway will
       show this tenant as "down" even though the service is operational. Fix
       candidate: per-tenant `health_path` field in tenants.ts (deferred —

--- a/packages/freeside-registry/tests/worldline-score-api-registry.test.ts
+++ b/packages/freeside-registry/tests/worldline-score-api-registry.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Worldline coherence · score-api registry notes (loa-freeside#417 network slice)
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REGISTRY_ROOT = join(__dirname, '..');
+
+test('registry.yaml score-api notes document Railway prod and dormant ECS', () => {
+  const yaml = readFileSync(join(REGISTRY_ROOT, 'registry.yaml'), 'utf8');
+  const block = yaml.match(/score-api:[\s\S]*?(?=\n  [a-z-]+-api:|\nmodules:|\Z)/);
+  assert.ok(block, 'score-api block must exist in registry.yaml');
+  assert.match(block![0], /beacon_url: https:\/\/score\.0xhoneyjar\.xyz/);
+  assert.match(block![0], /deployment_url: https:\/\/score-api-production\.up\.railway\.app/);
+  assert.match(block![0], /DORMANT/i, 'registry notes must mention dormant ECS');
+});


### PR DESCRIPTION
## Summary

Network-only follow-up to merged #418 (ADR-007 §D-3 split). Adds agent-facing DORMANT ECS notes to `registry.yaml` + regression test.

Closes remaining #417 registry slice.

## Test plan

- [x] `npx tsx --test tests/worldline-score-api-registry.test.ts`


Made with [Cursor](https://cursor.com)