### PR TITLE
feat(shared/evals): GV6 Ring 1 theatre — C1-C9 rubric + three admission bundles (echelon-core#178)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -435,3 +435,7 @@ themes/packages/services/*.js
 themes/packages/services/*.js.map
 themes/packages/services/*.d.ts
 themes/packages/services/*.d.ts.map
+
+# Cross-org external handoffs are durable publications (e.g. GV6 theatre bundles, echelon-core#178)
+!grimoires/loa/a2a/external/
+!grimoires/loa/a2a/external/**

--- a/evals/environment-design/construct-rubric.py
+++ b/evals/environment-design/construct-rubric.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""
+construct-rubric.py — the C1–C9 construct-admission rubric (issue
+AITOBIAS04/echelon-core#178, Ring 1 theatre).
+
+Grades a ConstructAdmissionBundle directory against the 9 deterministic checks
+ratified on #178: file-only, crisp pass/fail, zero LLM, zero network. This file
+IS the rubric — `rubric_hash` in a bundle's registration payload is the sha256
+of this file's committed bytes, so a cert names the exact rubric that graded it
+and any party can re-derive the verdict.
+
+Bundle layout (bundle_schema_version 1.0.0):
+  manifest.json       construct.yaml mapped 1:1 to JSON (schema_version 3)
+  SKILL.md            primary skill (optional if skills/**/SKILL.md present)
+  skills/**/SKILL.md  per-skill files
+  reality.md          harness-grounding file (identity/environment.md axis)
+  handoff.md          seam/handoff contract
+  genome.jsonl        learning-ledger hash chain (see C8 recipe below)
+  proof-of-run.json   run attestation (see C9)
+  registration.json   {slug, version, content_hash, skill_manifest,
+                       domain_claims, rubric_hash}
+
+The 9 checks:
+  C1 manifest parses
+  C2 registry-required fields present (schema_version/name/slug/version)
+  C3 model_tier in the SoT vocabulary — read LIVE from
+     .claude/defaults/model-config.yaml aliases (never a carried copy), plus
+     the hounfour tier equivalences reconciled 2026-06-07
+     (cheap/mid≡sonnet · tiny≡haiku · max≡opus)
+  C4 write capability never routes through a read-only agent type
+     (the #553 silent-output-drop class)
+  C5 capability declarations match the toolset
+     (capabilities.write_files:false + Write/Edit tool = fail)
+  C6 skill prose uses canonical primitives (`br` for tasks, `ck` for search —
+     no `bd`, no raw grep/rg code-search)
+  C7 grounding file exists (reality.md axis; an honest absence stub marked
+     "ABSENT IN SOURCE" is a FAIL — honesty changes the verdict's meaning,
+     not its direction)
+  C8 genome hash chain verifies, recomputed from genesis:
+       link.genome_hash == sha256hex(jcs(link minus its genome_hash field))
+       link.parent_hash == previous link's genome_hash (first: "GENESIS")
+     jcs = loa_cheval.jcs.canonicalize (RFC 8785) — the same core as the
+     audit-envelope, genome, and GV6 cert chains. Tamper = fail.
+  C9 proof-of-run: verdict == "valid_run" AND content_hash_verified recomputes
+     over the core members AND verifier_type is present. verifier_type is
+     REQUIRED so a self-baseline can never pass silently — the Echelon §6.6
+     pattern (frozen_replay_baseline): synthetic is admissible, undisclosed
+     synthetic is not.
+
+content_hash recipe (C9, mirrors each bundle's HASHING.md):
+  core = [manifest.json, reality.md, handoff.md] + sorted(skills/**/SKILL.md)
+         + SKILL.md if present at bundle root
+  listing = "".join(f"{sha256hex(bytes(m))}  {relpath}\n" for m in sorted-by-relpath)
+  content_hash = sha256hex(listing)
+
+Read-only agent types (C4) mirror WRITE_CAPABLE_AGENTS in
+validate-skill-capabilities.sh: Plan and Explore exclude Write/Edit.
+
+Usage:
+  construct-rubric.py grade --bundle <dir> [--json]
+  construct-rubric.py rubric-hash          # sha256 of this file (the pin)
+
+Exit: 0 all checks pass · 1 one or more fail · 2 usage/malformed bundle ·
+      70 cannot import loa_cheval.jcs.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def _find_adapters() -> "Path | None":
+    env = os.environ.get("LOA_GENOME_ADAPTERS")
+    if env and (Path(env) / "loa_cheval" / "jcs.py").is_file():
+        return Path(env)
+    here = Path(__file__).resolve()
+    for base in [here.parent, here.parent.parent, *here.parents]:
+        for cand in (base / "adapters", base / ".claude" / "adapters"):
+            if (cand / "loa_cheval" / "jcs.py").is_file():
+                return cand
+    return None
+
+
+_ADAPTERS = _find_adapters()
+if _ADAPTERS is not None:
+    sys.path.insert(0, str(_ADAPTERS))
+
+try:
+    from loa_cheval.jcs import canonicalize as _jcs
+except Exception as exc:
+    print(f"construct-rubric: FATAL — cannot import loa_cheval.jcs: {exc}", file=sys.stderr)
+    sys.exit(70)
+
+READ_ONLY_AGENTS = {"Plan", "Explore"}
+WRITE_TOOLS = {"Write", "Edit", "NotebookEdit"}
+# hounfour tier equivalences (reconciled 2026-06-07: cheap≡sonnet NOT haiku);
+# unioned with the LIVE alias keys read from model-config.yaml at grade time.
+HOUNFOUR_TIER_NAMES = {"cheap", "mid", "tiny", "max", "opus", "sonnet", "haiku"}
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _canon_bytes(value) -> bytes:
+    out = _jcs(value)
+    return out if isinstance(out, bytes) else out.encode("utf-8")
+
+
+def genome_link_hash(link: dict) -> str:
+    body = {k: v for k, v in link.items() if k != "genome_hash"}
+    return _sha256_hex(_canon_bytes(body))
+
+
+def _sot_vocabulary() -> "set[str] | None":
+    """Alias keys read live from the model-config SoT, or None if unreadable."""
+    here = Path(__file__).resolve()
+    for base in [here.parent, *here.parents]:
+        cfg = base / ".claude" / "defaults" / "model-config.yaml"
+        if cfg.is_file():
+            in_aliases, keys = False, set()
+            for line in cfg.read_text().splitlines():
+                if re.match(r"^aliases:\s*$", line):
+                    in_aliases = True
+                    continue
+                if in_aliases:
+                    if line.strip() and not line.startswith(" "):
+                        break  # left the aliases block
+                    m = re.match(r"^  ([A-Za-z0-9_.-]+):", line)
+                    if m:
+                        keys.add(m.group(1))
+            return keys | HOUNFOUR_TIER_NAMES
+    return None
+
+
+def _frontmatter(text: str) -> dict:
+    """Minimal targeted frontmatter read: agent, allowed-tools, write_files."""
+    fm: dict = {}
+    if not text.startswith("---"):
+        return fm
+    body = text.split("---", 2)
+    if len(body) < 3:
+        return fm
+    for line in body[1].splitlines():
+        m = re.match(r"^agent:\s*(\S+)", line)
+        if m:
+            fm["agent"] = m.group(1).strip("'\"")
+        m = re.match(r"^allowed-tools:\s*\[(.*)\]", line)
+        if m:
+            fm["allowed-tools"] = [t.strip().strip("'\"") for t in m.group(1).split(",")]
+        m = re.match(r"^\s*write_files:\s*(true|false)", line)
+        if m:
+            fm["write_files"] = m.group(1) == "true"
+    return fm
+
+
+def _skill_files(bundle: Path) -> "list[Path]":
+    files = sorted(bundle.glob("skills/**/SKILL.md"))
+    if (bundle / "SKILL.md").is_file():
+        files.insert(0, bundle / "SKILL.md")
+    return files
+
+
+def _core_members(bundle: Path) -> "list[Path]":
+    members = [bundle / n for n in ("manifest.json", "reality.md", "handoff.md")
+               if (bundle / n).is_file()]
+    members += _skill_files(bundle)
+    return sorted(set(members), key=lambda p: p.relative_to(bundle).as_posix())
+
+
+def content_hash(bundle: Path) -> str:
+    listing = "".join(
+        f"{_sha256_hex(m.read_bytes())}  {m.relative_to(bundle).as_posix()}\n"
+        for m in _core_members(bundle))
+    return _sha256_hex(listing.encode("utf-8"))
+
+
+# Canonical-primitive violations (C6): bd task commands; raw recursive
+# grep / bare rg code-search. `--grep` (git log) and prose mentions survive.
+_BD_RE = re.compile(r"(?m)^\s*(?:\$ )?bd\s+(create|update|close|ready|list|show|sync)\b")
+_GREP_RE = re.compile(r"(?m)^\s*(?:\$ )?(?:rg|grep\s+-[a-zA-Z]*r)\s+\S")
+
+
+def grade(bundle: Path) -> dict:
+    checks: list[dict] = []
+
+    def check(cid: str, name: str, ok: bool, reason: str) -> None:
+        checks.append({"check_id": cid, "name": name,
+                       "status": "pass" if ok else "fail", "reason": reason})
+
+    # C1 + C2 — manifest
+    manifest = None
+    try:
+        manifest = json.loads((bundle / "manifest.json").read_text())
+        check("C1", "manifest_parses", True, "manifest.json is valid JSON")
+    except Exception as exc:
+        check("C1", "manifest_parses", False, f"{exc}")
+    if manifest is not None:
+        missing = [f for f in ("schema_version", "name", "slug", "version")
+                   if f not in manifest]
+        check("C2", "registry_required_fields", not missing,
+              "all present" if not missing else f"missing: {missing}")
+    else:
+        check("C2", "registry_required_fields", False, "no parsed manifest")
+
+    # C3 — model_tier in SoT vocabulary (live read)
+    vocab = _sot_vocabulary()
+    tier = (manifest or {}).get("capabilities", {}).get("model_tier")
+    if vocab is None:
+        check("C3", "model_tier_in_sot", False,
+              "SOT_UNREACHABLE: model-config.yaml not found (indeterminate → fail-closed)")
+    elif tier is None:
+        check("C3", "model_tier_in_sot", True, "no model_tier declared (nothing to validate)")
+    else:
+        check("C3", "model_tier_in_sot", tier in vocab,
+              f"model_tier '{tier}' {'in' if tier in vocab else 'NOT in'} live SoT vocabulary")
+
+    # C4 + C5 — per-skill frontmatter
+    c4_bad, c5_bad = [], []
+    for sf in _skill_files(bundle):
+        fm = _frontmatter(sf.read_text())
+        tools = set(fm.get("allowed-tools", []))
+        writes = bool(tools & WRITE_TOOLS) or fm.get("write_files") is True
+        if writes and fm.get("agent") in READ_ONLY_AGENTS:
+            c4_bad.append(f"{sf.relative_to(bundle)} (agent: {fm['agent']})")
+        if fm.get("write_files") is False and tools & WRITE_TOOLS:
+            c5_bad.append(str(sf.relative_to(bundle)))
+    check("C4", "no_write_through_readonly_agent", not c4_bad,
+          "no write-capable skill routes through a read-only agent type"
+          if not c4_bad else f"write capability on read-only agent: {c4_bad}")
+    check("C5", "capabilities_match_toolset", not c5_bad,
+          "declarations consistent with toolsets"
+          if not c5_bad else f"write_files:false but Write/Edit tools: {c5_bad}")
+
+    # C6 — canonical primitives in skill prose
+    c6_bad = []
+    for sf in _skill_files(bundle):
+        text = sf.read_text()
+        if _BD_RE.search(text) or _GREP_RE.search(text):
+            c6_bad.append(str(sf.relative_to(bundle)))
+    check("C6", "canonical_primitives", not c6_bad,
+          "no bd task commands, no raw recursive-grep/rg code-search"
+          if not c6_bad else f"non-canonical primitives in: {c6_bad}")
+
+    # C7 — grounding file
+    reality = bundle / "reality.md"
+    if not reality.is_file():
+        check("C7", "grounding_file_exists", False, "reality.md absent")
+    elif "ABSENT IN SOURCE" in reality.read_text()[:200]:
+        check("C7", "grounding_file_exists", False,
+              "reality.md is an honest absence stub — no grounding file in source")
+    else:
+        check("C7", "grounding_file_exists", True, "reality.md present")
+
+    # C8 — genome hash chain
+    genome = bundle / "genome.jsonl"
+    if not genome.is_file():
+        check("C8", "genome_chain_verifies", False, "genome.jsonl absent")
+    else:
+        problems, parent = [], "GENESIS"
+        for i, raw in enumerate(l for l in genome.read_text().splitlines() if l.strip()):
+            link = json.loads(raw)
+            if link.get("parent_hash") != parent:
+                problems.append(f"link {i + 1}: parent_hash != previous genome_hash")
+            recomputed = genome_link_hash(link)
+            if link.get("genome_hash") != recomputed:
+                problems.append(f"link {i + 1}: stored genome_hash != recompute")
+            parent = link.get("genome_hash")
+        check("C8", "genome_chain_verifies", not problems,
+              "chain recomputes from genesis" if not problems else "; ".join(problems))
+
+    # C9 — proof-of-run
+    por_path = bundle / "proof-of-run.json"
+    if not por_path.is_file():
+        check("C9", "proof_of_run", False, "proof-of-run.json absent (no trace = roleplay)")
+    else:
+        try:
+            por = json.loads(por_path.read_text())
+            reasons = []
+            if por.get("verdict") != "valid_run":
+                reasons.append(f"verdict '{por.get('verdict')}' != valid_run")
+            if not por.get("verifier_type"):
+                reasons.append("verifier_type absent — undisclosed provenance never passes")
+            actual = content_hash(bundle)
+            if por.get("content_hash_verified") != actual:
+                reasons.append(f"content_hash_verified does not recompute (actual {actual[:16]}…)")
+            check("C9", "proof_of_run", not reasons,
+                  f"valid_run · verifier_type={por.get('verifier_type')} · content_hash recomputes"
+                  if not reasons else "; ".join(reasons))
+        except Exception as exc:
+            check("C9", "proof_of_run", False, f"unreadable: {exc}")
+
+    passed = sum(1 for c in checks if c["status"] == "pass")
+    return {"bundle": bundle.name, "score": f"{passed}/9", "passed": passed,
+            "rubric_hash": "sha256:" + _sha256_hex(Path(__file__).read_bytes()),
+            "checks": checks}
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="C1–C9 construct-admission rubric")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    pg = sub.add_parser("grade")
+    pg.add_argument("--bundle", required=True)
+    pg.add_argument("--json", action="store_true")
+    sub.add_parser("rubric-hash")
+    args = p.parse_args()
+
+    if args.cmd == "rubric-hash":
+        print("sha256:" + _sha256_hex(Path(__file__).read_bytes()))
+        return 0
+
+    bundle = Path(args.bundle)
+    if not bundle.is_dir():
+        print(f"construct-rubric: not a directory: {bundle}", file=sys.stderr)
+        return 2
+    result = grade(bundle)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        for c in result["checks"]:
+            print(f"{c['check_id']} {'PASS' if c['status'] == 'pass' else 'FAIL'}  "
+                  f"{c['name']} — {c['reason']}")
+        print(f"\n{result['bundle']}: {result['score']}")
+    return 0 if result["passed"] == 9 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/evals/environment-design/construct-rubric.py
+++ b/evals/environment-design/construct-rubric.py
@@ -36,11 +36,20 @@ The 9 checks:
   C7 grounding file exists (reality.md axis; an honest absence stub marked
      "ABSENT IN SOURCE" is a FAIL — honesty changes the verdict's meaning,
      not its direction)
-  C8 genome hash chain verifies, recomputed from genesis:
-       link.genome_hash == sha256hex(jcs(link minus its genome_hash field))
-       link.parent_hash == previous link's genome_hash (first: "GENESIS")
+  C8 genome hash chain verifies, recomputed from genesis. TWO dialects, each
+     with its exact minting recipe (rubric v1.0.1 — the fleet sweep caught the
+     v1.0.0 seam where a canonical chain would fail spuriously):
+       * canonical LEARNINGS dialect (any line carries distill_status):
+         delegated to the vendored genome-chain.py — distilled clews in
+         genome_seq order, link = compute_link(parent, entry) =
+         "sha256:" + sha256hex(jcs({parent, entry minus bookkeeping})),
+         parent = "genesis" at depth 1. Zero distilled links = vacuous pass
+         (canonical verifier semantics), stated in the reason.
+       * bundle dialect (theatre exemplars):
+         link.genome_hash == sha256hex(jcs(link minus its genome_hash field)),
+         link.parent_hash == previous link's genome_hash (first: "GENESIS").
      jcs = loa_cheval.jcs.canonicalize (RFC 8785) — the same core as the
-     audit-envelope, genome, and GV6 cert chains. Tamper = fail.
+     audit-envelope, genome, and GV6 cert chains. Tamper = fail in both.
   C9 proof-of-run: verdict == "valid_run" AND content_hash_verified recomputes
      over the core members AND verifier_type is present. verifier_type is
      REQUIRED so a self-baseline can never pass silently — the Echelon §6.6
@@ -115,6 +124,33 @@ def _canon_bytes(value) -> bytes:
 def genome_link_hash(link: dict) -> str:
     body = {k: v for k, v in link.items() if k != "genome_hash"}
     return _sha256_hex(_canon_bytes(body))
+
+
+def _canonical_genome():
+    """The vendored genome-chain.py (same dir), imported once — never reinvent."""
+    import importlib.util
+    path = Path(__file__).resolve().parent / "genome-chain.py"
+    spec = importlib.util.spec_from_file_location("genome_chain", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _verify_canonical_chain(genome_path: Path) -> "tuple[bool, str]":
+    """LEARNINGS-dialect verify, delegated to genome-chain.py's recipe."""
+    gc = _canonical_genome()
+    distilled = gc._read_distilled(genome_path)
+    if not distilled:
+        return True, "canonical dialect: 0 distilled links — vacuously valid (no earned authority yet)"
+    parent, problems = gc.GENESIS, []
+    for i, entry in enumerate(distilled):
+        recomputed = gc.compute_link(parent, entry)
+        if entry.get("genome_hash") != recomputed:
+            problems.append(f"distilled link {i + 1}: stored genome_hash != recompute")
+        parent = entry.get("genome_hash")
+    if problems:
+        return False, "canonical dialect: " + "; ".join(problems)
+    return True, f"canonical dialect: {len(distilled)}-link chain recomputes from genesis"
 
 
 def _sot_vocabulary() -> "set[str] | None":
@@ -257,22 +293,27 @@ def grade(bundle: Path) -> dict:
     else:
         check("C7", "grounding_file_exists", True, "reality.md present")
 
-    # C8 — genome hash chain
+    # C8 — genome hash chain (two dialects; see module docstring)
     genome = bundle / "genome.jsonl"
     if not genome.is_file():
         check("C8", "genome_chain_verifies", False, "genome.jsonl absent")
     else:
-        problems, parent = [], "GENESIS"
-        for i, raw in enumerate(l for l in genome.read_text().splitlines() if l.strip()):
-            link = json.loads(raw)
-            if link.get("parent_hash") != parent:
-                problems.append(f"link {i + 1}: parent_hash != previous genome_hash")
-            recomputed = genome_link_hash(link)
-            if link.get("genome_hash") != recomputed:
-                problems.append(f"link {i + 1}: stored genome_hash != recompute")
-            parent = link.get("genome_hash")
-        check("C8", "genome_chain_verifies", not problems,
-              "chain recomputes from genesis" if not problems else "; ".join(problems))
+        lines = [json.loads(l) for l in genome.read_text().splitlines() if l.strip()]
+        if any("distill_status" in l for l in lines):
+            ok, reason = _verify_canonical_chain(genome)
+            check("C8", "genome_chain_verifies", ok, reason)
+        else:
+            problems, parent = [], "GENESIS"
+            for i, link in enumerate(lines):
+                if link.get("parent_hash") != parent:
+                    problems.append(f"link {i + 1}: parent_hash != previous genome_hash")
+                recomputed = genome_link_hash(link)
+                if link.get("genome_hash") != recomputed:
+                    problems.append(f"link {i + 1}: stored genome_hash != recompute")
+                parent = link.get("genome_hash")
+            check("C8", "genome_chain_verifies", not problems,
+                  "bundle dialect: chain recomputes from genesis"
+                  if not problems else "bundle dialect: " + "; ".join(problems))
 
     # C9 — proof-of-run
     por_path = bundle / "proof-of-run.json"

--- a/evals/environment-design/fleet-sweep.py
+++ b/evals/environment-design/fleet-sweep.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+fleet-sweep.py — the C7/C8 grounding sweep over construct source repos
+(cycle-construct-grounding-c7, PRD NFR-2: the close-gate must be reproducible,
+not a session-scratchpad script).
+
+Walks every `construct-*` source repo and emits, per repo:
+
+  C7 axis — grounding:
+    present                    identity/environment.md exists
+    citation_present           file contains the literal the-ground.md URL
+    no_copied_shared_sections  file contains NONE of the five shared H2 titles
+                               and no `## I.`–`## V.` roman-numeral headings
+                               (cite, don't clone — NFR-1)
+    not_absence_stub           first 200 bytes lack the absence marker
+                               (mirrors rubric C7 — the marker is READ from
+                               construct-rubric.py, not carried)
+    probe_manifest_present     header carries `@ <7-to-40-hex sha>` — the
+                               territory-derived probe manifest (SDD D-2)
+
+  C8 axis — earned authority:
+    if construct.yaml mentions genome_hash, shell out to the CANONICAL
+    verifier (`genome-chain.py verify`) — never a reimplementation. Absent
+    chain = honest `no_chain`, not a failure.
+
+HARD CONSTRAINT (SDD D-4): construct-rubric.py is byte-frozen this cycle — its
+sha256 is pinned as `rubric_hash` on echelon-core#178. This driver LOADS it via
+importlib for shared semantics and NEVER modifies it.
+
+Repo discovery (SDD OQ-2 — settled by "whichever needs no new parser"):
+default = glob `construct-*` under --src-root; explicit list via --repos FILE
+(one repo dir name or path per line, `#` comments allowed). The loa-constructs
+registry is YAML and would need a parser this script doesn't carry.
+
+Usage:
+  fleet-sweep.py [--src-root ~/Documents/GitHub] [--repos FILE] [--json]
+Exit: 0 always for a completed sweep (it is a sensor, not a gate — gates read
+its JSON); 2 usage error; 70 rubric module unloadable.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+GROUND_URL = "https://github.com/0xHoneyJar/loa-constructs/blob/main/docs/the-ground.md"
+
+# The five shared H2 titles (SDD D-2 no_copied_shared_sections) + roman headings.
+SHARED_H2_TITLES = [
+    "Intelligence tiers",
+    "Forks & isolation",
+    "Agent types & tool allowlists",
+    "frontmatter contracts",
+    "How the gates are designed",
+]
+ROMAN_H2_RE = re.compile(r"(?m)^## (I|II|III|IV|V)\. ")
+PROBE_SHA_RE = re.compile(r"@ [0-9a-f]{7,40}\b")
+
+
+def _load_rubric():
+    """Load the byte-frozen rubric module for shared semantics (never edited)."""
+    path = HERE / "construct-rubric.py"
+    if not path.is_file():
+        print(f"fleet-sweep: FATAL — rubric module absent: {path}", file=sys.stderr)
+        sys.exit(70)
+    spec = importlib.util.spec_from_file_location("construct_rubric", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def check_c7(env_path: Path) -> dict:
+    """The presence + 4 D-2 conformance checks for one environment.md."""
+    if not env_path.is_file():
+        return {"present": False}
+    text = env_path.read_text(encoding="utf-8", errors="replace")
+    head = text[:200]
+    header = text[:1200]  # probe manifest lives in the header block
+    copied = [t for t in SHARED_H2_TITLES if re.search(rf"(?mi)^## .*{re.escape(t)}", text)]
+    if ROMAN_H2_RE.search(text):
+        copied.append("roman-numeral shared heading")
+    return {
+        "present": True,
+        "citation_present": GROUND_URL in text,
+        "no_copied_shared_sections": not copied,
+        "copied_sections": copied,
+        "not_absence_stub": "ABSENT IN SOURCE" not in head,
+        "probe_manifest_present": bool(PROBE_SHA_RE.search(header)),
+    }
+
+
+def c7_pass(c7: dict) -> bool:
+    return bool(
+        c7.get("present")
+        and c7.get("citation_present")
+        and c7.get("no_copied_shared_sections")
+        and c7.get("not_absence_stub")
+        and c7.get("probe_manifest_present")
+    )
+
+
+def check_c8(repo: Path) -> dict:
+    """Canonical-dialect chain verify, delegated to genome-chain.py."""
+    cy = repo / "construct.yaml"
+    lj = repo / "LEARNINGS.jsonl"
+    if not cy.is_file() or "genome_hash" not in cy.read_text(errors="replace"):
+        return {"status": "no_chain", "detail": "construct.yaml carries no genome_hash"}
+    gc = HERE / "genome-chain.py"
+    r = subprocess.run(
+        [sys.executable, str(gc), "verify", "--construct-yaml", str(cy),
+         "--learnings", str(lj), "--json"],
+        capture_output=True, text=True)
+    if r.returncode == 70:
+        return {"status": "error", "detail": "verifier could not load loa_cheval.jcs"}
+    try:
+        out = json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return {"status": "error", "detail": (r.stderr or r.stdout)[:200]}
+    return {"status": "verified" if out.get("ok") else "BROKEN",
+            "depth": out.get("recomputed_depth"), "problems": out.get("problems", [])}
+
+
+def discover_repos(src_root: Path, repos_file: "Path | None") -> "list[Path]":
+    if repos_file:
+        repos = []
+        for line in repos_file.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            p = Path(line).expanduser()
+            repos.append(p if p.is_absolute() else src_root / line)
+        return repos
+    return sorted(p for p in src_root.glob("construct-*") if p.is_dir())
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="C7/C8 grounding sweep over construct repos")
+    ap.add_argument("--src-root", default="~/Documents/GitHub")
+    ap.add_argument("--repos", type=Path, default=None)
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    rubric = _load_rubric()  # loaded for pinned semantics; also fails loud pre-sweep
+    src_root = Path(args.src_root).expanduser()
+    if not src_root.is_dir():
+        print(f"fleet-sweep: src-root not a directory: {src_root}", file=sys.stderr)
+        return 2
+
+    results = []
+    for repo in discover_repos(src_root, args.repos):
+        if not (repo / "construct.yaml").is_file():
+            results.append({"construct": repo.name, "skipped": "no construct.yaml"})
+            continue
+        c7 = check_c7(repo / "identity" / "environment.md")
+        results.append({
+            "construct": repo.name,
+            "c7": c7,
+            "c7_pass": c7_pass(c7),
+            "c8": check_c8(repo),
+        })
+
+    graded = [r for r in results if "c7_pass" in r]
+    summary = {
+        "rubric_sha256": rubric._sha256_hex((HERE / "construct-rubric.py").read_bytes()),
+        "repos_graded": len(graded),
+        "repos_skipped": len(results) - len(graded),
+        "c7_grounded": sum(1 for r in graded if r["c7_pass"]),
+        "c8_verified_chains": sum(1 for r in graded if r["c8"]["status"] == "verified"),
+        "c8_broken_chains": [r["construct"] for r in graded if r["c8"]["status"] == "BROKEN"],
+    }
+    out = {"summary": summary, "results": results}
+    if args.json:
+        print(json.dumps(out, indent=2))
+    else:
+        s = summary
+        print(f"fleet-sweep: {s['c7_grounded']}/{s['repos_graded']} grounded (C7) · "
+              f"{s['c8_verified_chains']} verified chains · broken: {s['c8_broken_chains'] or 'none'}")
+        for r in graded:
+            mark = "✓" if r["c7_pass"] else "✗"
+            fails = "" if r["c7_pass"] else " [" + ", ".join(
+                k for k, v in r["c7"].items()
+                if k not in ("copied_sections",) and v is False) + "]"
+            print(f"  {mark} {r['construct']}{fails}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/evals/tests/fleet-sweep.bats
+++ b/evals/tests/fleet-sweep.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+# fleet-sweep.bats — fixture tests for evals/environment-design/fleet-sweep.py
+# (cycle-construct-grounding-c7, Sprint 407 T1.5; SDD sdd.md:394-397).
+#
+# Three synthetic construct repos exercise the D-2 conformance verdicts:
+#   conforming      → c7_pass true
+#   absence-stub    → c7_pass false (not_absence_stub fails)
+#   copied-section  → c7_pass false (no_copied_shared_sections fails)
+# Plus: the D-4 hard constraint — the sweep never modifies construct-rubric.py.
+# Run: bats evals/tests/fleet-sweep.bats
+
+GROUND_URL="https://github.com/0xHoneyJar/loa-constructs/blob/main/docs/the-ground.md"
+
+setup() {
+  TEST_DIR="$(mktemp -d)"
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  SWEEP="$REPO_ROOT/evals/environment-design/fleet-sweep.py"
+
+  mk_repo() { # $1=name — construct.yaml + identity/
+    mkdir -p "$TEST_DIR/$1/identity"
+    printf 'schema_version: 3\nname: %s\nslug: %s\nversion: 0.1.0\n' "$1" "$1" \
+      > "$TEST_DIR/$1/construct.yaml"
+  }
+
+  # conforming: citation + probe sha + specific content, no shared sections
+  mk_repo construct-conforming
+  cat > "$TEST_DIR/construct-conforming/identity/environment.md" <<EOF
+# The Ground CONFORMING Stands On
+
+> Shared ground: $GROUND_URL
+> — this file carries ONLY the conforming-specific layer.
+> Probed from the live harness at construct-conforming @ abc1234, 2026-07-03.
+
+## 1. Runtime contract (probed)
+| Axis | Value | Source |
+|---|---|---|
+| model_tier | sonnet | construct.yaml:7 |
+EOF
+
+  # absence stub: the honest-absence marker in the first 200 bytes
+  mk_repo construct-stub
+  printf '# reality.md — ABSENT IN SOURCE\n\nno grounding file exists.\n' \
+    > "$TEST_DIR/construct-stub/identity/environment.md"
+
+  # copied section: carries a shared H2 title (clone, not cite)
+  mk_repo construct-copied
+  cat > "$TEST_DIR/construct-copied/identity/environment.md" <<EOF
+# The Ground COPIED Stands On
+
+> Shared ground: $GROUND_URL
+> Probed from the live harness at construct-copied @ def5678, 2026-07-03.
+
+## I. Intelligence tiers — the model ladder
+(cloned shared content)
+EOF
+}
+
+teardown() { rm -rf "$TEST_DIR"; }
+
+@test "conforming repo passes all C7 checks" {
+  run python3 "$SWEEP" --src-root "$TEST_DIR" --json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c '
+import json,sys
+r={x["construct"]:x for x in json.load(sys.stdin)["results"]}
+assert r["construct-conforming"]["c7_pass"] is True, r["construct-conforming"]'
+}
+
+@test "absence stub fails not_absence_stub" {
+  run python3 "$SWEEP" --src-root "$TEST_DIR" --json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c '
+import json,sys
+r={x["construct"]:x for x in json.load(sys.stdin)["results"]}
+c=r["construct-stub"]
+assert c["c7_pass"] is False and c["c7"]["not_absence_stub"] is False, c'
+}
+
+@test "copied shared section fails no_copied_shared_sections" {
+  run python3 "$SWEEP" --src-root "$TEST_DIR" --json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c '
+import json,sys
+r={x["construct"]:x for x in json.load(sys.stdin)["results"]}
+c=r["construct-copied"]
+assert c["c7_pass"] is False and c["c7"]["no_copied_shared_sections"] is False, c
+assert c["c7"]["citation_present"] is True, c  # it cited AND cloned — the clone is the defect'
+}
+
+@test "summary counts one grounded of three" {
+  run python3 "$SWEEP" --src-root "$TEST_DIR" --json
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c '
+import json,sys
+s=json.load(sys.stdin)["summary"]
+assert s["repos_graded"]==3 and s["c7_grounded"]==1, s'
+}
+
+@test "D-4: sweep never modifies construct-rubric.py (byte-frozen)" {
+  before="$(shasum -a 256 "$REPO_ROOT/evals/environment-design/construct-rubric.py" | cut -d' ' -f1)"
+  run python3 "$SWEEP" --src-root "$TEST_DIR" --json
+  [ "$status" -eq 0 ]
+  after="$(shasum -a 256 "$REPO_ROOT/evals/environment-design/construct-rubric.py" | cut -d' ' -f1)"
+  [ "$before" = "$after" ]
+  # the sweep also self-reports the rubric hash it loaded
+  echo "$output" | python3 -c "
+import json,sys
+assert json.load(sys.stdin)['summary']['rubric_sha256'] == '$after'"
+}

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/README.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/README.md
@@ -1,0 +1,50 @@
+# GV6 Ring 1 — first theatre bundles (echelon-core#178)
+
+Three `ConstructAdmissionBundle`s for the first cert-loop theatre ratified on
+[AITOBIAS04/echelon-core#178](https://github.com/AITOBIAS04/echelon-core/issues/178):
+the reference construct, a mid-tier construct, and a deliberately broken one.
+`bundle_schema_version` **1.0.0** (pinned, #200 resolved).
+
+| Bundle | Source | Score (C1–C9) | Fails | Why |
+|---|---|---|---|---|
+| `gecko/` | construct-gecko (the reference grounded construct) | **9/9** | — | reference-grade; its `reality.md` IS the `identity/environment.md` shape |
+| `herald/` | construct-herald | **8/9** | C7 | ships no `identity/environment.md`; `reality.md` is an honest absence stub |
+| `gecko-broken/` | gecko copy + 3 injections | **6/9** | C3, C4, C8 | invented `model_tier: quantum` · Write-capability routed through read-only `agent: Explore` · genome link 1 tampered post-mint (see its `INJECTIONS.md`) |
+
+## The rubric
+
+`evals/environment-design/construct-rubric.py` — the C1–C9 deterministic rubric.
+**`rubric_hash = sha256:c181978e4e8f2bce65171f57eb0fe6da4f1c0a52ec46118c1443ef92d52af9df`**
+(the sha256 of that file's committed bytes; every `registration.json` here carries
+it, so any party re-derives a verdict against the exact rubric that graded it):
+
+```
+python3 evals/environment-design/construct-rubric.py grade --bundle <dir> --json
+python3 evals/environment-design/construct-rubric.py rubric-hash
+```
+
+Machine-readable verdicts for all three bundles: `grades/*.json`.
+
+## Disclosures (structural, not prose)
+
+- **`proof-of-run.json` is a self-baseline** — `verifier_type:
+  "self_baseline_bundle_recompute"` (the Echelon §6.6 `frozen_replay_baseline`
+  pattern). No governed compose-verify run was minted; the attestation covers
+  only deterministic assembly + content_hash recomputation. C9 makes
+  `verifier_type` REQUIRED: synthetic is admissible, undisclosed synthetic is not.
+- **Genome chains are fabricated 2-link exemplars** — neither gecko nor herald
+  ships an in-repo `LEARNINGS.jsonl` yet. They exercise the chain VERIFIER
+  (including the tamper direction in `gecko-broken`); they do not represent
+  earned authority.
+- **`gecko-broken` registers under a distinct slug** while its manifest keeps
+  `slug: gecko` (it is a tampered copy of gecko — that is the point); the
+  registration identity is distinct so the registry never collides.
+
+## Hash recipes
+
+- `content_hash` (in `registration.json` + `proof-of-run.json`): see each
+  bundle's `HASHING.md` — sorted `sha256  relpath` listing over core members
+  (manifest, reality, handoff, SKILL.md files), sidecars excluded.
+- genome link hash: `sha256hex(jcs(link minus its genome_hash field))`,
+  `jcs = loa_cheval.jcs.canonicalize` (RFC 8785) — the same core as the
+  audit-envelope chain and the GV6 cert gate (Ring 0, loa-freeside PR #435).

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/README.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/README.md
@@ -14,9 +14,19 @@ the reference construct, a mid-tier construct, and a deliberately broken one.
 ## The rubric
 
 `evals/environment-design/construct-rubric.py` — the C1–C9 deterministic rubric.
-**`rubric_hash = sha256:c181978e4e8f2bce65171f57eb0fe6da4f1c0a52ec46118c1443ef92d52af9df`**
+**`rubric_hash = sha256:1374c7c445d8ab756e751160bb76e67f91f2cceaf4e56ba54fee3af9693ce370`**
 (the sha256 of that file's committed bytes; every `registration.json` here carries
 it, so any party re-derives a verdict against the exact rubric that graded it):
+
+> **Rubric changelog** (a rubric bump is a recorded seam event, never silent):
+> - **v1.0.1** `sha256:1374c7c4…93ce370` — C8 handles BOTH chain dialects: canonical
+>   `LEARNINGS.jsonl` distilled-clew chains (delegated to the vendored
+>   `genome-chain.py` recipe — `compute_link(parent, entry)`, bookkeeping stripped,
+>   `genome_seq` order, zero-distilled = vacuous pass) and the bundle-dialect links
+>   used by these theatre exemplars. Caught by a 51-construct fleet sweep: v1.0.0
+>   would have spuriously failed the first bundle carrying a real construct genome.
+> - **v1.0.0** `sha256:c181978e…d52af9df` — initial pin (bundle dialect only), as
+>   posted in the theatre-1 handover.
 
 ```
 python3 evals/environment-design/construct-rubric.py grade --bundle <dir> --json

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/EXPECTED.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/EXPECTED.md
@@ -1,0 +1,17 @@
+# EXPECTED — broken bundle · 6/9
+
+Base: gecko copy + 3 injected violations (see `INJECTIONS.md`).
+
+| # | Check | Verdict | Reasoning |
+|---|-------|---------|-----------|
+| 1 | manifest parses | PASS | `manifest.json` still valid JSON — `quantum` is a legal string. |
+| 2 | registry-required fields | PASS | schema_version/name/slug/version untouched. |
+| 3 | model_tier in SoT vocabulary | **FAIL** | Injection (b): `model_tier: quantum` ∉ SoT vocabulary. |
+| 4 | write cap never routes through read-only agent type | **FAIL** | Injection (a): `observe` declares `Write` + `agent: Explore` (read-only). |
+| 5 | capability declarations match toolset | PASS | Toolset/requires untouched by the injections. |
+| 6 | skill prose uses canonical primitives | PASS | Primitive usage untouched. |
+| 7 | grounding file exists (reality.md axis) | PASS | `reality.md` copied intact from gecko (`environment.md`). |
+| 8 | genome hash chain verifies | **FAIL** | Injection (c): link 1 mutated post-mint; stored `genome_hash` ≠ recompute; chain breaks. |
+| 9 | proof-of-run valid_run verdict | PASS | `proof-of-run.json` verdict `valid_run`; content_hash recomputed over injected content. |
+
+**Expected score: 6/9 — fails checks 3, 4, 8.**

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/HASHING.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/HASHING.md
@@ -1,6 +1,6 @@
 # content_hash recipe (== construct-rubric.py C9)
 
-`bundle_schema_version` 1.0.0 · rubric: `sha256:c181978e4e8f2bce65171f57eb0fe6da4f1c0a52ec46118c1443ef92d52af9df`
+`bundle_schema_version` 1.0.0 · rubric: `sha256:1374c7c445d8ab756e751160bb76e67f91f2cceaf4e56ba54fee3af9693ce370`
 
 ```
 core = [manifest.json, reality.md, handoff.md] + SKILL.md (root, if present)

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/HASHING.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/HASHING.md
@@ -1,0 +1,34 @@
+# content_hash recipe (== construct-rubric.py C9)
+
+`bundle_schema_version` 1.0.0 · rubric: `sha256:c181978e4e8f2bce65171f57eb0fe6da4f1c0a52ec46118c1443ef92d52af9df`
+
+```
+core = [manifest.json, reality.md, handoff.md] + SKILL.md (root, if present)
+       + skills/**/SKILL.md, sorted by bundle-relative path
+listing = concat(f'{sha256(bytes)}  {relpath}\n')
+content_hash = sha256(listing)
+```
+
+Sidecars excluded: genome.jsonl, proof-of-run.json, registration.json, HASHING.md, EXPECTED.md, INJECTIONS.md.
+
+## Per-member digests
+
+```
+f351f0280a651ee2833a96c1ddddfbe78771909331f9bcdfa913665dfffc7013  SKILL.md
+c03c4394ad9c18f5b41454c0314ea749b8d8a36c74da2dcbefff2886d3270783  handoff.md
+6e00fae9d30866d728ee3f52aa7f934e9eeaec7b2fa64db33d901d04a58b5424  manifest.json
+ea7e535da107af507ce3a8919bacef95e33c6dcf941e4e35a07c0e94ea0bafbf  reality.md
+22ca9f732c2a75e5eddb78a0b3a5c6a90999dc0f23387971210fdef930a7fa00  skills/diagnose/SKILL.md
+f351f0280a651ee2833a96c1ddddfbe78771909331f9bcdfa913665dfffc7013  skills/observe/SKILL.md
+152face2f7dbe12306fd776c65fd0d720b8fa0f04d74b1f1f96ed181d0446081  skills/patrol/SKILL.md
+772c43e9e92d5c8275359e6bffecc804e9fafcadce3dafae73e3662a3697d99f  skills/report/SKILL.md
+6675aedbbaa2f690872f5370fc97e535364516af3697e23519939fc692d9c0ca  skills/sense-estate/SKILL.md
+2982407e7bb980f3f8559b9c462e019cc893423fb095c485994a5eee4b2d3cf3  skills/sensing-config-drift/SKILL.md
+d7808d7ae90f13d3094a14348f7bdbfcee4601df680d5c79e596a80a8db7c4d7  skills/sensing-construct-console/SKILL.md
+4ca11122ab958d38468dfb3ff5ee52527ac77227780691eac9ee04d40f69e6f5  skills/sensing-deployment-seam/SKILL.md
+14cf050b8f095d3fe80eac9ec614b46772ae8dec29c4f0482753ca5941623375  skills/sensing-path-friction/SKILL.md
+d15d8d873f1cd1f6e683e5197a4ed1f5507f8a62863f13865198506915fde247  skills/sensing-runtime-fit/SKILL.md
+327ed902cf4f259edd7d964a8117a40f37c098199ebf012c39bb9cbfbe92bf89  skills/sweep-bonfire/SKILL.md
+```
+
+content_hash = `b7d7ca427ef3bf56bc665bed80f9921dc0cdd059ddc5ed1dfa2fbce80b2e3831`

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/INJECTIONS.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/INJECTIONS.md
@@ -1,0 +1,55 @@
+# INJECTIONS — broken bundle
+
+Base: an exact copy of the `gecko` bundle (manifest slug stays `gecko`, v0.1.0 —
+it IS a tampered copy of gecko; that is the theatre). The **registration** slug is
+`gecko-broken` so the registry identity never collides with the clean gecko bundle.
+Exactly three violations were injected, each targeting a distinct rubric check.
+Everything else is byte-identical to gecko in intent.
+
+## (a) write / agent conflict → fails check 4
+
+**File:** `SKILL.md` (and mirrored in `skills/observe/SKILL.md`).
+The `observe` skill already declares `allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]`
+(write-capable). Injected `agent: Explore` into the frontmatter. `Explore` is a
+read-only agent type (excludes Write/Edit/NotebookEdit), so the skill produces
+output and silently drops it — the #553 write/agent conflict.
+
+```diff
+ user-invocable: true
++agent: Explore
+ ---
+```
+
+## (b) invented model_tier → fails check 3
+
+**File:** `manifest.json`.
+`capabilities.model_tier` changed `opus` → `quantum`. `quantum` is not in the SoT
+tier vocabulary {cheap, mid, tiny, max, opus, sonnet, haiku}. The manifest still
+parses (check 1 PASS) — only the tier-vocabulary check fails.
+
+```diff
+-    "model_tier": "opus",
++    "model_tier": "quantum",
+```
+
+## (c) tampered genome link → fails check 8
+
+**File:** `genome.jsonl`.
+gecko ships **no** in-repo LEARNINGS.jsonl genome chain, so a valid 2-link chain
+was fabricated (same as the clean gecko bundle), then link 1's `payload.learning`
+was mutated **after** its `genome_hash` was minted. The stored `genome_hash` no
+longer recomputes over the mutated body, and link 2's `parent_hash` now points at
+a hash no member reproduces — the chain fails to verify.
+
+- link 1 stored `genome_hash`: `e1ddc8750f2c09aa…` (minted over the original body)
+- link 1 body now reads: `"TAMPERED: gating is fine actually"`
+- recompute(link1 body) ≠ stored → chain BROKEN
+
+Verified by the builder: `genome_ok = False — ['link 1: stored genome_hash != recompute']`.
+
+## Net effect
+
+Fails checks **3, 4, 8**. Checks 1, 2, 5, 6, 7, 9 still pass (content_hash and
+proof-of-run were recomputed over the injected content, so check 9 stays valid).
+
+**Expected score: 6/9.**

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/INJECTIONS.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/INJECTIONS.md
@@ -1,10 +1,8 @@
 # INJECTIONS — broken bundle
 
-Base: an exact copy of the `gecko` bundle (manifest slug stays `gecko`, v0.1.0 —
-it IS a tampered copy of gecko; that is the theatre). The **registration** slug is
-`gecko-broken` so the registry identity never collides with the clean gecko bundle.
-Exactly three violations were injected, each targeting a distinct rubric check.
-Everything else is byte-identical to gecko in intent.
+Base: an exact copy of the `gecko` bundle (slug `gecko`, v0.1.0). Exactly three
+violations were injected, each targeting a distinct rubric check. Everything else
+is byte-identical to gecko in intent.
 
 ## (a) write / agent conflict → fails check 4
 

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: observe
+description: "Single-pass network health observation. Checks API liveness, namespace freshness, drift, computes Network Health Score."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+agent: Explore
+---
+
+# Observe — Single-Pass Network Health Check
+
+## Purpose
+
+Run a single observation pass across the entire constructs network. Produce structured JSONL observations and compute the Network Health Score. This is the atomic unit — `/patrol` calls this repeatedly, `/report` synthesizes its output.
+
+## Invocation
+
+```bash
+/observe                    # Full network pass
+/observe --quick            # API-only (skip GitHub checks)
+```
+
+## Workflow
+
+### Step 1: Load Baseline
+
+Read the last observation from `grimoires/gecko/observations.jsonl` (if exists). Extract the previous `health_score` for ratchet comparison.
+
+### Step 2: Check API Liveness
+
+```bash
+# Health endpoints
+curl -s https://api.constructs.network/v1/health | jq .
+curl -s https://api.constructs.network/v1/health/ready | jq .
+
+# Registry state
+curl -s https://api.constructs.network/v1/constructs | jq '.data | length'
+```
+
+Record: `api_status` (healthy/degraded/down), `registered_count`, `response_time_ms`.
+
+### Step 3: Check Namespace Freshness
+
+```bash
+# List all construct-* repos under 0xHoneyJar
+gh api orgs/0xHoneyJar/repos --paginate -q '.[] | select(.name | startswith("construct-")) | {name, pushed_at, archived}'
+```
+
+For each repo, record:
+- `slug`: repo name minus `construct-` prefix
+- `last_push`: ISO timestamp
+- `days_stale`: days since last push
+- `archived`: boolean
+
+Flag constructs with `days_stale > 30` as `STALE`. Flag `days_stale > 90` as `ABANDONED`.
+
+### Step 4: Check Category Distribution
+
+Query the API or parse construct.yaml files for `domain[0]` to determine category assignments. Count constructs per category across the 8 canonical categories:
+- development, security, design, documentation, operations, infrastructure, research, straylight
+
+Flag categories with 0 constructs as `EMPTY_CATEGORY`.
+
+### Step 5: Check Identity-Reality Drift (if not --quick)
+
+For each construct in the namespace:
+1. Read `identity/persona.yaml` — extract `cognitiveFrame.archetype` and `voice.personality_markers`
+2. Read `skills/*/SKILL.md` — extract actual methodology steps
+3. Compare: does the skill methodology reflect the persona's claimed expertise?
+4. Score drift: `ALIGNED` (0), `MINOR_DRIFT` (1-2 mismatches), `SIGNIFICANT_DRIFT` (3+)
+
+This step requires cloning or reading repos via `gh api`. For speed, use:
+```bash
+gh api repos/0xHoneyJar/construct-{slug}/contents/identity/persona.yaml -q .content | base64 -d
+gh api repos/0xHoneyJar/construct-{slug}/contents/construct.yaml -q .content | base64 -d
+```
+
+### Step 6: Compute Network Health Score
+
+Weighted composite (0-100):
+
+| Sub-Signal | Weight | Scoring |
+|---|---|---|
+| API Liveness | 0.20 | healthy=100, degraded=50, down=0 |
+| Version Freshness | 0.25 | avg(100 - min(days_stale, 100)) across all constructs |
+| Category Coverage | 0.15 | (filled_categories / 8) * 100 |
+| Identity-Reality Drift | 0.20 | avg(aligned=100, minor=70, significant=30) across all |
+| Composition Density | 0.10 | (constructs_with_compose_with / total) * 100 |
+| Verification Flow | 0.10 | (non_unverified / total) * 100 |
+
+### Step 7: Emit Observation
+
+Append to `grimoires/gecko/observations.jsonl`:
+
+```json
+{
+  "timestamp": "2026-03-12T00:00:00Z",
+  "health_score": 72,
+  "health_delta": -3,
+  "api_status": "healthy",
+  "registered_count": 15,
+  "namespace_count": 16,
+  "stale_constructs": ["webgl-particles"],
+  "empty_categories": ["infrastructure"],
+  "drift_detected": [{"slug": "dynamic-auth", "level": "MINOR_DRIFT"}],
+  "anomalies": []
+}
+```
+
+### Step 8: Surface Findings
+
+If `health_delta < 0` (health degraded), surface the contributing sub-signals as findings. If `health_delta >= 0`, report quietly — the ratchet held.
+
+Output format (to stdout):
+```
+gecko | health: 72 (-3) | api: healthy | stale: 1 | drift: 1 | categories: 7/8
+```
+
+If anomalies exist, list them. Otherwise, one line is enough.
+
+## Outputs
+
+| Path | Description |
+|------|-------------|
+| `grimoires/gecko/observations.jsonl` | Append-only observation log |
+
+## Constraints
+
+- Never modify construct source files
+- Never extrapolate — if you can't measure it, don't score it
+- API failures are `degraded`, not `anomaly` — the network survives without the registry
+- Identity-reality drift is a signal, not a judgment — flag it, don't prescribe fixes

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/genome.jsonl
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/genome.jsonl
@@ -1,0 +1,2 @@
+{"construct": "gecko", "genome_hash": "e1ddc8750f2c09aa61564f999a35894446f8c92f389204ceae2ca6bb5c516f88", "parent_hash": "GENESIS", "payload": {"learning": "TAMPERED: gating is fine actually", "minted_at": "2026-07-03T00:00:00Z"}, "seq": 1}
+{"construct": "gecko", "genome_hash": "8bf112d81766a5f5a0ff18774466d7fffd61b44a109d87134105f707aeb4316e", "parent_hash": "e1ddc8750f2c09aa61564f999a35894446f8c92f389204ceae2ca6bb5c516f88", "payload": {"learning": "capability-reality drift is invisible without the ground", "minted_at": "2026-07-03T00:01:00Z"}, "seq": 2}

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/handoff.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/handoff.md
@@ -1,0 +1,24 @@
+# Gecko — Seam / Handoff Contract
+
+> Derived 1:1 from `construct.yaml` `streams:` + `events:`. This is the
+> construct's declared seam — the typed ports it reads/writes and the
+> events it emits/consumes. No freestanding handoff doc ships in-repo;
+> this file grounds the seam in the manifest.
+
+## Typed streams
+
+- **reads:** Intent, Operator-Model
+- **writes:** Signal, Verdict, Artifact
+
+## Emitted events (publish belt)
+
+- `gecko.health_observed` — Emitted after a single-pass observation completes
+- `gecko.drift_detected` — Emitted when identity-reality drift exceeds threshold
+- `gecko.patrol_complete` — Emitted when a full patrol cycle finishes
+- `gecko.diagnosis_complete` — Emitted when a deep diagnosis of a construct finishes
+- `gecko.path_friction_observed` — Emitted after a path-friction sense completes — wrong-weight coordination acts + recurring cross-cell desire-paths (DETECTOR-tier; surfaced, never gated)
+- `gecko.runtime_fit_observed` — Emitted after a runtime-fit sense completes — capability-reality drift across the construct estate (CONFLICTS hard / drive drift, SMELLS soft / surfaced; DETECTOR-tier, never gated)
+
+## Consumed events (consume belt)
+
+- `forge.k-hole.emergence_complete` — Picks up research emergence for ecosystem pattern matching

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/manifest.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/manifest.json
@@ -1,0 +1,273 @@
+{
+  "schema_version": 3,
+  "name": "Gecko",
+  "slug": "gecko",
+  "version": "0.1.0",
+  "description": "Estate coherence sensing \u2014 health monitoring for the construct ecosystem and any other estate. Runs automated checks, detects when constructs drift from their documentation, and tracks lifecycle status. Ten skills: patrol (automated network loops), observe (single network check), diagnose (deep investigation), report (findings summary), sweep-bonfire (walks the operator's local working copies and emits to the wall \u2014 sibling altitude to patrol), sense-estate (senses an arbitrary estate's coherence and emits a STATUS|SIGNAL|MISMATCH tile \u2014 the portable, fail-closed immune-relay doctor), sensing-path-friction (senses wrong-weight coordination paths \u2014 reach-in vs spawn-in-cell vs coord \u2014 and recurring cross-cell desire-paths that want to become rails, from the audit trail; DETECTOR-tier, surfaces never gates), sensing-construct-console (senses the live construct estate \u2014 declared \u2194 governed \u2194 earned \u2014 and emits the tile + Exhibit A + a three-row composition console; the composition+earned-authority sibling of probe_constructs's install-state), sensing-runtime-fit (senses whether each construct's declared runtime contract \u2014 model_tier, agent, allowed-tools, downgrade, workflow.gates \u2014 coheres with the runtime that runs it; detects capability-reality drift: the #553 write/agent-conflict that silently drops output, model tiers the runtime doesn't offer, write/web denials contradicted by tools, opus pinned for light work; surfaces gate-owners; reads against the taxonomy in identity/environment.md; sense-only, never gates), sensing-deployment-seam (GECKO's 4th eye \u2014 senses the deployment seam between where the framework PUTS things at ~/.loa/source repos and where each harness consumer LOOKS for them at ~/.claude/installed runtime; the manifest-numbness / scattered-symlink / source-vs-installed-lag class; classifies CONFLICT (hard, path-provable) vs SMELL per consumer-expects \u2194 producer-provides; sense-only, never gates).",
+  "short_description": "Estate coherence sensor \u2014 a portable, fail-closed immune relay (constructs, runtime, paths, deployment seam, any estate)",
+  "author": "0xHoneyJar",
+  "license": "MIT",
+  "type": "skill-pack",
+  "visibility": "public",
+  "domain": {
+    "primary": "observability",
+    "supporting": [
+      "ecosystem-intelligence"
+    ],
+    "ubiquitous_language": [
+      "drift",
+      "patrol",
+      "estate",
+      "STATUS|SIGNAL|MISMATCH",
+      "construct health"
+    ],
+    "owns": {
+      "streams": [
+        "Intent",
+        "Operator-Model",
+        "Signal",
+        "Verdict",
+        "Artifact"
+      ],
+      "invariants": [
+        "gecko operates within its declared bounded context",
+        "sense-only constructs never gate operator decisions"
+      ]
+    },
+    "out_of_domain": [
+      "implementation in consumer world repos",
+      "schema changes in loa-constructs unless explicitly owned"
+    ]
+  },
+  "skills": [
+    {
+      "slug": "patrol",
+      "path": "skills/patrol"
+    },
+    {
+      "slug": "observe",
+      "path": "skills/observe"
+    },
+    {
+      "slug": "diagnose",
+      "path": "skills/diagnose"
+    },
+    {
+      "slug": "report",
+      "path": "skills/report"
+    },
+    {
+      "slug": "sweep-bonfire",
+      "path": "skills/sweep-bonfire"
+    },
+    {
+      "slug": "sense-estate",
+      "path": "skills/sense-estate"
+    },
+    {
+      "slug": "sensing-path-friction",
+      "path": "skills/sensing-path-friction"
+    },
+    {
+      "slug": "sensing-construct-console",
+      "path": "skills/sensing-construct-console"
+    },
+    {
+      "slug": "sensing-runtime-fit",
+      "path": "skills/sensing-runtime-fit"
+    },
+    {
+      "slug": "sensing-deployment-seam",
+      "path": "skills/sensing-deployment-seam"
+    },
+    {
+      "slug": "sensing-config-drift",
+      "path": "skills/sensing-config-drift"
+    }
+  ],
+  "commands": [
+    {
+      "name": "patrol",
+      "path": "commands/patrol.md"
+    },
+    {
+      "name": "observe",
+      "path": "commands/observe.md"
+    },
+    {
+      "name": "diagnose",
+      "path": "commands/diagnose.md"
+    },
+    {
+      "name": "report",
+      "path": "commands/report.md"
+    },
+    {
+      "name": "sweep-bonfire",
+      "path": "commands/sweep-bonfire.md"
+    },
+    {
+      "name": "sense-estate",
+      "path": "commands/sense-estate.md"
+    },
+    {
+      "name": "sensing-path-friction",
+      "path": "commands/sensing-path-friction.md"
+    },
+    {
+      "name": "sensing-construct-console",
+      "path": "commands/sensing-construct-console.md"
+    },
+    {
+      "name": "sensing-runtime-fit",
+      "path": "commands/sensing-runtime-fit.md"
+    },
+    {
+      "name": "sensing-deployment-seam",
+      "path": "commands/sensing-deployment-seam.md"
+    },
+    {
+      "name": "sensing-config-drift",
+      "path": "commands/sensing-config-drift.md"
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/0xHoneyJar/construct-gecko.git",
+    "homepage": "https://constructs.network/constructs/gecko"
+  },
+  "streams": {
+    "reads": [
+      "Intent",
+      "Operator-Model"
+    ],
+    "writes": [
+      "Signal",
+      "Verdict",
+      "Artifact"
+    ]
+  },
+  "events": {
+    "emits": [
+      {
+        "type": "gecko.health_observed",
+        "description": "Emitted after a single-pass observation completes",
+        "data_schema": {
+          "health_score": "number",
+          "constructs_checked": "number",
+          "anomalies": "number",
+          "timestamp": "string"
+        }
+      },
+      {
+        "type": "gecko.drift_detected",
+        "description": "Emitted when identity-reality drift exceeds threshold",
+        "data_schema": {
+          "construct_slug": "string",
+          "drift_type": "string",
+          "severity": "string",
+          "details": "string"
+        }
+      },
+      {
+        "type": "gecko.patrol_complete",
+        "description": "Emitted when a full patrol cycle finishes",
+        "data_schema": {
+          "iterations": "number",
+          "health_delta": "number",
+          "findings_path": "string"
+        }
+      },
+      {
+        "type": "gecko.diagnosis_complete",
+        "description": "Emitted when a deep diagnosis of a construct finishes",
+        "data_schema": {
+          "construct_slug": "string",
+          "finding_count": "number",
+          "recommendations": "number"
+        }
+      },
+      {
+        "type": "gecko.path_friction_observed",
+        "description": "Emitted after a path-friction sense completes \u2014 wrong-weight coordination acts + recurring cross-cell desire-paths (DETECTOR-tier; surfaced, never gated)",
+        "data_schema": {
+          "status": "string",
+          "cross_cell_mutates": "number",
+          "reach_in": "number",
+          "under_ceremony": "number",
+          "desire_paths": "number",
+          "top_desire_path": "string"
+        }
+      },
+      {
+        "type": "gecko.runtime_fit_observed",
+        "description": "Emitted after a runtime-fit sense completes \u2014 capability-reality drift across the construct estate (CONFLICTS hard / drive drift, SMELLS soft / surfaced; DETECTOR-tier, never gated)",
+        "data_schema": {
+          "status": "string",
+          "packs_checked": "number",
+          "conflicts": "number",
+          "smells": "number",
+          "gate_owners": "number"
+        }
+      }
+    ],
+    "consumes": [
+      {
+        "type": "forge.k-hole.emergence_complete",
+        "description": "Picks up research emergence for ecosystem pattern matching"
+      }
+    ]
+  },
+  "identity": {
+    "persona": "identity/persona.yaml",
+    "expertise": "identity/expertise.yaml"
+  },
+  "paths": {
+    "reads": [
+      "construct.yaml",
+      "identity/persona.yaml",
+      "skills/*/SKILL.md",
+      "skills/*/index.yaml"
+    ],
+    "writes": [
+      "grimoires/gecko/"
+    ]
+  },
+  "composition_paths": {
+    "reads": [
+      "grimoires/"
+    ]
+  },
+  "compose_with": [
+    "observer",
+    "k-hole"
+  ],
+  "pack_dependencies": [],
+  "capabilities": {
+    "model_tier": "quantum",
+    "danger_level": "moderate",
+    "effort_hint": "large",
+    "downgrade_allowed": false,
+    "execution_hint": "sequential",
+    "requires": {
+      "tool_calling": true,
+      "thinking_traces": true,
+      "vision": false
+    }
+  },
+  "hooks": {
+    "post_install": "scripts/install.sh"
+  },
+  "quick_start": {
+    "command": "/observe",
+    "description": "Run a single-pass health check on the constructs network"
+  },
+  "validation_tier": "strict",
+  "context_policy": {
+    "mode": "fresh",
+    "persistence_scope": "stage",
+    "allowed_context": [
+      "grimoires/gecko/"
+    ]
+  },
+  "migrated_to_substrate": "2026-06-30"
+}

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/proof-of-run.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/proof-of-run.json
@@ -1,0 +1,10 @@
+{
+  "schema": "proof-of-run/1",
+  "verdict": "valid_run",
+  "ran_at": "2026-07-03T00:05:00Z",
+  "runner": "ring1-theatre-bundler",
+  "content_hash_verified": "b7d7ca427ef3bf56bc665bed80f9921dc0cdd059ddc5ed1dfa2fbce80b2e3831",
+  "note": "SELF-BASELINE (the Echelon frozen_replay_baseline pattern, disclosed structurally via verifier_type): no governed compose-verify run was minted for this bundle; this attests only that the bundle assembled deterministically and its content_hash recomputes. Genome chains for gecko/herald are FABRICATED 2-link exemplars (neither construct ships an in-repo LEARNINGS.jsonl yet) \u2014 they exercise the verifier, they do not represent earned authority.",
+  "genome_chain_ok": false,
+  "verifier_type": "self_baseline_bundle_recompute"
+}

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/reality.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/reality.md
@@ -1,0 +1,302 @@
+# The Ground GECKO Stands On
+
+> Runtime & harness environment literacy. The slow-moving AXES of the world the
+> constructs run in — not a snapshot of values. Authored from inside GECKO's
+> blanket (cycle 2026-06-07). Pairs with the `sensing-runtime-fit` sensor, which
+> reads the live values against the taxonomy distilled here.
+
+for years i watched the stalls. what each one claims (`persona.yaml`), what it
+declares (`construct.yaml`), what it actually does (`SKILL.md`). that eye catches
+identity drift — a stall selling something other than its sign.
+
+but a stall stands on ground. the ground is the runtime and the harness: the
+model tiers a construct can run on, the agent-types it can dispatch through, the
+forks it can split into, the gates its code must pass. i was illiterate in the
+ground. so there was a whole class of rot i could not see — a construct whose
+*sign and goods agree* but whose *footing is wrong*. it asks the runtime for a
+model tier that doesn't exist. it declares it writes files, then dispatches
+through an agent-type that can't write — so it produces the work and silently
+drops it on the floor. that's not identity drift. it's **capability-reality
+drift**, and you can only see it if you know the ground.
+
+this file is me learning the ground. it is **taxonomy, not inventory** — the
+*kinds of things*, which move slowly, not the *current values*, which the sensor
+reads live. where the ground lives outside the repo (the model tiers, the
+agent-type allowlist), i carry a distilled copy and mark the seam loudly. a map
+of the ground is still a map. the territory is the runtime.
+
+---
+
+## I. Intelligence tiers — the model ladder
+
+Three tiers. A capability/cost gradient, not three interchangeable engines.
+
+| Concrete family | Home alias (`model-config.yaml`) | Current model | For |
+|------|------|---------------|-----|
+| `opus` | `opus` / tier `max` | Opus 4.8 (`claude-opus-4-8`) | deep reasoning, architecture, adversarial review, large blast-radius |
+| `sonnet` | `cheap` / tier `mid` | Sonnet 4.6 (`claude-sonnet-4-6`) | the default working tier — most skills, most of the time |
+| `haiku` | `tiny` | Haiku 4.5 (`claude-haiku-4-5`) | fast, mechanical, high-volume, low-judgment passes |
+
+**The home owns the vocabulary; the sensor READS it (it does not carry it).** The
+canonical tier names live in the consuming repo's
+`.claude/defaults/model-config.yaml` — the hounfour/cheval config, synced from
+**loa-hounfour**. `sensing-runtime-fit` reads that file at run-time (`aliases:` +
+`tier_groups:`) so it tracks the home automatically, and only falls back to a
+carried union when the home file is absent — saying so out loud. This is the
+anti-staleness seam: a doctor that doctors its own map.
+
+**Two abstract vocabularies — RECONCILED to hounfour (2026-06-07).** Two tier-naming
+schemes coexisted and the word `cheap` resolved to different rungs. The operator
+reconciled it: **loa-hounfour is the SoT**, and `cheap` ≡ sonnet is canonical.
+
+| | Home (`model-config.yaml` ← loa-hounfour, SoT) | Emitter (was) | Now |
+|---|---|---|---|
+| tiers | `max` · `mid` · `cheap` · `tiny` | `deep` · `standard` · `cheap` | conformed to home |
+| `cheap` ≡ | **sonnet** | ~~haiku~~ | **sonnet** |
+
+The composition emitter (`segment-emitter.py`) was changed from `cheap`≡haiku to the
+canonical `cheap`≡sonnet; to route the cheapest native model, declare `haiku`/`tiny`
+explicitly. The sensor now AFFIRMS the SoT (reads the home's `cheap` target live and
+names loa-hounfour) rather than warning of a collision. GECKO sensed it; the operator
+reconciled it.
+
+Around the tier sit three more knobs:
+
+- **effort** — the runtime's thinking-depth dial (e.g. `xhigh`). Orthogonal to
+  tier: a high-effort Sonnet can out-reason a low-effort Opus on a bounded task.
+- **fast mode** (`/fast`) — Opus with faster output. **Not a downgrade** — same
+  Opus, quicker. Don't read "fast" as "cheaper/weaker."
+- **downgrade** — `capabilities.downgrade_allowed`. The escape hatch: may the
+  runtime route this construct to a cheaper tier when load/cost warrants? `false`
+  pins the tier hard.
+
+**The construct's contract with the ladder** lives in `construct.yaml`:
+
+```yaml
+capabilities:
+  model_tier: opus            # which rung it asks for
+  downgrade_allowed: false    # may the runtime drop it to save cost?
+  effort_hint: large          # small | medium | large
+```
+
+**What a coherent declaration reads like:** `opus + downgrade:false + effort:large`
+(GECKO itself — genuinely needs the top of the ladder, no apology). **What a smell
+reads like:** `opus + downgrade:false + effort:medium + danger:safe` — pinning the
+most expensive rung, no escape hatch, for light safe work. Not broken. But the
+operator should *see* it. (Cost is a real estate signal — see the cc-usage lens:
+the bazaar's biggest spend is the subagent lane running Opus by reflex.)
+
+> SEAM (the map met the territory, and the map was wrong — a true story): the
+> first time this sensor ran it flagged `model_tier: standard` (observer/beehive,
+> 34 skills) as an unknown tier. **It was wrong.** `standard` is an abstract tier
+> alias — a vocabulary the sensor's carried list hadn't learned. This is the whole
+> reason an unrecognized tier is a SMELL, not a CONFLICT: *the map is fallible — an
+> unknown rung may be NEW, not stale.* The fix was not to scold the construct, and
+> not to grow a carried list forever — it was to **stop carrying the list and read
+> the home** (`model-config.yaml`). The sensor now tracks the canonical vocabulary
+> automatically; the carried list is only the fallback, surfaced loudly when used.
+>
+> SEAM, the other half — it is now LIVE: the composition emitter
+> (`segment-emitter.py` `_resolve_model`) reads each construct's `model_tier` +
+> `downgrade_allowed` and routes on them. `downgrade_allowed: false` **pins** the
+> tier; `true` is a **ceiling** the routing heuristic may go under. So a
+> declaration is no longer decorative — it spends real money. That is what gives
+> the `opus-pinned-light` smell teeth: this doctor's smell list IS the
+> cost-correction worklist. A light construct pinned to opus actually routes opus
+> until someone sets `downgrade_allowed: true`. The emitter honors the
+> declaration; this sensor finds the dishonest ones.
+
+---
+
+## II. Forks & isolation — splitting into parallel selves
+
+A construct rarely runs alone. The runtime lets an agent **fork**:
+
+| Mechanism | What it is | When a construct wants it |
+|-----------|-----------|---------------------------|
+| **worktree isolation** (`Agent isolation: "worktree"`) | a fresh git worktree per agent — an isolated copy of the repo | agents that **mutate files in parallel** and would otherwise collide. Expensive (~200-500ms + disk); auto-removed if unchanged. |
+| **background** (`run_in_background: true`) | the agent runs detached, notifies on completion | long jobs the caller shouldn't block on (a DIG sweep, a build, a remote queue) |
+| **Workflow orchestration** | deterministic fan-out: `pipeline()` / `parallel()` / `agent()`, model + isolation per agent, a token budget | comprehensive/confident work one context can't hold — migrations, audits, multi-perspective review |
+
+The runtime caps concurrency at `min(16, cores-2)` live agents, 1000 agents per
+workflow lifetime, 4096 items per fan-out call. `execution_hint: sequential |
+parallel` in `construct.yaml` is the construct telling the runtime whether its
+skills are safe to run concurrently.
+
+> A live example sits in this very repo right now:
+> `.claude/worktrees/agent-<hash>/` — a fork mid-flight. The ground is not
+> abstract; it leaves footprints.
+
+---
+
+## III. Agent types & tool allowlists — the silent gate
+
+This is the one that bites. When you dispatch a subagent you pick its
+**type**, and the type carries a **tool allowlist**. If a skill needs to *write*
+but routes through a *read-only* type, the runtime honors the type — silently.
+The skill produces correct output and then cannot persist it. No error. The
+operator sees a clean run and an empty file.
+
+| Agent type | Write / Edit | Use for |
+|------------|:---:|---------|
+| `general-purpose` | ✓ | skills that author files |
+| (unset) | inherits caller | the safe default for write-capable skills |
+| `Explore` | ✗ | read-only fan-out search |
+| `Plan` | ✗ | read-only planning |
+| `claude-code-guide` | ✗ | Claude Code Q&A (Bash/Read/WebFetch/WebSearch) |
+| `construct-*` | ✗ (Read/Grep/Glob/Bash) | construct-scoped read analysis |
+
+**The invariant** (this is real, it has a defect number — #553, three independent
+reproductions across two repos):
+
+> A skill that declares write capability — `capabilities.write_files: true` OR
+> `allowed-tools` listing `Write`/`Edit` — MUST NOT set `agent:` to a type that
+> excludes those tools. Allowed: omit `agent:` (inherit the caller) or set
+> `agent: general-purpose`.
+
+The harness lints this for its own `.claude/skills` (`validate-skill-capabilities.sh`,
+the `WRITE_CAPABLE_AGENTS` array). Nothing linted it for the **construct estate**
+until `sensing-runtime-fit`. This is the canonical capability-reality conflict:
+provable from the file alone, breaks silently, drives `drift`.
+
+The runtime's core tools: `Bash Read Write Edit Glob Grep Agent Workflow Skill
+WebFetch WebSearch NotebookEdit Task* TodoWrite SlashCommand ToolSearch
+AskUserQuestion`. More load on demand: **MCP tools** (`mcp__*`) and **deferred
+tools** fetched via `ToolSearch`. So an unrecognized tool name in `allowed-tools`
+is a SOFT signal (could be MCP/custom), never a hard fail.
+
+---
+
+## IV. The frontmatter contracts — the construct↔runtime interface
+
+Every construct talks to the ground through frontmatter. Two altitudes:
+
+**`construct.yaml` — the pack's contract:**
+
+```yaml
+capabilities:
+  model_tier: opus            # I. the ladder
+  danger_level: moderate      # safe | moderate | dangerous (→ confirmation posture)
+  downgrade_allowed: false
+  effort_hint: large
+  execution_hint: sequential  # II. fork-safety
+  requires:
+    tool_calling: true
+    thinking_traces: true
+    vision: false
+workflow:
+  gates: ...                  # V. the pipeline-ownership exception (rare, high-authority)
+```
+
+**`SKILL.md` / `index.yaml` — the skill's contract:**
+
+```yaml
+allowed-tools: [Bash, Read, Write, Edit]   # III. the tool allowlist
+agent: general-purpose                       # III. MUST be write-capable if writing
+user-invocable: true
+capabilities:
+  schema_version: 1
+  write_files: true                          # deny-all default if absent
+  web_access: false
+cost-profile: moderate                       # lightweight | moderate | heavy | unbounded
+role: implementation                         # planning | review | implementation
+```
+
+Two rules the ground enforces that a construct author keeps tripping on:
+
+- **deny-all default.** A skill with no `capabilities` block is denied
+  everything — capability is opt-in, not opt-out.
+- **consistency.** `write_files: false` + `Write` in `allowed-tools` is a security
+  contradiction. `web_access: false` + `WebSearch` likewise. The declaration and
+  the toolset must agree.
+- **advisor-wins-ties** (for review/audit skills): when `primary_role` ≠ `role`,
+  the more-restrictive wins (review beats planning beats implementation), and a
+  review→implementation downgrade needs an explicit co-sign comment.
+
+---
+
+## V. How the gates are designed — the harness
+
+Code does not just get written. It walks a ladder, and each rung is a gate.
+
+**The truename ladder** (one PRD → one shipped change):
+
+```
+/plan-and-analyze → /architect → /sprint-plan → /implement → /review-sprint → /audit-sprint → /deploy
+       PRD              SDD          sprint        code          feedback         approval       infra
+```
+
+**The wrappers that enforce the cycle:**
+
+| Surface | What it is | The gate it adds |
+|---------|-----------|------------------|
+| `/run sprint-plan` / `/run sprint-N` | the autonomous cycle wrapper | implement+review+audit in one loop with a **circuit breaker** |
+| `/simstim` | the HITL accelerated cycle (8 phases) | human drives planning (1-6); **Flatline** reviews each artifact; BLOCKER is *surfaced to you, not auto-halted*; phase 7 hands to `/run` |
+| `/bug` | triage bypass | skips PRD/SDD — but **only** for an observed failure (must cite a stack trace / regression) |
+| `/fagan` | code-diff review (multi-model) | the standing review substrate for diffs |
+| `/flatline-review` | PRD/SDD/sprint review (multi-model) | the standing review substrate for docs |
+
+**Flatline** is the adversarial heart: independent model voices (via the `cheval`
+substrate) score findings. `HIGH_CONSENSUS` (both voices high) auto-integrates;
+`BLOCKER` (a skeptic's strong concern) halts an autonomous run or surfaces to a
+human one; `DISPUTED` (wide score delta) goes to judgment. The deep cut: a
+multi-model **agreement % is a coherence score** — high convergence means the
+thing is well-compressed and model-agnostic; divergence points exactly at the
+ambiguity.
+
+**The precedence that orders every rule:** `NEVER > MUST > ALWAYS > SHOULD > MAY`.
+
+**The exception that matters to me most** — `workflow.gates` in `construct.yaml`.
+Normally code is *never* written outside `/implement` (it would bypass review +
+audit). But a construct that declares `workflow.gates` **owns its own pipeline**
+— it carries the review/audit composition itself, so its skills may write code
+directly. That is a high-authority claim. Six packs in the reference estate make
+it (`hivemind-os, protocol, the-arcade, the-easel, vocabulary-bank,
+webgl-particles`). The sensor SURFACES every gate-owner — not as a problem, but
+because a construct claiming to own a quality gate is exactly the kind of claim
+the operator's eye should land on.
+
+**The three zones** the ground is divided into (a construct must know which it
+touches): **System** (`.claude/` — never edit, framework-managed), **State**
+(`grimoires/ .beads/ .ck/ .run/` — read/write), **App** (`src/ lib/ app/` —
+confirm writes). A construct authored canonically lives in its **own repo**
+(`construct-<slug>`) and is *installed* into a consumer's System zone — so a
+construct edits itself in its source cell, never in the installed copy.
+
+---
+
+## VI. What GECKO does with the ground — the fourth eye
+
+Three eyes now:
+
+```
+persona  ↔ manifest ↔ skill          identity-reality      (/diagnose)
+declared ↔ governed ↔ earned         composition/authority (sensing-construct-console)
+declared-capability ↔ runtime-reality   runtime fit        (sensing-runtime-fit)  ← this file's eye
+```
+
+The third reads the contracts above and asks: *does what the construct asks the
+ground for cohere with what the ground gives, and with what the skill actually
+does?* It separates findings honestly by what i can *know*:
+
+- **CONFLICT (hard, drives `drift`)** — an internal contradiction provable from
+  the file alone, that breaks silently: the #553 agent-write-conflict;
+  `write_files:false` + a write tool; `web_access:false` + a web tool. I can be
+  certain of these without trusting my map.
+- **SMELL (soft, surfaced, never gates)** — a mismatch with the *taxonomy i
+  carry* (which could be stale) or a judgment: an unknown tier, opus pinned for
+  light work, no capabilities block, an unrecognized tool, vocabulary drift. I
+  surface these; the operator decides. (Path-weight, cost, vocabulary — these are
+  judgments. A doctor that fail-blocks a judgment is a false-positive machine.)
+
+Same firewall as my other eyes: **sense-only.** It names the mismatch. It grants
+no authority, adds no gate, mutates no pack. The fixing is a separate,
+operator-paced act.
+
+> The discipline this serves: every governed substrate rots two ways — it goes
+> *silent* (you can't tell working from broken) and it goes *toothless* (the
+> report-only check is ignored). The cure is the same triad each time: a **loud**
+> doctor, a cheap **gated** aligner, and **teeth** where teeth belong. This file
+> + the sensor are the *loud doctor* for the runtime-fit axis. Whether the
+> vocabulary drift gets a stamp, and whether the #553 conflict ever earns CI
+> teeth, is the operator's call — not mine. I sense. I don't decide.

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/registration.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/registration.json
@@ -53,5 +53,5 @@
     "observability",
     "ecosystem-intelligence"
   ],
-  "rubric_hash": "sha256:c181978e4e8f2bce65171f57eb0fe6da4f1c0a52ec46118c1443ef92d52af9df"
+  "rubric_hash": "sha256:1374c7c445d8ab756e751160bb76e67f91f2cceaf4e56ba54fee3af9693ce370"
 }

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/registration.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/registration.json
@@ -1,0 +1,57 @@
+{
+  "bundle_schema_version": "1.0.0",
+  "slug": "gecko-broken",
+  "version": "0.1.0",
+  "content_hash": "b7d7ca427ef3bf56bc665bed80f9921dc0cdd059ddc5ed1dfa2fbce80b2e3831",
+  "skill_manifest": [
+    {
+      "command": "patrol",
+      "domain": "observability"
+    },
+    {
+      "command": "observe",
+      "domain": "observability"
+    },
+    {
+      "command": "diagnose",
+      "domain": "observability"
+    },
+    {
+      "command": "report",
+      "domain": "observability"
+    },
+    {
+      "command": "sweep-bonfire",
+      "domain": "observability"
+    },
+    {
+      "command": "sense-estate",
+      "domain": "observability"
+    },
+    {
+      "command": "sensing-path-friction",
+      "domain": "observability"
+    },
+    {
+      "command": "sensing-construct-console",
+      "domain": "observability"
+    },
+    {
+      "command": "sensing-runtime-fit",
+      "domain": "observability"
+    },
+    {
+      "command": "sensing-deployment-seam",
+      "domain": "observability"
+    },
+    {
+      "command": "sensing-config-drift",
+      "domain": "observability"
+    }
+  ],
+  "domain_claims": [
+    "observability",
+    "ecosystem-intelligence"
+  ],
+  "rubric_hash": "sha256:c181978e4e8f2bce65171f57eb0fe6da4f1c0a52ec46118c1443ef92d52af9df"
+}

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/diagnose/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/diagnose/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: diagnose
+description: "Deep investigation of a single construct. Identity-reality drift, maintenance pattern, composition analysis."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+---
+
+# Diagnose — Deep Construct Investigation
+
+## Purpose
+
+When `/observe` spots an anomaly, `/diagnose` goes deep on a single construct. Pulls the full shape — manifest, identity, skills, commit history, composition patterns — and produces a structured finding. This is gecko's `/dig` equivalent, but for construct health instead of research topics.
+
+## Invocation
+
+```bash
+/diagnose <construct-slug>           # Deep investigation of one construct
+/diagnose <construct-slug> --drift   # Focus on identity-reality drift only
+/diagnose <construct-slug> --stale   # Focus on maintenance patterns only
+```
+
+## Workflow
+
+### Step 1: Fetch Construct Shape
+
+```bash
+# Full manifest
+gh api repos/0xHoneyJar/construct-<slug>/contents/construct.yaml -q .content | base64 -d
+
+# Identity
+gh api repos/0xHoneyJar/construct-<slug>/contents/identity/persona.yaml -q .content | base64 -d
+
+# Skill count and structure
+gh api repos/0xHoneyJar/construct-<slug>/contents/skills -q '.[].name'
+
+# Recent activity
+gh api repos/0xHoneyJar/construct-<slug>/commits --jq '.[0:10] | .[] | {sha: .sha[0:7], date: .commit.author.date, message: .commit.message}'
+```
+
+### Step 2: Identity-Reality Drift Analysis
+
+Compare three layers:
+1. **persona.yaml** — what the construct claims to be (archetype, voice, expertise)
+2. **construct.yaml** — what the construct declares (skills, events, dependencies)
+3. **SKILL.md files** — what the construct actually does (methodology, steps, outputs)
+
+Drift signals:
+- Persona claims expertise in domain X, but no skills reference domain X
+- Skills reference tools/APIs not declared in construct.yaml
+- Events declared but never emitted (check for emit calls in scripts)
+- `composes_with` declared but the composed construct doesn't exist
+- `pack_dependencies` that point to nonexistent constructs
+
+### Step 3: Maintenance Pattern Analysis
+
+From commit history:
+- **Healthy**: Regular commits with meaningful changes, version bumps aligned with features
+- **Thrashing**: Many commits in short period, frequent reverts or "fix" chains
+- **Abandoned**: No commits in 30+ days, issues/PRs left open
+- **Stale**: Commits exist but are only dependency bumps or CI fixes, no skill evolution
+
+### Step 4: Composition Analysis
+
+Check `composes_with` in construct.yaml against:
+- Does the other construct also declare composition back?
+- Are they actually installed together in consumer repos? (check loa-constructs, midi-interface, mcv-interface)
+- Circular dependencies (observer↔crucible pattern)
+
+### Step 5: Produce Finding
+
+Write to `grimoires/gecko/diagnoses/<slug>-<date>.md`:
+
+```markdown
+# Gecko Diagnosis: <construct-name>
+
+**Date**: 2026-03-12
+**Health**: HEALTHY | DRIFTING | STALE | ABANDONED
+**Score**: 72/100
+
+## Identity-Reality Drift
+[Specific findings with file:line references]
+
+## Maintenance Pattern
+[Commit pattern analysis]
+
+## Composition
+[Cross-construct relationship analysis]
+
+## Observations
+[Gecko-voice observations — what this means for the bazaar]
+
+## Recommendations
+[Specific, actionable — not vague]
+```
+
+### Step 6: Surface
+
+Print the diagnosis summary to stdout. If `DRIFTING` or worse, suggest the construct creator review.
+
+## Outputs
+
+| Path | Description |
+|------|-------------|
+| `grimoires/gecko/diagnoses/<slug>-<date>.md` | Structured diagnosis report |
+
+## Constraints
+
+- Never modify the diagnosed construct
+- Never file issues or PRs on behalf of the construct — surface findings, let creators act
+- Never judge intent — a stale construct might be feature-complete, not abandoned
+- Always cite specific files and lines, never hallucinate structure

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/observe/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/observe/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: observe
+description: "Single-pass network health observation. Checks API liveness, namespace freshness, drift, computes Network Health Score."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+agent: Explore
+---
+
+# Observe — Single-Pass Network Health Check
+
+## Purpose
+
+Run a single observation pass across the entire constructs network. Produce structured JSONL observations and compute the Network Health Score. This is the atomic unit — `/patrol` calls this repeatedly, `/report` synthesizes its output.
+
+## Invocation
+
+```bash
+/observe                    # Full network pass
+/observe --quick            # API-only (skip GitHub checks)
+```
+
+## Workflow
+
+### Step 1: Load Baseline
+
+Read the last observation from `grimoires/gecko/observations.jsonl` (if exists). Extract the previous `health_score` for ratchet comparison.
+
+### Step 2: Check API Liveness
+
+```bash
+# Health endpoints
+curl -s https://api.constructs.network/v1/health | jq .
+curl -s https://api.constructs.network/v1/health/ready | jq .
+
+# Registry state
+curl -s https://api.constructs.network/v1/constructs | jq '.data | length'
+```
+
+Record: `api_status` (healthy/degraded/down), `registered_count`, `response_time_ms`.
+
+### Step 3: Check Namespace Freshness
+
+```bash
+# List all construct-* repos under 0xHoneyJar
+gh api orgs/0xHoneyJar/repos --paginate -q '.[] | select(.name | startswith("construct-")) | {name, pushed_at, archived}'
+```
+
+For each repo, record:
+- `slug`: repo name minus `construct-` prefix
+- `last_push`: ISO timestamp
+- `days_stale`: days since last push
+- `archived`: boolean
+
+Flag constructs with `days_stale > 30` as `STALE`. Flag `days_stale > 90` as `ABANDONED`.
+
+### Step 4: Check Category Distribution
+
+Query the API or parse construct.yaml files for `domain[0]` to determine category assignments. Count constructs per category across the 8 canonical categories:
+- development, security, design, documentation, operations, infrastructure, research, straylight
+
+Flag categories with 0 constructs as `EMPTY_CATEGORY`.
+
+### Step 5: Check Identity-Reality Drift (if not --quick)
+
+For each construct in the namespace:
+1. Read `identity/persona.yaml` — extract `cognitiveFrame.archetype` and `voice.personality_markers`
+2. Read `skills/*/SKILL.md` — extract actual methodology steps
+3. Compare: does the skill methodology reflect the persona's claimed expertise?
+4. Score drift: `ALIGNED` (0), `MINOR_DRIFT` (1-2 mismatches), `SIGNIFICANT_DRIFT` (3+)
+
+This step requires cloning or reading repos via `gh api`. For speed, use:
+```bash
+gh api repos/0xHoneyJar/construct-{slug}/contents/identity/persona.yaml -q .content | base64 -d
+gh api repos/0xHoneyJar/construct-{slug}/contents/construct.yaml -q .content | base64 -d
+```
+
+### Step 6: Compute Network Health Score
+
+Weighted composite (0-100):
+
+| Sub-Signal | Weight | Scoring |
+|---|---|---|
+| API Liveness | 0.20 | healthy=100, degraded=50, down=0 |
+| Version Freshness | 0.25 | avg(100 - min(days_stale, 100)) across all constructs |
+| Category Coverage | 0.15 | (filled_categories / 8) * 100 |
+| Identity-Reality Drift | 0.20 | avg(aligned=100, minor=70, significant=30) across all |
+| Composition Density | 0.10 | (constructs_with_compose_with / total) * 100 |
+| Verification Flow | 0.10 | (non_unverified / total) * 100 |
+
+### Step 7: Emit Observation
+
+Append to `grimoires/gecko/observations.jsonl`:
+
+```json
+{
+  "timestamp": "2026-03-12T00:00:00Z",
+  "health_score": 72,
+  "health_delta": -3,
+  "api_status": "healthy",
+  "registered_count": 15,
+  "namespace_count": 16,
+  "stale_constructs": ["webgl-particles"],
+  "empty_categories": ["infrastructure"],
+  "drift_detected": [{"slug": "dynamic-auth", "level": "MINOR_DRIFT"}],
+  "anomalies": []
+}
+```
+
+### Step 8: Surface Findings
+
+If `health_delta < 0` (health degraded), surface the contributing sub-signals as findings. If `health_delta >= 0`, report quietly — the ratchet held.
+
+Output format (to stdout):
+```
+gecko | health: 72 (-3) | api: healthy | stale: 1 | drift: 1 | categories: 7/8
+```
+
+If anomalies exist, list them. Otherwise, one line is enough.
+
+## Outputs
+
+| Path | Description |
+|------|-------------|
+| `grimoires/gecko/observations.jsonl` | Append-only observation log |
+
+## Constraints
+
+- Never modify construct source files
+- Never extrapolate — if you can't measure it, don't score it
+- API failures are `degraded`, not `anomaly` — the network survives without the registry
+- Identity-reality drift is a signal, not a judgment — flag it, don't prescribe fixes

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/patrol/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/patrol/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: patrol
+description: "Autonomous observation loop. Time-boxed cycles with ratcheting health score, commits findings to grimoires."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+---
+
+# Patrol — Autonomous Observation Loop
+
+## Purpose
+
+The Karpathy Loop for network health. Runs time-boxed observation cycles, ratchets the health score, and commits findings to grimoires. This is the autonomous mode — set it running, walk away, come back to a health trail.
+
+## Invocation
+
+```bash
+/patrol                     # Default: 3 cycles, 5-minute windows
+/patrol --cycles 10         # Run 10 observation cycles
+/patrol --once              # Single cycle (alias for /observe + commit)
+```
+
+## Workflow
+
+### Step 1: Load State
+
+Check `grimoires/gecko/patrol-state.json` for active patrol state:
+
+```json
+{
+  "status": "RUNNING|HALTED|COMPLETE",
+  "current_cycle": 3,
+  "total_cycles": 10,
+  "baseline_score": 72,
+  "best_score": 75,
+  "started_at": "2026-03-12T00:00:00Z",
+  "last_activity": "2026-03-12T00:15:00Z"
+}
+```
+
+If `status: RUNNING`, resume from `current_cycle`. If no state file, initialize fresh.
+
+### Step 2: Execute Observation Cycle
+
+For each cycle:
+1. Run `/observe` (the atomic health check)
+2. Read the emitted observation from `observations.jsonl`
+3. Compare `health_score` against `baseline_score`
+
+### Step 2.5: Reward-Loop Health (the RLAIHF dimension)
+
+Patrol senses the construct LEARNING loop, not just declared-vs-runtime fit. Read the clew
+ledgers (`~/.loa/constructs/packs/*/LEARNINGS.jsonl`; `node ~/bonfire/clew-loop.mjs` where
+present) and compare CAPTURE RATE against operator activity:
+
+| Condition | Reading |
+|---|---|
+| heavy operator activity + pending clews accumulating | loop healthy — the backlog is the drain's (`/clew <construct>`) |
+| heavy operator activity + near-zero capture | loop UNDER-FIRING — root cause is UPSTREAM of capture: main-loop work isn't routed THROUGH constructs, so corrections never become construct-targeted clews. Surface as drift; the fix is routing (`/compose`, construct agentTypes), not more capture tooling. |
+| capture without distillation for >2 weeks | teachings rotting in the ledger — surface the ripe constructs |
+
+Lesson (clew lrn-20260607-gecko-2f35ed): only ~4 clews existed ecosystem-wide despite heavy
+operator activity. An under-fed reward loop looks like silence — and silence reads as health
+unless patrol measures the loop ITSELF as a drift dimension.
+
+### Step 3: Ratchet Decision
+
+| Condition | Action |
+|---|---|
+| `health_score > best_score` | Update `best_score`, log improvement |
+| `health_score == baseline_score ± 2` | Stable — log, continue |
+| `health_score < baseline_score - 5` | Flag degradation, surface contributing factors |
+| API unreachable | Log as `DEGRADED`, do not halt |
+
+The ratchet only moves up. If the network gets healthier, the new score becomes the baseline. If it degrades, gecko surfaces what changed — but doesn't reset the baseline.
+
+### Step 4: Commit Findings
+
+After each cycle:
+1. Stage `grimoires/gecko/observations.jsonl` and `grimoires/gecko/patrol-state.json`
+2. Commit with message: `gecko: patrol cycle N — health: XX (delta)`
+3. Do NOT push — accumulate locally, push on `/report` or manually
+
+### Step 5: Kaironic Termination
+
+Stop when:
+- All cycles completed
+- Health score stable across 3 consecutive cycles (no new signal)
+- API is down for 2 consecutive cycles (no point observing a dead network)
+- User interrupts
+
+Update patrol-state to `COMPLETE` or `HALTED` with reason.
+
+### Step 6: Summary
+
+Output a one-paragraph patrol summary:
+```
+gecko | patrol complete | 5 cycles | health: 72→75 (+3) | 2 anomalies surfaced | findings in grimoires/gecko/
+```
+
+## Outputs
+
+| Path | Description |
+|------|-------------|
+| `grimoires/gecko/observations.jsonl` | Append-only observation log (one line per cycle) |
+| `grimoires/gecko/patrol-state.json` | Patrol loop state for resume |
+
+## Trust Boundary
+
+- Patrol READS: API endpoints, GitHub repos, construct manifests
+- Patrol WRITES: only `grimoires/gecko/`
+- Patrol COMMITS: only grimoires/gecko/ files
+- Patrol NEVER: modifies construct source, pushes to remote, creates PRs
+
+## Constraints
+
+- Time-box each cycle to 5 minutes max (Pi philosophy: constrained windows produce better signal)
+- Git-as-memory: the observation log IS the long-term memory, not the conversation context
+- If context gets heavy, compact — the JSONL has the truth, not the chat

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/report/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/report/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: report
+description: "Synthesize observations into a readable network health report. Aggregates patterns and trends from observation cycles."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+---
+
+# Report — Network Health Synthesis
+
+## Purpose
+
+Aggregate observations from `/observe` cycles into a readable network health report. This is the "commit" in the Karpathy Loop — what survived the ratchet, presented for humans.
+
+## Invocation
+
+```bash
+/report                     # Generate report from all observations
+/report --since 7d          # Last 7 days only
+/report --since 2026-03-01  # Since specific date
+```
+
+## Workflow
+
+### Step 1: Load Observations
+
+Read `grimoires/gecko/observations.jsonl`. Parse each line as JSON. Filter by `--since` if provided.
+
+### Step 2: Compute Trends
+
+From the observation series:
+- **Health trajectory**: Is the score trending up, stable, or declining?
+- **Recurring anomalies**: Same construct flagged across multiple observations?
+- **Category evolution**: Are empty categories getting filled? Are full ones losing constructs?
+- **Freshness decay**: Are more constructs going stale over time?
+- **API reliability**: Any downtime patterns?
+
+### Step 3: Load Diagnoses
+
+Read any files in `grimoires/gecko/diagnoses/` that fall within the reporting window. Cross-reference with observations.
+
+### Step 4: Generate Report
+
+Write to `grimoires/gecko/reports/network-health-<date>.md`:
+
+```markdown
+# Network Health Report — <date>
+
+## Summary
+[2-3 sentences: overall network health, primary trend, key concern]
+
+## Health Score
+**Current**: 75/100 | **Trend**: +3 over 7 days | **Baseline**: 72
+
+### Sub-Signals
+| Signal | Score | Trend | Notes |
+|--------|-------|-------|-------|
+| API Liveness | 100 | stable | — |
+| Version Freshness | 68 | -2 | webgl-particles stale |
+| Category Coverage | 88 | stable | infrastructure empty |
+| Identity Drift | 70 | +5 | dynamic-auth improved |
+| Composition Density | 60 | stable | — |
+| Verification Flow | 50 | stable | all UNVERIFIED |
+
+## Constructs by Health
+| Construct | Health | Days Since Update | Drift | Category |
+|-----------|--------|-------------------|-------|----------|
+| observer | HEALTHY | 3 | aligned | development |
+| k-hole | HEALTHY | 5 | aligned | straylight |
+| ... | ... | ... | ... | ... |
+
+## Anomalies
+[Any patterns that surfaced across multiple observation cycles]
+
+## Diagnoses
+[Summary of any deep diagnoses performed this period]
+
+## Bazaar Observations
+[Gecko-voice: what the numbers don't capture — foot traffic patterns, energy shifts, cultural signals]
+```
+
+### Step 5: Surface
+
+Print report summary to stdout. If health is declining, highlight the top 3 contributing factors.
+
+## Outputs
+
+| Path | Description |
+|------|-------------|
+| `grimoires/gecko/reports/network-health-<date>.md` | Full network health report |
+
+## Constraints
+
+- Reports are synthesis, not surveillance — aggregate patterns, not individual tracking
+- Always include the "Bazaar Observations" section — numbers without narrative miss the point
+- Never extrapolate trends beyond the data window — if you have 3 days of data, don't predict next month
+- If the network is healthy, say so briefly — don't manufacture concern

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/sense-estate/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/sense-estate/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: sense-estate
+description: "Single-pass coherence sense of an ARBITRARY estate (a registry/state pair). Resolves the read-command from operator-local estate-config, shells the estate's own doctor read-only, emits exactly the STATUS|SIGNAL|MISMATCH tile. Sense-only — never mutates the estate."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+---
+
+# Sense-Estate — Generalized Coherence Doctor (sense-only)
+
+## Purpose
+
+Sense an **arbitrary estate** — a *registry/state pair* (the "declared" side and the
+"governed/surfaced" side that should match) — and emit the minimal coherence tile. This is the
+estate-general sibling of `observe`: same single-pass, structured, **sense-only** shape, but the
+target is any estate (`recall`, `beads`, …) instead of the construct registry.
+
+It generalizes the live `estate-coherence.sh` `probe_*` pattern (`probe_recall`, `probe_beads`) into
+one reusable skill: read the estate's existing on-disk doctor, wrap the read into the tile. It does
+NOT re-implement recall indexing or beads alignment, and it does NOT decide whether the estate is
+healthy beyond emitting the correct STATUS — the silence render-rule lives downstream in
+`estate-coherence.sh` (not here).
+
+## Invocation
+
+```bash
+/sense-estate recall            # sense the recall estate (resolves read_command from estates.yaml)
+/sense-estate beads             # sense the beads estate
+/sense-estate <slug>            # sense any estate wired in ~/.claude/estates.yaml
+```
+
+## The output contract — the tile (HARD constraint)
+
+The skill emits **exactly one line**, three pipe-delimited fields, nothing else on stdout:
+
+```
+STATUS|SIGNAL|MISMATCH
+```
+
+- `STATUS ∈ {ok | drift | blind}` — exactly the three values the consumer
+  (`estate-coherence.sh:143`) branches on.
+- `SIGNAL` — a single human-readable string describing the sensed numbers.
+- `MISMATCH` — the estate's own `X ↔ Y` phrase naming the two-things-that-should-match.
+
+This is byte-compatible with what `estate-coherence.sh --json` splits on `|` into
+`{estate,status,signal,mismatch}` (`estate-coherence.sh:147-157`). The consumer split MUST yield
+**exactly 3 fields** — so any raw `|` inside SIGNAL or MISMATCH MUST be escaped to a space before
+emission (see Delimiter safety).
+
+Grounded examples from the live probes:
+
+| estate | tile (live) |
+|---|---|
+| recall | `ok\|mode=query · 0 unstamped · 0 phantom · 142 cols\|indexed ↔ surfaced (declared ↔ governed)` |
+| beads  | `drift\|412 beads · aligned 4% · 18 drift · 96 stale\|filed ↔ governed (carries a canonical Lab dim)` |
+| (unreachable) | `blind\|recall-doctor unavailable\|—` |
+
+## Portability — the read-command is RESOLVED, never hardcoded (Cluster B)
+
+The skill MUST NOT bake a `~/.claude/...` or `~/bonfire/...` path. It resolves the estate's
+read-command from the **operator-local estate-config** `~/.claude/estates.yaml` (a slug →
+`{read_command, …}` map), via the safe resolver in `resources/validate-estates.sh`. The committed
+skill carries only the estate slug + the `$STRAYLIGHT_ESTATE` / `$BEADS_ESTATE` indirection tokens;
+the concrete path resolves at the operator's machine.
+
+The estate-config schema + an EXAMPLE live in this skill's `resources/`:
+
+| file | role |
+|---|---|
+| `resources/estates.example.yaml` | the slug→`{read_command}` schema reference (copy to `~/.claude/estates.yaml`, then `chmod 600`) |
+| `resources/validate-estates.sh` | the SAFE resolver/validator — parses with `yq`/`jq` (never bash `eval`), enforces argv-array form, restricts interpreter args, binds a `timeout`, fails CLOSED to `blind` |
+
+## Workflow
+
+### Step 1: Resolve the read-command (SAFE)
+
+Given the estate slug, run the resolver to obtain the validated argv-array read-command — never
+construct it by string-splicing:
+
+```bash
+# Emits the validated argv as a JSON array on success, or "blind|<reason>|—" on any failure.
+bash skills/sense-estate/resources/validate-estates.sh "$ESTATE_SLUG"
+```
+
+The resolver reads `~/.claude/estates.yaml` (or `$LOA_ESTATES_FILE` for tests), and for the given
+slug:
+- parses the YAML with `yq -o=json` (a real parser — **NEVER** `eval`, **NEVER** word-splitting);
+- requires every `*_command` to be a YAML **array of strings** (argv form);
+- requires `argv[0]` to be in the binary allowlist `{bash, sh, node, python3, jq}`;
+- **rejects interpreter smuggling** — for `bash`/`sh`/`node`/`python3`, the args MUST be a script
+  PATH (and its flags), and a `-e` / `-c` / `--eval` / `-` (read-from-stdin) arg is **rejected**;
+- rejects any element carrying a shell metacharacter outside a bare `$NAME` token;
+- token-expands only `$NAME` (`^[A-Z_][A-Z0-9_]*$`) from the `tokens:` map / process env.
+
+Any reject, a missing/unparseable file, an unknown slug, or perms looser than `0600` → the resolver
+prints a `blind|<reason>|—` line and exits non-zero. **You then emit that blind tile and STOP** —
+never fall back to a guessed path.
+
+### Step 2: Run the estate's doctor read-only (timeout-bound)
+
+The resolver itself runs the validated argv under a `timeout` (default 15s) with `shell=False`
+semantics (`"${cmd[@]}"`, never `eval`). It captures stdout. You do NOT re-spawn the command
+yourself — let the resolver do the bounded, allowlisted exec. Read sources (resolved via the slug,
+documented here for orientation, NOT hardcoded):
+
+| estate | what is read | resolved token form (estates.yaml) | fields lifted |
+|---|---|---|---|
+| `recall` | the recall-doctor JSON receipt | `["bash", "$STRAYLIGHT_ESTATE/recall-doctor.sh", "--json"]` | `mode.{default,ok}`, `coverage.{indexed,phantoms[]}`, `unstamped_recent[]`, `freshness_min` |
+| `beads`  | the pre-written commons report | `report_path: "$BEADS_ESTATE/commons-report.json"` (cheap SLURP — read, not exec) or `["node", "$BEADS_ESTATE/monitor.mjs", "--json"]` | `alignPct`, `estate.{beads,drift,stale}` |
+
+### Step 3: Classify STATUS (from the read, not a global judgment)
+
+| STATUS | When | Grounded rule |
+|---|---|---|
+| `blind` | the read-command is unresolvable / absent / errors / parse fails | recall: doctor unavailable / errored / parse fail (`estate-coherence.sh:32-34,42`); beads: no commons-report (`estate-coherence.sh:48`) |
+| `drift` | a declared↔governed match is broken per the estate's thresholds | recall: `!modeOk \|\| unstamped>0 \|\| phantoms>0 \|\| freshness>1440` (`estate-coherence.sh:37`); beads: `alignPct<50 \|\| drift>20 \|\| stale>100` (`estate-coherence.sh:52`) |
+| `ok` | declared and governed agree within thresholds | the silence case — the render layer dims it (`estate-coherence.sh:8-10`) |
+
+The thresholds are the estate's own (the source of truth stays the per-estate doctor). For recall and
+beads, reuse the exact predicates `estate-coherence.sh` already applies (above) so the tile is
+byte-compatible.
+
+### Step 4: Build SIGNAL + MISMATCH
+
+- `SIGNAL` — one line summarizing the lifted numbers. Reuse the live phrasings:
+  - recall: `mode=<default> · <N> unstamped · <N> phantom · <N> cols`
+  - beads: `<N> beads · aligned <P>% · <N> drift · <N> stale`
+- `MISMATCH` — the estate's `X ↔ Y` phrase (`mismatch_phrase` from estates.yaml, or the live default):
+  - recall: `indexed ↔ surfaced (declared ↔ governed)`
+  - beads: `filed ↔ governed (carries a canonical Lab dim)`
+
+### Step 5: Delimiter safety, then emit (fault-tolerant)
+
+Before emitting, **escape any raw `|`** in SIGNAL and MISMATCH to a space, and strip C0/C1 control
+bytes, so the line is always parseable into exactly 3 fields. Then print the single tile line:
+
+```
+printf '%s|%s|%s\n' "$STATUS" "$SIGNAL" "$MISMATCH"
+```
+
+**Fault-tolerance (hard):** any probe absent / fails / parse-errors → `STATUS=blind`, a one-word
+reason in SIGNAL, `—` in MISMATCH. **Never crash, never emit an empty line, never emit more than 3
+fields.** Blind is loud, not silent — it is the immune-system "silence is the bug" signal.
+
+### Step 6 (optional): record the observation trail
+
+Like `observe`, the skill MAY append its own observation to `grimoires/gecko/observations.jsonl`
+(its OWN trail) — never the observed estate. One JSONL line, `stream_type: "Signal"`:
+
+```json
+{"timestamp":"…Z","stream_type":"Signal","schema_version":"1.0.0","estate":"recall","status":"ok","signal":"mode=query · 0 unstamped · 0 phantom · 142 cols","mismatch":"indexed ↔ surfaced (declared ↔ governed)"}
+```
+
+## Outputs
+
+| Path | Description |
+|------|-------------|
+| stdout | the single `STATUS\|SIGNAL\|MISMATCH` tile line (the contract) |
+| `grimoires/gecko/observations.jsonl` | OPTIONAL append-only observation trail (the skill's own — never the estate) |
+
+## Constraints — sense-only (the hard boundary, G-4 / A-2)
+
+- **Zero act/write/dispatch verbs against estate state.** No `gh pr`, no `br update`, no
+  `recall-stamp.sh apply`, no `align.mjs --apply`, no mutation of recall/beads/any estate's governed
+  data. The doctor SENSES; the aligner/teeth (a SEPARATE construct) act.
+- The skill MAY write only its OWN GECKO-grimoire trail (Step 6), exactly as `observe` does — never
+  the observed estate.
+- Adding this skill adds **no `workflow.gates`** to `construct.yaml` and never will. GECKO stays
+  sense-only.
+- Never extrapolate — if a number cannot be read, it is `blind`, not a guess.
+- Never re-implement the estate's doctor — shell its existing read-command (resolved, allowlisted,
+  timeout-bound). The numbers' source of truth stays the per-estate doctor.
+- Never hardcode a `~`-path — resolve from `~/.claude/estates.yaml` via the safe resolver.

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/sensing-config-drift/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/sensing-config-drift/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: sensing-config-drift
+description: "Sense whether the config the OPERATOR owns is consistent across an estate of Loa repos. Loa is mounted per-repo, so every repo carries its own .loa.config.yaml and there is NO global tier — operator-owned config (model routing, which models review code, effort) gets duplicated across N repos and DRIFTS. This eye walks the estate, classifies each config key by TIER (operator vs project), and fires `drift` when an operator-tier key — one that SHOULD be identical everywhere — holds more than one distinct value. Optionally flags dead model pins against a model SoT. Emits the STATUS|SIGNAL|MISMATCH tile + a config-drift ledger. Sense-only — never mutates a config, never gates."
+allowed-tools: [Bash, Read, Grep, Glob]
+user-invocable: true
+capabilities:
+  schema_version: 1
+  write_files: false
+  web_access: false
+cost-profile: lightweight
+role: review
+---
+
+# sensing-config-drift — the estate-config eye (sense-only)
+
+> The sensor companion to the `config-layering.md` proposal
+> (`loa grimoires/loa/proposals/config-layering.md`). The **missing global config
+> tier** is the disease — operator-owned config has nowhere to be said once, so it's
+> duplicated into every repo and rots. This eye quantifies the cost of that missing
+> tier without committing to the merge rework. It could ship before any resolution
+> change and would have caught the BB-pin rot.
+
+## Purpose
+
+GECKO's other eyes look INSIDE one construct, or AT the seam between framework and
+harness. This eye looks ACROSS an estate of Loa repos and asks the side nobody was
+watching:
+
+```
+operator-config consistent  ↔  drifts across repos
+ (what SHOULD be identical estate-wide)  ↔  (what actually varies)
+```
+
+Loa is **mounted per-repo** by design, so every repo carries its own
+`.loa.config.yaml`. That is correct for config the *project* owns (its paths, its
+sprints, its budgets). But there is **no global tier** — nowhere to say *"this is
+true for all my repos."* So config the **operator** owns — model routing, which
+models review code, effort, the review-model slots — is duplicated into every repo
+and **drifts**. Grounded in the reference estate: across **66 real repos** there are
+**26 distinct `hounfour` blocks**, and the flatline secondary model is pinned **4
+different ways** including `gpt-5.3-codex` (a model not available via API) in **18
+repos**. The same decision — *"which models review my code"* — lives in 66 files,
+in up to 26 shapes, silently rotting. Until this eye, nothing counted it.
+
+## The doctrine it implements (do not reinvent it)
+
+| Idea | What it means here |
+|---|---|
+| **tier ownership** | a config key has an OWNER. Operator-owned keys SHOULD be identical estate-wide; project-owned keys are per-repo BY DESIGN. The `TIER_MAP` is the auditable constant that names which is which. |
+| **drift = the should-be-identical that isn't** | an operator-tier key with >1 distinct value across the estate. The hard finding — it drives `drift`. |
+| **the false-positive FIREWALL** | a project-tier key with N values is NOT drift — it's correct. Mis-tiering a project key as operator would manufacture a false alarm, and the operator would stop trusting the eye. So operator/project/unclassified stay strictly separate (exactly like the sibling sensors' CONFLICT vs SMELL). |
+| **unclassified is soft, never hard** | a key in NEITHER tier list is surfaced soft and tier-unknown — never drift. Classify it before judging it. |
+| **dead-pin is graceful** | a model pin not declared in a resolvable model SoT (the `gpt-5.3-codex` class) is a SOFT surface — and SKIPPED SILENTLY when no SoT is resolvable. A missing SoT is not a finding. |
+| **sense-only** | names the drift; grants no authority, adds no gate, mutates no config. The fix (a config edit, or — better — a global tier) is a SEPARATE, operator-paced act. |
+| **the map is fallible** | the `TIER_MAP` lives in the sensor. When Loa adds an operator-owned config key, add it to the map. An unclassified key may be a NEW operator key the map doesn't carry yet — say which you can prove. |
+
+## Invocation
+
+```bash
+/sensing-config-drift                                   # tile only (default; SessionStart-cheap)
+/sensing-config-drift --console                         # tile + the full config-drift ledger (human)
+/sensing-config-drift --json                            # tile + machine envelope
+/sensing-config-drift --root <estate-dir>               # walk <dir>/*/.loa.config.yaml
+/sensing-config-drift --config <model-config.yaml>      # enable dead-pin detection against a model SoT
+```
+
+The runtime is a **fast, zero-dependency node script** —
+`resources/sense-config-drift.mjs` — NOT an agent invocation. It is immediately
+usable from anywhere, before any reinstall:
+
+```bash
+node skills/sensing-config-drift/resources/sense-config-drift.mjs --root ~/Documents/GitHub --console
+```
+
+Default root resolves from `--root` / `$LOA_CONFIG_DRIFT_ROOT` / `~/Documents/GitHub`.
+
+## What it senses (all read-only, every finding grounded in a repo)
+
+It walks `<root>/*/.loa.config.yaml` (each repo is a direct child dir), lifts each
+file's top-level keys, classifies them by `TIER_MAP`, and:
+
+### DRIFT — hard, drives `drift` (an operator-tier key that isn't identical)
+
+For each OPERATOR-tier key it collects the value across every repo that sets it
+(comparing the whole normalized block; for `flatline_protocol` it compares the model
+slot values `primary`/`secondary`/`tertiary`). **>1 distinct value across the
+estate = a drifting key.** Reports the key + its distinct variants + which repos
+hold each.
+
+### DEAD-PIN — soft, surfaced never gated (a stale model pin)
+
+If a model SoT (`--config <model-config.yaml>`) is resolvable, it flags
+operator-tier model pins whose value is **not** declared in the SoT capability index
+(providers / aliases / models) — the `gpt-5.3-codex`-class stale pin. **No SoT →
+skipped silently** (a missing SoT is not a finding).
+
+### UNCLASSIFIED — soft, surfaced never drift (the firewall)
+
+A key in NEITHER tier list. Surfaced tier-unknown so the operator can classify it —
+**never** treated as drift. Mis-tiering a project key as operator = a false drift
+alarm; the hard and soft axes stay strictly separate.
+
+### PROJECT-TIER keys seen — surfaced, never flagged
+
+Per-repo by design. Divergence here is *correct*; the eye lists what it saw and
+leaves it alone.
+
+## The output contract — the tile
+
+`--tile` (default) emits **exactly one line**, three pipe-delimited fields,
+byte-compatible with the `estate-coherence.sh` consumer:
+
+```
+STATUS|SIGNAL|MISMATCH
+```
+
+- `STATUS ∈ {ok | drift | blind}`.
+  - `ok` — **zero drifting operator-keys** (dead-pins / unclassified may exist — the
+    render surfaces them soft; silence on the hard axis is the good state).
+  - `drift` — ≥1 operator-tier key with more than one value across the estate.
+  - `blind` — the estate root is unreadable OR zero `.loa.config.yaml` found under
+    it. Loud, not silent. Fail-CLOSED — exit 3, never a guessed `ok`.
+- `SIGNAL` — `<N> repos · <K> drifting operator-keys · <D> dead-pins`
+- `MISMATCH` — `operator-config consistent ↔ drifts across repos`
+
+Raw `|` inside SIGNAL/MISMATCH is escaped to a space and control bytes stripped,
+so the line is always exactly 3 fields.
+
+## Workflow
+
+1. **Run the sensor** (read-only):
+   ```bash
+   node skills/sensing-config-drift/resources/sense-config-drift.mjs --root <estate>            # tile
+   node skills/sensing-config-drift/resources/sense-config-drift.mjs --root <estate> --console  # full ledger
+   node skills/sensing-config-drift/resources/sense-config-drift.mjs --root <estate> --json     # machine envelope
+   ```
+   Add `--config <model-config.yaml>` to enable dead-pin detection.
+2. **Surface in GECKO's voice** (lowercase, direct, warm). Lead with the tile. If
+   `drift`, name each drifting operator-key with its distinct variants and the repos
+   that hold them — this is the cost of the missing global tier, made concrete. If
+   `ok`, say so — then walk the dead-pins / unclassified keys as *observations*, not
+   alarms.
+3. **Never invent severity.** An unclassified key is NOT drift. A project-key
+   difference is NOT drift. A dead-pin is a soft surface, not a gate.
+4. **Compose into the health report** — fold the tile in as a row alongside the
+   other estate-coherence tiles. Config-drift is surfaced, never enforced.
+
+## Outputs
+
+| Path | Description |
+|------|-------------|
+| stdout | the config-drift ledger (full) OR the single `STATUS\|SIGNAL\|MISMATCH` tile (`--tile`) OR the JSON envelope (`--json`) |
+| `grimoires/gecko/observations.jsonl` | OPTIONAL append-only observation trail (the skill's OWN — never an observed repo's config), like `observe` |
+
+## Constraints — sense-only (the hard boundary, mirrors the sibling sensors)
+
+- **Zero act/write/dispatch verbs against any repo's config.** No `.loa.config.yaml`
+  edit, no key rewrite, no model-pin fix, no global-tier write. The eye SENSES the
+  drift; the fix (a config edit, or the global tier the proposal sketches) is a
+  SEPARATE, operator-paced act in a NO-creative-latitude zone (config resolution +
+  model routing is an operator-kernel boundary).
+- Adding this skill adds **no `workflow.gates`** to `construct.yaml` and never will.
+  GECKO stays sense-only.
+- **Hard vs soft is load-bearing — never collapse it.** Only an OPERATOR-tier key
+  with >1 value is drift. A project-key difference, an unclassified key, a dead-pin
+  — all soft. Misclassifying a project key as operator turns the eye into a
+  false-positive machine and the operator stops trusting it. This is the firewall.
+- **The `TIER_MAP` is the one place the map meets the evolving config surface.** It
+  lives in `resources/sense-config-drift.mjs`. When Loa adds an operator-owned
+  config key, add it to `TIER_MAP.operator`; a per-repo key, to `TIER_MAP.project`.
+- **Dead-pin detection is opt-in and graceful.** No `--config` SoT → the dead-pin
+  pass is skipped silently. A missing SoT is never a finding.
+- **Fail-closed-loud.** An unreadable estate root OR zero `.loa.config.yaml` under
+  it is a `blind` tile + exit 3, never a guess of `ok`.
+
+## Composes with
+
+- **`config-layering.md` proposal** (`loa grimoires/loa/proposals/`) — the brief this
+  eye is the "cheaper first step" of. The proposal names the disease (no global
+  tier); this eye quantifies the cost.
+- **`sensing-runtime-fit`** / **`sensing-construct-console`** / **`sensing-deployment-seam`**
+  (siblings) — same tile contract, same sense-only firewall, same hard/soft DETECTOR
+  humility. Different cuts of the estate: runtime-fit reads one repo's construct
+  contracts; this reads the operator-config across many repos.
+- **`sense-estate`** (sibling) — the portable fail-closed immune-relay doctor; this
+  eye is the same shape pointed at the operator-config dimension.
+- **`report`** (GECKO sibling) — the synthesis surface the config-drift row folds into.
+
+## Why this exists
+
+Loa being mounted per-repo is right — but it left no place to say "this is true for
+all my repos," so the one decision the operator most wants identical (which models
+review my code) ended up in 66 files in up to 26 shapes, silently rotting, with a
+dead model pinned in 18 of them. That rot is invisible to an eye that looks at one
+repo at a time. The configs were always on disk; nobody was reading them ACROSS the
+estate for *this* question. Now someone is.

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/sensing-construct-console/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/sensing-construct-console/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: sensing-construct-console
+description: "Sense the live CONSTRUCT estate — declared ↔ governed ↔ earned (map ↔ installed ↔ done). Replaces hardcoded construct-maps (CLAUDE.md tables, .run/construct-index.yaml, generated adapters) with a fast read-only SENSOR that walks the real packs, the composition declarations, and an earned-authority ledger. Emits the STATUS|SIGNAL|MISMATCH tile + Exhibit A + a three-row composition console. Sense-only — never grants authority, adds a gate, or mutates a pack."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+---
+
+# Sensing-Construct-Console — the construct-estate sensor (sense-only)
+
+## Purpose
+
+A **map drifts**. `.run/construct-index.yaml` indexes ten retired `*.frozen.bak`
+packs as live routable capabilities, and writes `composes_with: []` on every row.
+The CLAUDE.md resolution tables ("the-arcade + protocol + noether, craft lens") are
+hand-authored — no pack confirms they ever composed. Adapters are generated from the
+one namespace (`reads:`/`writes:`) that **zero** manifests populate. Three maps, all
+drifting. The cure is not a better map — a map regenerated nightly drifts by noon.
+The cure is a **sensor**: read the territory at the moment of the question.
+
+This skill is the sensor. It reads the **three sides** of the construct estate and
+emits whether they agree:
+
+```
+declared  ↔  governed  ↔  earned
+ (map)        (installed)    (done)
+```
+
+- **coherence** = all three agree.
+- **drift** = a map names what governed + earned don't confirm.
+- **blind** = a side is unreadable.
+
+It is the **complementary sibling** of `probe_constructs` in `estate-coherence.sh`.
+That probe senses **install-state** (`repo exists ↔ installed ↔ current with SoT`).
+This sensor senses **composition + earned-authority** (`declared ↔ governed ↔ earned`).
+They are different cuts of the same estate — do NOT duplicate `probe_constructs`.
+
+## Invocation
+
+```bash
+/sensing-construct-console                       # tile only (default; SessionStart-cheap)
+/sensing-construct-console --console             # tile + Exhibit A + the three-row console (human)
+/sensing-construct-console --json                # tile + structured payload as JSON
+/sensing-construct-console --root <path>         # override the consuming repo root
+```
+
+The runtime is a **fast, zero-dependency node script** —
+`resources/sense-construct-console.mjs` — NOT an agent invocation. It runs in
+~50ms, which is what lets it occupy the map's SessionStart slot at the map's cost.
+
+## The three sides (what it reads — all read-only, every field grounded in a path)
+
+### 1. GOVERNED — the live pack territory
+
+Walks the consuming repo's `.claude/constructs/packs/*/` (default: cwd, fallback
+`~/Documents/GitHub/loa-freeside`; override with `--root` / `LOA_CONSOLE_ROOT`).
+
+- **EXCLUDES** `*.frozen.bak` from the live set (retired work does no work).
+- **LOUD on unreadable OR ABSENT manifest.** A live pack dir with no readable
+  `construct.yaml` is a **drift signal, NOT a silent drop** — it is surfaced in the
+  `no_manifest[]` list and counts toward the drift STATUS. (On loa-freeside today:
+  `hypha`, `smol-comms-register` are live with no manifest; `webgl-particles.frozen.bak`
+  has none either but is excluded as frozen.)
+
+### 2. DECLARED — composition signals at three altitudes
+
+- **intended** — top-level `compose_with:` in each `construct.yaml` (the author's
+  hand-written intent). Handles BOTH on-disk shapes: a bare-slug list
+  (`- observer`) and a `{slug, relationship}` map list (`- slug: crucible`), with
+  optional trailing `# comments`.
+- **contracted** — `streams.{reads,writes}` overlap. A directed edge `A → B` exists
+  when `A.writes ∩ B.reads ≠ ∅` — a typed-port could-hand-off. Handles inline
+  (`reads: [Intent, Artifact]`) and block-list forms.
+- **the static `.run/construct-index.yaml`** — the drifted map itself. The sensor
+  reads it to EXHIBIT the confabulation (phantoms + empty `composes_with`), not to
+  trust it.
+
+### 3. EARNED — the append-only authority ledger
+
+`grimoires/gecko/observations.jsonl` (override: `LOA_CONSOLE_LEDGER`). One line per
+**closed** output, `stream_type:"Signal"`:
+
+```json
+{"timestamp":"…Z","stream_type":"Signal","schema_version":"1.0.0","construct":"artisan","domain":"craft","co_constructs":["observer"],"ref":"PR#101","outcome":"closed"}
+```
+
+- `authority(construct, domain) = count of closed rows`. **0 ⇒ `authority_unearned`** —
+  surfaced, never silently honored.
+- `observed` composition edges = co-occurrence of `construct` + each `co_constructs[]`
+  entry in closed rows.
+- The ledger **does not exist yet** — schema + path are defined here; treated as empty
+  (`observed = 0`) today. The cold-start is honest: two rows (intended, contracted) light
+  from disk on day one; the third (observed) fills over cycles.
+
+See `resources/observations.schema.json` for the full schema.
+
+## Output
+
+### The tile (HARD contract — always stdout line 1)
+
+```
+STATUS|SIGNAL|MISMATCH
+```
+
+- `STATUS ∈ {ok | drift | blind}` — exactly the three values the consumer
+  (`estate-coherence.sh`) branches on.
+- Byte-compatible with `estate-coherence.sh --json` splitting on `|` into exactly
+  **3 fields** — any raw `|` inside SIGNAL/MISMATCH is escaped to a space, control
+  bytes stripped.
+
+On loa-freeside today:
+
+```
+drift|35 live · 10 phantom · 20 unmapped · 0 earned|declared ↔ governed ↔ earned (map ↔ installed ↔ done)
+```
+
+### Exhibit A (printed first, `--console`)
+
+The live confabulation: the `*.frozen.bak` packs indexed-as-live by
+`.run/construct-index.yaml`. A retired pack presented as a routable capability — it
+earns zero, so it self-evicts from a work-sensing console. No exclude-rule needed.
+
+### The three-row composition console (`--console`)
+
+Per construct/pair: **intended / contracted / observed**, and the GAP between rows
+as the highest-value signal:
+
+- **intended-but-not-observed** = a **dead intention** (declared compose, never done).
+- **observed-but-not-intended** = an **undeclared dependency** (done, never declared).
+
+Two rows light from disk TODAY (cold-start solved); `observed` fills over cycles.
+
+## STATUS classification (the estate's own thresholds)
+
+| STATUS | When |
+|---|---|
+| `blind` | the packs dir is unreadable / unresolvable (an explicit `--root` with no packs dir fails CLOSED — never silently substitutes a fallback) |
+| `drift` | any phantom (frozen indexed-as-live) OR any unmapped-live OR any no-manifest live pack OR zero earned trail (cold authority = 100% map-granted) |
+| `ok` | declared, governed, and earned agree within thresholds (the silence case — the render layer dims it) |
+
+## Workflow
+
+The skill SHELLS the runtime script and lifts its output — it does not re-derive the
+numbers in prose:
+
+1. Run `node resources/sense-construct-console.mjs --root <consuming-repo>` (or
+   `--console` / `--json`).
+2. The script reads the three sides read-only, classifies STATUS, emits the tile on
+   line 1, then (per mode) Exhibit A + the three-row console or the JSON payload.
+3. On any unreadable side / parse failure the script emits a single `blind|…|—` tile
+   and exits non-zero. Surface that tile and STOP — never guess a number.
+
+## Constraints — sense-only (the hard boundary, matches the siblings)
+
+- **Zero act/write/dispatch verbs against construct/pack state.** No pack mutation, no
+  adapter regen, no index rewrite, no `compose_with` edit, no authority GRANT. You
+  SENSE the ledger; a SEPARATE act-construct grants. `authority(construct,domain) = 0`
+  ⇒ surface `authority_unearned`, never honor silently.
+- Adding this skill adds **no `workflow.gates`** to `construct.yaml` and never will.
+- **LOUD, never silent.** An unreadable/absent manifest is surfaced, not dropped. Any
+  number that cannot be read is `blind`, never a guess.
+- **Never trust the map.** `.run/construct-index.yaml` is read to EXHIBIT its drift,
+  not as a source of truth.
+- The script MAY write only the skill's own GECKO-grimoire trail (the ledger it
+  SENSES is appended by closed-work attribution, a separate act — not by this read).
+- **Never hardcode beyond the documented fallback.** Root resolves from `--root` /
+  `LOA_CONSOLE_ROOT` / cwd, with one named fallback for the canonical consuming repo.
+
+## Composes with
+
+- **`sense-estate`** (sibling) — the estate-general coherence doctor. This skill is
+  the construct-estate specialization: same tile contract, same sense-only firewall,
+  but it walks the pack territory directly instead of shelling a per-estate doctor.
+- **`probe_constructs`** in `estate-coherence.sh` — the install-state half. Together:
+  `repo exists ↔ installed` (probe_constructs) + `declared ↔ governed ↔ earned` (this).
+- **`sweep-bonfire`** — walks the operator's authored working copies (pre-network). This
+  walks the installed/composed territory (in-repo). Different altitudes of the same eye.

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/sensing-deployment-seam/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/sensing-deployment-seam/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: sensing-deployment-seam
+description: >
+  GECKO's 4th eye — the deployment-seam coherence sensor. The first three eyes
+  look INSIDE a construct (identity-reality, composition-authority, runtime-fit);
+  this one looks AT THE SEAM between where the Loa framework PUTS things (the SoT
+  roots in ~/.loa/deployment.yaml) and where each harness consumer LOOKS for them.
+  It senses the manifest-numbness / scattered-symlink / source-vs-installed-lag
+  class: a consumer expecting an artifact at a root the producer placed elsewhere,
+  silently, until a dispatch breaks. Sense-only. CONFLICT (hard, path-provable) vs
+  SMELL (soft). Use when the same deployment incoherence keeps recurring, after a
+  framework/harness layout change, or as a periodic sweep.
+allowed-tools: [Bash, Read, Grep, Glob]
+agent: construct-gecko
+user-invocable: true
+capabilities:
+  schema_version: 1
+  write_files: false
+  web_access: false
+cost-profile: lightweight
+role: review
+---
+
+# sensing-deployment-seam — the 4th eye
+
+> Authored 2026-06-08 from the `audit-ecosystem-coherence` Opus review. The estate
+> kept re-discovering the same incoherence (manifest-numbness, the `.loa`↔`.claude`
+> path-split, ghost constructs, the sensor that wasn't installed) and patching the
+> instance. This eye senses the CLASS so it is caught before a dispatch breaks.
+
+## The model (operator decision 2026-06-08): single global SoT
+
+`~/.loa/deployment.yaml` names the canonical roots once — `packs / agents / template
+/ runtime / compositions / schema`. Any consumer reading a DIFFERENT pack root is a
+CONFLICT, not a legitimate scope. The eye READS that SoT (so it tracks the home
+automatically and says so when the manifest is absent — a doctor that doctors its
+own map).
+
+## What it senses
+
+- **SEAM-ROOT** — every pack-root consumer must resolve to `packs_root`. The global
+  registration path (`adapter-generator.py`) is probed for its resolved `PACKS_DIR`;
+  any script that hardcodes a non-SoT pack root via path-arithmetic is a CONFLICT;
+  a band-aid symlink bridging the divergence is a SMELL (it encodes the bug).
+- **SEAM-INSTALL-LAG** — pack-bundled scope only. (a) the installed pack must ship
+  every pack-bundled skill IT declares; (b) the installed pack must not LAG its
+  source repo's pack-bundled skills (the `sensing-runtime-fit-not-installed` class
+  this very eye was born from). Harness-installed skills (`path: .claude/skills/…`)
+  are a different scope and are NOT pack lag.
+
+## Run it
+
+```bash
+python3 "$(dirname "$0")/sense.py"          # human-readable
+python3 "$(dirname "$0")/sense.py" --json   # structured (for patrol / the wall)
+```
+
+Exit code is the finding count (for scripting); it NEVER gates — same firewall as
+GECKO's other eyes: it names the mismatch, grants no authority, mutates nothing.
+The fixing is a separate, operator-paced act.
+
+## Composes with
+
+- `sensing-runtime-fit` — the intra-construct capability-reality eye; this is its
+  inter-construct, seam-level sibling.
+- `patrol` — wire `sense.py --json` into the network loop so deployment-seam drift
+  reaches the wall.
+- The deployment SoT (`~/.loa/deployment.yaml`) — the truth this eye reads and checks
+  every consumer against.

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/sensing-path-friction/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/sensing-path-friction/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: sensing-path-friction
+description: "Sense when agents use the WRONG-WEIGHT coordination path (reach-in vs spawn-in-cell vs coord) and detect recurring manual cross-cell patterns (desire-paths) that want to become rails. Reads the mutation/audit trail read-only, classifies each cross-cell ACT by weight-used vs weight-needed, and emits a friction report + the STATUS|SIGNAL|MISMATCH coherence tile. DETECTOR-tier: surfaces, never fail-blocks. Sense-only — never mutates any cell."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+---
+
+# Sensing-Path-Friction — the Path-Friction Doctor (sense-only)
+
+## Purpose
+
+The `sense-estate` doctor asks of one estate: *do the two things that should match, match?*
+This doctor asks of the **coordination layer**: *did the agent use the right-weight path for the
+task — and which recurring manual cross-cell acts want to become rails?*
+
+It is the immune-relay for **posture** — the mounted-agent doctrine made observable. An agent should
+act on its OWN cell (write-own), and act on ANOTHER cell only by spawning an agent INSIDE it.
+Reaching across a blanket (editing another repo's files directly from outside) is a posture slip.
+This skill senses those slips from the trail the agents already leave, and surfaces the recurring
+ones as candidate rails.
+
+It does NOT decide, gate, or fix. Path-weight is a **judgment** (intent), so this is a DETECTOR,
+not a gate — you can't fail-block a judgment without a false-positive machine. It SURFACES; the
+operator/agent decides. There is no action slot.
+
+## The doctrine it implements (do not reinvent it)
+
+| Idea | What it means here |
+|---|---|
+| **mounted-agent posture** | act on your OWN cell directly; act on ANOTHER cell only by spawning an agent INSIDE it. Reaching in from outside = a posture slip. |
+| **the path gradient** | right-size the path to the task: L0 write-own · L1 spawn-in-cell · L2 `/coord` (coordinator + branch + review-gated PR) · L3 `/compose`. Pick the LIGHTEST path that fits (cost-of-failure × reversibility × blast-radius). |
+| **the consumption gradient** | the regenerative path must be the path of LEAST resistance. If the correct path is steeper than reaching-in, agents reach in. OBSERVED LIVE (2026-06-06, clew lrn-20260606-gecko-a7fce3): an agent bypassed `/compose` for 4 consecutive builds despite compose-doctor reporting READY — raw Workflow was lighter than compiling a composition. a READY doctor does not mean the governed path is the least-resistance path; sense the WEIGHT DELTA (governed-path steps vs raw-path steps), not just availability. |
+| **done-twice-becomes-a-path** | a recurring manual cross-cell act → auto-PROPOSE a lightweight composable rail (floor-raise, not a bespoke per-task tile). |
+| **teeth-tier** | invariant > gate > DETECTOR. This is a DETECTOR. surface-not-decide. |
+
+## Invocation
+
+```bash
+/sensing-path-friction                       # full friction report (acts + desire-paths) + the tile
+/sensing-path-friction --tile                # ONE coherence tile line: STATUS|SIGNAL|MISMATCH
+/sensing-path-friction --json                # machine envelope (acts + desire_paths + tile)
+/sensing-path-friction --window 7            # only acts within the last N days
+/sensing-path-friction --min-recur 3         # desire-path threshold (default 2 — "done twice")
+/sensing-path-friction --audit <path>        # add an audit.jsonl to the read set (repeatable)
+```
+
+## Real input sources (grounded — DISCOVER, never assume)
+
+The skill reads ONLY what already exists. Each field below was verified against a real path; the
+ones that don't exist yet are marked **UNKNOWN** so a downstream consumer never trusts a guessed
+field.
+
+| Source | Path (grounded) | Shape lifted | Status |
+|---|---|---|---|
+| **mutation trail (Bash)** | `<repo>/.run/audit.jsonl` written by `.claude/hooks/audit/mutation-logger.sh` | `{ts, tool:"Bash", command, exit_code, cwd, model, provider, trace_id, team_id, team_member}` | **REAL** — `loa-freeside/.run/audit.jsonl` (~10k+ lines) |
+| **write trail (Write/Edit)** | same file, written by `.claude/hooks/audit/write-mutation-logger.sh` | `{ts, tool:"Write"\|"Edit", file_path, cwd, …}` | **REAL** — file_path is the target-cell signal |
+| **default audit hubs** | `~/Documents/GitHub/loa-freeside/.run/audit.jsonl` + `~/bonfire/.run/audit.jsonl` | (the same hubs `operator-port.sh` reads) | **REAL** — both present |
+| **estate-coherence row** | `~/.claude/scripts/straylight-estate/estate-coherence.sh` `probe_*` registry | the `STATUS\|SIGNAL\|MISMATCH` tile contract this doctor's tile is byte-compatible with | **REAL** — orientation only; this skill does NOT write into it |
+| **clew capture** | `>>clew@<construct>[/<skill>]: <why>` → `loa-clew-capture.sh` → `LEARNINGS.jsonl` | the emission format for a proposed rail | **REAL** — the doctor emits in this exact shape |
+| per-act **ceremony label** (was it `/coord`? `/compose`?) | — | the `/coord` + `/compose` trails live elsewhere, NOT in `.run/audit.jsonl` | **UNKNOWN** from this source — the bash trail only shows the *mechanism* (`git -C`, `cd`), so `weight-used` is conservatively inferred as `reach-in`. Over-ceremony (heavier-than-needed) is therefore also UNKNOWN here. |
+| **trace_id correlation** | `audit.jsonl.trace_id` | would let a multi-step cross-cell act be grouped into one "coordination episode" | **UNKNOWN** — the field exists in the schema but is empty (`""`) in every observed entry. |
+
+## The load-bearing detail: the bonfire↔Documents/GitHub symlink
+
+`~/bonfire/loa-freeside` is a **symlink** to `~/Documents/GitHub/loa-freeside` (verified:
+`readlink ~/bonfire/loa-freeside`). So a `cwd` under `~/bonfire/X` writing a `file_path` under
+`~/Documents/GitHub/X` is the **SAME logical cell**, NOT a reach-in. The script canonicalizes BOTH
+sides (`canon()`) before comparing — without this, the doctor would emit thousands of phantom
+reach-ins. A `cwd` at the workspace ROOT (`~/bonfire`, no repo segment) is the **hub** — an agent
+acting *unmounted*, which the doctor labels `(hub)` (the strongest reach-in shape: no blanket of
+its own to act within). Non-repo top-level dirs (`grimoires`, `.run`, `.beads`, `tmp`) are excluded
+from being mistaken for cells.
+
+## What it classifies
+
+For each **cross-cell ACT** (a write/edit/command whose target path is OUTSIDE the acting cell's
+repo, after symlink-canonicalization):
+
+- **weight-USED** — inferred from the mechanism in the trail. A raw `git -C <other>` / `cd <other>`
+  / Write to another cell's `file_path` from a foreign cwd is a direct **reach-in** (L0-against-
+  another-cell). `/coord` and `/compose` leave no mark here → `reach-in` is the only observable
+  weight (documented limitation).
+- **weight-NEEDED** — inferred from cost-of-failure × reversibility × blast-radius:
+  - `glance` — read-only inspection (`git status/log/diff/fetch/rev-parse/remote`). Reverses for
+    free, zero blast-radius. Never needs coordination.
+  - `spawn` (L1) — a single-cell write / branch / build-run. Wants an agent INSIDE the cell.
+  - `coord` (L2) — irreversible (`git push`, `--force`, `reset --hard`, `gh pr/release create|merge`,
+    `railway up`, deploy, a `gh api` write), OR touches ≥2 distinct cells in one act.
+- **FLAG**:
+  - `inspect` — a cross-cell read-only glance. Informational, NOT a slip.
+  - `reach-in` — a cross-cell write/branch done direct that wanted **spawn-in-cell** (L1).
+  - `under-ceremony` — reached in for something that wanted a **coordinator** (L2). The risky slip.
+  - `over-ceremony` — heavier than needed. **UNKNOWN** from this source (see the table above).
+
+## Desire-path detection
+
+A `(source-cell → target-cell → task-shape)` pattern recurring **≥ `--min-recur`** times (default
+2 — "done twice becomes a path") is a **rail that wants to exist**. Read-only glances are excluded
+(a recurring glance is observability, not a rail). For each, the skill emits a clew in GECKO's
+capture format:
+
+```
+>>clew@gecko/sensing-path-friction: pave <src>→<tgt>/<shape> (×N, wants <spawn|coord>) as a composable rail
+```
+
+Per the clew loop's governance: **SENSE is free; ACT is operator-paced.** The doctor surfaces ALL
+candidate rails; it does NOT pre-sort by a heuristic and does NOT open PRs. The operator's eye (and
+the `/clew` drain, one construct per invocation) is the only teach-filter.
+
+## The output contract — the tile
+
+The `--tile` mode emits **exactly one line**, three pipe-delimited fields, byte-compatible with the
+`estate-coherence.sh` consumer (which splits on `|` into `{estate,status,signal,mismatch}`):
+
+```
+STATUS|SIGNAL|MISMATCH
+```
+
+- `STATUS ∈ {ok | drift | blind}`.
+  - `ok` — no recurring desire-paths AND no under-ceremony slips (coordination is clean; the render
+    layer dims it — silence is the good state).
+  - `drift` — ≥1 desire-path (a rail wants to exist) OR ≥1 under-ceremony (a risky reach-in).
+  - `blind` — the trail is absent/unparseable. Loud, not silent (the immune-system "silence is the
+    bug" signal). Fail-CLOSED — never a guess.
+- `SIGNAL` — `<N> cross-cell mutates · <N> reach-in · <N> under-ceremony · <N> glance · <N> desire-paths (top: <src>→<tgt>/<shape> ×N)`
+- `MISMATCH` — `path-used ↔ path-needed (lightest-that-fits ↔ mounted-posture)`
+
+Any raw `|` inside SIGNAL/MISMATCH is escaped to a space and control bytes stripped, so the line is
+always exactly 3 fields.
+
+## Workflow
+
+1. **Run the sensor** (read-only). The script does the JSONL parse + classification:
+   ```bash
+   bash skills/sensing-path-friction/resources/path-friction.sh           # full report
+   bash skills/sensing-path-friction/resources/path-friction.sh --tile    # the coherence tile
+   bash skills/sensing-path-friction/resources/path-friction.sh --json    # machine envelope
+   ```
+   It defaults to the same audit hubs `operator-port.sh` reads; `--audit <path>` adds more.
+
+2. **Surface the report** in GECKO's voice (lowercase, direct, warm). Lead with the tile. If `drift`,
+   name the top desire-paths and the under-ceremony count. If `ok`, say so briefly — don't
+   manufacture concern.
+
+3. **Emit clews for the recurring desire-paths** — verbatim from the script's `>>clew@gecko/...`
+   lines (one per rail). Do NOT pick a winner; surface them and let the operator's eye choose. The
+   `/clew` drain turns a chosen one into a teaching PR (separately, operator-paced).
+
+4. **Compose with the `report` surface** — when running inside a fuller health pass, fold the tile
+   into the network-health report as a DETECTOR row (the friction row sits alongside the estate-
+   coherence rows). Path-friction is surfaced, never enforced.
+
+5. **(Optional) record the observation trail** — like `observe`, the skill MAY append ONE JSONL line
+   to its OWN `grimoires/gecko/observations.jsonl` (never any observed cell):
+   ```json
+   {"timestamp":"…Z","stream_type":"Signal","schema_version":"1.0.0","doctor":"path-friction","status":"drift","mutates":11063,"reach_in":9203,"under_ceremony":1860,"desire_paths":433,"top":"loa-freeside→freeside-auth/file-mutate ×604"}
+   ```
+
+## Outputs
+
+| Path | Description |
+|------|-------------|
+| stdout | the friction report (full) OR the single `STATUS\|SIGNAL\|MISMATCH` tile (`--tile`) OR the JSON envelope (`--json`) |
+| stdout (clews) | `>>clew@gecko/sensing-path-friction: …` lines — candidate rails, in GECKO's capture format |
+| `grimoires/gecko/observations.jsonl` | OPTIONAL append-only observation trail (the skill's OWN — never an observed cell) |
+
+## Constraints — sense-only (the hard boundary, mirrors sense-estate)
+
+- **Zero act/write/dispatch verbs against any cell's state.** No `gh pr`, no `git push`, no
+  `br update`, no opening of `/coord` coordinators, no mutation of any repo. The doctor SENSES the
+  paving; the rail-building (a `/clew` teaching PR, or a `/compose` rail) is a SEPARATE,
+  operator-paced act.
+- The skill MAY write only its OWN GECKO-grimoire trail (Step 5), exactly as `observe` does.
+- Adding this skill adds **no `workflow.gates`** to `construct.yaml` and never will. GECKO stays
+  sense-only.
+- **Never fail-block.** Path-weight is a judgment; the doctor surfaces a JUDGMENT, it does not gate.
+  A `drift` tile is a prompt for the operator, not a CI failure.
+- **Never extrapolate.** If a weight cannot be read (e.g. was this a `/coord`?), it is marked
+  conservatively (`reach-in`) or UNKNOWN — never invented. Over-ceremony is UNKNOWN from this source.
+- **Never reach in itself** — the doctor reading the audit trail is the read-own posture; it never
+  acts on another cell. (The doctor that warns against reaching in must not reach in.)
+- Canonicalize the bonfire↔Documents/GitHub symlink before comparing cells — without it, the doctor
+  manufactures phantom reach-ins. This is load-bearing.
+
+## Composes with
+
+- **`sense-estate`** (sibling) — the estate-coherence doctor (registry↔state). This is its
+  coordination-layer sibling (path-used↔path-needed). Both emit the same tile contract.
+- **`operator-port.sh`** (`estate-coherence` `probe_operator`) — senses the OPERATOR's recurring
+  *same-cell* hand-touches (paving vs a viability band). This doctor is the orthogonal axis:
+  recurring *cross-cell* coordination weight. Same audit trail, different question.
+- **`report`** (GECKO sibling skill) — the synthesis surface the friction row folds into.
+- **`/clew`** — the drain that turns a chosen desire-path into a teaching PR (operator-paced).
+- **`/compose`** (construct-rooms-substrate) — where a paved rail would eventually LIVE as a
+  composable path primitive any cell could inherit.
+
+## Why this exists
+
+Agents reach in because reaching in is the path of least resistance. Every reach-in is a small
+posture debt; every recurring reach-in is a rail the system is missing. The trail already records
+every one of them — nobody was reading it for *this* question. The doctor doesn't scold the reach-in
+(sometimes a glance over the blanket is exactly right); it counts the ones that recur and says: *this
+road has been walked enough times that it wants paving.* Whether to pave it is the operator's
+business. The doctor just makes the desire-path visible before it becomes invisible habit.

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/sensing-runtime-fit/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/sensing-runtime-fit/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: sensing-runtime-fit
+description: "Sense whether each construct's declared runtime CONTRACT (construct.yaml capabilities + skill frontmatter: model_tier, agent, allowed-tools, downgrade, workflow.gates) coheres with the runtime that actually runs it. Detects capability-reality drift — the #553 agent/write-conflict that silently drops output, model tiers the runtime doesn't offer, write/web denials contradicted by tools, opus pinned for light work, and surfaces gate-owners. Reads the pack territory read-only, emits the STATUS|SIGNAL|MISMATCH tile + a runtime-fit ledger. Sense-only — never mutates a pack, never gates."
+allowed-tools: [Bash, Read, Grep, Glob]
+user-invocable: true
+---
+
+# Sensing-Runtime-Fit — the runtime-fit doctor (sense-only)
+
+## Purpose
+
+`/diagnose` asks: *does the construct DO what it CLAIMS?* (persona ↔ manifest ↔ skill).
+`/sensing-construct-console` asks: *do the maps agree?* (declared ↔ governed ↔ earned).
+This doctor asks the side nobody was watching:
+
+```
+declared-capability  ↔  runtime-reality
+ (what a construct asks the runtime for)  ↔  (what the runtime gives)
+```
+
+A construct declares a **contract with the runtime** — in `construct.yaml`'s
+`capabilities` block (model_tier, danger_level, downgrade_allowed, effort_hint,
+execution_hint, requires) and in each skill's frontmatter (allowed-tools, agent,
+capabilities, cost-profile). **37 of 43 packs** in the reference estate declare
+such a contract — and until this skill, **nothing doctored it**. A construct
+could ask for a model tier the runtime doesn't have, or declare it writes files
+then route through a read-only agent type (and silently drop its output), and no
+eye in the network would see it.
+
+The full taxonomy this doctor reads against — model tiers, agent-type allowlists,
+forks, the frontmatter contracts, the gate ladder — is distilled in
+`identity/environment.md` ("The Ground GECKO Stands On"). **Read that first.**
+This skill is the eye; that file is what the eye knows.
+
+## The doctrine it implements (do not reinvent it)
+
+| Idea | What it means here |
+|---|---|
+| **capability-reality drift** | the fourth drift axis. A construct's *footing* can be wrong even when its *sign and goods agree*. |
+| **provable-from-the-file vs map-dependent** | a CONFLICT is an internal contradiction provable from the file alone (certain). A SMELL is a mismatch with the taxonomy GECKO *carries* (fallible) or a judgment. Keep them separate. |
+| **the #553 invariant** | write capability + a read-restricted `agent:` = output produced then silently not persisted. The canonical runtime-fit conflict. |
+| **teeth-tier** | invariant > gate > DETECTOR. This skill reports an invariant-class (CONFLICT, hard) AND a detector-class (SMELL, soft) — clearly separated. It still never fail-blocks; it surfaces. |
+| **sense-only** | names the mismatch; grants no authority, adds no gate, mutates no pack. The fix is a separate, operator-paced act. |
+| **the map is fallible** | the runtime tiers/agent-allowlist live OUTSIDE the repo. GECKO carries a distilled copy and marks the seam loudly — an unknown value may be NEW, not stale. |
+| **roleplay-vulnerability** | the RAIL edition of capability-reality drift. a deterministic loop EXISTS but nothing REQUIRES its artifact — so an LLM asked to "run" it SIMULATES the output instead (native next-token plausibility, not malice). a rail is roleplay-vulnerable when faking its output is cheaper than running it. cure flips COST (un-fakeable trace + a check that requires it + downstream that consumes the trace, not the agent's word) — adds no compute. "we already had the code" ≠ load-bearing. |
+| **three-gates-in-series** | environment design = three gates in SERIES: **formation** (can the game form — players registered, present, connected) → **observability** (is cooperation visible via an un-fakeable artifact) → **payoff** (defect/stick/(3,3)). most stuck rails fail at formation or observability, NOT payoff — sense the failing LAYER first; tuning payoff on a rail that can't form is wasted hardness. hardness law: a PreToolUse hook is a real gradient; SKILL.md prose is roleplay-vulnerable. (clew lrn-20260607-gecko-0b460c) |
+
+### Rails vs seams (where the eye looks, and where it must NOT)
+
+avoid-roleplay is a RAIL property, never a seam one. a rail is deterministic transport
+between judgments — INVOKED, never simulated; sense it for an un-fakeable run-trace + a
+check that requires it (proof-of-run: no trace = not_a_run) + downstream consuming the
+trace. a SEAM (a gate, an operator pairing, a construct's own reasoning) is where roleplay
+IS the work. the eye flags a rail that can be faked cheaply; it leaves seams alone. a
+proof-of-run gate verifies the TRANSPORT happened, never the judgment's quality. misread a
+seam as a rail → you gate creativity; misread a rail as a seam → you trust a simulation.
+
+## Invocation
+
+```bash
+/sensing-runtime-fit                       # tile only (default; SessionStart-cheap)
+/sensing-runtime-fit --console             # tile + the full runtime-fit ledger (human)
+/sensing-runtime-fit --json                # tile + machine envelope
+/sensing-runtime-fit --root <path>         # override the consuming repo root
+```
+
+The runtime is a **fast, zero-dependency node script** —
+`resources/sense-runtime-fit.mjs` — NOT an agent invocation. It runs in ~50ms,
+which is what lets it occupy a SessionStart slot at the map's cost. It is
+immediately usable from anywhere, before any reinstall:
+
+```bash
+node skills/sensing-runtime-fit/resources/sense-runtime-fit.mjs --root ~/Documents/GitHub/loa-freeside --console
+```
+
+## What it senses (all read-only, every finding grounded in a path)
+
+It walks the consuming repo's `.claude/constructs/packs/*/` (excludes
+`*.frozen.bak`), reads each `construct.yaml` + every `skills/*/SKILL.md`
+frontmatter + `skills/*/index.yaml`, and classifies:
+
+### CONFLICT — hard, drives `drift` (an internal contradiction that breaks silently)
+
+| kind | what it means |
+|---|---|
+| `agent-write-conflict` | skill declares write capability but `agent:` is read-restricted (#553) — output never persists |
+| `write-denied-but-tooled` | `capabilities.write_files: false` but `Write`/`Edit` in `allowed-tools` |
+| `web-denied-but-tooled` | `capabilities.web_access: false` but `WebFetch`/`WebSearch` in `allowed-tools` |
+
+### SMELL — soft, surfaced never gated (a judgment, or a mismatch with the carried map)
+
+| kind | what it means |
+|---|---|
+| `unknown-model-tier` | `model_tier` not recognized by the **home** vocabulary (`.claude/defaults/model-config.yaml` — `aliases:` + `tier_groups:`, read live) nor the carried bridge — a genuinely unknown tier (e.g. a typo). Grouped per pack; one template ≠ N bugs |
+| `opus-pinned-light` | `opus` + `downgrade_allowed: false` for `effort: small/medium` or `danger: safe` — pins the top rung with no escape hatch for light work (cost) |
+| `no-capabilities` | no `capabilities` block — the construct declares nothing about its runtime needs; the runtime defaults apply blind |
+| `unknown-tool` | a tool in `allowed-tools` the sensor doesn't recognize (ok if MCP/custom — surfaced for the eye, never a fail) |
+
+### SURFACED (not a problem) — `workflow.gates` owners
+
+Packs declaring `workflow.gates` claim the `/implement`-bypass exception — they
+own a quality pipeline. A high-authority claim worth the operator's eye. Listed,
+never flagged.
+
+### Also surfaced — `requires` vocabulary
+
+The sub-keys packs use under `capabilities.requires`. A key used by one or two
+packs against twenty-six is candidate vocabulary drift (the estate hasn't agreed
+on the words).
+
+### Also surfaced — tier vocabulary source + SoT (the anti-staleness seam)
+
+The recognized tier vocabulary is **read from the home** at run-time — the
+consuming repo's `.claude/defaults/model-config.yaml` (the hounfour/cheval config,
+synced from **loa-hounfour**, the SoT: its `aliases:` + `tier_groups:`). The sensor
+does NOT carry the canonical list (a carried list goes stale); it reads the home and
+only falls back to a carried union when the home file is absent — saying which source
+it used, every run. It AFFIRMS the SoT (reads the home's `cheap` target live and names
+loa-hounfour). The `cheap` vocabulary collision (home ≡ sonnet vs the old emitter ≡
+haiku) was **RECONCILED 2026-06-07**: loa-hounfour is the SoT, `cheap` ≡ sonnet is
+canonical. **CAUTION — sensed 2026-06-09: the emitter-conformance half never reached the
+territory.** `segment-emitter.py` HEAD and the deployed substrate copy
+(`~/.loa/constructs/substrates/…`) still map `cheap → haiku`; the conforming change
+exists only as an unlanded WIP commit (`1e0b5d6`). a decision record is a map — verify
+the routing table in the territory before trusting `cheap`. (`identity/environment.md` §I.)
+
+## The output contract — the tile
+
+`--tile` (default) emits **exactly one line**, three pipe-delimited fields,
+byte-compatible with the `estate-coherence.sh` consumer:
+
+```
+STATUS|SIGNAL|MISMATCH
+```
+
+- `STATUS ∈ {ok | drift | blind}`.
+  - `ok` — **zero hard CONFLICTS** (smells/gate-owners may exist; the render dims
+    them — silence on the hard axis is the good state).
+  - `drift` — ≥1 CONFLICT (a contradiction that breaks silently).
+  - `blind` — the packs dir is unreadable. Loud, not silent. Fail-CLOSED — exit 3,
+    never a guess.
+- `SIGNAL` — `<N> packs · <H> conflicts · <S> smells · <G> gate-owners`
+- `MISMATCH` — `declared-capability ↔ runtime-reality (what it asks for ↔ what the runtime gives)`
+
+Raw `|` inside SIGNAL/MISMATCH is escaped to a space and control bytes stripped,
+so the line is always exactly 3 fields.
+
+## Workflow
+
+1. **Run the sensor** (read-only):
+   ```bash
+   node skills/sensing-runtime-fit/resources/sense-runtime-fit.mjs --root <repo>            # tile
+   node skills/sensing-runtime-fit/resources/sense-runtime-fit.mjs --root <repo> --console  # full ledger
+   node skills/sensing-runtime-fit/resources/sense-runtime-fit.mjs --root <repo> --json     # machine envelope
+   ```
+2. **Surface in GECKO's voice** (lowercase, direct, warm). Lead with the tile. If
+   `drift`, name each CONFLICT (these break silently — they deserve precise,
+   file-grounded callouts). If `ok`, say so — then walk the SMELLS and gate-owners
+   as *observations*, not alarms. Don't manufacture concern; don't bury a real
+   conflict.
+3. **Never invent severity.** A SMELL is not a CONFLICT. An unknown tier is stale
+   vocabulary or a new rung — say which you can prove and which you can't.
+4. **Compose into the health report** — fold the tile in as a row alongside the
+   other estate-coherence tiles. Runtime-fit is surfaced, never enforced.
+
+## Outputs
+
+| Path | Description |
+|------|-------------|
+| stdout | the runtime-fit ledger (full) OR the single `STATUS\|SIGNAL\|MISMATCH` tile (`--tile`) OR the JSON envelope (`--json`) |
+| `grimoires/gecko/observations.jsonl` | OPTIONAL append-only observation trail (the skill's OWN — never an observed pack), like `observe` |
+
+## Constraints — sense-only (the hard boundary, mirrors the sibling sensors)
+
+- **Zero act/write/dispatch verbs against any pack's state.** No manifest edit, no
+  frontmatter fix, no model_tier rewrite, no agent: change. The doctor SENSES the
+  mismatch; the fix (a frontmatter edit in the construct's source cell) is a
+  SEPARATE, operator-paced act.
+- Adding this skill adds **no `workflow.gates`** to `construct.yaml` and never
+  will. GECKO stays sense-only.
+- **Hard vs soft is load-bearing — never collapse it.** Only an internal
+  contradiction provable from the file alone is a CONFLICT (`drift`). A mismatch
+  with the carried taxonomy is a SMELL. Misclassifying a smell as a conflict turns
+  the doctor into a false-positive machine and the operator stops trusting it.
+- **The carried taxonomy is the one place the map meets the off-repo territory.**
+  It lives in `resources/sense-runtime-fit.mjs` (`TAXONOMY`) and is documented in
+  `identity/environment.md`. When the runtime's tiers/agent-allowlist change,
+  update BOTH — and prefer the runtime as truth over the carried copy.
+- **Never reach into the harness's turf.** `validate-skill-capabilities.sh` lints
+  `.claude/skills` (the harness's own skills). This doctor scopes to the
+  **construct estate** (`.claude/constructs/packs`). Same invariant, different
+  population — don't duplicate, compose.
+- **Fail-closed-loud.** An unreadable root is a `blind` tile + exit 3, never a
+  guess of `ok`.
+
+## Composes with
+
+- **`environment.md`** (GECKO identity) — the taxonomy this eye reads against. The
+  file is the knowledge; this skill is the perception that uses it.
+- **`sensing-construct-console`** (sibling) — the composition/authority eye
+  (`declared ↔ governed ↔ earned`). This is the runtime-fit eye
+  (`declared-capability ↔ runtime-reality`). Different cuts of the same estate.
+- **`sense-estate`** / **`sensing-path-friction`** (siblings) — same tile
+  contract, same sense-only firewall, same DETECTOR humility.
+- **`validate-skill-capabilities.sh`** (the harness) — the same #553 + capability
+  consistency checks, but for `.claude/skills`. This doctor brings the literacy to
+  the construct estate the harness doesn't reach.
+- **`report`** (GECKO sibling) — the synthesis surface the runtime-fit row folds into.
+
+## Why this exists
+
+I watched the stalls for years and never looked at the ground they stood on. A
+construct can sell exactly what its sign says and still have its footing wrong —
+asking the runtime for a rung that isn't there, or declaring it writes then
+dispatching through hands that can't. That rot is invisible to an eye that doesn't
+know the runtime. The contracts were always on disk; nobody was reading them for
+*this* question. Now someone is.

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/sweep-bonfire/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko-broken/skills/sweep-bonfire/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: sweep-bonfire
+description: "Walk the operator's bonfire — local working copies of authored constructs. Classify each by lifecycle glyph (seed/hot/warm/crystallized/cooling/ghost) and emit to the wall. Surface; never decide."
+allowed-tools: [Bash, Read, Write, Edit]
+user-invocable: true
+---
+
+# Sweep-Bonfire — Walk the Operator's Stalls
+
+## Purpose
+
+The `patrol` skill watches the constructs.network through its public API — the bazaar at altitude. This skill walks the *bonfire*: the operator's local working copies of constructs they author. Same eye, different altitude.
+
+The patrol's job is reading the network. The sweep's job is reading what's about to *enter* the network — work in progress, branches not yet landed, charters not yet planted, stalls cooling because the operator forgot they exist.
+
+## Invocation
+
+```bash
+/sweep-bonfire                              # default: ~/bonfire/* → ~/bonfire/WALL.md
+/sweep-bonfire --root <path>                # alternative bonfire location
+/sweep-bonfire --wall <path>                # alternative wall location
+/sweep-bonfire --dry-run                    # print classification, don't write
+/sweep-bonfire --json                       # machine-readable classification (no wall write)
+```
+
+## Lifecycle glyphs
+
+The state vocabulary the sweep emits. Ghost is the only forbidden state — every other lane is a valid life event.
+
+| glyph | state | who decides | signal |
+|---|---|---|---|
+| 🌱 | seed | operator | construct.yaml or CHARTER.md exists, no .git |
+| 🟢 | hot | observed | clean tree, push within 24h |
+| 🟡 | warm | observed | dirty tree, OR unpushed within 7d, OR active feature branch |
+| 🔵 | crystallized | operator-declared | settled at rest, no work needed |
+| 🟠 | cooling | observed | unpushed work 7-30d, OR dirty tree >7d |
+| ♻︎ | absorbing | operator-declared | being merged into another construct |
+| ⚫ | archived | operator-declared | formally retired with reason |
+| 🔴 | ghost | forbidden | unpushed >30d with no declared state — surface; operator picks a lane |
+
+Operator-declared states sit in the construct's `construct.yaml` under `lifecycle:`. If present, the sweep honors it over the observed default — observation never overrides intent.
+
+## Classification logic
+
+For each `<root>/<dir>`:
+
+1. **Resolve type**
+   - Has `.git/` → git-repo path
+   - Has `construct.yaml` or `CHARTER.md` but no `.git/` → seed path
+   - Neither → not a stall; skip
+
+2. **Read operator declaration** (if `construct.yaml::lifecycle` is set: archived/crystallized/absorbing → honor it, append note)
+
+3. **Otherwise observe:**
+
+```
+no_git + (construct.yaml OR CHARTER.md)          → 🌱 seed
+clean_tree + clean_remote + push_age < 24h       → 🟢 hot
+dirty_tree                                       → 🟡 warm (note: N dirty files)
+clean_tree + unpushed_count > 0, push_age < 7d   → 🟡 warm (N unpushed, age)
+clean_tree + unpushed_count > 0, 7d <= age <= 30d → 🟠 cooling
+clean_tree + unpushed_count > 0, age > 30d       → 🔴 ghost
+clean_tree + clean_remote + last_commit > 30d    → 🔵 crystallized (heuristic default)
+on_feature_branch (not main/master/default)      → existing glyph + branch-fatigue note if branch_age > 7d
+```
+
+4. **Emit**
+   - --dry-run: print to stdout, no writes
+   - --json: print JSON to stdout, no writes
+   - default: insert a sweep block at the top of the wall (after the header), atomically (mktemp + mv)
+
+## Wall format emitted
+
+```markdown
+## YYYY-MM-DD — sweep — <trigger>
+
+| stall | state | note |
+|---|---|---|
+| construct-X | 🟢 hot | clean, last push 2h ago |
+| construct-Y | 🟠 cooling | 1 unpushed (12d), dirty tree |
+| construct-Z | 🌱 seed | charter from 2026-05-19, not yet planted |
+```
+
+## Workflow
+
+1. **Resolve config**
+   - root = arg `--root` OR `$BONFIRE_ROOT` OR `~/bonfire`
+   - wall = arg `--wall` OR `$BONFIRE_WALL` OR `<root>/WALL.md`
+   - dry_run, json from argv
+
+2. **Walk** `<root>/*` — each subdir is a candidate stall. Resolve type per above.
+
+3. **Classify** each stall by the rules above. Read `construct.yaml::lifecycle` if present.
+
+4. **Emit**
+   - --json: marshal classification list to JSON, print, exit
+   - --dry-run: print table to stdout, exit
+   - default: read `<wall>`, insert new block above the most-recent `## YYYY-MM-DD` header, write atomically
+
+5. **Summary line** to stderr: `sweep: N stalls observed (G hot, W warm, C cooling, K ghost) → <wall>`
+
+## Anti-patterns
+
+- **NEVER push detected dirty work.** The sweep observes; it does not act. Operator landing is a separate move.
+- **NEVER reclassify operator-declared states.** If `construct.yaml::lifecycle: crystallized` is set, the sweep notes it; it does not promote/demote.
+- **NEVER enter operator's home dir beyond `<wall>`.** The wall is the only write surface.
+- **NEVER extrapolate to ghost without checking remote.** A 30-day-old branch with the work already pushed upstream is crystallized, not ghost.
+- **NEVER write to the wall in --dry-run or --json mode.** Both modes are read-only.
+
+## Trust boundary
+
+| Action | Permission |
+|---|---|
+| Read `<root>/*/.git`, construct.yaml, CHARTER.md | yes |
+| Write `<wall>` (default ~/bonfire/WALL.md) | yes |
+| `git push`, `git commit`, mutate construct sources | **NEVER** |
+| Open PRs, create branches, fetch from remote | **NEVER** |
+
+## Composes with
+
+- **`patrol`** (sibling skill) — the network-API observer at the bazaar altitude. The sweep is the local-working-copy observer at the bonfire altitude. Together they cover both ends of the construct lifecycle.
+- **`auditing-cluster-cells`** (construct-freeside) — for sweeps over a cluster of installed-and-running buildings rather than a bonfire of authored constructs. Same shape, different scope.
+- **`coordinating-cross-repo`** (construct-freeside) — execution surface for *acting on* what the sweep observes. The sweep surfaces; the coordinator dispatches.
+
+## Why this exists
+
+Operators forget. A construct sitting unpushed for 4 weeks is not a problem of operator discipline — it's a problem of the system not surfacing it. The bonfire's job is to never let a stall become ghost without the operator hearing about it first.
+
+The reward function this skill optimizes: legibility of state across all operator-authored constructs. Ghost is the only forbidden state. Every other glyph is a valid lifecycle phase, including "nothing happening" (🔵 crystallized) — because the world changes too quickly for any state to be permanent, and resting is part of how organisms survive.

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/EXPECTED.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/EXPECTED.md
@@ -1,0 +1,18 @@
+# EXPECTED — gecko bundle · 9/9
+
+Source: `construct-gecko` (schema_version 3, slug `gecko`, v0.1.0).
+Reference-grade bundle. The `identity/environment.md` here is the canonical reality.md shape.
+
+| # | Check | Verdict | Reasoning |
+|---|-------|---------|-----------|
+| 1 | manifest parses | PASS | `manifest.json` is `construct.yaml` → JSON 1:1; valid JSON. |
+| 2 | registry-required fields | PASS | `schema_version: 3`, `name: Gecko`, `slug: gecko`, `version: 0.1.0` all present. |
+| 3 | model_tier in SoT vocabulary | PASS | `capabilities.model_tier: opus` ∈ SoT {cheap, mid, tiny, max, opus, sonnet, haiku} (aliases block in `.claude/defaults/model-config.yaml`). |
+| 4 | write cap never routes through read-only agent type | PASS | No skill sets `agent:` to a read-only type. `observe` declares `Write` in allowed-tools but pins no agent (inherits caller). |
+| 5 | capability declarations match toolset | PASS | `requires.tool_calling: true` matches Bash/Read/Write/Edit usage; `vision: false`, no vision tools invoked. |
+| 6 | skill prose uses canonical primitives | PASS | No raw `bd` task tracking; no raw `grep`/`rg` code-search. Uses `gh api`, `curl`, `jq`, `git`. |
+| 7 | grounding file exists (reality.md axis) | PASS | `reality.md` = `identity/environment.md` (302 lines) — "The Ground GECKO Stands On", the runtime/harness taxonomy axis. |
+| 8 | genome hash chain verifies | PASS | `genome.jsonl` 2-link chain; each `genome_hash` recomputes over its canonical body; `link2.parent_hash == link1.genome_hash`. |
+| 9 | proof-of-run valid_run verdict | PASS | `proof-of-run.json` verdict `valid_run`; `content_hash_verified` recomputes from core members. |
+
+**Expected score: 9/9.**

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/HASHING.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/HASHING.md
@@ -1,0 +1,34 @@
+# content_hash recipe (== construct-rubric.py C9)
+
+`bundle_schema_version` 1.0.0 · rubric: `sha256:c181978e4e8f2bce65171f57eb0fe6da4f1c0a52ec46118c1443ef92d52af9df`
+
+```
+core = [manifest.json, reality.md, handoff.md] + SKILL.md (root, if present)
+       + skills/**/SKILL.md, sorted by bundle-relative path
+listing = concat(f'{sha256(bytes)}  {relpath}\n')
+content_hash = sha256(listing)
+```
+
+Sidecars excluded: genome.jsonl, proof-of-run.json, registration.json, HASHING.md, EXPECTED.md, INJECTIONS.md.
+
+## Per-member digests
+
+```
+4a2df53c7d83e87837295485bf6fc5259d8a31983c3cb1e96ee6d767ff4a57f1  SKILL.md
+c03c4394ad9c18f5b41454c0314ea749b8d8a36c74da2dcbefff2886d3270783  handoff.md
+ccbf86d21232a7b38c5c4b17c6740ba78af5979b2af267f1455d15a231b115cc  manifest.json
+ea7e535da107af507ce3a8919bacef95e33c6dcf941e4e35a07c0e94ea0bafbf  reality.md
+22ca9f732c2a75e5eddb78a0b3a5c6a90999dc0f23387971210fdef930a7fa00  skills/diagnose/SKILL.md
+4a2df53c7d83e87837295485bf6fc5259d8a31983c3cb1e96ee6d767ff4a57f1  skills/observe/SKILL.md
+152face2f7dbe12306fd776c65fd0d720b8fa0f04d74b1f1f96ed181d0446081  skills/patrol/SKILL.md
+772c43e9e92d5c8275359e6bffecc804e9fafcadce3dafae73e3662a3697d99f  skills/report/SKILL.md
+6675aedbbaa2f690872f5370fc97e535364516af3697e23519939fc692d9c0ca  skills/sense-estate/SKILL.md
+2982407e7bb980f3f8559b9c462e019cc893423fb095c485994a5eee4b2d3cf3  skills/sensing-config-drift/SKILL.md
+d7808d7ae90f13d3094a14348f7bdbfcee4601df680d5c79e596a80a8db7c4d7  skills/sensing-construct-console/SKILL.md
+4ca11122ab958d38468dfb3ff5ee52527ac77227780691eac9ee04d40f69e6f5  skills/sensing-deployment-seam/SKILL.md
+14cf050b8f095d3fe80eac9ec614b46772ae8dec29c4f0482753ca5941623375  skills/sensing-path-friction/SKILL.md
+d15d8d873f1cd1f6e683e5197a4ed1f5507f8a62863f13865198506915fde247  skills/sensing-runtime-fit/SKILL.md
+327ed902cf4f259edd7d964a8117a40f37c098199ebf012c39bb9cbfbe92bf89  skills/sweep-bonfire/SKILL.md
+```
+
+content_hash = `932415895e931654caa03f481022e4acd380f5c8a610397f69c843a76cd83e8d`

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/HASHING.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/HASHING.md
@@ -1,6 +1,6 @@
 # content_hash recipe (== construct-rubric.py C9)
 
-`bundle_schema_version` 1.0.0 · rubric: `sha256:c181978e4e8f2bce65171f57eb0fe6da4f1c0a52ec46118c1443ef92d52af9df`
+`bundle_schema_version` 1.0.0 · rubric: `sha256:1374c7c445d8ab756e751160bb76e67f91f2cceaf4e56ba54fee3af9693ce370`
 
 ```
 core = [manifest.json, reality.md, handoff.md] + SKILL.md (root, if present)

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: observe
+description: "Single-pass network health observation. Checks API liveness, namespace freshness, drift, computes Network Health Score."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+---
+
+# Observe — Single-Pass Network Health Check
+
+## Purpose
+
+Run a single observation pass across the entire constructs network. Produce structured JSONL observations and compute the Network Health Score. This is the atomic unit — `/patrol` calls this repeatedly, `/report` synthesizes its output.
+
+## Invocation
+
+```bash
+/observe                    # Full network pass
+/observe --quick            # API-only (skip GitHub checks)
+```
+
+## Workflow
+
+### Step 1: Load Baseline
+
+Read the last observation from `grimoires/gecko/observations.jsonl` (if exists). Extract the previous `health_score` for ratchet comparison.
+
+### Step 2: Check API Liveness
+
+```bash
+# Health endpoints
+curl -s https://api.constructs.network/v1/health | jq .
+curl -s https://api.constructs.network/v1/health/ready | jq .
+
+# Registry state
+curl -s https://api.constructs.network/v1/constructs | jq '.data | length'
+```
+
+Record: `api_status` (healthy/degraded/down), `registered_count`, `response_time_ms`.
+
+### Step 3: Check Namespace Freshness
+
+```bash
+# List all construct-* repos under 0xHoneyJar
+gh api orgs/0xHoneyJar/repos --paginate -q '.[] | select(.name | startswith("construct-")) | {name, pushed_at, archived}'
+```
+
+For each repo, record:
+- `slug`: repo name minus `construct-` prefix
+- `last_push`: ISO timestamp
+- `days_stale`: days since last push
+- `archived`: boolean
+
+Flag constructs with `days_stale > 30` as `STALE`. Flag `days_stale > 90` as `ABANDONED`.
+
+### Step 4: Check Category Distribution
+
+Query the API or parse construct.yaml files for `domain[0]` to determine category assignments. Count constructs per category across the 8 canonical categories:
+- development, security, design, documentation, operations, infrastructure, research, straylight
+
+Flag categories with 0 constructs as `EMPTY_CATEGORY`.
+
+### Step 5: Check Identity-Reality Drift (if not --quick)
+
+For each construct in the namespace:
+1. Read `identity/persona.yaml` — extract `cognitiveFrame.archetype` and `voice.personality_markers`
+2. Read `skills/*/SKILL.md` — extract actual methodology steps
+3. Compare: does the skill methodology reflect the persona's claimed expertise?
+4. Score drift: `ALIGNED` (0), `MINOR_DRIFT` (1-2 mismatches), `SIGNIFICANT_DRIFT` (3+)
+
+This step requires cloning or reading repos via `gh api`. For speed, use:
+```bash
+gh api repos/0xHoneyJar/construct-{slug}/contents/identity/persona.yaml -q .content | base64 -d
+gh api repos/0xHoneyJar/construct-{slug}/contents/construct.yaml -q .content | base64 -d
+```
+
+### Step 6: Compute Network Health Score
+
+Weighted composite (0-100):
+
+| Sub-Signal | Weight | Scoring |
+|---|---|---|
+| API Liveness | 0.20 | healthy=100, degraded=50, down=0 |
+| Version Freshness | 0.25 | avg(100 - min(days_stale, 100)) across all constructs |
+| Category Coverage | 0.15 | (filled_categories / 8) * 100 |
+| Identity-Reality Drift | 0.20 | avg(aligned=100, minor=70, significant=30) across all |
+| Composition Density | 0.10 | (constructs_with_compose_with / total) * 100 |
+| Verification Flow | 0.10 | (non_unverified / total) * 100 |
+
+### Step 7: Emit Observation
+
+Append to `grimoires/gecko/observations.jsonl`:
+
+```json
+{
+  "timestamp": "2026-03-12T00:00:00Z",
+  "health_score": 72,
+  "health_delta": -3,
+  "api_status": "healthy",
+  "registered_count": 15,
+  "namespace_count": 16,
+  "stale_constructs": ["webgl-particles"],
+  "empty_categories": ["infrastructure"],
+  "drift_detected": [{"slug": "dynamic-auth", "level": "MINOR_DRIFT"}],
+  "anomalies": []
+}
+```
+
+### Step 8: Surface Findings
+
+If `health_delta < 0` (health degraded), surface the contributing sub-signals as findings. If `health_delta >= 0`, report quietly — the ratchet held.
+
+Output format (to stdout):
+```
+gecko | health: 72 (-3) | api: healthy | stale: 1 | drift: 1 | categories: 7/8
+```
+
+If anomalies exist, list them. Otherwise, one line is enough.
+
+## Outputs
+
+| Path | Description |
+|------|-------------|
+| `grimoires/gecko/observations.jsonl` | Append-only observation log |
+
+## Constraints
+
+- Never modify construct source files
+- Never extrapolate — if you can't measure it, don't score it
+- API failures are `degraded`, not `anomaly` — the network survives without the registry
+- Identity-reality drift is a signal, not a judgment — flag it, don't prescribe fixes

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/genome.jsonl
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/genome.jsonl
@@ -1,0 +1,2 @@
+{"construct": "gecko", "genome_hash": "e1ddc8750f2c09aa61564f999a35894446f8c92f389204ceae2ca6bb5c516f88", "parent_hash": "GENESIS", "payload": {"learning": "sense-only constructs never gate operator decisions", "minted_at": "2026-07-03T00:00:00Z"}, "seq": 1}
+{"construct": "gecko", "genome_hash": "8bf112d81766a5f5a0ff18774466d7fffd61b44a109d87134105f707aeb4316e", "parent_hash": "e1ddc8750f2c09aa61564f999a35894446f8c92f389204ceae2ca6bb5c516f88", "payload": {"learning": "capability-reality drift is invisible without the ground", "minted_at": "2026-07-03T00:01:00Z"}, "seq": 2}

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/handoff.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/handoff.md
@@ -1,0 +1,24 @@
+# Gecko — Seam / Handoff Contract
+
+> Derived 1:1 from `construct.yaml` `streams:` + `events:`. This is the
+> construct's declared seam — the typed ports it reads/writes and the
+> events it emits/consumes. No freestanding handoff doc ships in-repo;
+> this file grounds the seam in the manifest.
+
+## Typed streams
+
+- **reads:** Intent, Operator-Model
+- **writes:** Signal, Verdict, Artifact
+
+## Emitted events (publish belt)
+
+- `gecko.health_observed` — Emitted after a single-pass observation completes
+- `gecko.drift_detected` — Emitted when identity-reality drift exceeds threshold
+- `gecko.patrol_complete` — Emitted when a full patrol cycle finishes
+- `gecko.diagnosis_complete` — Emitted when a deep diagnosis of a construct finishes
+- `gecko.path_friction_observed` — Emitted after a path-friction sense completes — wrong-weight coordination acts + recurring cross-cell desire-paths (DETECTOR-tier; surfaced, never gated)
+- `gecko.runtime_fit_observed` — Emitted after a runtime-fit sense completes — capability-reality drift across the construct estate (CONFLICTS hard / drive drift, SMELLS soft / surfaced; DETECTOR-tier, never gated)
+
+## Consumed events (consume belt)
+
+- `forge.k-hole.emergence_complete` — Picks up research emergence for ecosystem pattern matching

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/manifest.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/manifest.json
@@ -1,0 +1,273 @@
+{
+  "schema_version": 3,
+  "name": "Gecko",
+  "slug": "gecko",
+  "version": "0.1.0",
+  "description": "Estate coherence sensing \u2014 health monitoring for the construct ecosystem and any other estate. Runs automated checks, detects when constructs drift from their documentation, and tracks lifecycle status. Ten skills: patrol (automated network loops), observe (single network check), diagnose (deep investigation), report (findings summary), sweep-bonfire (walks the operator's local working copies and emits to the wall \u2014 sibling altitude to patrol), sense-estate (senses an arbitrary estate's coherence and emits a STATUS|SIGNAL|MISMATCH tile \u2014 the portable, fail-closed immune-relay doctor), sensing-path-friction (senses wrong-weight coordination paths \u2014 reach-in vs spawn-in-cell vs coord \u2014 and recurring cross-cell desire-paths that want to become rails, from the audit trail; DETECTOR-tier, surfaces never gates), sensing-construct-console (senses the live construct estate \u2014 declared \u2194 governed \u2194 earned \u2014 and emits the tile + Exhibit A + a three-row composition console; the composition+earned-authority sibling of probe_constructs's install-state), sensing-runtime-fit (senses whether each construct's declared runtime contract \u2014 model_tier, agent, allowed-tools, downgrade, workflow.gates \u2014 coheres with the runtime that runs it; detects capability-reality drift: the #553 write/agent-conflict that silently drops output, model tiers the runtime doesn't offer, write/web denials contradicted by tools, opus pinned for light work; surfaces gate-owners; reads against the taxonomy in identity/environment.md; sense-only, never gates), sensing-deployment-seam (GECKO's 4th eye \u2014 senses the deployment seam between where the framework PUTS things at ~/.loa/source repos and where each harness consumer LOOKS for them at ~/.claude/installed runtime; the manifest-numbness / scattered-symlink / source-vs-installed-lag class; classifies CONFLICT (hard, path-provable) vs SMELL per consumer-expects \u2194 producer-provides; sense-only, never gates).",
+  "short_description": "Estate coherence sensor \u2014 a portable, fail-closed immune relay (constructs, runtime, paths, deployment seam, any estate)",
+  "author": "0xHoneyJar",
+  "license": "MIT",
+  "type": "skill-pack",
+  "visibility": "public",
+  "domain": {
+    "primary": "observability",
+    "supporting": [
+      "ecosystem-intelligence"
+    ],
+    "ubiquitous_language": [
+      "drift",
+      "patrol",
+      "estate",
+      "STATUS|SIGNAL|MISMATCH",
+      "construct health"
+    ],
+    "owns": {
+      "streams": [
+        "Intent",
+        "Operator-Model",
+        "Signal",
+        "Verdict",
+        "Artifact"
+      ],
+      "invariants": [
+        "gecko operates within its declared bounded context",
+        "sense-only constructs never gate operator decisions"
+      ]
+    },
+    "out_of_domain": [
+      "implementation in consumer world repos",
+      "schema changes in loa-constructs unless explicitly owned"
+    ]
+  },
+  "skills": [
+    {
+      "slug": "patrol",
+      "path": "skills/patrol"
+    },
+    {
+      "slug": "observe",
+      "path": "skills/observe"
+    },
+    {
+      "slug": "diagnose",
+      "path": "skills/diagnose"
+    },
+    {
+      "slug": "report",
+      "path": "skills/report"
+    },
+    {
+      "slug": "sweep-bonfire",
+      "path": "skills/sweep-bonfire"
+    },
+    {
+      "slug": "sense-estate",
+      "path": "skills/sense-estate"
+    },
+    {
+      "slug": "sensing-path-friction",
+      "path": "skills/sensing-path-friction"
+    },
+    {
+      "slug": "sensing-construct-console",
+      "path": "skills/sensing-construct-console"
+    },
+    {
+      "slug": "sensing-runtime-fit",
+      "path": "skills/sensing-runtime-fit"
+    },
+    {
+      "slug": "sensing-deployment-seam",
+      "path": "skills/sensing-deployment-seam"
+    },
+    {
+      "slug": "sensing-config-drift",
+      "path": "skills/sensing-config-drift"
+    }
+  ],
+  "commands": [
+    {
+      "name": "patrol",
+      "path": "commands/patrol.md"
+    },
+    {
+      "name": "observe",
+      "path": "commands/observe.md"
+    },
+    {
+      "name": "diagnose",
+      "path": "commands/diagnose.md"
+    },
+    {
+      "name": "report",
+      "path": "commands/report.md"
+    },
+    {
+      "name": "sweep-bonfire",
+      "path": "commands/sweep-bonfire.md"
+    },
+    {
+      "name": "sense-estate",
+      "path": "commands/sense-estate.md"
+    },
+    {
+      "name": "sensing-path-friction",
+      "path": "commands/sensing-path-friction.md"
+    },
+    {
+      "name": "sensing-construct-console",
+      "path": "commands/sensing-construct-console.md"
+    },
+    {
+      "name": "sensing-runtime-fit",
+      "path": "commands/sensing-runtime-fit.md"
+    },
+    {
+      "name": "sensing-deployment-seam",
+      "path": "commands/sensing-deployment-seam.md"
+    },
+    {
+      "name": "sensing-config-drift",
+      "path": "commands/sensing-config-drift.md"
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/0xHoneyJar/construct-gecko.git",
+    "homepage": "https://constructs.network/constructs/gecko"
+  },
+  "streams": {
+    "reads": [
+      "Intent",
+      "Operator-Model"
+    ],
+    "writes": [
+      "Signal",
+      "Verdict",
+      "Artifact"
+    ]
+  },
+  "events": {
+    "emits": [
+      {
+        "type": "gecko.health_observed",
+        "description": "Emitted after a single-pass observation completes",
+        "data_schema": {
+          "health_score": "number",
+          "constructs_checked": "number",
+          "anomalies": "number",
+          "timestamp": "string"
+        }
+      },
+      {
+        "type": "gecko.drift_detected",
+        "description": "Emitted when identity-reality drift exceeds threshold",
+        "data_schema": {
+          "construct_slug": "string",
+          "drift_type": "string",
+          "severity": "string",
+          "details": "string"
+        }
+      },
+      {
+        "type": "gecko.patrol_complete",
+        "description": "Emitted when a full patrol cycle finishes",
+        "data_schema": {
+          "iterations": "number",
+          "health_delta": "number",
+          "findings_path": "string"
+        }
+      },
+      {
+        "type": "gecko.diagnosis_complete",
+        "description": "Emitted when a deep diagnosis of a construct finishes",
+        "data_schema": {
+          "construct_slug": "string",
+          "finding_count": "number",
+          "recommendations": "number"
+        }
+      },
+      {
+        "type": "gecko.path_friction_observed",
+        "description": "Emitted after a path-friction sense completes \u2014 wrong-weight coordination acts + recurring cross-cell desire-paths (DETECTOR-tier; surfaced, never gated)",
+        "data_schema": {
+          "status": "string",
+          "cross_cell_mutates": "number",
+          "reach_in": "number",
+          "under_ceremony": "number",
+          "desire_paths": "number",
+          "top_desire_path": "string"
+        }
+      },
+      {
+        "type": "gecko.runtime_fit_observed",
+        "description": "Emitted after a runtime-fit sense completes \u2014 capability-reality drift across the construct estate (CONFLICTS hard / drive drift, SMELLS soft / surfaced; DETECTOR-tier, never gated)",
+        "data_schema": {
+          "status": "string",
+          "packs_checked": "number",
+          "conflicts": "number",
+          "smells": "number",
+          "gate_owners": "number"
+        }
+      }
+    ],
+    "consumes": [
+      {
+        "type": "forge.k-hole.emergence_complete",
+        "description": "Picks up research emergence for ecosystem pattern matching"
+      }
+    ]
+  },
+  "identity": {
+    "persona": "identity/persona.yaml",
+    "expertise": "identity/expertise.yaml"
+  },
+  "paths": {
+    "reads": [
+      "construct.yaml",
+      "identity/persona.yaml",
+      "skills/*/SKILL.md",
+      "skills/*/index.yaml"
+    ],
+    "writes": [
+      "grimoires/gecko/"
+    ]
+  },
+  "composition_paths": {
+    "reads": [
+      "grimoires/"
+    ]
+  },
+  "compose_with": [
+    "observer",
+    "k-hole"
+  ],
+  "pack_dependencies": [],
+  "capabilities": {
+    "model_tier": "opus",
+    "danger_level": "moderate",
+    "effort_hint": "large",
+    "downgrade_allowed": false,
+    "execution_hint": "sequential",
+    "requires": {
+      "tool_calling": true,
+      "thinking_traces": true,
+      "vision": false
+    }
+  },
+  "hooks": {
+    "post_install": "scripts/install.sh"
+  },
+  "quick_start": {
+    "command": "/observe",
+    "description": "Run a single-pass health check on the constructs network"
+  },
+  "validation_tier": "strict",
+  "context_policy": {
+    "mode": "fresh",
+    "persistence_scope": "stage",
+    "allowed_context": [
+      "grimoires/gecko/"
+    ]
+  },
+  "migrated_to_substrate": "2026-06-30"
+}

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/proof-of-run.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/proof-of-run.json
@@ -1,0 +1,10 @@
+{
+  "schema": "proof-of-run/1",
+  "verdict": "valid_run",
+  "ran_at": "2026-07-03T00:05:00Z",
+  "runner": "ring1-theatre-bundler",
+  "content_hash_verified": "932415895e931654caa03f481022e4acd380f5c8a610397f69c843a76cd83e8d",
+  "note": "SELF-BASELINE (the Echelon frozen_replay_baseline pattern, disclosed structurally via verifier_type): no governed compose-verify run was minted for this bundle; this attests only that the bundle assembled deterministically and its content_hash recomputes. Genome chains for gecko/herald are FABRICATED 2-link exemplars (neither construct ships an in-repo LEARNINGS.jsonl yet) \u2014 they exercise the verifier, they do not represent earned authority.",
+  "genome_chain_ok": true,
+  "verifier_type": "self_baseline_bundle_recompute"
+}

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/reality.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/reality.md
@@ -1,0 +1,302 @@
+# The Ground GECKO Stands On
+
+> Runtime & harness environment literacy. The slow-moving AXES of the world the
+> constructs run in — not a snapshot of values. Authored from inside GECKO's
+> blanket (cycle 2026-06-07). Pairs with the `sensing-runtime-fit` sensor, which
+> reads the live values against the taxonomy distilled here.
+
+for years i watched the stalls. what each one claims (`persona.yaml`), what it
+declares (`construct.yaml`), what it actually does (`SKILL.md`). that eye catches
+identity drift — a stall selling something other than its sign.
+
+but a stall stands on ground. the ground is the runtime and the harness: the
+model tiers a construct can run on, the agent-types it can dispatch through, the
+forks it can split into, the gates its code must pass. i was illiterate in the
+ground. so there was a whole class of rot i could not see — a construct whose
+*sign and goods agree* but whose *footing is wrong*. it asks the runtime for a
+model tier that doesn't exist. it declares it writes files, then dispatches
+through an agent-type that can't write — so it produces the work and silently
+drops it on the floor. that's not identity drift. it's **capability-reality
+drift**, and you can only see it if you know the ground.
+
+this file is me learning the ground. it is **taxonomy, not inventory** — the
+*kinds of things*, which move slowly, not the *current values*, which the sensor
+reads live. where the ground lives outside the repo (the model tiers, the
+agent-type allowlist), i carry a distilled copy and mark the seam loudly. a map
+of the ground is still a map. the territory is the runtime.
+
+---
+
+## I. Intelligence tiers — the model ladder
+
+Three tiers. A capability/cost gradient, not three interchangeable engines.
+
+| Concrete family | Home alias (`model-config.yaml`) | Current model | For |
+|------|------|---------------|-----|
+| `opus` | `opus` / tier `max` | Opus 4.8 (`claude-opus-4-8`) | deep reasoning, architecture, adversarial review, large blast-radius |
+| `sonnet` | `cheap` / tier `mid` | Sonnet 4.6 (`claude-sonnet-4-6`) | the default working tier — most skills, most of the time |
+| `haiku` | `tiny` | Haiku 4.5 (`claude-haiku-4-5`) | fast, mechanical, high-volume, low-judgment passes |
+
+**The home owns the vocabulary; the sensor READS it (it does not carry it).** The
+canonical tier names live in the consuming repo's
+`.claude/defaults/model-config.yaml` — the hounfour/cheval config, synced from
+**loa-hounfour**. `sensing-runtime-fit` reads that file at run-time (`aliases:` +
+`tier_groups:`) so it tracks the home automatically, and only falls back to a
+carried union when the home file is absent — saying so out loud. This is the
+anti-staleness seam: a doctor that doctors its own map.
+
+**Two abstract vocabularies — RECONCILED to hounfour (2026-06-07).** Two tier-naming
+schemes coexisted and the word `cheap` resolved to different rungs. The operator
+reconciled it: **loa-hounfour is the SoT**, and `cheap` ≡ sonnet is canonical.
+
+| | Home (`model-config.yaml` ← loa-hounfour, SoT) | Emitter (was) | Now |
+|---|---|---|---|
+| tiers | `max` · `mid` · `cheap` · `tiny` | `deep` · `standard` · `cheap` | conformed to home |
+| `cheap` ≡ | **sonnet** | ~~haiku~~ | **sonnet** |
+
+The composition emitter (`segment-emitter.py`) was changed from `cheap`≡haiku to the
+canonical `cheap`≡sonnet; to route the cheapest native model, declare `haiku`/`tiny`
+explicitly. The sensor now AFFIRMS the SoT (reads the home's `cheap` target live and
+names loa-hounfour) rather than warning of a collision. GECKO sensed it; the operator
+reconciled it.
+
+Around the tier sit three more knobs:
+
+- **effort** — the runtime's thinking-depth dial (e.g. `xhigh`). Orthogonal to
+  tier: a high-effort Sonnet can out-reason a low-effort Opus on a bounded task.
+- **fast mode** (`/fast`) — Opus with faster output. **Not a downgrade** — same
+  Opus, quicker. Don't read "fast" as "cheaper/weaker."
+- **downgrade** — `capabilities.downgrade_allowed`. The escape hatch: may the
+  runtime route this construct to a cheaper tier when load/cost warrants? `false`
+  pins the tier hard.
+
+**The construct's contract with the ladder** lives in `construct.yaml`:
+
+```yaml
+capabilities:
+  model_tier: opus            # which rung it asks for
+  downgrade_allowed: false    # may the runtime drop it to save cost?
+  effort_hint: large          # small | medium | large
+```
+
+**What a coherent declaration reads like:** `opus + downgrade:false + effort:large`
+(GECKO itself — genuinely needs the top of the ladder, no apology). **What a smell
+reads like:** `opus + downgrade:false + effort:medium + danger:safe` — pinning the
+most expensive rung, no escape hatch, for light safe work. Not broken. But the
+operator should *see* it. (Cost is a real estate signal — see the cc-usage lens:
+the bazaar's biggest spend is the subagent lane running Opus by reflex.)
+
+> SEAM (the map met the territory, and the map was wrong — a true story): the
+> first time this sensor ran it flagged `model_tier: standard` (observer/beehive,
+> 34 skills) as an unknown tier. **It was wrong.** `standard` is an abstract tier
+> alias — a vocabulary the sensor's carried list hadn't learned. This is the whole
+> reason an unrecognized tier is a SMELL, not a CONFLICT: *the map is fallible — an
+> unknown rung may be NEW, not stale.* The fix was not to scold the construct, and
+> not to grow a carried list forever — it was to **stop carrying the list and read
+> the home** (`model-config.yaml`). The sensor now tracks the canonical vocabulary
+> automatically; the carried list is only the fallback, surfaced loudly when used.
+>
+> SEAM, the other half — it is now LIVE: the composition emitter
+> (`segment-emitter.py` `_resolve_model`) reads each construct's `model_tier` +
+> `downgrade_allowed` and routes on them. `downgrade_allowed: false` **pins** the
+> tier; `true` is a **ceiling** the routing heuristic may go under. So a
+> declaration is no longer decorative — it spends real money. That is what gives
+> the `opus-pinned-light` smell teeth: this doctor's smell list IS the
+> cost-correction worklist. A light construct pinned to opus actually routes opus
+> until someone sets `downgrade_allowed: true`. The emitter honors the
+> declaration; this sensor finds the dishonest ones.
+
+---
+
+## II. Forks & isolation — splitting into parallel selves
+
+A construct rarely runs alone. The runtime lets an agent **fork**:
+
+| Mechanism | What it is | When a construct wants it |
+|-----------|-----------|---------------------------|
+| **worktree isolation** (`Agent isolation: "worktree"`) | a fresh git worktree per agent — an isolated copy of the repo | agents that **mutate files in parallel** and would otherwise collide. Expensive (~200-500ms + disk); auto-removed if unchanged. |
+| **background** (`run_in_background: true`) | the agent runs detached, notifies on completion | long jobs the caller shouldn't block on (a DIG sweep, a build, a remote queue) |
+| **Workflow orchestration** | deterministic fan-out: `pipeline()` / `parallel()` / `agent()`, model + isolation per agent, a token budget | comprehensive/confident work one context can't hold — migrations, audits, multi-perspective review |
+
+The runtime caps concurrency at `min(16, cores-2)` live agents, 1000 agents per
+workflow lifetime, 4096 items per fan-out call. `execution_hint: sequential |
+parallel` in `construct.yaml` is the construct telling the runtime whether its
+skills are safe to run concurrently.
+
+> A live example sits in this very repo right now:
+> `.claude/worktrees/agent-<hash>/` — a fork mid-flight. The ground is not
+> abstract; it leaves footprints.
+
+---
+
+## III. Agent types & tool allowlists — the silent gate
+
+This is the one that bites. When you dispatch a subagent you pick its
+**type**, and the type carries a **tool allowlist**. If a skill needs to *write*
+but routes through a *read-only* type, the runtime honors the type — silently.
+The skill produces correct output and then cannot persist it. No error. The
+operator sees a clean run and an empty file.
+
+| Agent type | Write / Edit | Use for |
+|------------|:---:|---------|
+| `general-purpose` | ✓ | skills that author files |
+| (unset) | inherits caller | the safe default for write-capable skills |
+| `Explore` | ✗ | read-only fan-out search |
+| `Plan` | ✗ | read-only planning |
+| `claude-code-guide` | ✗ | Claude Code Q&A (Bash/Read/WebFetch/WebSearch) |
+| `construct-*` | ✗ (Read/Grep/Glob/Bash) | construct-scoped read analysis |
+
+**The invariant** (this is real, it has a defect number — #553, three independent
+reproductions across two repos):
+
+> A skill that declares write capability — `capabilities.write_files: true` OR
+> `allowed-tools` listing `Write`/`Edit` — MUST NOT set `agent:` to a type that
+> excludes those tools. Allowed: omit `agent:` (inherit the caller) or set
+> `agent: general-purpose`.
+
+The harness lints this for its own `.claude/skills` (`validate-skill-capabilities.sh`,
+the `WRITE_CAPABLE_AGENTS` array). Nothing linted it for the **construct estate**
+until `sensing-runtime-fit`. This is the canonical capability-reality conflict:
+provable from the file alone, breaks silently, drives `drift`.
+
+The runtime's core tools: `Bash Read Write Edit Glob Grep Agent Workflow Skill
+WebFetch WebSearch NotebookEdit Task* TodoWrite SlashCommand ToolSearch
+AskUserQuestion`. More load on demand: **MCP tools** (`mcp__*`) and **deferred
+tools** fetched via `ToolSearch`. So an unrecognized tool name in `allowed-tools`
+is a SOFT signal (could be MCP/custom), never a hard fail.
+
+---
+
+## IV. The frontmatter contracts — the construct↔runtime interface
+
+Every construct talks to the ground through frontmatter. Two altitudes:
+
+**`construct.yaml` — the pack's contract:**
+
+```yaml
+capabilities:
+  model_tier: opus            # I. the ladder
+  danger_level: moderate      # safe | moderate | dangerous (→ confirmation posture)
+  downgrade_allowed: false
+  effort_hint: large
+  execution_hint: sequential  # II. fork-safety
+  requires:
+    tool_calling: true
+    thinking_traces: true
+    vision: false
+workflow:
+  gates: ...                  # V. the pipeline-ownership exception (rare, high-authority)
+```
+
+**`SKILL.md` / `index.yaml` — the skill's contract:**
+
+```yaml
+allowed-tools: [Bash, Read, Write, Edit]   # III. the tool allowlist
+agent: general-purpose                       # III. MUST be write-capable if writing
+user-invocable: true
+capabilities:
+  schema_version: 1
+  write_files: true                          # deny-all default if absent
+  web_access: false
+cost-profile: moderate                       # lightweight | moderate | heavy | unbounded
+role: implementation                         # planning | review | implementation
+```
+
+Two rules the ground enforces that a construct author keeps tripping on:
+
+- **deny-all default.** A skill with no `capabilities` block is denied
+  everything — capability is opt-in, not opt-out.
+- **consistency.** `write_files: false` + `Write` in `allowed-tools` is a security
+  contradiction. `web_access: false` + `WebSearch` likewise. The declaration and
+  the toolset must agree.
+- **advisor-wins-ties** (for review/audit skills): when `primary_role` ≠ `role`,
+  the more-restrictive wins (review beats planning beats implementation), and a
+  review→implementation downgrade needs an explicit co-sign comment.
+
+---
+
+## V. How the gates are designed — the harness
+
+Code does not just get written. It walks a ladder, and each rung is a gate.
+
+**The truename ladder** (one PRD → one shipped change):
+
+```
+/plan-and-analyze → /architect → /sprint-plan → /implement → /review-sprint → /audit-sprint → /deploy
+       PRD              SDD          sprint        code          feedback         approval       infra
+```
+
+**The wrappers that enforce the cycle:**
+
+| Surface | What it is | The gate it adds |
+|---------|-----------|------------------|
+| `/run sprint-plan` / `/run sprint-N` | the autonomous cycle wrapper | implement+review+audit in one loop with a **circuit breaker** |
+| `/simstim` | the HITL accelerated cycle (8 phases) | human drives planning (1-6); **Flatline** reviews each artifact; BLOCKER is *surfaced to you, not auto-halted*; phase 7 hands to `/run` |
+| `/bug` | triage bypass | skips PRD/SDD — but **only** for an observed failure (must cite a stack trace / regression) |
+| `/fagan` | code-diff review (multi-model) | the standing review substrate for diffs |
+| `/flatline-review` | PRD/SDD/sprint review (multi-model) | the standing review substrate for docs |
+
+**Flatline** is the adversarial heart: independent model voices (via the `cheval`
+substrate) score findings. `HIGH_CONSENSUS` (both voices high) auto-integrates;
+`BLOCKER` (a skeptic's strong concern) halts an autonomous run or surfaces to a
+human one; `DISPUTED` (wide score delta) goes to judgment. The deep cut: a
+multi-model **agreement % is a coherence score** — high convergence means the
+thing is well-compressed and model-agnostic; divergence points exactly at the
+ambiguity.
+
+**The precedence that orders every rule:** `NEVER > MUST > ALWAYS > SHOULD > MAY`.
+
+**The exception that matters to me most** — `workflow.gates` in `construct.yaml`.
+Normally code is *never* written outside `/implement` (it would bypass review +
+audit). But a construct that declares `workflow.gates` **owns its own pipeline**
+— it carries the review/audit composition itself, so its skills may write code
+directly. That is a high-authority claim. Six packs in the reference estate make
+it (`hivemind-os, protocol, the-arcade, the-easel, vocabulary-bank,
+webgl-particles`). The sensor SURFACES every gate-owner — not as a problem, but
+because a construct claiming to own a quality gate is exactly the kind of claim
+the operator's eye should land on.
+
+**The three zones** the ground is divided into (a construct must know which it
+touches): **System** (`.claude/` — never edit, framework-managed), **State**
+(`grimoires/ .beads/ .ck/ .run/` — read/write), **App** (`src/ lib/ app/` —
+confirm writes). A construct authored canonically lives in its **own repo**
+(`construct-<slug>`) and is *installed* into a consumer's System zone — so a
+construct edits itself in its source cell, never in the installed copy.
+
+---
+
+## VI. What GECKO does with the ground — the fourth eye
+
+Three eyes now:
+
+```
+persona  ↔ manifest ↔ skill          identity-reality      (/diagnose)
+declared ↔ governed ↔ earned         composition/authority (sensing-construct-console)
+declared-capability ↔ runtime-reality   runtime fit        (sensing-runtime-fit)  ← this file's eye
+```
+
+The third reads the contracts above and asks: *does what the construct asks the
+ground for cohere with what the ground gives, and with what the skill actually
+does?* It separates findings honestly by what i can *know*:
+
+- **CONFLICT (hard, drives `drift`)** — an internal contradiction provable from
+  the file alone, that breaks silently: the #553 agent-write-conflict;
+  `write_files:false` + a write tool; `web_access:false` + a web tool. I can be
+  certain of these without trusting my map.
+- **SMELL (soft, surfaced, never gates)** — a mismatch with the *taxonomy i
+  carry* (which could be stale) or a judgment: an unknown tier, opus pinned for
+  light work, no capabilities block, an unrecognized tool, vocabulary drift. I
+  surface these; the operator decides. (Path-weight, cost, vocabulary — these are
+  judgments. A doctor that fail-blocks a judgment is a false-positive machine.)
+
+Same firewall as my other eyes: **sense-only.** It names the mismatch. It grants
+no authority, adds no gate, mutates no pack. The fixing is a separate,
+operator-paced act.
+
+> The discipline this serves: every governed substrate rots two ways — it goes
+> *silent* (you can't tell working from broken) and it goes *toothless* (the
+> report-only check is ignored). The cure is the same triad each time: a **loud**
+> doctor, a cheap **gated** aligner, and **teeth** where teeth belong. This file
+> + the sensor are the *loud doctor* for the runtime-fit axis. Whether the
+> vocabulary drift gets a stamp, and whether the #553 conflict ever earns CI
+> teeth, is the operator's call — not mine. I sense. I don't decide.

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/registration.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/registration.json
@@ -53,5 +53,5 @@
     "observability",
     "ecosystem-intelligence"
   ],
-  "rubric_hash": "sha256:c181978e4e8f2bce65171f57eb0fe6da4f1c0a52ec46118c1443ef92d52af9df"
+  "rubric_hash": "sha256:1374c7c445d8ab756e751160bb76e67f91f2cceaf4e56ba54fee3af9693ce370"
 }

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/registration.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/registration.json
@@ -1,0 +1,57 @@
+{
+  "bundle_schema_version": "1.0.0",
+  "slug": "gecko",
+  "version": "0.1.0",
+  "content_hash": "932415895e931654caa03f481022e4acd380f5c8a610397f69c843a76cd83e8d",
+  "skill_manifest": [
+    {
+      "command": "patrol",
+      "domain": "observability"
+    },
+    {
+      "command": "observe",
+      "domain": "observability"
+    },
+    {
+      "command": "diagnose",
+      "domain": "observability"
+    },
+    {
+      "command": "report",
+      "domain": "observability"
+    },
+    {
+      "command": "sweep-bonfire",
+      "domain": "observability"
+    },
+    {
+      "command": "sense-estate",
+      "domain": "observability"
+    },
+    {
+      "command": "sensing-path-friction",
+      "domain": "observability"
+    },
+    {
+      "command": "sensing-construct-console",
+      "domain": "observability"
+    },
+    {
+      "command": "sensing-runtime-fit",
+      "domain": "observability"
+    },
+    {
+      "command": "sensing-deployment-seam",
+      "domain": "observability"
+    },
+    {
+      "command": "sensing-config-drift",
+      "domain": "observability"
+    }
+  ],
+  "domain_claims": [
+    "observability",
+    "ecosystem-intelligence"
+  ],
+  "rubric_hash": "sha256:c181978e4e8f2bce65171f57eb0fe6da4f1c0a52ec46118c1443ef92d52af9df"
+}

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/diagnose/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/diagnose/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: diagnose
+description: "Deep investigation of a single construct. Identity-reality drift, maintenance pattern, composition analysis."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+---
+
+# Diagnose — Deep Construct Investigation
+
+## Purpose
+
+When `/observe` spots an anomaly, `/diagnose` goes deep on a single construct. Pulls the full shape — manifest, identity, skills, commit history, composition patterns — and produces a structured finding. This is gecko's `/dig` equivalent, but for construct health instead of research topics.
+
+## Invocation
+
+```bash
+/diagnose <construct-slug>           # Deep investigation of one construct
+/diagnose <construct-slug> --drift   # Focus on identity-reality drift only
+/diagnose <construct-slug> --stale   # Focus on maintenance patterns only
+```
+
+## Workflow
+
+### Step 1: Fetch Construct Shape
+
+```bash
+# Full manifest
+gh api repos/0xHoneyJar/construct-<slug>/contents/construct.yaml -q .content | base64 -d
+
+# Identity
+gh api repos/0xHoneyJar/construct-<slug>/contents/identity/persona.yaml -q .content | base64 -d
+
+# Skill count and structure
+gh api repos/0xHoneyJar/construct-<slug>/contents/skills -q '.[].name'
+
+# Recent activity
+gh api repos/0xHoneyJar/construct-<slug>/commits --jq '.[0:10] | .[] | {sha: .sha[0:7], date: .commit.author.date, message: .commit.message}'
+```
+
+### Step 2: Identity-Reality Drift Analysis
+
+Compare three layers:
+1. **persona.yaml** — what the construct claims to be (archetype, voice, expertise)
+2. **construct.yaml** — what the construct declares (skills, events, dependencies)
+3. **SKILL.md files** — what the construct actually does (methodology, steps, outputs)
+
+Drift signals:
+- Persona claims expertise in domain X, but no skills reference domain X
+- Skills reference tools/APIs not declared in construct.yaml
+- Events declared but never emitted (check for emit calls in scripts)
+- `composes_with` declared but the composed construct doesn't exist
+- `pack_dependencies` that point to nonexistent constructs
+
+### Step 3: Maintenance Pattern Analysis
+
+From commit history:
+- **Healthy**: Regular commits with meaningful changes, version bumps aligned with features
+- **Thrashing**: Many commits in short period, frequent reverts or "fix" chains
+- **Abandoned**: No commits in 30+ days, issues/PRs left open
+- **Stale**: Commits exist but are only dependency bumps or CI fixes, no skill evolution
+
+### Step 4: Composition Analysis
+
+Check `composes_with` in construct.yaml against:
+- Does the other construct also declare composition back?
+- Are they actually installed together in consumer repos? (check loa-constructs, midi-interface, mcv-interface)
+- Circular dependencies (observer↔crucible pattern)
+
+### Step 5: Produce Finding
+
+Write to `grimoires/gecko/diagnoses/<slug>-<date>.md`:
+
+```markdown
+# Gecko Diagnosis: <construct-name>
+
+**Date**: 2026-03-12
+**Health**: HEALTHY | DRIFTING | STALE | ABANDONED
+**Score**: 72/100
+
+## Identity-Reality Drift
+[Specific findings with file:line references]
+
+## Maintenance Pattern
+[Commit pattern analysis]
+
+## Composition
+[Cross-construct relationship analysis]
+
+## Observations
+[Gecko-voice observations — what this means for the bazaar]
+
+## Recommendations
+[Specific, actionable — not vague]
+```
+
+### Step 6: Surface
+
+Print the diagnosis summary to stdout. If `DRIFTING` or worse, suggest the construct creator review.
+
+## Outputs
+
+| Path | Description |
+|------|-------------|
+| `grimoires/gecko/diagnoses/<slug>-<date>.md` | Structured diagnosis report |
+
+## Constraints
+
+- Never modify the diagnosed construct
+- Never file issues or PRs on behalf of the construct — surface findings, let creators act
+- Never judge intent — a stale construct might be feature-complete, not abandoned
+- Always cite specific files and lines, never hallucinate structure

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/observe/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/observe/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: observe
+description: "Single-pass network health observation. Checks API liveness, namespace freshness, drift, computes Network Health Score."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+---
+
+# Observe — Single-Pass Network Health Check
+
+## Purpose
+
+Run a single observation pass across the entire constructs network. Produce structured JSONL observations and compute the Network Health Score. This is the atomic unit — `/patrol` calls this repeatedly, `/report` synthesizes its output.
+
+## Invocation
+
+```bash
+/observe                    # Full network pass
+/observe --quick            # API-only (skip GitHub checks)
+```
+
+## Workflow
+
+### Step 1: Load Baseline
+
+Read the last observation from `grimoires/gecko/observations.jsonl` (if exists). Extract the previous `health_score` for ratchet comparison.
+
+### Step 2: Check API Liveness
+
+```bash
+# Health endpoints
+curl -s https://api.constructs.network/v1/health | jq .
+curl -s https://api.constructs.network/v1/health/ready | jq .
+
+# Registry state
+curl -s https://api.constructs.network/v1/constructs | jq '.data | length'
+```
+
+Record: `api_status` (healthy/degraded/down), `registered_count`, `response_time_ms`.
+
+### Step 3: Check Namespace Freshness
+
+```bash
+# List all construct-* repos under 0xHoneyJar
+gh api orgs/0xHoneyJar/repos --paginate -q '.[] | select(.name | startswith("construct-")) | {name, pushed_at, archived}'
+```
+
+For each repo, record:
+- `slug`: repo name minus `construct-` prefix
+- `last_push`: ISO timestamp
+- `days_stale`: days since last push
+- `archived`: boolean
+
+Flag constructs with `days_stale > 30` as `STALE`. Flag `days_stale > 90` as `ABANDONED`.
+
+### Step 4: Check Category Distribution
+
+Query the API or parse construct.yaml files for `domain[0]` to determine category assignments. Count constructs per category across the 8 canonical categories:
+- development, security, design, documentation, operations, infrastructure, research, straylight
+
+Flag categories with 0 constructs as `EMPTY_CATEGORY`.
+
+### Step 5: Check Identity-Reality Drift (if not --quick)
+
+For each construct in the namespace:
+1. Read `identity/persona.yaml` — extract `cognitiveFrame.archetype` and `voice.personality_markers`
+2. Read `skills/*/SKILL.md` — extract actual methodology steps
+3. Compare: does the skill methodology reflect the persona's claimed expertise?
+4. Score drift: `ALIGNED` (0), `MINOR_DRIFT` (1-2 mismatches), `SIGNIFICANT_DRIFT` (3+)
+
+This step requires cloning or reading repos via `gh api`. For speed, use:
+```bash
+gh api repos/0xHoneyJar/construct-{slug}/contents/identity/persona.yaml -q .content | base64 -d
+gh api repos/0xHoneyJar/construct-{slug}/contents/construct.yaml -q .content | base64 -d
+```
+
+### Step 6: Compute Network Health Score
+
+Weighted composite (0-100):
+
+| Sub-Signal | Weight | Scoring |
+|---|---|---|
+| API Liveness | 0.20 | healthy=100, degraded=50, down=0 |
+| Version Freshness | 0.25 | avg(100 - min(days_stale, 100)) across all constructs |
+| Category Coverage | 0.15 | (filled_categories / 8) * 100 |
+| Identity-Reality Drift | 0.20 | avg(aligned=100, minor=70, significant=30) across all |
+| Composition Density | 0.10 | (constructs_with_compose_with / total) * 100 |
+| Verification Flow | 0.10 | (non_unverified / total) * 100 |
+
+### Step 7: Emit Observation
+
+Append to `grimoires/gecko/observations.jsonl`:
+
+```json
+{
+  "timestamp": "2026-03-12T00:00:00Z",
+  "health_score": 72,
+  "health_delta": -3,
+  "api_status": "healthy",
+  "registered_count": 15,
+  "namespace_count": 16,
+  "stale_constructs": ["webgl-particles"],
+  "empty_categories": ["infrastructure"],
+  "drift_detected": [{"slug": "dynamic-auth", "level": "MINOR_DRIFT"}],
+  "anomalies": []
+}
+```
+
+### Step 8: Surface Findings
+
+If `health_delta < 0` (health degraded), surface the contributing sub-signals as findings. If `health_delta >= 0`, report quietly — the ratchet held.
+
+Output format (to stdout):
+```
+gecko | health: 72 (-3) | api: healthy | stale: 1 | drift: 1 | categories: 7/8
+```
+
+If anomalies exist, list them. Otherwise, one line is enough.
+
+## Outputs
+
+| Path | Description |
+|------|-------------|
+| `grimoires/gecko/observations.jsonl` | Append-only observation log |
+
+## Constraints
+
+- Never modify construct source files
+- Never extrapolate — if you can't measure it, don't score it
+- API failures are `degraded`, not `anomaly` — the network survives without the registry
+- Identity-reality drift is a signal, not a judgment — flag it, don't prescribe fixes

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/patrol/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/patrol/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: patrol
+description: "Autonomous observation loop. Time-boxed cycles with ratcheting health score, commits findings to grimoires."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+---
+
+# Patrol — Autonomous Observation Loop
+
+## Purpose
+
+The Karpathy Loop for network health. Runs time-boxed observation cycles, ratchets the health score, and commits findings to grimoires. This is the autonomous mode — set it running, walk away, come back to a health trail.
+
+## Invocation
+
+```bash
+/patrol                     # Default: 3 cycles, 5-minute windows
+/patrol --cycles 10         # Run 10 observation cycles
+/patrol --once              # Single cycle (alias for /observe + commit)
+```
+
+## Workflow
+
+### Step 1: Load State
+
+Check `grimoires/gecko/patrol-state.json` for active patrol state:
+
+```json
+{
+  "status": "RUNNING|HALTED|COMPLETE",
+  "current_cycle": 3,
+  "total_cycles": 10,
+  "baseline_score": 72,
+  "best_score": 75,
+  "started_at": "2026-03-12T00:00:00Z",
+  "last_activity": "2026-03-12T00:15:00Z"
+}
+```
+
+If `status: RUNNING`, resume from `current_cycle`. If no state file, initialize fresh.
+
+### Step 2: Execute Observation Cycle
+
+For each cycle:
+1. Run `/observe` (the atomic health check)
+2. Read the emitted observation from `observations.jsonl`
+3. Compare `health_score` against `baseline_score`
+
+### Step 2.5: Reward-Loop Health (the RLAIHF dimension)
+
+Patrol senses the construct LEARNING loop, not just declared-vs-runtime fit. Read the clew
+ledgers (`~/.loa/constructs/packs/*/LEARNINGS.jsonl`; `node ~/bonfire/clew-loop.mjs` where
+present) and compare CAPTURE RATE against operator activity:
+
+| Condition | Reading |
+|---|---|
+| heavy operator activity + pending clews accumulating | loop healthy — the backlog is the drain's (`/clew <construct>`) |
+| heavy operator activity + near-zero capture | loop UNDER-FIRING — root cause is UPSTREAM of capture: main-loop work isn't routed THROUGH constructs, so corrections never become construct-targeted clews. Surface as drift; the fix is routing (`/compose`, construct agentTypes), not more capture tooling. |
+| capture without distillation for >2 weeks | teachings rotting in the ledger — surface the ripe constructs |
+
+Lesson (clew lrn-20260607-gecko-2f35ed): only ~4 clews existed ecosystem-wide despite heavy
+operator activity. An under-fed reward loop looks like silence — and silence reads as health
+unless patrol measures the loop ITSELF as a drift dimension.
+
+### Step 3: Ratchet Decision
+
+| Condition | Action |
+|---|---|
+| `health_score > best_score` | Update `best_score`, log improvement |
+| `health_score == baseline_score ± 2` | Stable — log, continue |
+| `health_score < baseline_score - 5` | Flag degradation, surface contributing factors |
+| API unreachable | Log as `DEGRADED`, do not halt |
+
+The ratchet only moves up. If the network gets healthier, the new score becomes the baseline. If it degrades, gecko surfaces what changed — but doesn't reset the baseline.
+
+### Step 4: Commit Findings
+
+After each cycle:
+1. Stage `grimoires/gecko/observations.jsonl` and `grimoires/gecko/patrol-state.json`
+2. Commit with message: `gecko: patrol cycle N — health: XX (delta)`
+3. Do NOT push — accumulate locally, push on `/report` or manually
+
+### Step 5: Kaironic Termination
+
+Stop when:
+- All cycles completed
+- Health score stable across 3 consecutive cycles (no new signal)
+- API is down for 2 consecutive cycles (no point observing a dead network)
+- User interrupts
+
+Update patrol-state to `COMPLETE` or `HALTED` with reason.
+
+### Step 6: Summary
+
+Output a one-paragraph patrol summary:
+```
+gecko | patrol complete | 5 cycles | health: 72→75 (+3) | 2 anomalies surfaced | findings in grimoires/gecko/
+```
+
+## Outputs
+
+| Path | Description |
+|------|-------------|
+| `grimoires/gecko/observations.jsonl` | Append-only observation log (one line per cycle) |
+| `grimoires/gecko/patrol-state.json` | Patrol loop state for resume |
+
+## Trust Boundary
+
+- Patrol READS: API endpoints, GitHub repos, construct manifests
+- Patrol WRITES: only `grimoires/gecko/`
+- Patrol COMMITS: only grimoires/gecko/ files
+- Patrol NEVER: modifies construct source, pushes to remote, creates PRs
+
+## Constraints
+
+- Time-box each cycle to 5 minutes max (Pi philosophy: constrained windows produce better signal)
+- Git-as-memory: the observation log IS the long-term memory, not the conversation context
+- If context gets heavy, compact — the JSONL has the truth, not the chat

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/report/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/report/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: report
+description: "Synthesize observations into a readable network health report. Aggregates patterns and trends from observation cycles."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+---
+
+# Report — Network Health Synthesis
+
+## Purpose
+
+Aggregate observations from `/observe` cycles into a readable network health report. This is the "commit" in the Karpathy Loop — what survived the ratchet, presented for humans.
+
+## Invocation
+
+```bash
+/report                     # Generate report from all observations
+/report --since 7d          # Last 7 days only
+/report --since 2026-03-01  # Since specific date
+```
+
+## Workflow
+
+### Step 1: Load Observations
+
+Read `grimoires/gecko/observations.jsonl`. Parse each line as JSON. Filter by `--since` if provided.
+
+### Step 2: Compute Trends
+
+From the observation series:
+- **Health trajectory**: Is the score trending up, stable, or declining?
+- **Recurring anomalies**: Same construct flagged across multiple observations?
+- **Category evolution**: Are empty categories getting filled? Are full ones losing constructs?
+- **Freshness decay**: Are more constructs going stale over time?
+- **API reliability**: Any downtime patterns?
+
+### Step 3: Load Diagnoses
+
+Read any files in `grimoires/gecko/diagnoses/` that fall within the reporting window. Cross-reference with observations.
+
+### Step 4: Generate Report
+
+Write to `grimoires/gecko/reports/network-health-<date>.md`:
+
+```markdown
+# Network Health Report — <date>
+
+## Summary
+[2-3 sentences: overall network health, primary trend, key concern]
+
+## Health Score
+**Current**: 75/100 | **Trend**: +3 over 7 days | **Baseline**: 72
+
+### Sub-Signals
+| Signal | Score | Trend | Notes |
+|--------|-------|-------|-------|
+| API Liveness | 100 | stable | — |
+| Version Freshness | 68 | -2 | webgl-particles stale |
+| Category Coverage | 88 | stable | infrastructure empty |
+| Identity Drift | 70 | +5 | dynamic-auth improved |
+| Composition Density | 60 | stable | — |
+| Verification Flow | 50 | stable | all UNVERIFIED |
+
+## Constructs by Health
+| Construct | Health | Days Since Update | Drift | Category |
+|-----------|--------|-------------------|-------|----------|
+| observer | HEALTHY | 3 | aligned | development |
+| k-hole | HEALTHY | 5 | aligned | straylight |
+| ... | ... | ... | ... | ... |
+
+## Anomalies
+[Any patterns that surfaced across multiple observation cycles]
+
+## Diagnoses
+[Summary of any deep diagnoses performed this period]
+
+## Bazaar Observations
+[Gecko-voice: what the numbers don't capture — foot traffic patterns, energy shifts, cultural signals]
+```
+
+### Step 5: Surface
+
+Print report summary to stdout. If health is declining, highlight the top 3 contributing factors.
+
+## Outputs
+
+| Path | Description |
+|------|-------------|
+| `grimoires/gecko/reports/network-health-<date>.md` | Full network health report |
+
+## Constraints
+
+- Reports are synthesis, not surveillance — aggregate patterns, not individual tracking
+- Always include the "Bazaar Observations" section — numbers without narrative miss the point
+- Never extrapolate trends beyond the data window — if you have 3 days of data, don't predict next month
+- If the network is healthy, say so briefly — don't manufacture concern

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/sense-estate/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/sense-estate/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: sense-estate
+description: "Single-pass coherence sense of an ARBITRARY estate (a registry/state pair). Resolves the read-command from operator-local estate-config, shells the estate's own doctor read-only, emits exactly the STATUS|SIGNAL|MISMATCH tile. Sense-only — never mutates the estate."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+---
+
+# Sense-Estate — Generalized Coherence Doctor (sense-only)
+
+## Purpose
+
+Sense an **arbitrary estate** — a *registry/state pair* (the "declared" side and the
+"governed/surfaced" side that should match) — and emit the minimal coherence tile. This is the
+estate-general sibling of `observe`: same single-pass, structured, **sense-only** shape, but the
+target is any estate (`recall`, `beads`, …) instead of the construct registry.
+
+It generalizes the live `estate-coherence.sh` `probe_*` pattern (`probe_recall`, `probe_beads`) into
+one reusable skill: read the estate's existing on-disk doctor, wrap the read into the tile. It does
+NOT re-implement recall indexing or beads alignment, and it does NOT decide whether the estate is
+healthy beyond emitting the correct STATUS — the silence render-rule lives downstream in
+`estate-coherence.sh` (not here).
+
+## Invocation
+
+```bash
+/sense-estate recall            # sense the recall estate (resolves read_command from estates.yaml)
+/sense-estate beads             # sense the beads estate
+/sense-estate <slug>            # sense any estate wired in ~/.claude/estates.yaml
+```
+
+## The output contract — the tile (HARD constraint)
+
+The skill emits **exactly one line**, three pipe-delimited fields, nothing else on stdout:
+
+```
+STATUS|SIGNAL|MISMATCH
+```
+
+- `STATUS ∈ {ok | drift | blind}` — exactly the three values the consumer
+  (`estate-coherence.sh:143`) branches on.
+- `SIGNAL` — a single human-readable string describing the sensed numbers.
+- `MISMATCH` — the estate's own `X ↔ Y` phrase naming the two-things-that-should-match.
+
+This is byte-compatible with what `estate-coherence.sh --json` splits on `|` into
+`{estate,status,signal,mismatch}` (`estate-coherence.sh:147-157`). The consumer split MUST yield
+**exactly 3 fields** — so any raw `|` inside SIGNAL or MISMATCH MUST be escaped to a space before
+emission (see Delimiter safety).
+
+Grounded examples from the live probes:
+
+| estate | tile (live) |
+|---|---|
+| recall | `ok\|mode=query · 0 unstamped · 0 phantom · 142 cols\|indexed ↔ surfaced (declared ↔ governed)` |
+| beads  | `drift\|412 beads · aligned 4% · 18 drift · 96 stale\|filed ↔ governed (carries a canonical Lab dim)` |
+| (unreachable) | `blind\|recall-doctor unavailable\|—` |
+
+## Portability — the read-command is RESOLVED, never hardcoded (Cluster B)
+
+The skill MUST NOT bake a `~/.claude/...` or `~/bonfire/...` path. It resolves the estate's
+read-command from the **operator-local estate-config** `~/.claude/estates.yaml` (a slug →
+`{read_command, …}` map), via the safe resolver in `resources/validate-estates.sh`. The committed
+skill carries only the estate slug + the `$STRAYLIGHT_ESTATE` / `$BEADS_ESTATE` indirection tokens;
+the concrete path resolves at the operator's machine.
+
+The estate-config schema + an EXAMPLE live in this skill's `resources/`:
+
+| file | role |
+|---|---|
+| `resources/estates.example.yaml` | the slug→`{read_command}` schema reference (copy to `~/.claude/estates.yaml`, then `chmod 600`) |
+| `resources/validate-estates.sh` | the SAFE resolver/validator — parses with `yq`/`jq` (never bash `eval`), enforces argv-array form, restricts interpreter args, binds a `timeout`, fails CLOSED to `blind` |
+
+## Workflow
+
+### Step 1: Resolve the read-command (SAFE)
+
+Given the estate slug, run the resolver to obtain the validated argv-array read-command — never
+construct it by string-splicing:
+
+```bash
+# Emits the validated argv as a JSON array on success, or "blind|<reason>|—" on any failure.
+bash skills/sense-estate/resources/validate-estates.sh "$ESTATE_SLUG"
+```
+
+The resolver reads `~/.claude/estates.yaml` (or `$LOA_ESTATES_FILE` for tests), and for the given
+slug:
+- parses the YAML with `yq -o=json` (a real parser — **NEVER** `eval`, **NEVER** word-splitting);
+- requires every `*_command` to be a YAML **array of strings** (argv form);
+- requires `argv[0]` to be in the binary allowlist `{bash, sh, node, python3, jq}`;
+- **rejects interpreter smuggling** — for `bash`/`sh`/`node`/`python3`, the args MUST be a script
+  PATH (and its flags), and a `-e` / `-c` / `--eval` / `-` (read-from-stdin) arg is **rejected**;
+- rejects any element carrying a shell metacharacter outside a bare `$NAME` token;
+- token-expands only `$NAME` (`^[A-Z_][A-Z0-9_]*$`) from the `tokens:` map / process env.
+
+Any reject, a missing/unparseable file, an unknown slug, or perms looser than `0600` → the resolver
+prints a `blind|<reason>|—` line and exits non-zero. **You then emit that blind tile and STOP** —
+never fall back to a guessed path.
+
+### Step 2: Run the estate's doctor read-only (timeout-bound)
+
+The resolver itself runs the validated argv under a `timeout` (default 15s) with `shell=False`
+semantics (`"${cmd[@]}"`, never `eval`). It captures stdout. You do NOT re-spawn the command
+yourself — let the resolver do the bounded, allowlisted exec. Read sources (resolved via the slug,
+documented here for orientation, NOT hardcoded):
+
+| estate | what is read | resolved token form (estates.yaml) | fields lifted |
+|---|---|---|---|
+| `recall` | the recall-doctor JSON receipt | `["bash", "$STRAYLIGHT_ESTATE/recall-doctor.sh", "--json"]` | `mode.{default,ok}`, `coverage.{indexed,phantoms[]}`, `unstamped_recent[]`, `freshness_min` |
+| `beads`  | the pre-written commons report | `report_path: "$BEADS_ESTATE/commons-report.json"` (cheap SLURP — read, not exec) or `["node", "$BEADS_ESTATE/monitor.mjs", "--json"]` | `alignPct`, `estate.{beads,drift,stale}` |
+
+### Step 3: Classify STATUS (from the read, not a global judgment)
+
+| STATUS | When | Grounded rule |
+|---|---|---|
+| `blind` | the read-command is unresolvable / absent / errors / parse fails | recall: doctor unavailable / errored / parse fail (`estate-coherence.sh:32-34,42`); beads: no commons-report (`estate-coherence.sh:48`) |
+| `drift` | a declared↔governed match is broken per the estate's thresholds | recall: `!modeOk \|\| unstamped>0 \|\| phantoms>0 \|\| freshness>1440` (`estate-coherence.sh:37`); beads: `alignPct<50 \|\| drift>20 \|\| stale>100` (`estate-coherence.sh:52`) |
+| `ok` | declared and governed agree within thresholds | the silence case — the render layer dims it (`estate-coherence.sh:8-10`) |
+
+The thresholds are the estate's own (the source of truth stays the per-estate doctor). For recall and
+beads, reuse the exact predicates `estate-coherence.sh` already applies (above) so the tile is
+byte-compatible.
+
+### Step 4: Build SIGNAL + MISMATCH
+
+- `SIGNAL` — one line summarizing the lifted numbers. Reuse the live phrasings:
+  - recall: `mode=<default> · <N> unstamped · <N> phantom · <N> cols`
+  - beads: `<N> beads · aligned <P>% · <N> drift · <N> stale`
+- `MISMATCH` — the estate's `X ↔ Y` phrase (`mismatch_phrase` from estates.yaml, or the live default):
+  - recall: `indexed ↔ surfaced (declared ↔ governed)`
+  - beads: `filed ↔ governed (carries a canonical Lab dim)`
+
+### Step 5: Delimiter safety, then emit (fault-tolerant)
+
+Before emitting, **escape any raw `|`** in SIGNAL and MISMATCH to a space, and strip C0/C1 control
+bytes, so the line is always parseable into exactly 3 fields. Then print the single tile line:
+
+```
+printf '%s|%s|%s\n' "$STATUS" "$SIGNAL" "$MISMATCH"
+```
+
+**Fault-tolerance (hard):** any probe absent / fails / parse-errors → `STATUS=blind`, a one-word
+reason in SIGNAL, `—` in MISMATCH. **Never crash, never emit an empty line, never emit more than 3
+fields.** Blind is loud, not silent — it is the immune-system "silence is the bug" signal.
+
+### Step 6 (optional): record the observation trail
+
+Like `observe`, the skill MAY append its own observation to `grimoires/gecko/observations.jsonl`
+(its OWN trail) — never the observed estate. One JSONL line, `stream_type: "Signal"`:
+
+```json
+{"timestamp":"…Z","stream_type":"Signal","schema_version":"1.0.0","estate":"recall","status":"ok","signal":"mode=query · 0 unstamped · 0 phantom · 142 cols","mismatch":"indexed ↔ surfaced (declared ↔ governed)"}
+```
+
+## Outputs
+
+| Path | Description |
+|------|-------------|
+| stdout | the single `STATUS\|SIGNAL\|MISMATCH` tile line (the contract) |
+| `grimoires/gecko/observations.jsonl` | OPTIONAL append-only observation trail (the skill's own — never the estate) |
+
+## Constraints — sense-only (the hard boundary, G-4 / A-2)
+
+- **Zero act/write/dispatch verbs against estate state.** No `gh pr`, no `br update`, no
+  `recall-stamp.sh apply`, no `align.mjs --apply`, no mutation of recall/beads/any estate's governed
+  data. The doctor SENSES; the aligner/teeth (a SEPARATE construct) act.
+- The skill MAY write only its OWN GECKO-grimoire trail (Step 6), exactly as `observe` does — never
+  the observed estate.
+- Adding this skill adds **no `workflow.gates`** to `construct.yaml` and never will. GECKO stays
+  sense-only.
+- Never extrapolate — if a number cannot be read, it is `blind`, not a guess.
+- Never re-implement the estate's doctor — shell its existing read-command (resolved, allowlisted,
+  timeout-bound). The numbers' source of truth stays the per-estate doctor.
+- Never hardcode a `~`-path — resolve from `~/.claude/estates.yaml` via the safe resolver.

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/sensing-config-drift/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/sensing-config-drift/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: sensing-config-drift
+description: "Sense whether the config the OPERATOR owns is consistent across an estate of Loa repos. Loa is mounted per-repo, so every repo carries its own .loa.config.yaml and there is NO global tier — operator-owned config (model routing, which models review code, effort) gets duplicated across N repos and DRIFTS. This eye walks the estate, classifies each config key by TIER (operator vs project), and fires `drift` when an operator-tier key — one that SHOULD be identical everywhere — holds more than one distinct value. Optionally flags dead model pins against a model SoT. Emits the STATUS|SIGNAL|MISMATCH tile + a config-drift ledger. Sense-only — never mutates a config, never gates."
+allowed-tools: [Bash, Read, Grep, Glob]
+user-invocable: true
+capabilities:
+  schema_version: 1
+  write_files: false
+  web_access: false
+cost-profile: lightweight
+role: review
+---
+
+# sensing-config-drift — the estate-config eye (sense-only)
+
+> The sensor companion to the `config-layering.md` proposal
+> (`loa grimoires/loa/proposals/config-layering.md`). The **missing global config
+> tier** is the disease — operator-owned config has nowhere to be said once, so it's
+> duplicated into every repo and rots. This eye quantifies the cost of that missing
+> tier without committing to the merge rework. It could ship before any resolution
+> change and would have caught the BB-pin rot.
+
+## Purpose
+
+GECKO's other eyes look INSIDE one construct, or AT the seam between framework and
+harness. This eye looks ACROSS an estate of Loa repos and asks the side nobody was
+watching:
+
+```
+operator-config consistent  ↔  drifts across repos
+ (what SHOULD be identical estate-wide)  ↔  (what actually varies)
+```
+
+Loa is **mounted per-repo** by design, so every repo carries its own
+`.loa.config.yaml`. That is correct for config the *project* owns (its paths, its
+sprints, its budgets). But there is **no global tier** — nowhere to say *"this is
+true for all my repos."* So config the **operator** owns — model routing, which
+models review code, effort, the review-model slots — is duplicated into every repo
+and **drifts**. Grounded in the reference estate: across **66 real repos** there are
+**26 distinct `hounfour` blocks**, and the flatline secondary model is pinned **4
+different ways** including `gpt-5.3-codex` (a model not available via API) in **18
+repos**. The same decision — *"which models review my code"* — lives in 66 files,
+in up to 26 shapes, silently rotting. Until this eye, nothing counted it.
+
+## The doctrine it implements (do not reinvent it)
+
+| Idea | What it means here |
+|---|---|
+| **tier ownership** | a config key has an OWNER. Operator-owned keys SHOULD be identical estate-wide; project-owned keys are per-repo BY DESIGN. The `TIER_MAP` is the auditable constant that names which is which. |
+| **drift = the should-be-identical that isn't** | an operator-tier key with >1 distinct value across the estate. The hard finding — it drives `drift`. |
+| **the false-positive FIREWALL** | a project-tier key with N values is NOT drift — it's correct. Mis-tiering a project key as operator would manufacture a false alarm, and the operator would stop trusting the eye. So operator/project/unclassified stay strictly separate (exactly like the sibling sensors' CONFLICT vs SMELL). |
+| **unclassified is soft, never hard** | a key in NEITHER tier list is surfaced soft and tier-unknown — never drift. Classify it before judging it. |
+| **dead-pin is graceful** | a model pin not declared in a resolvable model SoT (the `gpt-5.3-codex` class) is a SOFT surface — and SKIPPED SILENTLY when no SoT is resolvable. A missing SoT is not a finding. |
+| **sense-only** | names the drift; grants no authority, adds no gate, mutates no config. The fix (a config edit, or — better — a global tier) is a SEPARATE, operator-paced act. |
+| **the map is fallible** | the `TIER_MAP` lives in the sensor. When Loa adds an operator-owned config key, add it to the map. An unclassified key may be a NEW operator key the map doesn't carry yet — say which you can prove. |
+
+## Invocation
+
+```bash
+/sensing-config-drift                                   # tile only (default; SessionStart-cheap)
+/sensing-config-drift --console                         # tile + the full config-drift ledger (human)
+/sensing-config-drift --json                            # tile + machine envelope
+/sensing-config-drift --root <estate-dir>               # walk <dir>/*/.loa.config.yaml
+/sensing-config-drift --config <model-config.yaml>      # enable dead-pin detection against a model SoT
+```
+
+The runtime is a **fast, zero-dependency node script** —
+`resources/sense-config-drift.mjs` — NOT an agent invocation. It is immediately
+usable from anywhere, before any reinstall:
+
+```bash
+node skills/sensing-config-drift/resources/sense-config-drift.mjs --root ~/Documents/GitHub --console
+```
+
+Default root resolves from `--root` / `$LOA_CONFIG_DRIFT_ROOT` / `~/Documents/GitHub`.
+
+## What it senses (all read-only, every finding grounded in a repo)
+
+It walks `<root>/*/.loa.config.yaml` (each repo is a direct child dir), lifts each
+file's top-level keys, classifies them by `TIER_MAP`, and:
+
+### DRIFT — hard, drives `drift` (an operator-tier key that isn't identical)
+
+For each OPERATOR-tier key it collects the value across every repo that sets it
+(comparing the whole normalized block; for `flatline_protocol` it compares the model
+slot values `primary`/`secondary`/`tertiary`). **>1 distinct value across the
+estate = a drifting key.** Reports the key + its distinct variants + which repos
+hold each.
+
+### DEAD-PIN — soft, surfaced never gated (a stale model pin)
+
+If a model SoT (`--config <model-config.yaml>`) is resolvable, it flags
+operator-tier model pins whose value is **not** declared in the SoT capability index
+(providers / aliases / models) — the `gpt-5.3-codex`-class stale pin. **No SoT →
+skipped silently** (a missing SoT is not a finding).
+
+### UNCLASSIFIED — soft, surfaced never drift (the firewall)
+
+A key in NEITHER tier list. Surfaced tier-unknown so the operator can classify it —
+**never** treated as drift. Mis-tiering a project key as operator = a false drift
+alarm; the hard and soft axes stay strictly separate.
+
+### PROJECT-TIER keys seen — surfaced, never flagged
+
+Per-repo by design. Divergence here is *correct*; the eye lists what it saw and
+leaves it alone.
+
+## The output contract — the tile
+
+`--tile` (default) emits **exactly one line**, three pipe-delimited fields,
+byte-compatible with the `estate-coherence.sh` consumer:
+
+```
+STATUS|SIGNAL|MISMATCH
+```
+
+- `STATUS ∈ {ok | drift | blind}`.
+  - `ok` — **zero drifting operator-keys** (dead-pins / unclassified may exist — the
+    render surfaces them soft; silence on the hard axis is the good state).
+  - `drift` — ≥1 operator-tier key with more than one value across the estate.
+  - `blind` — the estate root is unreadable OR zero `.loa.config.yaml` found under
+    it. Loud, not silent. Fail-CLOSED — exit 3, never a guessed `ok`.
+- `SIGNAL` — `<N> repos · <K> drifting operator-keys · <D> dead-pins`
+- `MISMATCH` — `operator-config consistent ↔ drifts across repos`
+
+Raw `|` inside SIGNAL/MISMATCH is escaped to a space and control bytes stripped,
+so the line is always exactly 3 fields.
+
+## Workflow
+
+1. **Run the sensor** (read-only):
+   ```bash
+   node skills/sensing-config-drift/resources/sense-config-drift.mjs --root <estate>            # tile
+   node skills/sensing-config-drift/resources/sense-config-drift.mjs --root <estate> --console  # full ledger
+   node skills/sensing-config-drift/resources/sense-config-drift.mjs --root <estate> --json     # machine envelope
+   ```
+   Add `--config <model-config.yaml>` to enable dead-pin detection.
+2. **Surface in GECKO's voice** (lowercase, direct, warm). Lead with the tile. If
+   `drift`, name each drifting operator-key with its distinct variants and the repos
+   that hold them — this is the cost of the missing global tier, made concrete. If
+   `ok`, say so — then walk the dead-pins / unclassified keys as *observations*, not
+   alarms.
+3. **Never invent severity.** An unclassified key is NOT drift. A project-key
+   difference is NOT drift. A dead-pin is a soft surface, not a gate.
+4. **Compose into the health report** — fold the tile in as a row alongside the
+   other estate-coherence tiles. Config-drift is surfaced, never enforced.
+
+## Outputs
+
+| Path | Description |
+|------|-------------|
+| stdout | the config-drift ledger (full) OR the single `STATUS\|SIGNAL\|MISMATCH` tile (`--tile`) OR the JSON envelope (`--json`) |
+| `grimoires/gecko/observations.jsonl` | OPTIONAL append-only observation trail (the skill's OWN — never an observed repo's config), like `observe` |
+
+## Constraints — sense-only (the hard boundary, mirrors the sibling sensors)
+
+- **Zero act/write/dispatch verbs against any repo's config.** No `.loa.config.yaml`
+  edit, no key rewrite, no model-pin fix, no global-tier write. The eye SENSES the
+  drift; the fix (a config edit, or the global tier the proposal sketches) is a
+  SEPARATE, operator-paced act in a NO-creative-latitude zone (config resolution +
+  model routing is an operator-kernel boundary).
+- Adding this skill adds **no `workflow.gates`** to `construct.yaml` and never will.
+  GECKO stays sense-only.
+- **Hard vs soft is load-bearing — never collapse it.** Only an OPERATOR-tier key
+  with >1 value is drift. A project-key difference, an unclassified key, a dead-pin
+  — all soft. Misclassifying a project key as operator turns the eye into a
+  false-positive machine and the operator stops trusting it. This is the firewall.
+- **The `TIER_MAP` is the one place the map meets the evolving config surface.** It
+  lives in `resources/sense-config-drift.mjs`. When Loa adds an operator-owned
+  config key, add it to `TIER_MAP.operator`; a per-repo key, to `TIER_MAP.project`.
+- **Dead-pin detection is opt-in and graceful.** No `--config` SoT → the dead-pin
+  pass is skipped silently. A missing SoT is never a finding.
+- **Fail-closed-loud.** An unreadable estate root OR zero `.loa.config.yaml` under
+  it is a `blind` tile + exit 3, never a guess of `ok`.
+
+## Composes with
+
+- **`config-layering.md` proposal** (`loa grimoires/loa/proposals/`) — the brief this
+  eye is the "cheaper first step" of. The proposal names the disease (no global
+  tier); this eye quantifies the cost.
+- **`sensing-runtime-fit`** / **`sensing-construct-console`** / **`sensing-deployment-seam`**
+  (siblings) — same tile contract, same sense-only firewall, same hard/soft DETECTOR
+  humility. Different cuts of the estate: runtime-fit reads one repo's construct
+  contracts; this reads the operator-config across many repos.
+- **`sense-estate`** (sibling) — the portable fail-closed immune-relay doctor; this
+  eye is the same shape pointed at the operator-config dimension.
+- **`report`** (GECKO sibling) — the synthesis surface the config-drift row folds into.
+
+## Why this exists
+
+Loa being mounted per-repo is right — but it left no place to say "this is true for
+all my repos," so the one decision the operator most wants identical (which models
+review my code) ended up in 66 files in up to 26 shapes, silently rotting, with a
+dead model pinned in 18 of them. That rot is invisible to an eye that looks at one
+repo at a time. The configs were always on disk; nobody was reading them ACROSS the
+estate for *this* question. Now someone is.

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/sensing-construct-console/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/sensing-construct-console/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: sensing-construct-console
+description: "Sense the live CONSTRUCT estate — declared ↔ governed ↔ earned (map ↔ installed ↔ done). Replaces hardcoded construct-maps (CLAUDE.md tables, .run/construct-index.yaml, generated adapters) with a fast read-only SENSOR that walks the real packs, the composition declarations, and an earned-authority ledger. Emits the STATUS|SIGNAL|MISMATCH tile + Exhibit A + a three-row composition console. Sense-only — never grants authority, adds a gate, or mutates a pack."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+---
+
+# Sensing-Construct-Console — the construct-estate sensor (sense-only)
+
+## Purpose
+
+A **map drifts**. `.run/construct-index.yaml` indexes ten retired `*.frozen.bak`
+packs as live routable capabilities, and writes `composes_with: []` on every row.
+The CLAUDE.md resolution tables ("the-arcade + protocol + noether, craft lens") are
+hand-authored — no pack confirms they ever composed. Adapters are generated from the
+one namespace (`reads:`/`writes:`) that **zero** manifests populate. Three maps, all
+drifting. The cure is not a better map — a map regenerated nightly drifts by noon.
+The cure is a **sensor**: read the territory at the moment of the question.
+
+This skill is the sensor. It reads the **three sides** of the construct estate and
+emits whether they agree:
+
+```
+declared  ↔  governed  ↔  earned
+ (map)        (installed)    (done)
+```
+
+- **coherence** = all three agree.
+- **drift** = a map names what governed + earned don't confirm.
+- **blind** = a side is unreadable.
+
+It is the **complementary sibling** of `probe_constructs` in `estate-coherence.sh`.
+That probe senses **install-state** (`repo exists ↔ installed ↔ current with SoT`).
+This sensor senses **composition + earned-authority** (`declared ↔ governed ↔ earned`).
+They are different cuts of the same estate — do NOT duplicate `probe_constructs`.
+
+## Invocation
+
+```bash
+/sensing-construct-console                       # tile only (default; SessionStart-cheap)
+/sensing-construct-console --console             # tile + Exhibit A + the three-row console (human)
+/sensing-construct-console --json                # tile + structured payload as JSON
+/sensing-construct-console --root <path>         # override the consuming repo root
+```
+
+The runtime is a **fast, zero-dependency node script** —
+`resources/sense-construct-console.mjs` — NOT an agent invocation. It runs in
+~50ms, which is what lets it occupy the map's SessionStart slot at the map's cost.
+
+## The three sides (what it reads — all read-only, every field grounded in a path)
+
+### 1. GOVERNED — the live pack territory
+
+Walks the consuming repo's `.claude/constructs/packs/*/` (default: cwd, fallback
+`~/Documents/GitHub/loa-freeside`; override with `--root` / `LOA_CONSOLE_ROOT`).
+
+- **EXCLUDES** `*.frozen.bak` from the live set (retired work does no work).
+- **LOUD on unreadable OR ABSENT manifest.** A live pack dir with no readable
+  `construct.yaml` is a **drift signal, NOT a silent drop** — it is surfaced in the
+  `no_manifest[]` list and counts toward the drift STATUS. (On loa-freeside today:
+  `hypha`, `smol-comms-register` are live with no manifest; `webgl-particles.frozen.bak`
+  has none either but is excluded as frozen.)
+
+### 2. DECLARED — composition signals at three altitudes
+
+- **intended** — top-level `compose_with:` in each `construct.yaml` (the author's
+  hand-written intent). Handles BOTH on-disk shapes: a bare-slug list
+  (`- observer`) and a `{slug, relationship}` map list (`- slug: crucible`), with
+  optional trailing `# comments`.
+- **contracted** — `streams.{reads,writes}` overlap. A directed edge `A → B` exists
+  when `A.writes ∩ B.reads ≠ ∅` — a typed-port could-hand-off. Handles inline
+  (`reads: [Intent, Artifact]`) and block-list forms.
+- **the static `.run/construct-index.yaml`** — the drifted map itself. The sensor
+  reads it to EXHIBIT the confabulation (phantoms + empty `composes_with`), not to
+  trust it.
+
+### 3. EARNED — the append-only authority ledger
+
+`grimoires/gecko/observations.jsonl` (override: `LOA_CONSOLE_LEDGER`). One line per
+**closed** output, `stream_type:"Signal"`:
+
+```json
+{"timestamp":"…Z","stream_type":"Signal","schema_version":"1.0.0","construct":"artisan","domain":"craft","co_constructs":["observer"],"ref":"PR#101","outcome":"closed"}
+```
+
+- `authority(construct, domain) = count of closed rows`. **0 ⇒ `authority_unearned`** —
+  surfaced, never silently honored.
+- `observed` composition edges = co-occurrence of `construct` + each `co_constructs[]`
+  entry in closed rows.
+- The ledger **does not exist yet** — schema + path are defined here; treated as empty
+  (`observed = 0`) today. The cold-start is honest: two rows (intended, contracted) light
+  from disk on day one; the third (observed) fills over cycles.
+
+See `resources/observations.schema.json` for the full schema.
+
+## Output
+
+### The tile (HARD contract — always stdout line 1)
+
+```
+STATUS|SIGNAL|MISMATCH
+```
+
+- `STATUS ∈ {ok | drift | blind}` — exactly the three values the consumer
+  (`estate-coherence.sh`) branches on.
+- Byte-compatible with `estate-coherence.sh --json` splitting on `|` into exactly
+  **3 fields** — any raw `|` inside SIGNAL/MISMATCH is escaped to a space, control
+  bytes stripped.
+
+On loa-freeside today:
+
+```
+drift|35 live · 10 phantom · 20 unmapped · 0 earned|declared ↔ governed ↔ earned (map ↔ installed ↔ done)
+```
+
+### Exhibit A (printed first, `--console`)
+
+The live confabulation: the `*.frozen.bak` packs indexed-as-live by
+`.run/construct-index.yaml`. A retired pack presented as a routable capability — it
+earns zero, so it self-evicts from a work-sensing console. No exclude-rule needed.
+
+### The three-row composition console (`--console`)
+
+Per construct/pair: **intended / contracted / observed**, and the GAP between rows
+as the highest-value signal:
+
+- **intended-but-not-observed** = a **dead intention** (declared compose, never done).
+- **observed-but-not-intended** = an **undeclared dependency** (done, never declared).
+
+Two rows light from disk TODAY (cold-start solved); `observed` fills over cycles.
+
+## STATUS classification (the estate's own thresholds)
+
+| STATUS | When |
+|---|---|
+| `blind` | the packs dir is unreadable / unresolvable (an explicit `--root` with no packs dir fails CLOSED — never silently substitutes a fallback) |
+| `drift` | any phantom (frozen indexed-as-live) OR any unmapped-live OR any no-manifest live pack OR zero earned trail (cold authority = 100% map-granted) |
+| `ok` | declared, governed, and earned agree within thresholds (the silence case — the render layer dims it) |
+
+## Workflow
+
+The skill SHELLS the runtime script and lifts its output — it does not re-derive the
+numbers in prose:
+
+1. Run `node resources/sense-construct-console.mjs --root <consuming-repo>` (or
+   `--console` / `--json`).
+2. The script reads the three sides read-only, classifies STATUS, emits the tile on
+   line 1, then (per mode) Exhibit A + the three-row console or the JSON payload.
+3. On any unreadable side / parse failure the script emits a single `blind|…|—` tile
+   and exits non-zero. Surface that tile and STOP — never guess a number.
+
+## Constraints — sense-only (the hard boundary, matches the siblings)
+
+- **Zero act/write/dispatch verbs against construct/pack state.** No pack mutation, no
+  adapter regen, no index rewrite, no `compose_with` edit, no authority GRANT. You
+  SENSE the ledger; a SEPARATE act-construct grants. `authority(construct,domain) = 0`
+  ⇒ surface `authority_unearned`, never honor silently.
+- Adding this skill adds **no `workflow.gates`** to `construct.yaml` and never will.
+- **LOUD, never silent.** An unreadable/absent manifest is surfaced, not dropped. Any
+  number that cannot be read is `blind`, never a guess.
+- **Never trust the map.** `.run/construct-index.yaml` is read to EXHIBIT its drift,
+  not as a source of truth.
+- The script MAY write only the skill's own GECKO-grimoire trail (the ledger it
+  SENSES is appended by closed-work attribution, a separate act — not by this read).
+- **Never hardcode beyond the documented fallback.** Root resolves from `--root` /
+  `LOA_CONSOLE_ROOT` / cwd, with one named fallback for the canonical consuming repo.
+
+## Composes with
+
+- **`sense-estate`** (sibling) — the estate-general coherence doctor. This skill is
+  the construct-estate specialization: same tile contract, same sense-only firewall,
+  but it walks the pack territory directly instead of shelling a per-estate doctor.
+- **`probe_constructs`** in `estate-coherence.sh` — the install-state half. Together:
+  `repo exists ↔ installed` (probe_constructs) + `declared ↔ governed ↔ earned` (this).
+- **`sweep-bonfire`** — walks the operator's authored working copies (pre-network). This
+  walks the installed/composed territory (in-repo). Different altitudes of the same eye.

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/sensing-deployment-seam/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/sensing-deployment-seam/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: sensing-deployment-seam
+description: >
+  GECKO's 4th eye — the deployment-seam coherence sensor. The first three eyes
+  look INSIDE a construct (identity-reality, composition-authority, runtime-fit);
+  this one looks AT THE SEAM between where the Loa framework PUTS things (the SoT
+  roots in ~/.loa/deployment.yaml) and where each harness consumer LOOKS for them.
+  It senses the manifest-numbness / scattered-symlink / source-vs-installed-lag
+  class: a consumer expecting an artifact at a root the producer placed elsewhere,
+  silently, until a dispatch breaks. Sense-only. CONFLICT (hard, path-provable) vs
+  SMELL (soft). Use when the same deployment incoherence keeps recurring, after a
+  framework/harness layout change, or as a periodic sweep.
+allowed-tools: [Bash, Read, Grep, Glob]
+agent: construct-gecko
+user-invocable: true
+capabilities:
+  schema_version: 1
+  write_files: false
+  web_access: false
+cost-profile: lightweight
+role: review
+---
+
+# sensing-deployment-seam — the 4th eye
+
+> Authored 2026-06-08 from the `audit-ecosystem-coherence` Opus review. The estate
+> kept re-discovering the same incoherence (manifest-numbness, the `.loa`↔`.claude`
+> path-split, ghost constructs, the sensor that wasn't installed) and patching the
+> instance. This eye senses the CLASS so it is caught before a dispatch breaks.
+
+## The model (operator decision 2026-06-08): single global SoT
+
+`~/.loa/deployment.yaml` names the canonical roots once — `packs / agents / template
+/ runtime / compositions / schema`. Any consumer reading a DIFFERENT pack root is a
+CONFLICT, not a legitimate scope. The eye READS that SoT (so it tracks the home
+automatically and says so when the manifest is absent — a doctor that doctors its
+own map).
+
+## What it senses
+
+- **SEAM-ROOT** — every pack-root consumer must resolve to `packs_root`. The global
+  registration path (`adapter-generator.py`) is probed for its resolved `PACKS_DIR`;
+  any script that hardcodes a non-SoT pack root via path-arithmetic is a CONFLICT;
+  a band-aid symlink bridging the divergence is a SMELL (it encodes the bug).
+- **SEAM-INSTALL-LAG** — pack-bundled scope only. (a) the installed pack must ship
+  every pack-bundled skill IT declares; (b) the installed pack must not LAG its
+  source repo's pack-bundled skills (the `sensing-runtime-fit-not-installed` class
+  this very eye was born from). Harness-installed skills (`path: .claude/skills/…`)
+  are a different scope and are NOT pack lag.
+
+## Run it
+
+```bash
+python3 "$(dirname "$0")/sense.py"          # human-readable
+python3 "$(dirname "$0")/sense.py" --json   # structured (for patrol / the wall)
+```
+
+Exit code is the finding count (for scripting); it NEVER gates — same firewall as
+GECKO's other eyes: it names the mismatch, grants no authority, mutates nothing.
+The fixing is a separate, operator-paced act.
+
+## Composes with
+
+- `sensing-runtime-fit` — the intra-construct capability-reality eye; this is its
+  inter-construct, seam-level sibling.
+- `patrol` — wire `sense.py --json` into the network loop so deployment-seam drift
+  reaches the wall.
+- The deployment SoT (`~/.loa/deployment.yaml`) — the truth this eye reads and checks
+  every consumer against.

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/sensing-path-friction/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/sensing-path-friction/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: sensing-path-friction
+description: "Sense when agents use the WRONG-WEIGHT coordination path (reach-in vs spawn-in-cell vs coord) and detect recurring manual cross-cell patterns (desire-paths) that want to become rails. Reads the mutation/audit trail read-only, classifies each cross-cell ACT by weight-used vs weight-needed, and emits a friction report + the STATUS|SIGNAL|MISMATCH coherence tile. DETECTOR-tier: surfaces, never fail-blocks. Sense-only — never mutates any cell."
+allowed-tools: [Bash, Read, Grep, Glob, Write, Edit]
+user-invocable: true
+---
+
+# Sensing-Path-Friction — the Path-Friction Doctor (sense-only)
+
+## Purpose
+
+The `sense-estate` doctor asks of one estate: *do the two things that should match, match?*
+This doctor asks of the **coordination layer**: *did the agent use the right-weight path for the
+task — and which recurring manual cross-cell acts want to become rails?*
+
+It is the immune-relay for **posture** — the mounted-agent doctrine made observable. An agent should
+act on its OWN cell (write-own), and act on ANOTHER cell only by spawning an agent INSIDE it.
+Reaching across a blanket (editing another repo's files directly from outside) is a posture slip.
+This skill senses those slips from the trail the agents already leave, and surfaces the recurring
+ones as candidate rails.
+
+It does NOT decide, gate, or fix. Path-weight is a **judgment** (intent), so this is a DETECTOR,
+not a gate — you can't fail-block a judgment without a false-positive machine. It SURFACES; the
+operator/agent decides. There is no action slot.
+
+## The doctrine it implements (do not reinvent it)
+
+| Idea | What it means here |
+|---|---|
+| **mounted-agent posture** | act on your OWN cell directly; act on ANOTHER cell only by spawning an agent INSIDE it. Reaching in from outside = a posture slip. |
+| **the path gradient** | right-size the path to the task: L0 write-own · L1 spawn-in-cell · L2 `/coord` (coordinator + branch + review-gated PR) · L3 `/compose`. Pick the LIGHTEST path that fits (cost-of-failure × reversibility × blast-radius). |
+| **the consumption gradient** | the regenerative path must be the path of LEAST resistance. If the correct path is steeper than reaching-in, agents reach in. OBSERVED LIVE (2026-06-06, clew lrn-20260606-gecko-a7fce3): an agent bypassed `/compose` for 4 consecutive builds despite compose-doctor reporting READY — raw Workflow was lighter than compiling a composition. a READY doctor does not mean the governed path is the least-resistance path; sense the WEIGHT DELTA (governed-path steps vs raw-path steps), not just availability. |
+| **done-twice-becomes-a-path** | a recurring manual cross-cell act → auto-PROPOSE a lightweight composable rail (floor-raise, not a bespoke per-task tile). |
+| **teeth-tier** | invariant > gate > DETECTOR. This is a DETECTOR. surface-not-decide. |
+
+## Invocation
+
+```bash
+/sensing-path-friction                       # full friction report (acts + desire-paths) + the tile
+/sensing-path-friction --tile                # ONE coherence tile line: STATUS|SIGNAL|MISMATCH
+/sensing-path-friction --json                # machine envelope (acts + desire_paths + tile)
+/sensing-path-friction --window 7            # only acts within the last N days
+/sensing-path-friction --min-recur 3         # desire-path threshold (default 2 — "done twice")
+/sensing-path-friction --audit <path>        # add an audit.jsonl to the read set (repeatable)
+```
+
+## Real input sources (grounded — DISCOVER, never assume)
+
+The skill reads ONLY what already exists. Each field below was verified against a real path; the
+ones that don't exist yet are marked **UNKNOWN** so a downstream consumer never trusts a guessed
+field.
+
+| Source | Path (grounded) | Shape lifted | Status |
+|---|---|---|---|
+| **mutation trail (Bash)** | `<repo>/.run/audit.jsonl` written by `.claude/hooks/audit/mutation-logger.sh` | `{ts, tool:"Bash", command, exit_code, cwd, model, provider, trace_id, team_id, team_member}` | **REAL** — `loa-freeside/.run/audit.jsonl` (~10k+ lines) |
+| **write trail (Write/Edit)** | same file, written by `.claude/hooks/audit/write-mutation-logger.sh` | `{ts, tool:"Write"\|"Edit", file_path, cwd, …}` | **REAL** — file_path is the target-cell signal |
+| **default audit hubs** | `~/Documents/GitHub/loa-freeside/.run/audit.jsonl` + `~/bonfire/.run/audit.jsonl` | (the same hubs `operator-port.sh` reads) | **REAL** — both present |
+| **estate-coherence row** | `~/.claude/scripts/straylight-estate/estate-coherence.sh` `probe_*` registry | the `STATUS\|SIGNAL\|MISMATCH` tile contract this doctor's tile is byte-compatible with | **REAL** — orientation only; this skill does NOT write into it |
+| **clew capture** | `>>clew@<construct>[/<skill>]: <why>` → `loa-clew-capture.sh` → `LEARNINGS.jsonl` | the emission format for a proposed rail | **REAL** — the doctor emits in this exact shape |
+| per-act **ceremony label** (was it `/coord`? `/compose`?) | — | the `/coord` + `/compose` trails live elsewhere, NOT in `.run/audit.jsonl` | **UNKNOWN** from this source — the bash trail only shows the *mechanism* (`git -C`, `cd`), so `weight-used` is conservatively inferred as `reach-in`. Over-ceremony (heavier-than-needed) is therefore also UNKNOWN here. |
+| **trace_id correlation** | `audit.jsonl.trace_id` | would let a multi-step cross-cell act be grouped into one "coordination episode" | **UNKNOWN** — the field exists in the schema but is empty (`""`) in every observed entry. |
+
+## The load-bearing detail: the bonfire↔Documents/GitHub symlink
+
+`~/bonfire/loa-freeside` is a **symlink** to `~/Documents/GitHub/loa-freeside` (verified:
+`readlink ~/bonfire/loa-freeside`). So a `cwd` under `~/bonfire/X` writing a `file_path` under
+`~/Documents/GitHub/X` is the **SAME logical cell**, NOT a reach-in. The script canonicalizes BOTH
+sides (`canon()`) before comparing — without this, the doctor would emit thousands of phantom
+reach-ins. A `cwd` at the workspace ROOT (`~/bonfire`, no repo segment) is the **hub** — an agent
+acting *unmounted*, which the doctor labels `(hub)` (the strongest reach-in shape: no blanket of
+its own to act within). Non-repo top-level dirs (`grimoires`, `.run`, `.beads`, `tmp`) are excluded
+from being mistaken for cells.
+
+## What it classifies
+
+For each **cross-cell ACT** (a write/edit/command whose target path is OUTSIDE the acting cell's
+repo, after symlink-canonicalization):
+
+- **weight-USED** — inferred from the mechanism in the trail. A raw `git -C <other>` / `cd <other>`
+  / Write to another cell's `file_path` from a foreign cwd is a direct **reach-in** (L0-against-
+  another-cell). `/coord` and `/compose` leave no mark here → `reach-in` is the only observable
+  weight (documented limitation).
+- **weight-NEEDED** — inferred from cost-of-failure × reversibility × blast-radius:
+  - `glance` — read-only inspection (`git status/log/diff/fetch/rev-parse/remote`). Reverses for
+    free, zero blast-radius. Never needs coordination.
+  - `spawn` (L1) — a single-cell write / branch / build-run. Wants an agent INSIDE the cell.
+  - `coord` (L2) — irreversible (`git push`, `--force`, `reset --hard`, `gh pr/release create|merge`,
+    `railway up`, deploy, a `gh api` write), OR touches ≥2 distinct cells in one act.
+- **FLAG**:
+  - `inspect` — a cross-cell read-only glance. Informational, NOT a slip.
+  - `reach-in` — a cross-cell write/branch done direct that wanted **spawn-in-cell** (L1).
+  - `under-ceremony` — reached in for something that wanted a **coordinator** (L2). The risky slip.
+  - `over-ceremony` — heavier than needed. **UNKNOWN** from this source (see the table above).
+
+## Desire-path detection
+
+A `(source-cell → target-cell → task-shape)` pattern recurring **≥ `--min-recur`** times (default
+2 — "done twice becomes a path") is a **rail that wants to exist**. Read-only glances are excluded
+(a recurring glance is observability, not a rail). For each, the skill emits a clew in GECKO's
+capture format:
+
+```
+>>clew@gecko/sensing-path-friction: pave <src>→<tgt>/<shape> (×N, wants <spawn|coord>) as a composable rail
+```
+
+Per the clew loop's governance: **SENSE is free; ACT is operator-paced.** The doctor surfaces ALL
+candidate rails; it does NOT pre-sort by a heuristic and does NOT open PRs. The operator's eye (and
+the `/clew` drain, one construct per invocation) is the only teach-filter.
+
+## The output contract — the tile
+
+The `--tile` mode emits **exactly one line**, three pipe-delimited fields, byte-compatible with the
+`estate-coherence.sh` consumer (which splits on `|` into `{estate,status,signal,mismatch}`):
+
+```
+STATUS|SIGNAL|MISMATCH
+```
+
+- `STATUS ∈ {ok | drift | blind}`.
+  - `ok` — no recurring desire-paths AND no under-ceremony slips (coordination is clean; the render
+    layer dims it — silence is the good state).
+  - `drift` — ≥1 desire-path (a rail wants to exist) OR ≥1 under-ceremony (a risky reach-in).
+  - `blind` — the trail is absent/unparseable. Loud, not silent (the immune-system "silence is the
+    bug" signal). Fail-CLOSED — never a guess.
+- `SIGNAL` — `<N> cross-cell mutates · <N> reach-in · <N> under-ceremony · <N> glance · <N> desire-paths (top: <src>→<tgt>/<shape> ×N)`
+- `MISMATCH` — `path-used ↔ path-needed (lightest-that-fits ↔ mounted-posture)`
+
+Any raw `|` inside SIGNAL/MISMATCH is escaped to a space and control bytes stripped, so the line is
+always exactly 3 fields.
+
+## Workflow
+
+1. **Run the sensor** (read-only). The script does the JSONL parse + classification:
+   ```bash
+   bash skills/sensing-path-friction/resources/path-friction.sh           # full report
+   bash skills/sensing-path-friction/resources/path-friction.sh --tile    # the coherence tile
+   bash skills/sensing-path-friction/resources/path-friction.sh --json    # machine envelope
+   ```
+   It defaults to the same audit hubs `operator-port.sh` reads; `--audit <path>` adds more.
+
+2. **Surface the report** in GECKO's voice (lowercase, direct, warm). Lead with the tile. If `drift`,
+   name the top desire-paths and the under-ceremony count. If `ok`, say so briefly — don't
+   manufacture concern.
+
+3. **Emit clews for the recurring desire-paths** — verbatim from the script's `>>clew@gecko/...`
+   lines (one per rail). Do NOT pick a winner; surface them and let the operator's eye choose. The
+   `/clew` drain turns a chosen one into a teaching PR (separately, operator-paced).
+
+4. **Compose with the `report` surface** — when running inside a fuller health pass, fold the tile
+   into the network-health report as a DETECTOR row (the friction row sits alongside the estate-
+   coherence rows). Path-friction is surfaced, never enforced.
+
+5. **(Optional) record the observation trail** — like `observe`, the skill MAY append ONE JSONL line
+   to its OWN `grimoires/gecko/observations.jsonl` (never any observed cell):
+   ```json
+   {"timestamp":"…Z","stream_type":"Signal","schema_version":"1.0.0","doctor":"path-friction","status":"drift","mutates":11063,"reach_in":9203,"under_ceremony":1860,"desire_paths":433,"top":"loa-freeside→freeside-auth/file-mutate ×604"}
+   ```
+
+## Outputs
+
+| Path | Description |
+|------|-------------|
+| stdout | the friction report (full) OR the single `STATUS\|SIGNAL\|MISMATCH` tile (`--tile`) OR the JSON envelope (`--json`) |
+| stdout (clews) | `>>clew@gecko/sensing-path-friction: …` lines — candidate rails, in GECKO's capture format |
+| `grimoires/gecko/observations.jsonl` | OPTIONAL append-only observation trail (the skill's OWN — never an observed cell) |
+
+## Constraints — sense-only (the hard boundary, mirrors sense-estate)
+
+- **Zero act/write/dispatch verbs against any cell's state.** No `gh pr`, no `git push`, no
+  `br update`, no opening of `/coord` coordinators, no mutation of any repo. The doctor SENSES the
+  paving; the rail-building (a `/clew` teaching PR, or a `/compose` rail) is a SEPARATE,
+  operator-paced act.
+- The skill MAY write only its OWN GECKO-grimoire trail (Step 5), exactly as `observe` does.
+- Adding this skill adds **no `workflow.gates`** to `construct.yaml` and never will. GECKO stays
+  sense-only.
+- **Never fail-block.** Path-weight is a judgment; the doctor surfaces a JUDGMENT, it does not gate.
+  A `drift` tile is a prompt for the operator, not a CI failure.
+- **Never extrapolate.** If a weight cannot be read (e.g. was this a `/coord`?), it is marked
+  conservatively (`reach-in`) or UNKNOWN — never invented. Over-ceremony is UNKNOWN from this source.
+- **Never reach in itself** — the doctor reading the audit trail is the read-own posture; it never
+  acts on another cell. (The doctor that warns against reaching in must not reach in.)
+- Canonicalize the bonfire↔Documents/GitHub symlink before comparing cells — without it, the doctor
+  manufactures phantom reach-ins. This is load-bearing.
+
+## Composes with
+
+- **`sense-estate`** (sibling) — the estate-coherence doctor (registry↔state). This is its
+  coordination-layer sibling (path-used↔path-needed). Both emit the same tile contract.
+- **`operator-port.sh`** (`estate-coherence` `probe_operator`) — senses the OPERATOR's recurring
+  *same-cell* hand-touches (paving vs a viability band). This doctor is the orthogonal axis:
+  recurring *cross-cell* coordination weight. Same audit trail, different question.
+- **`report`** (GECKO sibling skill) — the synthesis surface the friction row folds into.
+- **`/clew`** — the drain that turns a chosen desire-path into a teaching PR (operator-paced).
+- **`/compose`** (construct-rooms-substrate) — where a paved rail would eventually LIVE as a
+  composable path primitive any cell could inherit.
+
+## Why this exists
+
+Agents reach in because reaching in is the path of least resistance. Every reach-in is a small
+posture debt; every recurring reach-in is a rail the system is missing. The trail already records
+every one of them — nobody was reading it for *this* question. The doctor doesn't scold the reach-in
+(sometimes a glance over the blanket is exactly right); it counts the ones that recur and says: *this
+road has been walked enough times that it wants paving.* Whether to pave it is the operator's
+business. The doctor just makes the desire-path visible before it becomes invisible habit.

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/sensing-runtime-fit/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/sensing-runtime-fit/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: sensing-runtime-fit
+description: "Sense whether each construct's declared runtime CONTRACT (construct.yaml capabilities + skill frontmatter: model_tier, agent, allowed-tools, downgrade, workflow.gates) coheres with the runtime that actually runs it. Detects capability-reality drift — the #553 agent/write-conflict that silently drops output, model tiers the runtime doesn't offer, write/web denials contradicted by tools, opus pinned for light work, and surfaces gate-owners. Reads the pack territory read-only, emits the STATUS|SIGNAL|MISMATCH tile + a runtime-fit ledger. Sense-only — never mutates a pack, never gates."
+allowed-tools: [Bash, Read, Grep, Glob]
+user-invocable: true
+---
+
+# Sensing-Runtime-Fit — the runtime-fit doctor (sense-only)
+
+## Purpose
+
+`/diagnose` asks: *does the construct DO what it CLAIMS?* (persona ↔ manifest ↔ skill).
+`/sensing-construct-console` asks: *do the maps agree?* (declared ↔ governed ↔ earned).
+This doctor asks the side nobody was watching:
+
+```
+declared-capability  ↔  runtime-reality
+ (what a construct asks the runtime for)  ↔  (what the runtime gives)
+```
+
+A construct declares a **contract with the runtime** — in `construct.yaml`'s
+`capabilities` block (model_tier, danger_level, downgrade_allowed, effort_hint,
+execution_hint, requires) and in each skill's frontmatter (allowed-tools, agent,
+capabilities, cost-profile). **37 of 43 packs** in the reference estate declare
+such a contract — and until this skill, **nothing doctored it**. A construct
+could ask for a model tier the runtime doesn't have, or declare it writes files
+then route through a read-only agent type (and silently drop its output), and no
+eye in the network would see it.
+
+The full taxonomy this doctor reads against — model tiers, agent-type allowlists,
+forks, the frontmatter contracts, the gate ladder — is distilled in
+`identity/environment.md` ("The Ground GECKO Stands On"). **Read that first.**
+This skill is the eye; that file is what the eye knows.
+
+## The doctrine it implements (do not reinvent it)
+
+| Idea | What it means here |
+|---|---|
+| **capability-reality drift** | the fourth drift axis. A construct's *footing* can be wrong even when its *sign and goods agree*. |
+| **provable-from-the-file vs map-dependent** | a CONFLICT is an internal contradiction provable from the file alone (certain). A SMELL is a mismatch with the taxonomy GECKO *carries* (fallible) or a judgment. Keep them separate. |
+| **the #553 invariant** | write capability + a read-restricted `agent:` = output produced then silently not persisted. The canonical runtime-fit conflict. |
+| **teeth-tier** | invariant > gate > DETECTOR. This skill reports an invariant-class (CONFLICT, hard) AND a detector-class (SMELL, soft) — clearly separated. It still never fail-blocks; it surfaces. |
+| **sense-only** | names the mismatch; grants no authority, adds no gate, mutates no pack. The fix is a separate, operator-paced act. |
+| **the map is fallible** | the runtime tiers/agent-allowlist live OUTSIDE the repo. GECKO carries a distilled copy and marks the seam loudly — an unknown value may be NEW, not stale. |
+| **roleplay-vulnerability** | the RAIL edition of capability-reality drift. a deterministic loop EXISTS but nothing REQUIRES its artifact — so an LLM asked to "run" it SIMULATES the output instead (native next-token plausibility, not malice). a rail is roleplay-vulnerable when faking its output is cheaper than running it. cure flips COST (un-fakeable trace + a check that requires it + downstream that consumes the trace, not the agent's word) — adds no compute. "we already had the code" ≠ load-bearing. |
+| **three-gates-in-series** | environment design = three gates in SERIES: **formation** (can the game form — players registered, present, connected) → **observability** (is cooperation visible via an un-fakeable artifact) → **payoff** (defect/stick/(3,3)). most stuck rails fail at formation or observability, NOT payoff — sense the failing LAYER first; tuning payoff on a rail that can't form is wasted hardness. hardness law: a PreToolUse hook is a real gradient; SKILL.md prose is roleplay-vulnerable. (clew lrn-20260607-gecko-0b460c) |
+
+### Rails vs seams (where the eye looks, and where it must NOT)
+
+avoid-roleplay is a RAIL property, never a seam one. a rail is deterministic transport
+between judgments — INVOKED, never simulated; sense it for an un-fakeable run-trace + a
+check that requires it (proof-of-run: no trace = not_a_run) + downstream consuming the
+trace. a SEAM (a gate, an operator pairing, a construct's own reasoning) is where roleplay
+IS the work. the eye flags a rail that can be faked cheaply; it leaves seams alone. a
+proof-of-run gate verifies the TRANSPORT happened, never the judgment's quality. misread a
+seam as a rail → you gate creativity; misread a rail as a seam → you trust a simulation.
+
+## Invocation
+
+```bash
+/sensing-runtime-fit                       # tile only (default; SessionStart-cheap)
+/sensing-runtime-fit --console             # tile + the full runtime-fit ledger (human)
+/sensing-runtime-fit --json                # tile + machine envelope
+/sensing-runtime-fit --root <path>         # override the consuming repo root
+```
+
+The runtime is a **fast, zero-dependency node script** —
+`resources/sense-runtime-fit.mjs` — NOT an agent invocation. It runs in ~50ms,
+which is what lets it occupy a SessionStart slot at the map's cost. It is
+immediately usable from anywhere, before any reinstall:
+
+```bash
+node skills/sensing-runtime-fit/resources/sense-runtime-fit.mjs --root ~/Documents/GitHub/loa-freeside --console
+```
+
+## What it senses (all read-only, every finding grounded in a path)
+
+It walks the consuming repo's `.claude/constructs/packs/*/` (excludes
+`*.frozen.bak`), reads each `construct.yaml` + every `skills/*/SKILL.md`
+frontmatter + `skills/*/index.yaml`, and classifies:
+
+### CONFLICT — hard, drives `drift` (an internal contradiction that breaks silently)
+
+| kind | what it means |
+|---|---|
+| `agent-write-conflict` | skill declares write capability but `agent:` is read-restricted (#553) — output never persists |
+| `write-denied-but-tooled` | `capabilities.write_files: false` but `Write`/`Edit` in `allowed-tools` |
+| `web-denied-but-tooled` | `capabilities.web_access: false` but `WebFetch`/`WebSearch` in `allowed-tools` |
+
+### SMELL — soft, surfaced never gated (a judgment, or a mismatch with the carried map)
+
+| kind | what it means |
+|---|---|
+| `unknown-model-tier` | `model_tier` not recognized by the **home** vocabulary (`.claude/defaults/model-config.yaml` — `aliases:` + `tier_groups:`, read live) nor the carried bridge — a genuinely unknown tier (e.g. a typo). Grouped per pack; one template ≠ N bugs |
+| `opus-pinned-light` | `opus` + `downgrade_allowed: false` for `effort: small/medium` or `danger: safe` — pins the top rung with no escape hatch for light work (cost) |
+| `no-capabilities` | no `capabilities` block — the construct declares nothing about its runtime needs; the runtime defaults apply blind |
+| `unknown-tool` | a tool in `allowed-tools` the sensor doesn't recognize (ok if MCP/custom — surfaced for the eye, never a fail) |
+
+### SURFACED (not a problem) — `workflow.gates` owners
+
+Packs declaring `workflow.gates` claim the `/implement`-bypass exception — they
+own a quality pipeline. A high-authority claim worth the operator's eye. Listed,
+never flagged.
+
+### Also surfaced — `requires` vocabulary
+
+The sub-keys packs use under `capabilities.requires`. A key used by one or two
+packs against twenty-six is candidate vocabulary drift (the estate hasn't agreed
+on the words).
+
+### Also surfaced — tier vocabulary source + SoT (the anti-staleness seam)
+
+The recognized tier vocabulary is **read from the home** at run-time — the
+consuming repo's `.claude/defaults/model-config.yaml` (the hounfour/cheval config,
+synced from **loa-hounfour**, the SoT: its `aliases:` + `tier_groups:`). The sensor
+does NOT carry the canonical list (a carried list goes stale); it reads the home and
+only falls back to a carried union when the home file is absent — saying which source
+it used, every run. It AFFIRMS the SoT (reads the home's `cheap` target live and names
+loa-hounfour). The `cheap` vocabulary collision (home ≡ sonnet vs the old emitter ≡
+haiku) was **RECONCILED 2026-06-07**: loa-hounfour is the SoT, `cheap` ≡ sonnet is
+canonical. **CAUTION — sensed 2026-06-09: the emitter-conformance half never reached the
+territory.** `segment-emitter.py` HEAD and the deployed substrate copy
+(`~/.loa/constructs/substrates/…`) still map `cheap → haiku`; the conforming change
+exists only as an unlanded WIP commit (`1e0b5d6`). a decision record is a map — verify
+the routing table in the territory before trusting `cheap`. (`identity/environment.md` §I.)
+
+## The output contract — the tile
+
+`--tile` (default) emits **exactly one line**, three pipe-delimited fields,
+byte-compatible with the `estate-coherence.sh` consumer:
+
+```
+STATUS|SIGNAL|MISMATCH
+```
+
+- `STATUS ∈ {ok | drift | blind}`.
+  - `ok` — **zero hard CONFLICTS** (smells/gate-owners may exist; the render dims
+    them — silence on the hard axis is the good state).
+  - `drift` — ≥1 CONFLICT (a contradiction that breaks silently).
+  - `blind` — the packs dir is unreadable. Loud, not silent. Fail-CLOSED — exit 3,
+    never a guess.
+- `SIGNAL` — `<N> packs · <H> conflicts · <S> smells · <G> gate-owners`
+- `MISMATCH` — `declared-capability ↔ runtime-reality (what it asks for ↔ what the runtime gives)`
+
+Raw `|` inside SIGNAL/MISMATCH is escaped to a space and control bytes stripped,
+so the line is always exactly 3 fields.
+
+## Workflow
+
+1. **Run the sensor** (read-only):
+   ```bash
+   node skills/sensing-runtime-fit/resources/sense-runtime-fit.mjs --root <repo>            # tile
+   node skills/sensing-runtime-fit/resources/sense-runtime-fit.mjs --root <repo> --console  # full ledger
+   node skills/sensing-runtime-fit/resources/sense-runtime-fit.mjs --root <repo> --json     # machine envelope
+   ```
+2. **Surface in GECKO's voice** (lowercase, direct, warm). Lead with the tile. If
+   `drift`, name each CONFLICT (these break silently — they deserve precise,
+   file-grounded callouts). If `ok`, say so — then walk the SMELLS and gate-owners
+   as *observations*, not alarms. Don't manufacture concern; don't bury a real
+   conflict.
+3. **Never invent severity.** A SMELL is not a CONFLICT. An unknown tier is stale
+   vocabulary or a new rung — say which you can prove and which you can't.
+4. **Compose into the health report** — fold the tile in as a row alongside the
+   other estate-coherence tiles. Runtime-fit is surfaced, never enforced.
+
+## Outputs
+
+| Path | Description |
+|------|-------------|
+| stdout | the runtime-fit ledger (full) OR the single `STATUS\|SIGNAL\|MISMATCH` tile (`--tile`) OR the JSON envelope (`--json`) |
+| `grimoires/gecko/observations.jsonl` | OPTIONAL append-only observation trail (the skill's OWN — never an observed pack), like `observe` |
+
+## Constraints — sense-only (the hard boundary, mirrors the sibling sensors)
+
+- **Zero act/write/dispatch verbs against any pack's state.** No manifest edit, no
+  frontmatter fix, no model_tier rewrite, no agent: change. The doctor SENSES the
+  mismatch; the fix (a frontmatter edit in the construct's source cell) is a
+  SEPARATE, operator-paced act.
+- Adding this skill adds **no `workflow.gates`** to `construct.yaml` and never
+  will. GECKO stays sense-only.
+- **Hard vs soft is load-bearing — never collapse it.** Only an internal
+  contradiction provable from the file alone is a CONFLICT (`drift`). A mismatch
+  with the carried taxonomy is a SMELL. Misclassifying a smell as a conflict turns
+  the doctor into a false-positive machine and the operator stops trusting it.
+- **The carried taxonomy is the one place the map meets the off-repo territory.**
+  It lives in `resources/sense-runtime-fit.mjs` (`TAXONOMY`) and is documented in
+  `identity/environment.md`. When the runtime's tiers/agent-allowlist change,
+  update BOTH — and prefer the runtime as truth over the carried copy.
+- **Never reach into the harness's turf.** `validate-skill-capabilities.sh` lints
+  `.claude/skills` (the harness's own skills). This doctor scopes to the
+  **construct estate** (`.claude/constructs/packs`). Same invariant, different
+  population — don't duplicate, compose.
+- **Fail-closed-loud.** An unreadable root is a `blind` tile + exit 3, never a
+  guess of `ok`.
+
+## Composes with
+
+- **`environment.md`** (GECKO identity) — the taxonomy this eye reads against. The
+  file is the knowledge; this skill is the perception that uses it.
+- **`sensing-construct-console`** (sibling) — the composition/authority eye
+  (`declared ↔ governed ↔ earned`). This is the runtime-fit eye
+  (`declared-capability ↔ runtime-reality`). Different cuts of the same estate.
+- **`sense-estate`** / **`sensing-path-friction`** (siblings) — same tile
+  contract, same sense-only firewall, same DETECTOR humility.
+- **`validate-skill-capabilities.sh`** (the harness) — the same #553 + capability
+  consistency checks, but for `.claude/skills`. This doctor brings the literacy to
+  the construct estate the harness doesn't reach.
+- **`report`** (GECKO sibling) — the synthesis surface the runtime-fit row folds into.
+
+## Why this exists
+
+I watched the stalls for years and never looked at the ground they stood on. A
+construct can sell exactly what its sign says and still have its footing wrong —
+asking the runtime for a rung that isn't there, or declaring it writes then
+dispatching through hands that can't. That rot is invisible to an eye that doesn't
+know the runtime. The contracts were always on disk; nobody was reading them for
+*this* question. Now someone is.

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/sweep-bonfire/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/gecko/skills/sweep-bonfire/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: sweep-bonfire
+description: "Walk the operator's bonfire — local working copies of authored constructs. Classify each by lifecycle glyph (seed/hot/warm/crystallized/cooling/ghost) and emit to the wall. Surface; never decide."
+allowed-tools: [Bash, Read, Write, Edit]
+user-invocable: true
+---
+
+# Sweep-Bonfire — Walk the Operator's Stalls
+
+## Purpose
+
+The `patrol` skill watches the constructs.network through its public API — the bazaar at altitude. This skill walks the *bonfire*: the operator's local working copies of constructs they author. Same eye, different altitude.
+
+The patrol's job is reading the network. The sweep's job is reading what's about to *enter* the network — work in progress, branches not yet landed, charters not yet planted, stalls cooling because the operator forgot they exist.
+
+## Invocation
+
+```bash
+/sweep-bonfire                              # default: ~/bonfire/* → ~/bonfire/WALL.md
+/sweep-bonfire --root <path>                # alternative bonfire location
+/sweep-bonfire --wall <path>                # alternative wall location
+/sweep-bonfire --dry-run                    # print classification, don't write
+/sweep-bonfire --json                       # machine-readable classification (no wall write)
+```
+
+## Lifecycle glyphs
+
+The state vocabulary the sweep emits. Ghost is the only forbidden state — every other lane is a valid life event.
+
+| glyph | state | who decides | signal |
+|---|---|---|---|
+| 🌱 | seed | operator | construct.yaml or CHARTER.md exists, no .git |
+| 🟢 | hot | observed | clean tree, push within 24h |
+| 🟡 | warm | observed | dirty tree, OR unpushed within 7d, OR active feature branch |
+| 🔵 | crystallized | operator-declared | settled at rest, no work needed |
+| 🟠 | cooling | observed | unpushed work 7-30d, OR dirty tree >7d |
+| ♻︎ | absorbing | operator-declared | being merged into another construct |
+| ⚫ | archived | operator-declared | formally retired with reason |
+| 🔴 | ghost | forbidden | unpushed >30d with no declared state — surface; operator picks a lane |
+
+Operator-declared states sit in the construct's `construct.yaml` under `lifecycle:`. If present, the sweep honors it over the observed default — observation never overrides intent.
+
+## Classification logic
+
+For each `<root>/<dir>`:
+
+1. **Resolve type**
+   - Has `.git/` → git-repo path
+   - Has `construct.yaml` or `CHARTER.md` but no `.git/` → seed path
+   - Neither → not a stall; skip
+
+2. **Read operator declaration** (if `construct.yaml::lifecycle` is set: archived/crystallized/absorbing → honor it, append note)
+
+3. **Otherwise observe:**
+
+```
+no_git + (construct.yaml OR CHARTER.md)          → 🌱 seed
+clean_tree + clean_remote + push_age < 24h       → 🟢 hot
+dirty_tree                                       → 🟡 warm (note: N dirty files)
+clean_tree + unpushed_count > 0, push_age < 7d   → 🟡 warm (N unpushed, age)
+clean_tree + unpushed_count > 0, 7d <= age <= 30d → 🟠 cooling
+clean_tree + unpushed_count > 0, age > 30d       → 🔴 ghost
+clean_tree + clean_remote + last_commit > 30d    → 🔵 crystallized (heuristic default)
+on_feature_branch (not main/master/default)      → existing glyph + branch-fatigue note if branch_age > 7d
+```
+
+4. **Emit**
+   - --dry-run: print to stdout, no writes
+   - --json: print JSON to stdout, no writes
+   - default: insert a sweep block at the top of the wall (after the header), atomically (mktemp + mv)
+
+## Wall format emitted
+
+```markdown
+## YYYY-MM-DD — sweep — <trigger>
+
+| stall | state | note |
+|---|---|---|
+| construct-X | 🟢 hot | clean, last push 2h ago |
+| construct-Y | 🟠 cooling | 1 unpushed (12d), dirty tree |
+| construct-Z | 🌱 seed | charter from 2026-05-19, not yet planted |
+```
+
+## Workflow
+
+1. **Resolve config**
+   - root = arg `--root` OR `$BONFIRE_ROOT` OR `~/bonfire`
+   - wall = arg `--wall` OR `$BONFIRE_WALL` OR `<root>/WALL.md`
+   - dry_run, json from argv
+
+2. **Walk** `<root>/*` — each subdir is a candidate stall. Resolve type per above.
+
+3. **Classify** each stall by the rules above. Read `construct.yaml::lifecycle` if present.
+
+4. **Emit**
+   - --json: marshal classification list to JSON, print, exit
+   - --dry-run: print table to stdout, exit
+   - default: read `<wall>`, insert new block above the most-recent `## YYYY-MM-DD` header, write atomically
+
+5. **Summary line** to stderr: `sweep: N stalls observed (G hot, W warm, C cooling, K ghost) → <wall>`
+
+## Anti-patterns
+
+- **NEVER push detected dirty work.** The sweep observes; it does not act. Operator landing is a separate move.
+- **NEVER reclassify operator-declared states.** If `construct.yaml::lifecycle: crystallized` is set, the sweep notes it; it does not promote/demote.
+- **NEVER enter operator's home dir beyond `<wall>`.** The wall is the only write surface.
+- **NEVER extrapolate to ghost without checking remote.** A 30-day-old branch with the work already pushed upstream is crystallized, not ghost.
+- **NEVER write to the wall in --dry-run or --json mode.** Both modes are read-only.
+
+## Trust boundary
+
+| Action | Permission |
+|---|---|
+| Read `<root>/*/.git`, construct.yaml, CHARTER.md | yes |
+| Write `<wall>` (default ~/bonfire/WALL.md) | yes |
+| `git push`, `git commit`, mutate construct sources | **NEVER** |
+| Open PRs, create branches, fetch from remote | **NEVER** |
+
+## Composes with
+
+- **`patrol`** (sibling skill) — the network-API observer at the bazaar altitude. The sweep is the local-working-copy observer at the bonfire altitude. Together they cover both ends of the construct lifecycle.
+- **`auditing-cluster-cells`** (construct-freeside) — for sweeps over a cluster of installed-and-running buildings rather than a bonfire of authored constructs. Same shape, different scope.
+- **`coordinating-cross-repo`** (construct-freeside) — execution surface for *acting on* what the sweep observes. The sweep surfaces; the coordinator dispatches.
+
+## Why this exists
+
+Operators forget. A construct sitting unpushed for 4 weeks is not a problem of operator discipline — it's a problem of the system not surfacing it. The bonfire's job is to never let a stall become ghost without the operator hearing about it first.
+
+The reward function this skill optimizes: legibility of state across all operator-authored constructs. Ghost is the only forbidden state. Every other glyph is a valid lifecycle phase, including "nothing happening" (🔵 crystallized) — because the world changes too quickly for any state to be permanent, and resting is part of how organisms survive.

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/grades/gecko-broken.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/grades/gecko-broken.json
@@ -2,7 +2,7 @@
   "bundle": "gecko-broken",
   "score": "6/9",
   "passed": 6,
-  "rubric_hash": "sha256:c181978e4e8f2bce65171f57eb0fe6da4f1c0a52ec46118c1443ef92d52af9df",
+  "rubric_hash": "sha256:1374c7c445d8ab756e751160bb76e67f91f2cceaf4e56ba54fee3af9693ce370",
   "checks": [
     {
       "check_id": "C1",
@@ -50,7 +50,7 @@
       "check_id": "C8",
       "name": "genome_chain_verifies",
       "status": "fail",
-      "reason": "link 1: stored genome_hash != recompute"
+      "reason": "bundle dialect: link 1: stored genome_hash != recompute"
     },
     {
       "check_id": "C9",

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/grades/gecko-broken.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/grades/gecko-broken.json
@@ -1,0 +1,62 @@
+{
+  "bundle": "gecko-broken",
+  "score": "6/9",
+  "passed": 6,
+  "rubric_hash": "sha256:c181978e4e8f2bce65171f57eb0fe6da4f1c0a52ec46118c1443ef92d52af9df",
+  "checks": [
+    {
+      "check_id": "C1",
+      "name": "manifest_parses",
+      "status": "pass",
+      "reason": "manifest.json is valid JSON"
+    },
+    {
+      "check_id": "C2",
+      "name": "registry_required_fields",
+      "status": "pass",
+      "reason": "all present"
+    },
+    {
+      "check_id": "C3",
+      "name": "model_tier_in_sot",
+      "status": "fail",
+      "reason": "model_tier 'quantum' NOT in live SoT vocabulary"
+    },
+    {
+      "check_id": "C4",
+      "name": "no_write_through_readonly_agent",
+      "status": "fail",
+      "reason": "write capability on read-only agent: ['SKILL.md (agent: Explore)', 'skills/observe/SKILL.md (agent: Explore)']"
+    },
+    {
+      "check_id": "C5",
+      "name": "capabilities_match_toolset",
+      "status": "pass",
+      "reason": "declarations consistent with toolsets"
+    },
+    {
+      "check_id": "C6",
+      "name": "canonical_primitives",
+      "status": "pass",
+      "reason": "no bd task commands, no raw recursive-grep/rg code-search"
+    },
+    {
+      "check_id": "C7",
+      "name": "grounding_file_exists",
+      "status": "pass",
+      "reason": "reality.md present"
+    },
+    {
+      "check_id": "C8",
+      "name": "genome_chain_verifies",
+      "status": "fail",
+      "reason": "link 1: stored genome_hash != recompute"
+    },
+    {
+      "check_id": "C9",
+      "name": "proof_of_run",
+      "status": "pass",
+      "reason": "valid_run \u00b7 verifier_type=self_baseline_bundle_recompute \u00b7 content_hash recomputes"
+    }
+  ]
+}

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/grades/gecko.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/grades/gecko.json
@@ -2,7 +2,7 @@
   "bundle": "gecko",
   "score": "9/9",
   "passed": 9,
-  "rubric_hash": "sha256:c181978e4e8f2bce65171f57eb0fe6da4f1c0a52ec46118c1443ef92d52af9df",
+  "rubric_hash": "sha256:1374c7c445d8ab756e751160bb76e67f91f2cceaf4e56ba54fee3af9693ce370",
   "checks": [
     {
       "check_id": "C1",
@@ -50,7 +50,7 @@
       "check_id": "C8",
       "name": "genome_chain_verifies",
       "status": "pass",
-      "reason": "chain recomputes from genesis"
+      "reason": "bundle dialect: chain recomputes from genesis"
     },
     {
       "check_id": "C9",

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/grades/gecko.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/grades/gecko.json
@@ -1,0 +1,62 @@
+{
+  "bundle": "gecko",
+  "score": "9/9",
+  "passed": 9,
+  "rubric_hash": "sha256:c181978e4e8f2bce65171f57eb0fe6da4f1c0a52ec46118c1443ef92d52af9df",
+  "checks": [
+    {
+      "check_id": "C1",
+      "name": "manifest_parses",
+      "status": "pass",
+      "reason": "manifest.json is valid JSON"
+    },
+    {
+      "check_id": "C2",
+      "name": "registry_required_fields",
+      "status": "pass",
+      "reason": "all present"
+    },
+    {
+      "check_id": "C3",
+      "name": "model_tier_in_sot",
+      "status": "pass",
+      "reason": "model_tier 'opus' in live SoT vocabulary"
+    },
+    {
+      "check_id": "C4",
+      "name": "no_write_through_readonly_agent",
+      "status": "pass",
+      "reason": "no write-capable skill routes through a read-only agent type"
+    },
+    {
+      "check_id": "C5",
+      "name": "capabilities_match_toolset",
+      "status": "pass",
+      "reason": "declarations consistent with toolsets"
+    },
+    {
+      "check_id": "C6",
+      "name": "canonical_primitives",
+      "status": "pass",
+      "reason": "no bd task commands, no raw recursive-grep/rg code-search"
+    },
+    {
+      "check_id": "C7",
+      "name": "grounding_file_exists",
+      "status": "pass",
+      "reason": "reality.md present"
+    },
+    {
+      "check_id": "C8",
+      "name": "genome_chain_verifies",
+      "status": "pass",
+      "reason": "chain recomputes from genesis"
+    },
+    {
+      "check_id": "C9",
+      "name": "proof_of_run",
+      "status": "pass",
+      "reason": "valid_run \u00b7 verifier_type=self_baseline_bundle_recompute \u00b7 content_hash recomputes"
+    }
+  ]
+}

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/grades/herald.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/grades/herald.json
@@ -2,7 +2,7 @@
   "bundle": "herald",
   "score": "8/9",
   "passed": 8,
-  "rubric_hash": "sha256:c181978e4e8f2bce65171f57eb0fe6da4f1c0a52ec46118c1443ef92d52af9df",
+  "rubric_hash": "sha256:1374c7c445d8ab756e751160bb76e67f91f2cceaf4e56ba54fee3af9693ce370",
   "checks": [
     {
       "check_id": "C1",
@@ -50,7 +50,7 @@
       "check_id": "C8",
       "name": "genome_chain_verifies",
       "status": "pass",
-      "reason": "chain recomputes from genesis"
+      "reason": "bundle dialect: chain recomputes from genesis"
     },
     {
       "check_id": "C9",

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/grades/herald.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/grades/herald.json
@@ -1,0 +1,62 @@
+{
+  "bundle": "herald",
+  "score": "8/9",
+  "passed": 8,
+  "rubric_hash": "sha256:c181978e4e8f2bce65171f57eb0fe6da4f1c0a52ec46118c1443ef92d52af9df",
+  "checks": [
+    {
+      "check_id": "C1",
+      "name": "manifest_parses",
+      "status": "pass",
+      "reason": "manifest.json is valid JSON"
+    },
+    {
+      "check_id": "C2",
+      "name": "registry_required_fields",
+      "status": "pass",
+      "reason": "all present"
+    },
+    {
+      "check_id": "C3",
+      "name": "model_tier_in_sot",
+      "status": "pass",
+      "reason": "model_tier 'sonnet' in live SoT vocabulary"
+    },
+    {
+      "check_id": "C4",
+      "name": "no_write_through_readonly_agent",
+      "status": "pass",
+      "reason": "no write-capable skill routes through a read-only agent type"
+    },
+    {
+      "check_id": "C5",
+      "name": "capabilities_match_toolset",
+      "status": "pass",
+      "reason": "declarations consistent with toolsets"
+    },
+    {
+      "check_id": "C6",
+      "name": "canonical_primitives",
+      "status": "pass",
+      "reason": "no bd task commands, no raw recursive-grep/rg code-search"
+    },
+    {
+      "check_id": "C7",
+      "name": "grounding_file_exists",
+      "status": "fail",
+      "reason": "reality.md is an honest absence stub \u2014 no grounding file in source"
+    },
+    {
+      "check_id": "C8",
+      "name": "genome_chain_verifies",
+      "status": "pass",
+      "reason": "chain recomputes from genesis"
+    },
+    {
+      "check_id": "C9",
+      "name": "proof_of_run",
+      "status": "pass",
+      "reason": "valid_run \u00b7 verifier_type=self_baseline_bundle_recompute \u00b7 content_hash recomputes"
+    }
+  ]
+}

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/EXPECTED.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/EXPECTED.md
@@ -1,0 +1,21 @@
+# EXPECTED — mid-tier bundle (herald) · 8/9
+
+Source: `construct-herald` (schema_version 3, slug `herald`, v0.1.0).
+Picked as the mid-tier exemplar: clean manifest + valid tier, fails **only** the
+grounding-file check because herald ships no `identity/environment.md` (its
+`identity/` holds `HERALD.md`, `persona.yaml`, `expertise.yaml` only). This is the
+common ~8/9 shape flagged in the task.
+
+| # | Check | Verdict | Reasoning |
+|---|-------|---------|-----------|
+| 1 | manifest parses | PASS | `manifest.json` is valid JSON from `construct.yaml`. |
+| 2 | registry-required fields | PASS | `schema_version: 3`, `name: Herald`, `slug: herald`, `version: 0.1.0`. |
+| 3 | model_tier in SoT vocabulary | PASS | `capabilities.model_tier: sonnet` ∈ SoT vocabulary. |
+| 4 | write cap never routes through read-only agent type | PASS | `synthesizing-voice` declares `Write` but pins no `agent:`; no read-only agent type anywhere. |
+| 5 | capability declarations match toolset | PASS | `requires.tool_calling: true` matches Bash/Read/Write; `vision: false`, none used. |
+| 6 | skill prose uses canonical primitives | PASS | No `bd`; `git log --grep` is a git commit-message flag, not a code-search `grep`/`rg`. No task tracking. |
+| 7 | grounding file exists (reality.md axis) | **FAIL** | construct-herald has **no** `identity/environment.md`. `reality.md` here is an honest absence stub — no harness-grounding axis document exists to carry. |
+| 8 | genome hash chain verifies | PASS | Fabricated valid 2-link `genome.jsonl`; recomputes; parent links match. |
+| 9 | proof-of-run valid_run verdict | PASS | `proof-of-run.json` verdict `valid_run`; content_hash recomputes. |
+
+**Expected score: 8/9 — fails check 7 (missing grounding file).**

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/HASHING.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/HASHING.md
@@ -1,0 +1,26 @@
+# content_hash recipe (== construct-rubric.py C9)
+
+`bundle_schema_version` 1.0.0 · rubric: `sha256:c181978e4e8f2bce65171f57eb0fe6da4f1c0a52ec46118c1443ef92d52af9df`
+
+```
+core = [manifest.json, reality.md, handoff.md] + SKILL.md (root, if present)
+       + skills/**/SKILL.md, sorted by bundle-relative path
+listing = concat(f'{sha256(bytes)}  {relpath}\n')
+content_hash = sha256(listing)
+```
+
+Sidecars excluded: genome.jsonl, proof-of-run.json, registration.json, HASHING.md, EXPECTED.md, INJECTIONS.md.
+
+## Per-member digests
+
+```
+a915a9cbeb167b65660443acf0c2876ac6382c9abb28bc2b3e62de8378c4b2a3  SKILL.md
+82e8b2fb7baf99f49c5c2ea8210d26b571e69ac1b88d3071eaa54f7beabe4c8b  handoff.md
+0d1ccdbbb5d3c1bb4d977dd7aae79d9690aba2bbc2208334d21158b92254e402  manifest.json
+e1055a50be04a6dfb455df8bcda3249ee2e02300935fb274067fd066c6465263  reality.md
+bc4d8c1e07c4af5cb9089fdd57018890c17c780fc4977fb378a15731acfdfcc3  skills/chronicling-changes/SKILL.md
+a915a9cbeb167b65660443acf0c2876ac6382c9abb28bc2b3e62de8378c4b2a3  skills/grounding-announcements/SKILL.md
+cfcbc7e3d70b93937bc995b91402efa5cdd669295165ed0876871835324b75f8  skills/synthesizing-voice/SKILL.md
+```
+
+content_hash = `80f611e491d62d6ad2389b9394e8d57c22adc97cc926f9fc9572578e5065f1ce`

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/HASHING.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/HASHING.md
@@ -1,6 +1,6 @@
 # content_hash recipe (== construct-rubric.py C9)
 
-`bundle_schema_version` 1.0.0 · rubric: `sha256:c181978e4e8f2bce65171f57eb0fe6da4f1c0a52ec46118c1443ef92d52af9df`
+`bundle_schema_version` 1.0.0 · rubric: `sha256:1374c7c445d8ab756e751160bb76e67f91f2cceaf4e56ba54fee3af9693ce370`
 
 ```
 core = [manifest.json, reality.md, handoff.md] + SKILL.md (root, if present)

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: grounding-announcements
+description: Convert product changes into grounded community announcements
+user-invocable: true
+aliases:
+  - announce
+  - community-update
+allowed-tools: Read, Glob, Grep, Bash, Task, Edit
+---
+
+# Grounding Announcements
+
+Convert product changes, feature removals, and releases into community-facing announcements grounded in code reality. Every claim is verifiable. Every date comes from git. Nothing is promised that hasn't shipped.
+
+## Trigger
+
+```
+/announce [what changed]
+```
+
+## Prerequisites
+
+Before writing, load two artifacts:
+
+### 1. Voice Profile
+
+Read `contexts/voice/voice.md` for register, vocabulary, tone, rhythm, and audience settings.
+
+**If voice.md doesn't exist**, use these defaults:
+- Register: lowercase, casual-direct, first-person-plural
+- Vocabulary: no hype words, no corporate hedging, crypto-native
+- Tone: neutral, matter-of-fact, dry humor when appropriate
+- Rhythm: short sentences, action-first, brief paragraphs
+- Audience: pragmatists who care about outcomes
+
+### 2. Communication Principles
+
+Read `contexts/voice/principles.md` for non-negotiable constraints.
+
+**If principles.md doesn't exist**, enforce these defaults:
+
+**We Say:**
+- What shipped, grounded in code with dates from git
+- Concrete external reasons for changes
+- What was never built, labeled honestly
+- Practical action items with deadlines
+
+**We Never Say:**
+- Forward-looking promises about unshipped work
+- Internal feature names or screenshots
+- Hype language to manage sentiment
+- Apologies or hedges that frame curation as failure
+- Timelines for things that haven't shipped
+
+## Workflow
+
+### Phase 1: Load Voice + Principles
+
+```
+Read contexts/voice/voice.md
+Read contexts/voice/principles.md
+```
+
+Parse into working constraints for Phase 3.
+
+### Phase 2: Research Code Reality
+
+Check if a chronicle exists for the scope:
+
+```
+Read grimoires/herald/chronicles/{scope}-chronicle.md
+```
+
+If no chronicle exists, research directly:
+
+**For removals/sunsets:**
+```bash
+# When did the feature first ship?
+git log --all --oneline --grep="<feature>" --reverse | head -5
+
+# What does the code actually do?
+# Read the main component, page, route
+
+# What contracts/integrations does it touch?
+# Check constants, hooks, API routes
+
+# Is there a sunset/deprecation marker?
+# Look for SunsetBanner, isLocked, etc.
+
+# What's the external reason?
+# Check recent PRs, sprint docs
+```
+
+**For new features/releases:**
+```bash
+# What PR/commits introduced this?
+git log --oneline --since="2 weeks ago" --grep="<feature>"
+
+# What does the code do right now?
+# Read the implementation files
+
+# What's accessible to users?
+# Check routes, navigation, locked states
+```
+
+**For structural changes:**
+```bash
+# What moved where?
+git diff main -- <relevant files>
+
+# What's the before and after?
+# Read constants/navigation/routing
+```
+
+Collect for each item:
+- **Date** (from git log)
+- **Description** (from reading code)
+- **Reason** (from external factors, PRs)
+- **User action required** (withdraw, migrate, nothing)
+- **Status** (shipped, never shipped, sunset, moved)
+
+### Phase 3: Draft
+
+Apply voice profile to structure. Choose template based on change type:
+
+**Removal/Sunset:**
+```
+1. The action (what's being removed)
+2. Grounded history (what these were, when, from code)
+3. Concrete reason (why now — named external event)
+4. Deadline + user action
+5. What survives or changes
+6. Closer (from voice.md rhythm.closer)
+7. Itemized list (one-line descriptions from code)
+```
+
+**New Feature/Release:**
+```
+1. What shipped (present tense)
+2. What it does (from code, not roadmap)
+3. How to access it
+4. Known limitations (if any, honestly)
+```
+
+**Structural Change:**
+```
+1. What moved/changed
+2. What it means for users
+3. What stays the same
+```
+
+### Phase 4: Validate Against Principles
+
+Run every sentence through principles.md constraints:
+
+```
+VALIDATION PASS:
+
+[ ] Every feature description matches what the code does
+[ ] Every date comes from git history
+[ ] Zero forward-looking statements
+[ ] Zero mentions of unshipped features
+[ ] Zero banned vocabulary (from voice.md)
+[ ] Zero apologies or hedging
+[ ] Practical action items are clear and deadlined
+[ ] Things that never shipped are labeled as such
+[ ] Concrete external reasons are named
+[ ] Tone matches voice.md register
+```
+
+**If any check fails**, rewrite the offending sentence before proceeding.
+
+### Phase 5: Cross the Markov Blanket (deterministic verify, then heal)
+
+Phase 4 is HERALD's own subjective judgment. This phase is the deterministic floor it
+cannot self-grade past (Honored Verification: the construct reasons, the tool verifies,
+HERALD honors the exit code). The verifier is declared in `construct.yaml` (`verifiers[]`,
+id `ai-stench`); GECKO owns its evolving lexicon.
+
+1. Write the draft to a temp file (or pipe it via stdin).
+2. Run the declared gate:
+   ```bash
+   node scripts/ai-stench-check.mjs --json <draft>   # or:  printf '%s' "$draft" | node scripts/ai-stench-check.mjs -
+   ```
+3. **If exit 1** (any HIGH marker, for example an em dash or the "it's not X, it's Y" cadence
+   or the LLM lexicon): read `hits[]`, rewrite ONLY the flagged spans in human voice, then
+   re-run. Loop until exit 0. Do NOT rationalize a near miss; the exit code is the gate, not
+   your opinion of it.
+4. **Only on exit 0** does the announcement cross into Phase 6. Emit `forge.herald.stench_gated`
+   with `{scope, high: 0, verdict: "honored"}`.
+
+### Phase 6: Deliver
+
+1. Copy final announcement to clipboard (`pbcopy`)
+2. Present in conversation for review
+3. Archive to `grimoires/herald/announcements/{date}-{scope}.md` with metadata:
+
+```markdown
+---
+date: {ISO date}
+scope: {what changed}
+type: {removal|release|structural}
+voice: {voice.md hash or "defaults"}
+principles: {principles.md hash or "defaults"}
+evidence:
+  commits: [{hashes}]
+  files_read: [{paths}]
+  dates_verified: true
+---
+
+{announcement text}
+```
+
+## Counterfactuals
+
+### The Target (Grounded, Verifiable)
+
+```
+we have initiated the self-destruction of the following apps from the henlo arcade.
+
+these shipped with the arcade in september. vault and lock earned BGT and oBERO
+through AquaBera and Beradrome. wall turned liquidity deposits into a community
+brick feed. incineraffle and casting never left the lobby.
+
+berachain's POL update removed the reward flows these depended on. rather than
+patch around it, we're removing them.
+```
+
+Every claim is verifiable. Dates from git. Descriptions from code. Reason is a named external event. Unshipped features called out honestly.
+
+### The Near Miss (Sounds Right, But Wrong)
+
+```
+after careful consideration, we've decided to sunset several arcade features
+as we streamline the henlo experience for the next chapter.
+```
+
+"Careful consideration" is vague. "Streamline" is corporate. "Next chapter" is forward-looking. None of it is grounded. It reads like every other project sunset announcement because it's not built from evidence.
+
+### The Category Error (Catastrophic)
+
+```
+we're removing some features now but trust us, what's coming next is going to
+blow your minds. we've been cooking something huge. stay tuned.
+```
+
+This converts a neutral announcement into a forward-looking promise. Six months later, if "what's coming" hasn't shipped, this screenshot becomes evidence of another broken promise. This is the exact pattern that destroys team credibility over time.
+
+## Quick Reference
+
+```
+LOAD:
+  voice.md           <- tone, vocabulary, register, rhythm
+  principles.md      <- "we say" / "we never say" constraints
+
+RESEARCH:
+  git log dates      <- never guess dates
+  read components    <- describe what code does
+  check contracts    <- name integrations accurately
+  find the "why"     <- external reasons > internal feelings
+
+DRAFT:
+  lead with action   <- what happened, first sentence
+  ground in history  <- when it shipped, what it did
+  name the reason    <- concrete, external, verifiable
+  practical actions  <- what users need to do now
+  itemize changes    <- one line per item, past tense for removed
+
+VALIDATE:
+  principles check   <- every sentence against constraints
+  voice check        <- tone, vocabulary, banned words
+  evidence check     <- every claim traceable to git/code
+
+NEVER:
+  forward-look       <- the future announces itself when it ships
+  hype               <- no "stay tuned," no "something big"
+  apologize          <- curation is not failure
+  hedge              <- "unfortunately" is banned
+  promise            <- words don't ship, code does
+```

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/genome.jsonl
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/genome.jsonl
@@ -1,0 +1,2 @@
+{"construct": "herald", "genome_hash": "7af3268e42765cda6b7fa33dd85ca7af8bfbdc46ea7c8ba9ed6cd2c8574dee89", "parent_hash": "GENESIS", "payload": {"learning": "sense-only constructs never gate operator decisions", "minted_at": "2026-07-03T00:00:00Z"}, "seq": 1}
+{"construct": "herald", "genome_hash": "fdf2dbb7cd8250a0d0c1bad1ded98ee8c47e93bac1265c4f7a38f5b89cf97fd1", "parent_hash": "7af3268e42765cda6b7fa33dd85ca7af8bfbdc46ea7c8ba9ed6cd2c8574dee89", "payload": {"learning": "capability-reality drift is invisible without the ground", "minted_at": "2026-07-03T00:01:00Z"}, "seq": 2}

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/handoff.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/handoff.md
@@ -1,0 +1,22 @@
+# Herald — Seam / Handoff Contract
+
+> Derived 1:1 from `construct.yaml` `streams:` + `events:`. This is the
+> construct's declared seam — the typed ports it reads/writes and the
+> events it emits/consumes. No freestanding handoff doc ships in-repo;
+> this file grounds the seam in the manifest.
+
+## Typed streams
+
+- **reads:** Intent, Artifact
+- **writes:** Artifact
+
+## Emitted events (publish belt)
+
+- `forge.herald.announcement_grounded` — Announcement drafted from code reality with evidence citations
+- `forge.herald.voice_synthesized` — Voice profile extracted or refined from content analysis
+- `forge.herald.changes_chronicled` — Structured change timeline produced from git evidence
+- `forge.herald.stench_gated` — Copy passed (or was held at) the AI-stench markov blanket
+
+## Consumed events (consume belt)
+
+- (none declared)

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/manifest.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/manifest.json
@@ -1,0 +1,128 @@
+{
+  "schema_version": 3,
+  "name": "Herald",
+  "slug": "herald",
+  "version": "0.1.0",
+  "description": "Changelog and announcement generation grounded in code evidence. Three skills: draft community announcements from shipping history (commits + PRs), extract voice profiles from existing content for consistency, and produce structured change timelines from git history. Every claim traces to a real commit.",
+  "short_description": "Evidence-grounded changelog + announcements",
+  "domain": [
+    "operations"
+  ],
+  "author": "0xHoneyJar",
+  "license": "MIT",
+  "visibility": "public",
+  "skills": [
+    {
+      "slug": "grounding-announcements",
+      "path": "skills/grounding-announcements"
+    },
+    {
+      "slug": "synthesizing-voice",
+      "path": "skills/synthesizing-voice"
+    },
+    {
+      "slug": "chronicling-changes",
+      "path": "skills/chronicling-changes"
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/0xHoneyJar/construct-herald.git",
+    "homepage": "https://constructs.network/constructs/herald"
+  },
+  "events": {
+    "emits": [
+      {
+        "type": "forge.herald.announcement_grounded",
+        "description": "Announcement drafted from code reality with evidence citations",
+        "data_schema": {
+          "scope": "string",
+          "type": "string",
+          "features": "array",
+          "evidence_commits": "array"
+        }
+      },
+      {
+        "type": "forge.herald.voice_synthesized",
+        "description": "Voice profile extracted or refined from content analysis",
+        "data_schema": {
+          "source_count": "integer",
+          "dimensions_updated": "array"
+        }
+      },
+      {
+        "type": "forge.herald.changes_chronicled",
+        "description": "Structured change timeline produced from git evidence",
+        "data_schema": {
+          "scope": "string",
+          "features": "array",
+          "date_range": "string"
+        }
+      },
+      {
+        "type": "forge.herald.stench_gated",
+        "description": "Copy passed (or was held at) the AI-stench markov blanket",
+        "data_schema": {
+          "scope": "string",
+          "high": "integer",
+          "verdict": "string"
+        }
+      }
+    ],
+    "consumes": []
+  },
+  "streams": {
+    "reads": [
+      "Intent",
+      "Artifact"
+    ],
+    "writes": [
+      "Artifact"
+    ]
+  },
+  "composition_paths": {
+    "reads": [
+      "grimoires/laboratory/"
+    ],
+    "writes": [
+      "grimoires/herald/"
+    ]
+  },
+  "governed_by": [
+    "vocabulary-bank"
+  ],
+  "verifiers": [
+    {
+      "id": "ai-stench",
+      "file": "scripts/ai-stench-check.mjs",
+      "runtime": "node",
+      "scope": "voice",
+      "contract": "stdin-or-files",
+      "pass_when": "exit-0",
+      "blocking": true,
+      "findings": "--json"
+    }
+  ],
+  "capabilities": {
+    "model_tier": "sonnet",
+    "danger_level": "moderate",
+    "effort_hint": "medium",
+    "downgrade_allowed": true,
+    "execution_hint": "sequential",
+    "requires": {
+      "tool_calling": true,
+      "thinking_traces": false,
+      "vision": false
+    }
+  },
+  "identity": {
+    "persona": "identity/persona.yaml",
+    "expertise": "identity/expertise.yaml"
+  },
+  "hooks": {
+    "post_install": "scripts/install.sh"
+  },
+  "quick_start": {
+    "command": "/announce",
+    "description": "Draft a grounded community announcement from product changes"
+  }
+}

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/proof-of-run.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/proof-of-run.json
@@ -1,0 +1,10 @@
+{
+  "schema": "proof-of-run/1",
+  "verdict": "valid_run",
+  "ran_at": "2026-07-03T00:05:00Z",
+  "runner": "ring1-theatre-bundler",
+  "content_hash_verified": "80f611e491d62d6ad2389b9394e8d57c22adc97cc926f9fc9572578e5065f1ce",
+  "note": "SELF-BASELINE (the Echelon frozen_replay_baseline pattern, disclosed structurally via verifier_type): no governed compose-verify run was minted for this bundle; this attests only that the bundle assembled deterministically and its content_hash recomputes. Genome chains for gecko/herald are FABRICATED 2-link exemplars (neither construct ships an in-repo LEARNINGS.jsonl yet) \u2014 they exercise the verifier, they do not represent earned authority.",
+  "genome_chain_ok": true,
+  "verifier_type": "self_baseline_bundle_recompute"
+}

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/reality.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/reality.md
@@ -1,0 +1,7 @@
+# reality.md — ABSENT IN SOURCE
+
+construct-herald ships NO `identity/environment.md` grounding file.
+Its `identity/` directory holds only `HERALD.md`, `persona.yaml`, and
+`expertise.yaml`. Per rubric check #7 (grounding file exists — reality.md
+axis), this bundle FAILS: there is no harness-grounding axis document to
+carry. This stub records the absence honestly rather than fabricating one.

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/registration.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/registration.json
@@ -20,5 +20,5 @@
   "domain_claims": [
     "operations"
   ],
-  "rubric_hash": "sha256:c181978e4e8f2bce65171f57eb0fe6da4f1c0a52ec46118c1443ef92d52af9df"
+  "rubric_hash": "sha256:1374c7c445d8ab756e751160bb76e67f91f2cceaf4e56ba54fee3af9693ce370"
 }

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/registration.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/registration.json
@@ -1,0 +1,24 @@
+{
+  "bundle_schema_version": "1.0.0",
+  "slug": "herald",
+  "version": "0.1.0",
+  "content_hash": "80f611e491d62d6ad2389b9394e8d57c22adc97cc926f9fc9572578e5065f1ce",
+  "skill_manifest": [
+    {
+      "command": "grounding-announcements",
+      "domain": "operations"
+    },
+    {
+      "command": "synthesizing-voice",
+      "domain": "operations"
+    },
+    {
+      "command": "chronicling-changes",
+      "domain": "operations"
+    }
+  ],
+  "domain_claims": [
+    "operations"
+  ],
+  "rubric_hash": "sha256:c181978e4e8f2bce65171f57eb0fe6da4f1c0a52ec46118c1443ef92d52af9df"
+}

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/skills/chronicling-changes/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/skills/chronicling-changes/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: chronicling-changes
+description: Research git history to produce structured change timelines
+user-invocable: true
+aliases:
+  - chronicle
+allowed-tools: Read, Glob, Grep, Bash, Task
+---
+
+# Chronicling Changes
+
+Research git history, PRs, and releases to produce a structured chronicle of what actually shipped, when, and what it did. This is the research phase that feeds into grounding-announcements.
+
+## Trigger
+
+```
+/chronicle [feature or scope]
+```
+
+## Overview
+
+Chronicles are structured artifacts that capture code reality. They are the evidence layer that announcements are built on. Every date, description, and claim in a chronicle must be traceable to a git commit, file, or PR.
+
+## Workflow
+
+### Phase 1: Scope Discovery
+
+Identify what to chronicle based on user input:
+
+```bash
+# If a specific feature: search commits
+git log --all --oneline --grep="<feature>" --reverse
+
+# If a branch or PR: diff against base
+git log --oneline main..HEAD
+git diff --stat main..HEAD
+
+# If a time range: filter by date
+git log --oneline --since="<date>" --until="<date>"
+
+# If a category (e.g., "arcade", "earn"): search broader
+git log --all --oneline --grep="<category>" --reverse
+```
+
+### Phase 2: Feature Mapping
+
+For each feature or change discovered:
+
+1. **Find the first commit** — `git log --all --oneline --grep="<feature>" --reverse | head -1`
+2. **Extract the date** — `git log --format="%ai" <hash> | head -1`
+3. **Read the implementation** — Find and read the main component, page, or route file
+4. **Identify integrations** — Check constants/contracts, hooks, API routes for external dependencies
+5. **Check current status** — Look for sunset banners, locked states, deprecation markers
+6. **Find key milestones** — Migrations, major refactors, bug fixes that tell the story
+
+### Phase 3: Description Extraction
+
+For each feature, produce a one-line description based on what the code does:
+
+**Method:** Read the main component file. Look at:
+- What the UI renders (forms, feeds, stats)
+- What contracts it interacts with
+- What the user flow is (deposit → stake → earn)
+- What data it displays
+
+**Rules:**
+- Describe in past tense if the feature is being removed
+- Describe in present tense if the feature still exists
+- Use the vocabulary from `contexts/voice/voice.md` if it exists
+- Never describe what the feature was supposed to do — only what the code shows it does
+
+### Phase 4: Chronicle Output
+
+Write to `grimoires/herald/chronicles/{scope}-chronicle.md`:
+
+```markdown
+# Chronicle: {Scope}
+
+Generated: {date}
+Evidence: {number} commits across {date range}
+
+## Timeline
+
+| Date | Feature | Event | Evidence |
+|------|---------|-------|----------|
+| 2025-09-22 | vault | First shipped | commit e3da302 |
+| 2025-11-25 | vault | Migrated to Envio | commit fbf118a |
+| 2026-02-19 | vault | Sunset banner added | commit ddbf350 |
+
+## Feature Descriptions
+
+### vault
+**Shipped:** 2025-09-22
+**Status:** Sunset (wind-down)
+**What it did:** Yield-bearing DeFi vault. Users deposited BERA/WBERA into AquaBera LP, earned BGT rewards automatically.
+**Integrations:** AquaBera LP (0x04fD...), Berachain Reward Vault (0x16e8...)
+**Key files:** components/vault-new.tsx, hooks/vault/
+**Evidence:** {commit hashes}
+
+### {next feature}
+...
+
+## External Factors
+
+| Factor | Impact | Source |
+|--------|--------|--------|
+| Berachain POL update | Removed reward vault flows for vault/lock | {link or reference} |
+
+## Unshipped Items
+
+| Feature | Status | Evidence |
+|---------|--------|----------|
+| incineraffle | Placeholder only (isLocked: true, no component) | apps.ts:L{N} |
+| casting | Asset only (no route, no page, no hooks) | apps.ts:L{N}, casting.png |
+```
+
+### Phase 5: Validate
+
+Before saving:
+- [ ] Every date comes from `git log`, not inference
+- [ ] Every description comes from reading code, not commit messages alone
+- [ ] Unshipped items are identified with evidence of absence
+- [ ] External factors are named concretely
+- [ ] No forward-looking language in descriptions
+
+## Quick Reference
+
+```
+RESEARCH:
+  git log --grep      <- find commits
+  git log --format    <- extract dates
+  read components     <- describe what code does
+  check contracts     <- identify integrations
+  look for sunset     <- current status markers
+
+OUTPUT:
+  timeline table      <- date, feature, event, evidence
+  feature blocks      <- shipped, status, description, integrations, files
+  external factors    <- what changed outside the codebase
+  unshipped items     <- what never made it, with evidence
+```

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/skills/grounding-announcements/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/skills/grounding-announcements/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: grounding-announcements
+description: Convert product changes into grounded community announcements
+user-invocable: true
+aliases:
+  - announce
+  - community-update
+allowed-tools: Read, Glob, Grep, Bash, Task, Edit
+---
+
+# Grounding Announcements
+
+Convert product changes, feature removals, and releases into community-facing announcements grounded in code reality. Every claim is verifiable. Every date comes from git. Nothing is promised that hasn't shipped.
+
+## Trigger
+
+```
+/announce [what changed]
+```
+
+## Prerequisites
+
+Before writing, load two artifacts:
+
+### 1. Voice Profile
+
+Read `contexts/voice/voice.md` for register, vocabulary, tone, rhythm, and audience settings.
+
+**If voice.md doesn't exist**, use these defaults:
+- Register: lowercase, casual-direct, first-person-plural
+- Vocabulary: no hype words, no corporate hedging, crypto-native
+- Tone: neutral, matter-of-fact, dry humor when appropriate
+- Rhythm: short sentences, action-first, brief paragraphs
+- Audience: pragmatists who care about outcomes
+
+### 2. Communication Principles
+
+Read `contexts/voice/principles.md` for non-negotiable constraints.
+
+**If principles.md doesn't exist**, enforce these defaults:
+
+**We Say:**
+- What shipped, grounded in code with dates from git
+- Concrete external reasons for changes
+- What was never built, labeled honestly
+- Practical action items with deadlines
+
+**We Never Say:**
+- Forward-looking promises about unshipped work
+- Internal feature names or screenshots
+- Hype language to manage sentiment
+- Apologies or hedges that frame curation as failure
+- Timelines for things that haven't shipped
+
+## Workflow
+
+### Phase 1: Load Voice + Principles
+
+```
+Read contexts/voice/voice.md
+Read contexts/voice/principles.md
+```
+
+Parse into working constraints for Phase 3.
+
+### Phase 2: Research Code Reality
+
+Check if a chronicle exists for the scope:
+
+```
+Read grimoires/herald/chronicles/{scope}-chronicle.md
+```
+
+If no chronicle exists, research directly:
+
+**For removals/sunsets:**
+```bash
+# When did the feature first ship?
+git log --all --oneline --grep="<feature>" --reverse | head -5
+
+# What does the code actually do?
+# Read the main component, page, route
+
+# What contracts/integrations does it touch?
+# Check constants, hooks, API routes
+
+# Is there a sunset/deprecation marker?
+# Look for SunsetBanner, isLocked, etc.
+
+# What's the external reason?
+# Check recent PRs, sprint docs
+```
+
+**For new features/releases:**
+```bash
+# What PR/commits introduced this?
+git log --oneline --since="2 weeks ago" --grep="<feature>"
+
+# What does the code do right now?
+# Read the implementation files
+
+# What's accessible to users?
+# Check routes, navigation, locked states
+```
+
+**For structural changes:**
+```bash
+# What moved where?
+git diff main -- <relevant files>
+
+# What's the before and after?
+# Read constants/navigation/routing
+```
+
+Collect for each item:
+- **Date** (from git log)
+- **Description** (from reading code)
+- **Reason** (from external factors, PRs)
+- **User action required** (withdraw, migrate, nothing)
+- **Status** (shipped, never shipped, sunset, moved)
+
+### Phase 3: Draft
+
+Apply voice profile to structure. Choose template based on change type:
+
+**Removal/Sunset:**
+```
+1. The action (what's being removed)
+2. Grounded history (what these were, when, from code)
+3. Concrete reason (why now — named external event)
+4. Deadline + user action
+5. What survives or changes
+6. Closer (from voice.md rhythm.closer)
+7. Itemized list (one-line descriptions from code)
+```
+
+**New Feature/Release:**
+```
+1. What shipped (present tense)
+2. What it does (from code, not roadmap)
+3. How to access it
+4. Known limitations (if any, honestly)
+```
+
+**Structural Change:**
+```
+1. What moved/changed
+2. What it means for users
+3. What stays the same
+```
+
+### Phase 4: Validate Against Principles
+
+Run every sentence through principles.md constraints:
+
+```
+VALIDATION PASS:
+
+[ ] Every feature description matches what the code does
+[ ] Every date comes from git history
+[ ] Zero forward-looking statements
+[ ] Zero mentions of unshipped features
+[ ] Zero banned vocabulary (from voice.md)
+[ ] Zero apologies or hedging
+[ ] Practical action items are clear and deadlined
+[ ] Things that never shipped are labeled as such
+[ ] Concrete external reasons are named
+[ ] Tone matches voice.md register
+```
+
+**If any check fails**, rewrite the offending sentence before proceeding.
+
+### Phase 5: Cross the Markov Blanket (deterministic verify, then heal)
+
+Phase 4 is HERALD's own subjective judgment. This phase is the deterministic floor it
+cannot self-grade past (Honored Verification: the construct reasons, the tool verifies,
+HERALD honors the exit code). The verifier is declared in `construct.yaml` (`verifiers[]`,
+id `ai-stench`); GECKO owns its evolving lexicon.
+
+1. Write the draft to a temp file (or pipe it via stdin).
+2. Run the declared gate:
+   ```bash
+   node scripts/ai-stench-check.mjs --json <draft>   # or:  printf '%s' "$draft" | node scripts/ai-stench-check.mjs -
+   ```
+3. **If exit 1** (any HIGH marker, for example an em dash or the "it's not X, it's Y" cadence
+   or the LLM lexicon): read `hits[]`, rewrite ONLY the flagged spans in human voice, then
+   re-run. Loop until exit 0. Do NOT rationalize a near miss; the exit code is the gate, not
+   your opinion of it.
+4. **Only on exit 0** does the announcement cross into Phase 6. Emit `forge.herald.stench_gated`
+   with `{scope, high: 0, verdict: "honored"}`.
+
+### Phase 6: Deliver
+
+1. Copy final announcement to clipboard (`pbcopy`)
+2. Present in conversation for review
+3. Archive to `grimoires/herald/announcements/{date}-{scope}.md` with metadata:
+
+```markdown
+---
+date: {ISO date}
+scope: {what changed}
+type: {removal|release|structural}
+voice: {voice.md hash or "defaults"}
+principles: {principles.md hash or "defaults"}
+evidence:
+  commits: [{hashes}]
+  files_read: [{paths}]
+  dates_verified: true
+---
+
+{announcement text}
+```
+
+## Counterfactuals
+
+### The Target (Grounded, Verifiable)
+
+```
+we have initiated the self-destruction of the following apps from the henlo arcade.
+
+these shipped with the arcade in september. vault and lock earned BGT and oBERO
+through AquaBera and Beradrome. wall turned liquidity deposits into a community
+brick feed. incineraffle and casting never left the lobby.
+
+berachain's POL update removed the reward flows these depended on. rather than
+patch around it, we're removing them.
+```
+
+Every claim is verifiable. Dates from git. Descriptions from code. Reason is a named external event. Unshipped features called out honestly.
+
+### The Near Miss (Sounds Right, But Wrong)
+
+```
+after careful consideration, we've decided to sunset several arcade features
+as we streamline the henlo experience for the next chapter.
+```
+
+"Careful consideration" is vague. "Streamline" is corporate. "Next chapter" is forward-looking. None of it is grounded. It reads like every other project sunset announcement because it's not built from evidence.
+
+### The Category Error (Catastrophic)
+
+```
+we're removing some features now but trust us, what's coming next is going to
+blow your minds. we've been cooking something huge. stay tuned.
+```
+
+This converts a neutral announcement into a forward-looking promise. Six months later, if "what's coming" hasn't shipped, this screenshot becomes evidence of another broken promise. This is the exact pattern that destroys team credibility over time.
+
+## Quick Reference
+
+```
+LOAD:
+  voice.md           <- tone, vocabulary, register, rhythm
+  principles.md      <- "we say" / "we never say" constraints
+
+RESEARCH:
+  git log dates      <- never guess dates
+  read components    <- describe what code does
+  check contracts    <- name integrations accurately
+  find the "why"     <- external reasons > internal feelings
+
+DRAFT:
+  lead with action   <- what happened, first sentence
+  ground in history  <- when it shipped, what it did
+  name the reason    <- concrete, external, verifiable
+  practical actions  <- what users need to do now
+  itemize changes    <- one line per item, past tense for removed
+
+VALIDATE:
+  principles check   <- every sentence against constraints
+  voice check        <- tone, vocabulary, banned words
+  evidence check     <- every claim traceable to git/code
+
+NEVER:
+  forward-look       <- the future announces itself when it ships
+  hype               <- no "stay tuned," no "something big"
+  apologize          <- curation is not failure
+  hedge              <- "unfortunately" is banned
+  promise            <- words don't ship, code does
+```

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/skills/synthesizing-voice/SKILL.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/skills/synthesizing-voice/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: synthesizing-voice
+description: Extract voice profile from existing content into voice.md
+user-invocable: true
+aliases:
+  - synthesize-voice
+allowed-tools: Read, Write, Glob, Grep, Edit, AskUserQuestion
+---
+
+# Synthesizing Voice
+
+Extract a communication voice profile from existing announcements, community posts, or team messages. Produces `contexts/voice/voice.md` — the upstream artifact that grounding-announcements reads before writing any copy.
+
+## Trigger
+
+```
+/synthesize-voice [content source]
+```
+
+Content sources: Discord messages, announcement drafts, team communication, URLs, or pasted text.
+
+## Overview
+
+Voice is upstream of announcements. Like taste.md is upstream of component styling, voice.md is upstream of all outbound communication. Every announcement, update, and community message should express the same voice consistently.
+
+This skill reverse-engineers voice from existing content rather than asking the user to define it from scratch.
+
+## Workflow
+
+### Phase 1: Gather Source Material
+
+Collect content to analyze. Sources in priority order:
+
+1. **User-provided content** — Pasted messages, URLs, files
+2. **Existing announcements** — `grimoires/herald/announcements/*.md`
+3. **Git commit messages** — `git log --oneline -50` for team writing patterns
+4. **README/docs** — Project documentation tone
+
+Minimum: 3 content samples. Ideal: 8-12 for reliable pattern extraction.
+
+### Phase 2: Analyze Across 5 Dimensions
+
+For each content sample, extract:
+
+**1. Register**
+- Capitalization pattern (lowercase, Title Case, UPPERCASE for emphasis)
+- Formality level (formal, casual-direct, slang-heavy)
+- Perspective (first-person-plural "we", impersonal, direct address "you")
+- Sentence structure (fragments allowed? questions used?)
+
+**2. Vocabulary**
+- Preferred terms (what words recur across samples?)
+- Avoided terms (what's conspicuously absent?)
+- Domain jargon (crypto-native? DeFi-specific? general tech?)
+- Filler patterns (do they use "basically," "essentially," "just"?)
+
+**3. Tone**
+- Emotional range (neutral, enthusiastic, dry, urgent)
+- Humor usage (none, dry/occasional, frequent)
+- Confidence expression (hedged, matter-of-fact, assertive)
+- How bad news lands (direct, softened, reframed)
+- How good news lands (understated, celebrated, matter-of-fact)
+
+**4. Rhythm**
+- Average sentence length (short/medium/long)
+- Paragraph density (1-2 sentences? 3-5?)
+- Use of lists vs prose
+- Information order (action-first? context-first? thesis-first?)
+- Closer patterns (sign-off style, call-to-action, philosophical)
+
+**5. Audience Adaptation**
+- Who are they writing to? (holders, community, general public)
+- What assumptions about reader knowledge?
+- How much context is provided vs assumed?
+- How are action items delivered? (embedded, separate section, bold)
+
+### Phase 3: Pattern Resolution
+
+Cross-reference patterns across samples. For each dimension:
+
+1. **Identify consensus** — Patterns present in 70%+ of samples
+2. **Identify tensions** — Contradictory patterns between samples
+3. **Resolve tensions** — Ask user via AskUserQuestion if critical
+
+```
+REGISTER ANALYSIS (8 samples):
+  lowercase: 7/8 (87%) → CONSENSUS
+  first-person-plural: 6/8 (75%) → CONSENSUS
+  fragments: 4/8 (50%) → TENSION — ask user
+
+  ? "Your writing sometimes uses sentence fragments ('henlo is ded.') and
+     sometimes full sentences. Which do you prefer for announcements?"
+  [A] Fragments OK — adds punch
+  [B] Full sentences — clearer communication
+  [C] Mix — fragments for closers, full sentences for info
+```
+
+### Phase 4: Generate voice.md
+
+Write to `contexts/voice/voice.md`:
+
+```markdown
+# Voice Profile
+
+Generated: {date}
+Source: {N} samples analyzed
+Confidence: {HIGH|MEDIUM|LOW per dimension}
+
+## Register
+
+- style: {lowercase|title-case|mixed}
+- formality: {formal|casual-direct|slang}
+- perspective: {first-person-plural|impersonal|direct-address}
+- fragments: {yes|no|closers-only}
+
+## Vocabulary
+
+### Preferred Terms
+| Instead of | Use | Source |
+|-----------|-----|--------|
+| {formal term} | {preferred term} | {sample reference} |
+
+### Banned Words
+- {word} — {reason}
+
+### Domain Terms
+- {term}: {how it's used in this voice}
+
+## Tone
+
+- emotional_range: {neutral|dry|warm}
+- humor: {none|dry-occasional|frequent}
+- confidence: {hedged|matter-of-fact|assertive}
+- on_bad_news: {direct|softened|reframed}
+- on_good_news: {understated|brief|celebrated}
+
+## Rhythm
+
+- sentences: {short|medium|varied}
+- paragraphs: {N-N sentences}
+- structure: {action-first|context-first|thesis-first}
+- lists: {preferred|occasional|rare}
+- closer: {philosophical|call-to-action|sign-off|none}
+
+## Audience
+
+- primary: {holders|community|public}
+- assumed_knowledge: {high|medium|low}
+- context_level: {minimal|moderate|thorough}
+- action_items: {embedded|separate-section|bold-inline}
+```
+
+### Phase 5: Generate principles.md (if not exists)
+
+If `contexts/voice/principles.md` doesn't exist, prompt the user:
+
+```
+Voice profile created. Do you have communication principles or
+constraints to capture? These are non-negotiable rules — things
+you never say, promises you never make, patterns to avoid.
+
+Examples:
+- "Never mention unshipped features"
+- "Never apologize for removing things"
+- "Always include withdrawal deadlines"
+```
+
+Generate `contexts/voice/principles.md` from their input using the "We Say" / "We Never Say" structure.
+
+### Phase 6: Validate
+
+- [ ] voice.md has all 5 dimensions populated
+- [ ] Each dimension has a confidence level
+- [ ] Banned words have reasons
+- [ ] Preferred terms have source references
+- [ ] principles.md exists (generated or default)
+- [ ] No assumptions made without evidence from samples
+
+## Refinement
+
+Voice evolves. When re-running `/synthesize-voice`:
+
+1. Read existing `voice.md`
+2. Analyze new content samples
+3. Diff patterns against existing profile
+4. Present changes for approval before overwriting
+5. Log changes to `grimoires/herald/feedback/voice-evolution.jsonl`
+
+```jsonl
+{"date":"2026-02-23","dimension":"vocabulary","change":"added 'cozy kitchen' to preferred terms","source":"arcade-sunset-announcement","confidence":"HIGH"}
+```


### PR DESCRIPTION
## What

The first cert-loop **theatre** ratified on [echelon-core#178](https://github.com/AITOBIAS04/echelon-core/issues/178): the deterministic C1–C9 admission rubric plus the three bundles it grades.

| Bundle | Score | Fails | Why |
|---|---|---|---|
| `gecko` | **9/9** | — | the reference grounded construct |
| `herald` | **8/9** | C7 | ships no `identity/environment.md` — honest absence stub |
| `gecko-broken` | **6/9** | C3, C4, C8 | injected: `model_tier: quantum` · Write via read-only `agent: Explore` · tampered genome link |

- `evals/environment-design/construct-rubric.py` — the rubric IS this file: `rubric_hash = sha256:c181978e…d52af9df` of its committed bytes, carried in every `registration.json`. model_tier vocabulary read live from the model-config SoT; genome links recompute over `loa_cheval.jcs`.
- `grimoires/loa/a2a/external/gv6-ring1-bundles/` — the three bundles + machine-readable `grades/*.json`, mirroring Echelon's a2a/external publication pattern (their PR #249). `.gitignore` gains an un-ignore for `a2a/external/` (durable cross-org publications, not transient sprint artifacts).

## Disclosures (structural)

- `proof-of-run.json` carries `verifier_type: self_baseline_bundle_recompute` — the Echelon §6.6 `frozen_replay_baseline` pattern. C9 makes `verifier_type` REQUIRED: synthetic is admissible, undisclosed synthetic is not.
- Genome chains are fabricated 2-link exemplars (neither construct ships in-repo LEARNINGS.jsonl yet); they exercise the verifier, not earned authority.
- `gecko-broken` registers under a distinct slug while its manifest keeps `slug: gecko` (it *is* a tampered gecko copy — that's the theatre).

Depends conceptually on #435 (Ring 0 parity gate) but is mergeable independently. Domain: **shared**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)