### PR TITLE
feat(network/beacon-consumer): name loa model in nav pointer (F-3) + transition-address SSRF parity (BC-B-006)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ loa doctor              # live · health + discovery probe across registered bui
 loa caps                # live · capabilities reachable under the current grant (discovery == permission)
 loa where <dest>        # live · cheapest invocation to reach a destination (the `cd` of the ecosystem)
 loa census --graph      # live · the living building graph — set LOA_WORKSPACE=<cluster-root> first
+loa model <slug> --brief # live · one building's keyed orientation packet (is/is_not/capabilities/edges + verdict)
 
 # WRONG - do not hand-probe what loa already covers
 grep -r "deployment_url" packages/freeside-registry/registry.yaml  # stale hand-authored field
@@ -160,10 +161,12 @@ the verified path must be the path of least resistance.
 > buildings + constructs + worlds + zones). `ADR-011 §D-5` is the cited floor.
 
 To orient to ONE building — its `is`/`is_not`, capabilities, and composition edges — from its
-live beacon, run `freeside-cli inspect <slug>` (single-line JSON; `--pretty` to expand). It
-fetches the declared beacon over the SSRF-safe path and returns a keyed orientation packet with
-an honest classification (`beacon_valid`/`dark`/`void`/`invalid`/`unreachable`) — reach for it
-instead of grepping a building's source to learn what it does.
+live beacon, reach for the keyed orientation READ instead of grepping a building's source:
+`loa model <slug> --brief` (launcher-native, grant-gated) or, in-repo, `freeside-cli inspect
+<slug>` (single-line JSON; `--pretty` to expand). Both fetch the declared beacon over the SAME
+SSRF-safe path and return the same orientation packet with an honest classification
+(`beacon_valid`/`dark`/`void`/`invalid`/`unreachable`) — parity is pinned by the shared
+conformance vectors in `packages/beacon-schema/test-vectors/`.
 
 ---
 

--- a/packages/freeside-cli/src/lib/harden-beacon-fetch.ts
+++ b/packages/freeside-cli/src/lib/harden-beacon-fetch.ts
@@ -134,6 +134,13 @@ function isBlockedV6(ip: string): boolean {
     const v4 = `${(h[6] >> 8) & 0xff}.${h[6] & 0xff}.${(h[7] >> 8) & 0xff}.${h[7] & 0xff}`;
     return isBlockedV4(v4);
   }
+  // IPv4-embedding transition mechanisms — unwrap the embedded v4 (or block outright) (BB BC-B-006,
+  // mirrored from loa-cli#10 lib/model.mjs to keep the two SSRF surfaces at parity).
+  if (h[0] === 0x2002) return isBlockedV4(`${(h[1] >> 8) & 0xff}.${h[1] & 0xff}.${(h[2] >> 8) & 0xff}.${h[2] & 0xff}`); // 6to4 2002::/16
+  if (h[0] === 0x0064 && h[1] === 0xff9b && h[2] === 0 && h[3] === 0 && h[4] === 0 && h[5] === 0) {
+    return isBlockedV4(`${(h[6] >> 8) & 0xff}.${h[6] & 0xff}.${(h[7] >> 8) & 0xff}.${h[7] & 0xff}`); // NAT64 64:ff9b::/96
+  }
+  if (h[0] === 0x2001 && h[1] === 0x0000) return true; // Teredo 2001:0::/32 — block outright
   if ((h[0] & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
   if ((h[0] & 0xffc0) === 0xfec0) return true; // fec0::/10 deprecated site-local (defense-in-depth)
   if ((h[0] & 0xfe00) === 0xfc00) return true; // fc00::/7 ULA

--- a/packages/freeside-cli/tests/harden-beacon-fetch.test.ts
+++ b/packages/freeside-cli/tests/harden-beacon-fetch.test.ts
@@ -92,6 +92,14 @@ test("isBlockedAddress: IPv4-mapped IPv6 is unwrapped and blocked in BOTH dotted
   assert.equal(isBlockedAddress("not-an-ip"), true); // non-IP literal → fail-closed
 });
 
+test("isBlockedAddress: IPv4-embedding transition addresses are unwrapped/blocked (BC-B-006, loa-cli parity)", () => {
+  assert.equal(isBlockedAddress("2002:7f00:0001::"), true); // 6to4 embedding 127.0.0.1
+  assert.equal(isBlockedAddress("64:ff9b::a9fe:a9fe"), true); // NAT64 embedding 169.254.169.254 metadata
+  assert.equal(isBlockedAddress("2001:0::1"), true); // Teredo 2001:0::/32 blocked outright
+  assert.equal(isBlockedAddress("2002:0808:0808::"), false); // public 6to4 (embeds 8.8.8.8) → allowed
+  assert.equal(isBlockedAddress("2001:0db8::1"), false); // 2001:db8:: is NOT Teredo → allowed
+});
+
 // ── fetcher integration: pre-fetch rejects return before any socket (network-free) ──
 
 test("hardenedBeaconFetcher rejects http scheme before opening a socket", async () => {


### PR DESCRIPTION
## Close the beacon-consumer cycle — both surfaces live, one nav pointer, SSRF parity

Both read surfaces are now merged: `freeside-cli inspect` (#422) and `loa model <slug> --brief` (loa-cli#10). This lands the two remaining follow-ups as a single PR.

### F-3 — pointer flip (now unblocked)
`CLAUDE.md` "Ecosystem Navigation" now names **`loa model <slug> --brief`** (launcher-native) alongside `freeside-cli inspect`. The partial-rollout invariant is satisfied — the command exists, so `/recall` no longer sends an agent to a phantom command. Both are documented as the SAME SSRF-safe path, parity-pinned by the shared conformance vectors.

### BC-B-006 — SSRF transition-address parity
Bridgebuilder flagged (on loa-cli#10) that the v6 blocklist unwrapped `::ffff:` / `::x` but not the IPv4-embedding transition mechanisms. loa-cli#10 fixed it; this mirrors the same fix into freeside-cli's `harden-beacon-fetch.ts` `isBlockedV6` so the two SSRF surfaces stay at parity:
- **6to4** (`2002::/16`) — unwrap the embedded v4, apply the full block set
- **NAT64** (`64:ff9b::/96`) — unwrap the embedded v4
- **Teredo** (`2001:0::/32`) — block outright

A public 6to4 (embedding a public v4, e.g. `2002:0808:0808::` = 8.8.8.8) stays allowed. Local guard tests added for each form.

### Scope note
The **shared** conformance vectors are intentionally unchanged here — adding transition vectors to `beacon-schema/test-vectors/` would drift loa-cli#10's pinned checksum. Adding them to the shared suite + bumping loa-cli's pin is a coordinated cross-repo follow-up; this PR keeps both impls' code at parity + covers the new cases with per-repo tests.

### Verification
- freeside-cli: **94 pass / 0 fail / 1 env-gated skip** (incl. the new transition-address test)
- beacon-schema unchanged (59 + 3 green)
- `tools/check-beacon-domain.sh` → **network** (zero platform paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)