### PR TITLE
fix(shared/hooks): anchor hook command paths to git toplevel (worktree-safe)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -462,7 +462,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/scripts/upgrade-health-check.sh"
+            "command": "$(git rev-parse --show-toplevel)/.claude/scripts/upgrade-health-check.sh"
           }
         ]
       }
@@ -473,25 +473,25 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/scripts/check-updates.sh --notify",
+            "command": "$(git rev-parse --show-toplevel)/.claude/scripts/check-updates.sh --notify",
             "async": true,
             "once": true
           },
           {
             "type": "command",
-            "command": ".claude/hooks/session-start/loa-l6-surface-handoffs.sh",
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/session-start/loa-l6-surface-handoffs.sh",
             "async": true,
             "once": true
           },
           {
             "type": "command",
-            "command": ".claude/hooks/session-start/loa-l7-surface-soul.sh",
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/session-start/loa-l7-surface-soul.sh",
             "async": true,
             "once": true
           },
           {
             "type": "command",
-            "command": ".claude/hooks/session-start/loa-run-mode-session-title.sh",
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/session-start/loa-run-mode-session-title.sh",
             "async": true,
             "once": true
           }
@@ -504,7 +504,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/pre-compact-marker.sh"
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/pre-compact-marker.sh"
           }
         ]
       }
@@ -515,7 +515,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/post-compact-reminder.sh"
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/post-compact-reminder.sh"
           }
         ]
       }
@@ -526,7 +526,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/scripts/cleanup-context.sh --prompt"
+            "command": "$(git rev-parse --show-toplevel)/.claude/scripts/cleanup-context.sh --prompt"
           }
         ]
       },
@@ -535,11 +535,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/safety/block-destructive-bash.sh"
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/safety/block-destructive-bash.sh"
           },
           {
             "type": "command",
-            "command": ".claude/hooks/safety/team-role-guard.sh"
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/safety/team-role-guard.sh"
           }
         ]
       },
@@ -548,15 +548,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/safety/team-role-guard-write.sh"
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/safety/team-role-guard-write.sh"
           },
           {
             "type": "command",
-            "command": ".claude/hooks/safety/spiral-dispatch-guard.sh"
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/safety/spiral-dispatch-guard.sh"
           },
           {
             "type": "command",
-            "command": ".claude/hooks/safety/zone-write-guard.sh"
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/safety/zone-write-guard.sh"
           }
         ]
       },
@@ -565,7 +565,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/safety/adversarial-review-gate.sh"
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/safety/adversarial-review-gate.sh"
           }
         ]
       },
@@ -574,11 +574,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/safety/team-skill-guard.sh"
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/safety/team-skill-guard.sh"
           },
           {
             "type": "command",
-            "command": ".claude/hooks/safety/spiral-skill-sentinel.sh"
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/safety/spiral-skill-sentinel.sh"
           }
         ]
       }
@@ -589,7 +589,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/audit/mutation-logger.sh"
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/audit/mutation-logger.sh"
           }
         ]
       },
@@ -598,7 +598,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/audit/write-mutation-logger.sh"
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/audit/write-mutation-logger.sh"
           }
         ]
       },
@@ -607,7 +607,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/audit/write-mutation-logger.sh"
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/audit/write-mutation-logger.sh"
           }
         ]
       },
@@ -616,7 +616,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/quality/karpathy-surgical-diff-check.sh"
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/quality/karpathy-surgical-diff-check.sh"
           }
         ]
       }
@@ -627,11 +627,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/safety/run-mode-stop-guard.sh"
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/safety/run-mode-stop-guard.sh"
           },
           {
             "type": "command",
-            "command": ".claude/hooks/hygiene/settings-cleanup.sh"
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/hygiene/settings-cleanup.sh"
           }
         ]
       }
@@ -642,7 +642,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/scripts/permission-audit.sh log",
+            "command": "$(git rev-parse --show-toplevel)/.claude/scripts/permission-audit.sh log",
             "async": true
           }
         ]


### PR DESCRIPTION
## The bug

All 23 hook commands in `.claude/settings.json` use **bare-relative** paths (`.claude/hooks/...`). These only resolve when the hook's working directory contains `.claude/hooks/` — the repo root or a worktree root. For a git worktree nested under `.claude/worktrees/` (where `EnterWorktree` puts them), Claude Code anchors the hook cwd to an intermediate `.claude` / `.claude/worktrees` directory, so `.claude/hooks/…` double-nests to `.claude/.claude/hooks/…` and `/bin/sh` reports **"No such file or directory."**

Observed (another session, worktree at `.claude/worktrees/cycle-consumption-truth`):
```
PreToolUse:Bash hook error … /bin/sh: .claude/hooks/safety/block-destructive-bash.sh: No such file or directory
PreToolUse:Bash hook error … /bin/sh: .claude/hooks/safety/team-role-guard.sh: No such file or directory
PostToolUse:Bash hook error … /bin/sh: .claude/hooks/audit/mutation-logger.sh: No such file or directory
```

**Why it matters:** the failures are `non-blocking`, so the command proceeds — which means in that session the safety hooks (`block-destructive-bash`, `team-role-guard`, `mutation-logger`, …) **silently do not run**. The destructive-command fence and the audit trail are off. This is a security-relevant fail-open, not just log noise.

## Reproduction

```
cwd = <repo root>            → RESOLVES ✓
cwd = <worktree root>        → RESOLVES ✓
cwd = <repo>/.claude         → FAILS ✗  "No such file or directory"
cwd = <repo>/.claude/worktrees → FAILS ✗
```

## Fix

Prefix every hook command with `$(git rev-parse --show-toplevel)/`. `git rev-parse --show-toplevel` returns the correct toplevel (worktree **or** main) from **any** cwd inside the tree — verified to resolve from all four cwds above, including the two that previously failed. `$CLAUDE_PROJECT_DIR` was unreliable here (unset in-env), so the git anchor is the robust choice.

```diff
- "command": ".claude/hooks/safety/block-destructive-bash.sh"
+ "command": "$(git rev-parse --show-toplevel)/.claude/hooks/safety/block-destructive-bash.sh"
```

## Verification
- 23 insertions / 23 deletions (settings.json only); JSON validated
- the hook **executes clean** (exit 0, no error) invoked via the new command from the previously-failing `.claude/worktrees` cwd
- resolves from repo-root / worktree-root / `.claude` / `.claude/worktrees`

## Caveat
`.claude/settings.json` is **framework-managed** (last touched by "update Loa framework to v1.180.0"), so `/update-loa` will clobber this until the fix lands in the framework generator. Tracked upstream: https://github.com/0xHoneyJar/loa/issues/1172 — the framework should emit git-anchored (or `$CLAUDE_PROJECT_DIR`-anchored) hook paths, and Claude Code's project-root detection for worktrees under `.claude/worktrees/` is the deeper root cause worth reporting to Anthropic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
