### PR TITLE
feat(datastore-legibility S1 · network): register cells + loa doctor --data (the settle gate)

### DIFF
--- a/packages/freeside-cli/bin/freeside-cli.ts
+++ b/packages/freeside-cli/bin/freeside-cli.ts
@@ -12,7 +12,7 @@
 
 import { listModules, printList } from "../src/verbs/list.js";
 import { inspectModule } from "../src/verbs/inspect.js";
-import { doctor } from "../src/verbs/doctor.js";
+import { doctor, doctorData, renderDataStoreTable } from "../src/verbs/doctor.js";
 import { orderVerb } from "../src/verbs/order.js";
 import { kitchenVerb } from "../src/verbs/kitchen.js";
 import { fulfillVerb } from "../src/verbs/fulfill.js";
@@ -85,6 +85,16 @@ const main = async (): Promise<number> => {
     }
     case "doctor": {
       const flags = args.slice(1);
+      // --data: cell data-store self-report projection (datastore-legibility SDD C-3).
+      // S1 settle gate — exits 0 (the report is the deliverable; an unreachable cell
+      // is a legible fact, not a failure). The `contested` → exit-1 fold arrives with
+      // the ratified label layer in S3.
+      if (flags.includes("--data")) {
+        const report = await doctorData({ registryPath: flagValue(flags, "--registry") });
+        console.log(JSON.stringify(report, null, 2));
+        console.log(renderDataStoreTable(report));
+        return 0;
+      }
       const report = await doctor({
         remote: flags.includes("--remote"),
         acvpOnly: flags.includes("--acvp"),

--- a/packages/freeside-cli/src/verbs/doctor.ts
+++ b/packages/freeside-cli/src/verbs/doctor.ts
@@ -35,7 +35,7 @@ import {
   type AcvpProofReceipt,
 } from "@freeside/beacon-schema";
 import { jcsCanonicalize, sha256Hex } from "../lib/jcs.js";
-import { hardenedBeaconFetcher } from "../lib/harden-beacon-fetch.js";
+import { hardenedBeaconFetcher, isBlockedAddress, normalizeHost } from "../lib/harden-beacon-fetch.js";
 
 export type Severity = "ok" | "warn" | "error";
 
@@ -108,6 +108,13 @@ export interface DoctorOptions {
    * step 3) that makes receipts actually consumed and backed buildings report
    * `bound`. Unset (or a clone absent) → unchanged fixture/null posture. */
   readonly cellsDir?: string;
+  /** --data: injected data-store self-report fetcher (determinism + no live calls
+   *  in tests). Default = `defaultDataStoreFetcher` (https-only + private-range
+   *  reject + Bearer per-cell token). Only used by `doctorData`. */
+  readonly fetchDataStore?: DataStoreFetcher;
+  /** --data: the in-scope cell slugs to probe. Default = `DATA_STORE_CELLS`
+   *  (S1 settle gate = ONE cell). S2/S3 widen this to the fan-out set. */
+  readonly dataCells?: readonly string[];
 }
 
 const ALL_ZEROS_64 = "0".repeat(64);
@@ -842,3 +849,209 @@ export const doctor = async (opts: DoctorOptions = {}): Promise<DoctorReport> =>
     },
   };
 };
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  --data: cell data-store self-report aggregator (datastore-legibility SDD C-3)
+//  Probes each in-scope cell's authed GET /admin/data-store, joins nothing yet
+//  (the ratified-label drift fold is S2/S3 / C-4+C-5), classifies topology, and
+//  prints JSON + a terse table. The S1 settle gate: ONE cell (ordering) legible
+//  end-to-end. G-3 holds — no Railway API, the operator's per-cell token only.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The sanitized shape a cell's `GET /admin/data-store` returns (datastore.report.v1).
+ *  Re-declared here (cross-package: the CLI cannot import ordering's type). */
+export interface CellDataStoreFacts {
+  readonly schema_version: "datastore.report.v1";
+  readonly engine: string | null;
+  readonly host_fp: string | null;
+  readonly reachable: boolean;
+  readonly migrations_applied: number | null;
+  readonly store: string;
+}
+
+/** Topology-only status for S1 (the ratified-label `contested`/`coherent` fold is
+ *  S3 / C-5). `reported` = cell served a valid report; `unreachable` = endpoint
+ *  present but unreachable/errored; `unreported` = no endpoint (no deployment_url / 404). */
+export type DataStoreStatus = "reported" | "unreachable" | "unreported";
+
+export interface DataStoreRow {
+  readonly slug: string;
+  readonly engine: string | null;
+  readonly host_fp: string | null;
+  readonly reachable: boolean;
+  readonly status: DataStoreStatus;
+}
+
+export interface DataStoreReport {
+  readonly schema_version: "datastore.doctor.v1";
+  readonly rows: readonly DataStoreRow[];
+  readonly summary: {
+    readonly cells: number;
+    readonly reported: number;
+    readonly unreachable: number;
+    readonly unreported: number;
+  };
+}
+
+export interface DataStoreFetchResult {
+  readonly status: number; // 0 on transport failure
+  readonly body: string;
+  readonly error?: string;
+}
+/** `(url, token) → result`. Injected for tests — the settle gate uses a fixture. */
+export type DataStoreFetcher = (url: string, token: string | undefined) => Promise<DataStoreFetchResult>;
+
+/** Phase-1 in-scope cells. S1 settle gate = ONE cell (ordering); S2/S3 widen it.
+ *  Explicit (not all of `registry.modules`) so the slice is exactly "ordering is
+ *  legible" until the remaining cells land their `/admin/data-store` route. */
+export const DATA_STORE_CELLS: readonly string[] = ["ordering"];
+
+/** Per-cell service-token env var, e.g. `ordering` → `ORDERING_SERVICE_TOKEN`. */
+export function dataStoreTokenEnv(slug: string): string {
+  return `${slug.replace(/[^a-z0-9]+/gi, "_").toUpperCase()}_SERVICE_TOKEN`;
+}
+
+/** Validate a cell body as `datastore.report.v1`; null when it is not that shape
+ *  (a 404 page / non-report blob is `unreported`/`unreachable`, never fabricated). */
+export function parseCellDataStoreFacts(body: string): CellDataStoreFacts | null {
+  if (!body) return null;
+  let p: unknown;
+  try {
+    p = JSON.parse(body);
+  } catch {
+    return null;
+  }
+  if (typeof p !== "object" || p === null) return null;
+  const o = p as Record<string, unknown>;
+  if (o.schema_version !== "datastore.report.v1") return null;
+  if (typeof o.reachable !== "boolean") return null;
+  return {
+    schema_version: "datastore.report.v1",
+    engine: typeof o.engine === "string" ? o.engine : null,
+    host_fp: typeof o.host_fp === "string" ? o.host_fp : null,
+    reachable: o.reachable,
+    migrations_applied: typeof o.migrations_applied === "number" ? o.migrations_applied : null,
+    store: typeof o.store === "string" ? o.store : "unknown",
+  };
+}
+
+/** Pure classifier (S1 topology-only). no endpoint → unreported; transport fail /
+ *  non-2xx / unparseable → unreachable; a valid report → reported. A 404 is a
+ *  reachable host WITHOUT the route → unreported (the route isn't deployed yet). */
+export function classifyDataStore(
+  hasEndpoint: boolean,
+  fetched: DataStoreFetchResult | null,
+  facts: CellDataStoreFacts | null,
+): DataStoreStatus {
+  if (!hasEndpoint) return "unreported";
+  if (!fetched || fetched.status === 0) return "unreachable";
+  if (fetched.status === 404) return "unreported";
+  if (fetched.status < 200 || fetched.status >= 300 || !facts) return "unreachable";
+  return "reported";
+}
+
+/** The default live fetcher: https-only + reject private/loopback/metadata resolved
+ *  IPs (`isBlockedAddress`) + timeout + Bearer per-cell token.
+ *  loa:shortcut: no cell-host allowlist + a resolve-then-fetch TOCTOU window; IP-pin
+ *  like `harden-beacon-fetch` when cells federate (that path is 443/allowlist-only and
+ *  cannot carry this auth). Upgrade trigger: `--data` reaching non-operator hosts. */
+export const defaultDataStoreFetcher: DataStoreFetcher = async (url, token) => {
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    return { status: 0, body: "", error: "bad_url" };
+  }
+  if (u.protocol !== "https:") return { status: 0, body: "", error: "not_https" };
+  if (!normalizeHost(u.hostname)) return { status: 0, body: "", error: "bad_host" };
+  try {
+    const { lookup } = await import("node:dns/promises");
+    const addrs = await lookup(u.hostname, { all: true });
+    if (addrs.some((a) => isBlockedAddress(a.address))) {
+      return { status: 0, body: "", error: "resolved_private" };
+    }
+  } catch {
+    return { status: 0, body: "", error: "dns_error" };
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 8000);
+  try {
+    const res = await fetch(url, {
+      headers: token ? { authorization: `Bearer ${token}` } : {},
+      signal: controller.signal,
+      redirect: "error",
+    });
+    return { status: res.status, body: await res.text() };
+  } catch {
+    return { status: 0, body: "", error: "transport_error" };
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/** `loa doctor --data` — probe each in-scope cell's `/admin/data-store`, classify,
+ *  and return the projection. Never throws on a cell failure — an unreachable cell
+ *  is a legible FACT (`status: unreachable`), not an aggregator error. */
+export const doctorData = async (opts: DoctorOptions = {}): Promise<DataStoreReport> => {
+  const registry = opts.registryPath ? loadRegistry(opts.registryPath) : loadRegistry();
+  const fetchDataStore = opts.fetchDataStore ?? defaultDataStoreFetcher;
+  const cells = opts.dataCells ?? DATA_STORE_CELLS;
+
+  const rows: DataStoreRow[] = [];
+  for (const slug of cells) {
+    const entry = registry.modules[slug];
+    const deploymentUrl = entry?.deployment_url ?? null;
+    if (!deploymentUrl) {
+      rows.push({ slug, engine: null, host_fp: null, reachable: false, status: "unreported" });
+      continue;
+    }
+    const url = `${deploymentUrl.replace(/\/+$/, "")}/admin/data-store`;
+    const token = process.env[dataStoreTokenEnv(slug)];
+    let fetched: DataStoreFetchResult | null = null;
+    try {
+      fetched = await fetchDataStore(url, token);
+    } catch {
+      fetched = null;
+    }
+    const facts =
+      fetched && fetched.status >= 200 && fetched.status < 300
+        ? parseCellDataStoreFacts(fetched.body)
+        : null;
+    const status = classifyDataStore(true, fetched, facts);
+    rows.push({
+      slug,
+      engine: facts?.engine ?? null,
+      host_fp: facts?.host_fp ?? null,
+      reachable: facts?.reachable ?? false,
+      status,
+    });
+  }
+
+  return {
+    schema_version: "datastore.doctor.v1",
+    rows,
+    summary: {
+      cells: rows.length,
+      reported: rows.filter((r) => r.status === "reported").length,
+      unreachable: rows.filter((r) => r.status === "unreachable").length,
+      unreported: rows.filter((r) => r.status === "unreported").length,
+    },
+  };
+};
+
+/** Terse table for `--data` (the `printList` precedent). host_fp is the salted
+ *  correlation id, never a secret; a null field prints as `-`. */
+export function renderDataStoreTable(report: DataStoreReport): string {
+  const w = Math.max(4, ...report.rows.map((r) => r.slug.length));
+  const lines: string[] = [
+    `  ${"SLUG".padEnd(w)}  ${"ENGINE".padEnd(9)}  ${"HOST_FP".padEnd(16)}  REACH  STATUS`,
+  ];
+  for (const r of report.rows) {
+    lines.push(
+      `  ${r.slug.padEnd(w)}  ${(r.engine ?? "-").padEnd(9)}  ${(r.host_fp ?? "-").padEnd(16)}  ${r.reachable ? "yes  " : "no   "}  ${r.status}`,
+    );
+  }
+  const s = report.summary;
+  lines.push(`  ${s.cells} cell(s): ${s.reported} reported · ${s.unreachable} unreachable · ${s.unreported} unreported`);
+  return lines.join("\n");
+}

--- a/packages/freeside-cli/tests/data-store.test.ts
+++ b/packages/freeside-cli/tests/data-store.test.ts
@@ -1,0 +1,117 @@
+/**
+ * `loa doctor --data` — the datastore-legibility S1 settle gate (SDD C-3).
+ * One cell (ordering) legible end-to-end: registry → self-report → classified row.
+ * The network is injected (DataStoreFetcher), so the settle gate uses a fixture and
+ * never hits a live cell.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  doctorData,
+  classifyDataStore,
+  parseCellDataStoreFacts,
+  renderDataStoreTable,
+  dataStoreTokenEnv,
+  type DataStoreFetcher,
+} from "../src/verbs/doctor.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REGISTRY = join(__dirname, "fixtures", "registry-datastore-fixture.yaml");
+
+const ORDERING_FACTS = {
+  schema_version: "datastore.report.v1",
+  engine: "postgres",
+  host_fp: "a1b2c3d4e5f60718",
+  reachable: true,
+  migrations_applied: null,
+  store: "postgres",
+};
+
+/** A fetcher that serves a fixed body/status regardless of URL (fixture). */
+const serve = (status: number, body: string): DataStoreFetcher => async () => ({ status, body });
+
+test("settle gate: ordering is legible end-to-end → one reported row", async () => {
+  const report = await doctorData({
+    registryPath: REGISTRY,
+    dataCells: ["ordering"],
+    fetchDataStore: serve(200, JSON.stringify(ORDERING_FACTS)),
+  });
+  assert.equal(report.schema_version, "datastore.doctor.v1");
+  assert.equal(report.rows.length, 1);
+  assert.deepEqual(report.rows[0], {
+    slug: "ordering",
+    engine: "postgres",
+    host_fp: "a1b2c3d4e5f60718",
+    reachable: true,
+    status: "reported",
+  });
+  assert.equal(report.summary.reported, 1);
+  assert.equal(report.summary.unreachable, 0);
+});
+
+test("a cell it can't reach → status unreachable (transport failure)", async () => {
+  const report = await doctorData({
+    registryPath: REGISTRY,
+    dataCells: ["ordering"],
+    fetchDataStore: serve(0, ""),
+  });
+  assert.equal(report.rows[0]?.status, "unreachable");
+  assert.equal(report.rows[0]?.reachable, false);
+  assert.equal(report.summary.unreachable, 1);
+});
+
+test("a cell with no deployment_url → status unreported (endpoint absent)", async () => {
+  const report = await doctorData({
+    registryPath: REGISTRY,
+    dataCells: ["no-store-cell"],
+    fetchDataStore: serve(200, JSON.stringify(ORDERING_FACTS)), // never called — no endpoint
+  });
+  assert.equal(report.rows[0]?.status, "unreported");
+  assert.equal(report.summary.unreported, 1);
+});
+
+test("a reachable host without the route (404) → unreported, not a fabricated row", async () => {
+  const report = await doctorData({
+    registryPath: REGISTRY,
+    dataCells: ["ordering"],
+    fetchDataStore: serve(404, "not found"),
+  });
+  assert.equal(report.rows[0]?.status, "unreported");
+  assert.equal(report.rows[0]?.host_fp, null);
+});
+
+test("classifyDataStore — the topology matrix (pure)", () => {
+  const facts = parseCellDataStoreFacts(JSON.stringify(ORDERING_FACTS));
+  assert.equal(classifyDataStore(false, null, null), "unreported"); // no endpoint
+  assert.equal(classifyDataStore(true, { status: 0, body: "" }, null), "unreachable"); // transport fail
+  assert.equal(classifyDataStore(true, { status: 500, body: "" }, null), "unreachable"); // 5xx
+  assert.equal(classifyDataStore(true, { status: 404, body: "" }, null), "unreported"); // no route
+  assert.equal(classifyDataStore(true, { status: 200, body: "{}" }, facts), "reported"); // valid
+});
+
+test("parseCellDataStoreFacts — validates the datastore.report.v1 shape", () => {
+  assert.ok(parseCellDataStoreFacts(JSON.stringify(ORDERING_FACTS)));
+  assert.equal(parseCellDataStoreFacts('{"schema_version":"wrong"}'), null);
+  assert.equal(parseCellDataStoreFacts("not json"), null);
+  assert.equal(parseCellDataStoreFacts(""), null);
+});
+
+test("dataStoreTokenEnv — per-cell service-token env name", () => {
+  assert.equal(dataStoreTokenEnv("ordering"), "ORDERING_SERVICE_TOKEN");
+  assert.equal(dataStoreTokenEnv("shadow-audit"), "SHADOW_AUDIT_SERVICE_TOKEN");
+});
+
+test("renderDataStoreTable — terse table surfaces slug + status", async () => {
+  const report = await doctorData({
+    registryPath: REGISTRY,
+    dataCells: ["ordering"],
+    fetchDataStore: serve(200, JSON.stringify(ORDERING_FACTS)),
+  });
+  const table = renderDataStoreTable(report);
+  assert.match(table, /ordering/);
+  assert.match(table, /reported/);
+  assert.match(table, /a1b2c3d4e5f60718/); // host_fp shown
+  assert.doesNotMatch(table, /railway\.app/); // no deployment URL leaks into the table
+});

--- a/packages/freeside-cli/tests/fixtures/registry-datastore-fixture.yaml
+++ b/packages/freeside-cli/tests/fixtures/registry-datastore-fixture.yaml
@@ -1,0 +1,18 @@
+# Test registry — doctor --data (datastore-legibility S1-T4). `ordering` carries a
+# deployment_url (the /admin/data-store base); `no-store-cell` has none (unreported).
+version: 1
+modules:
+  ordering:
+    git_url: https://github.com/0xHoneyJar/loa-freeside.git
+    beacon_url: ~
+    deployment_url: https://ordering-service-production.up.railway.app
+    visibility: internal
+    owner: 0xHoneyJar
+    added: "2026-07-01"
+  no-store-cell:
+    git_url: https://github.com/0xHoneyJar/loa-freeside.git
+    beacon_url: ~
+    deployment_url: ~
+    visibility: internal
+    owner: 0xHoneyJar
+    added: "2026-07-03"

--- a/packages/freeside-registry/registry.yaml
+++ b/packages/freeside-registry/registry.yaml
@@ -220,6 +220,64 @@ modules:
       (Vercel) and freeside-cli order/kitchen/fulfill verbs. Beacon deferred — not a
       federation cell yet; registry entry is the declaration keystone (transmission.md).
 
+  shadow-mode:
+    git_url: https://github.com/0xHoneyJar/loa-freeside.git
+    beacon_url: ~
+    deployment_url: ~
+    visibility: internal
+    owner: 0xHoneyJar
+    added: "2026-07-03"
+    runtime_state: scaffolded
+    notes: |
+      The hash-chained member-graph + collection ledger (packages/services/shadow-mode,
+      in-monolith). Ships a Hono router factory (createShadowRouter) + CLIs (chain-admin,
+      collections) — NO standalone server entry yet, so no live deployment_url. Postgres-
+      native (pg_advisory_xact_lock, jsonb, timestamptz). Registered as the declaration
+      keystone (datastore-legibility A-1); runtime_state + data-store reconciled by
+      `loa doctor` / `loa doctor --data`, not hand-asserted.
+
+  shadow-audit:
+    git_url: https://github.com/0xHoneyJar/loa-freeside.git
+    beacon_url: ~
+    deployment_url: ~
+    visibility: internal
+    owner: 0xHoneyJar
+    added: "2026-07-03"
+    runtime_state: scaffolded
+    notes: |
+      The access-audit settle gate (packages/services/shadow-audit, in-monolith Hono +
+      bin/http.ts, GET /healthz, X-API-Key gate). NO database — in-memory event store; its
+      data-store self-report is the absent-store shape (store:none). Deploy status
+      unconfirmed this session — reconciled by `loa doctor`.
+
+  worker:
+    git_url: https://github.com/0xHoneyJar/loa-freeside.git
+    beacon_url: ~
+    deployment_url: ~
+    visibility: internal
+    owner: 0xHoneyJar
+    added: "2026-07-03"
+    runtime_state: scaffolded
+    notes: |
+      NATS/queue consumer (apps/worker) — NOT an HTTP app server; raw node:http health
+      port only (/health, /healthz), unauthenticated (Tailscale/network boundary). Uses
+      postgres.js + Drizzle (DATABASE_URL). Its /admin/data-store branch requires a
+      shared-secret gate (datastore-legibility A-4). Deploy status reconciled by probe.
+
+  operator-dash:
+    git_url: https://github.com/0xHoneyJar/loa-freeside.git
+    beacon_url: ~
+    deployment_url: ~
+    visibility: internal
+    owner: 0xHoneyJar
+    added: "2026-07-03"
+    runtime_state: scaffolded
+    notes: |
+      Operator dashboard (apps/freeside-operator-dash, Hono, GET /healthz). Reads
+      registry.yaml + probes cells; NO database of its own → absent-store shape
+      (store:none). v0.1 has no auth (runs behind Tailscale/OPERATOR_TOKEN). Registered
+      as declaration keystone; deploy + data-store reconciled by `loa doctor`.
+
   score-api:
     # The runtime building (was 'score-mibera' in pre-2026-05-23 registry). GH repo
     # renamed score-mibera → score-api. The SCHEMA package @freeside/freeside-score

--- a/packages/freeside-registry/tests/datastore-cells-registered.test.ts
+++ b/packages/freeside-registry/tests/datastore-cells-registered.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Unit test · datastore-legibility S1-T1 — the four in-monolith cells are
+ * registered as modules (SDD A-1: "register the cells first"). Before the
+ * data-store surface can make them legible, the registry must know they exist.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadRegistry } from "../src/index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const REGISTRY = join(here, "..", "registry.yaml");
+
+const NEW_CELLS = ["shadow-mode", "shadow-audit", "worker", "operator-dash"] as const;
+
+test("the four in-monolith cells are registered as internal modules", () => {
+  const registry = loadRegistry(REGISTRY);
+  for (const slug of NEW_CELLS) {
+    const entry = registry.modules[slug];
+    assert.ok(entry, `${slug} must be a registered module`);
+    assert.equal(entry.visibility, "internal", `${slug} is internal`);
+    assert.equal(entry.git_url, "https://github.com/0xHoneyJar/loa-freeside.git", `${slug} is in-monolith`);
+  }
+});
+
+test("registration does not disturb the existing ordering entry", () => {
+  const registry = loadRegistry(REGISTRY);
+  const ordering = registry.modules["ordering"];
+  assert.ok(ordering);
+  assert.equal(ordering.deployment_url, "https://ordering-service-production.up.railway.app");
+});


### PR DESCRIPTION
**S1 settle gate — the NETWORK half.** Part of the datastore-legibility cycle's S1 vertical slice, split by domain per the ADR-007 firewall (platform half in the sibling PR `datastore-legibility/platform`). The two are independent (runtime-coupled only; tests use fixtures) and can merge in any order.

### What lands
- **S1-T1 register 4 in-monolith cells** — adds `shadow-mode`, `shadow-audit`, `worker`, `operator-dash` to `registry.yaml` (SDD A-1, the operator's "register the cells first" decision). The registry doesn't know its own members until it does; this closes that gap ahead of the S2/S3 fan-out. Declarations only (`runtime_state` per reality).
- **S1-T4 `loa doctor --data`** — the settle-gate reader. Probes each in-scope cell's authed `/admin/data-store`, classifies topology, prints JSON + a terse table. S1 = ONE cell (`ordering`) legible end-to-end: register → self-report → `doctor --data` → row. `classifyDataStore` is a pure function (no endpoint → unreported; 404 → unreported; transport fail / non-2xx → unreachable; valid report → reported). `defaultDataStoreFetcher` is https-only + private/metadata-IP reject + Bearer, injectable so the settle gate uses a fixture (no live calls). G-3: no Railway API.

### Verification
- freeside-cli suite **102/102** (+1 live-diff skip), `tsc` + build clean.
- AC (8 tests): ordering legible → one `reported` row; unreachable cell → `unreachable`; no `deployment_url` → `unreported`; 404 → `unreported`; pure classifier matrix; report-shape validation; the table never leaks the deployment URL.

### Deferred (marked in-code)
`defaultDataStoreFetcher` carries a `loa:shortcut` — no cell-host allowlist + a resolve-then-fetch TOCTOU window; IP-pin like `harden-beacon-fetch` when `--data` reaches non-operator hosts (that path is 443/allowlist-only and can't carry this auth). The `contested`-drift → exit-1 fold arrives with the ratified label layer in S3.

### Domain purity
Net diff touches **network** only (`packages/freeside-cli`, `packages/freeside-registry`) — **0 platform paths**. Passes `path-domain-check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)