### PR TITLE
fix(network/freeside-registry): inventory deployment_url → live open read API

### DIFF
--- a/packages/freeside-registry/registry.yaml
+++ b/packages/freeside-registry/registry.yaml
@@ -129,17 +129,18 @@ modules:
   inventory-api:
     git_url: https://github.com/0xHoneyJar/inventory-api.git
     beacon_url: https://inventory.0xhoneyjar.xyz/.well-known/beacon.json
-    deployment_url: https://inventory-mcp-production.up.railway.app
+    deployment_url: https://inventory-api-production-3f25.up.railway.app
     visibility: internal
     owner: 0xHoneyJar
     added: "2026-05-18"
     runtime_state: deployed
     notes: |
       sonar⨝codex inventory/collections read API + ACVP completeness.
-      Deployed as MCP server at inventory-mcp-production.up.railway.app (returns
-      401 — auth-gated, requires API key). Per memory the inventory-api npm
-      library has live read counts; the MCP server is the federation-facing
-      shape. visibility: internal because of the auth gate.
+      Live HTTP read API at inventory-api-production-3f25.up.railway.app
+      (/health 200, /holdings + /profile open — privacy-gated fields verified
+      chain-derived 2026-07-03). The older inventory-mcp-production deployment
+      is edge-walled (401 on every path incl /health) — NOT the read plane.
+      Beacon 404 until inventory-api#18 merges.
 
   ledger-api:
     git_url: https://github.com/0xHoneyJar/ledger-api.git


### PR DESCRIPTION
Consumption-truth S3-L2 slice. Observed 2026-07-03: `inventory-api-production-3f25.up.railway.app` is the LIVE open read plane (/health 200, /holdings + /profile open; privacy gate PASS — all fields chain-derived). The registered `inventory-mcp-production` host 401s on EVERY path including /health and the beacon (edge wall) — consumers pointed there see silent-empty. Beacon stays 404 until inventory-api#18.

Follow-ups (beads): holdings return empty for known holders (read-plane divergence: service env points at belt-hasura-production, not canonical belt-gateway) — arrakis-rxax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)