### PR TITLE
feat(shared/evals): theatre refresh — herald 8/9 → 9/9 (C7 grounding, G-4)

### DIFF
--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/README.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/README.md
@@ -8,7 +8,7 @@ the reference construct, a mid-tier construct, and a deliberately broken one.
 | Bundle | Source | Score (C1–C9) | Fails | Why |
 |---|---|---|---|---|
 | `gecko/` | construct-gecko (the reference grounded construct) | **9/9** | — | reference-grade; its `reality.md` IS the `identity/environment.md` shape |
-| `herald/` | construct-herald | **8/9** | C7 | ships no `identity/environment.md`; `reality.md` is an honest absence stub |
+| `herald/` | construct-herald | **9/9** | — | grounded 2026-07-03 (C7 rollout): real thin-layer `identity/environment.md` citing the shared ground; was 8/9 pre-grounding |
 | `gecko-broken/` | gecko copy + 3 injections | **6/9** | C3, C4, C8 | invented `model_tier: quantum` · Write-capability routed through read-only `agent: Explore` · genome link 1 tampered post-mint (see its `INJECTIONS.md`) |
 
 ## The rubric

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/grades/herald.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/grades/herald.json
@@ -1,7 +1,7 @@
 {
   "bundle": "herald",
-  "score": "8/9",
-  "passed": 8,
+  "score": "9/9",
+  "passed": 9,
   "rubric_hash": "sha256:1374c7c445d8ab756e751160bb76e67f91f2cceaf4e56ba54fee3af9693ce370",
   "checks": [
     {
@@ -43,8 +43,8 @@
     {
       "check_id": "C7",
       "name": "grounding_file_exists",
-      "status": "fail",
-      "reason": "reality.md is an honest absence stub \u2014 no grounding file in source"
+      "status": "pass",
+      "reason": "reality.md present"
     },
     {
       "check_id": "C8",

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/EXPECTED.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/EXPECTED.md
@@ -1,4 +1,4 @@
-# EXPECTED — mid-tier bundle (herald) · 8/9
+# EXPECTED — mid-tier bundle (herald) · 9/9 (grounded 2026-07-03)
 
 Source: `construct-herald` (schema_version 3, slug `herald`, v0.1.0).
 Picked as the mid-tier exemplar: clean manifest + valid tier, fails **only** the
@@ -14,8 +14,8 @@ common ~8/9 shape flagged in the task.
 | 4 | write cap never routes through read-only agent type | PASS | `synthesizing-voice` declares `Write` but pins no `agent:`; no read-only agent type anywhere. |
 | 5 | capability declarations match toolset | PASS | `requires.tool_calling: true` matches Bash/Read/Write; `vision: false`, none used. |
 | 6 | skill prose uses canonical primitives | PASS | No `bd`; `git log --grep` is a git commit-message flag, not a code-search `grep`/`rg`. No task tracking. |
-| 7 | grounding file exists (reality.md axis) | **FAIL** | construct-herald has **no** `identity/environment.md`. `reality.md` here is an honest absence stub — no harness-grounding axis document exists to carry. |
+| 7 | grounding file exists (reality.md axis) | PASS | herald grounded in the C7 rollout (construct-herald@1886d07): thin construct-specific layer citing the shared ground (loa-constructs/docs/the-ground.md), probe manifest included. The 8/9→9/9 flip is the live demonstration that grounding moves the cert score. |
 | 8 | genome hash chain verifies | PASS | Fabricated valid 2-link `genome.jsonl`; recomputes; parent links match. |
 | 9 | proof-of-run valid_run verdict | PASS | `proof-of-run.json` verdict `valid_run`; content_hash recomputes. |
 
-**Expected score: 8/9 — fails check 7 (missing grounding file).**
+**Expected score: 9/9.** (Was 8/9 before the grounding rollout — C7 was the only gap.)

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/HASHING.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/HASHING.md
@@ -17,10 +17,10 @@ Sidecars excluded: genome.jsonl, proof-of-run.json, registration.json, HASHING.m
 a915a9cbeb167b65660443acf0c2876ac6382c9abb28bc2b3e62de8378c4b2a3  SKILL.md
 82e8b2fb7baf99f49c5c2ea8210d26b571e69ac1b88d3071eaa54f7beabe4c8b  handoff.md
 0d1ccdbbb5d3c1bb4d977dd7aae79d9690aba2bbc2208334d21158b92254e402  manifest.json
-e1055a50be04a6dfb455df8bcda3249ee2e02300935fb274067fd066c6465263  reality.md
+383309dbce4be33721af90d25c90fe1620c1038db07d649f41573c1cf441d15b  reality.md
 bc4d8c1e07c4af5cb9089fdd57018890c17c780fc4977fb378a15731acfdfcc3  skills/chronicling-changes/SKILL.md
 a915a9cbeb167b65660443acf0c2876ac6382c9abb28bc2b3e62de8378c4b2a3  skills/grounding-announcements/SKILL.md
 cfcbc7e3d70b93937bc995b91402efa5cdd669295165ed0876871835324b75f8  skills/synthesizing-voice/SKILL.md
 ```
 
-content_hash = `80f611e491d62d6ad2389b9394e8d57c22adc97cc926f9fc9572578e5065f1ce`
+content_hash = `486d3e35a047b19dcacbc7281a8dc2ac8c8d3d83e3139e66ca9aedc4c8a82d05`

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/proof-of-run.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/proof-of-run.json
@@ -3,7 +3,7 @@
   "verdict": "valid_run",
   "ran_at": "2026-07-03T00:05:00Z",
   "runner": "ring1-theatre-bundler",
-  "content_hash_verified": "80f611e491d62d6ad2389b9394e8d57c22adc97cc926f9fc9572578e5065f1ce",
+  "content_hash_verified": "486d3e35a047b19dcacbc7281a8dc2ac8c8d3d83e3139e66ca9aedc4c8a82d05",
   "note": "SELF-BASELINE (the Echelon frozen_replay_baseline pattern, disclosed structurally via verifier_type): no governed compose-verify run was minted for this bundle; this attests only that the bundle assembled deterministically and its content_hash recomputes. Genome chains for gecko/herald are FABRICATED 2-link exemplars (neither construct ships an in-repo LEARNINGS.jsonl yet) \u2014 they exercise the verifier, they do not represent earned authority.",
   "genome_chain_ok": true,
   "verifier_type": "self_baseline_bundle_recompute"

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/reality.md
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/reality.md
@@ -1,7 +1,52 @@
-# reality.md — ABSENT IN SOURCE
+# The Ground HERALD Stands On
 
-construct-herald ships NO `identity/environment.md` grounding file.
-Its `identity/` directory holds only `HERALD.md`, `persona.yaml`, and
-`expertise.yaml`. Per rubric check #7 (grounding file exists — reality.md
-axis), this bundle FAILS: there is no harness-grounding axis document to
-carry. This stub records the absence honestly rather than fabricating one.
+> Shared ground: https://github.com/0xHoneyJar/loa-constructs/blob/main/docs/the-ground.md
+> — this file carries ONLY the herald-specific layer. Tiers, forks, agent
+> types, frontmatter contracts, and gate design live THERE, not here.
+> Probed from the live harness at construct-herald @ 3e8e4e8, 2026-07-03.
+
+## 1. Runtime contract (probed)
+
+| Axis | Value | Source |
+|---|---|---|
+| model_tier | sonnet | construct.yaml:59 |
+| danger_level | moderate | construct.yaml:60 |
+| effort_hint | medium | construct.yaml:61 |
+| downgrade_allowed | **true** (ceiling, not pin — routing may go cheaper) | construct.yaml:62 |
+| execution_hint | sequential | construct.yaml:63 |
+| requires | tool_calling: true · vision: false | construct.yaml:65,67 |
+| workflow.gates | **none** — herald owns no pipeline; its writes ride the caller's gates | construct.yaml (absent) |
+| agent dispatch | no skill sets `agent:` — all inherit the caller (the safe default) | skills/*/SKILL.md frontmatter |
+| chronicling-changes tools | Read, Glob, Grep, Bash, Task (read-only + fan-out) | skills/chronicling-changes/SKILL.md:7 |
+| grounding-announcements tools | Read, Glob, Grep, Bash, Task, **Edit** (write-capable) | skills/grounding-announcements/SKILL.md:8 |
+| synthesizing-voice tools | Read, **Write**, Glob, Grep, **Edit**, AskUserQuestion (write-capable) | skills/synthesizing-voice/SKILL.md:7 |
+
+A coherent declaration: sonnet + downgrade:true + effort:medium is the honest
+middle of the ladder for evidence-grounded writing work — no opus pin, no
+apology needed.
+
+## 2. Capability-reality edges
+
+- **#553 class: CLEAN.** Two skills carry write tools (grounding-announcements,
+  synthesizing-voice) and neither sets `agent:` — both inherit the caller, so
+  the silent-output-drop conflict cannot occur here. (Probed: zero `agent:`
+  keys across skills/*/SKILL.md.)
+- **Deny-all edge (real, surfaced):** no skill declares a `capabilities:` block
+  (`write_files` absent everywhere). Under the shared ground's §IV deny-all
+  default, capability is carried by `allowed-tools` alone. A runtime that
+  enforces `capabilities.write_files` strictly would silently deny
+  synthesizing-voice's Write — the exact silent-drop shape, from the OTHER
+  contract altitude. This is a SMELL, not a conflict: the two declaration
+  layers don't contradict, one is simply absent.
+- **Evidence discipline is the identity edge:** every herald skill grounds
+  claims in git evidence (commits, PRs) — its writes are copy artifacts
+  (announcements, voice profiles, timelines), never source code. The runtime
+  contract matches: no gates owned, sequential, mid-tier.
+
+## 3. What HERALD does with the ground
+
+herald is the town crier who reads the ledger before ringing the bell: every
+announcement traces to a real commit or PR. the ground it needs is thin —
+mid-tier reasoning, read-heavy tools, a pen for the announcement itself. it
+asks for exactly that and nothing more: no pinned opus, no owned gates, no
+agent-type games. when the bell rings, the provenance is already in hand.

--- a/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/registration.json
+++ b/grimoires/loa/a2a/external/gv6-ring1-bundles/herald/registration.json
@@ -2,7 +2,7 @@
   "bundle_schema_version": "1.0.0",
   "slug": "herald",
   "version": "0.1.0",
-  "content_hash": "80f611e491d62d6ad2389b9394e8d57c22adc97cc926f9fc9572578e5065f1ce",
+  "content_hash": "486d3e35a047b19dcacbc7281a8dc2ac8c8d3d83e3139e66ca9aedc4c8a82d05",
   "skill_manifest": [
     {
       "command": "grounding-announcements",


### PR DESCRIPTION
The live demonstration that grounding moves the cert score: herald's bundle now carries its REAL `identity/environment.md` (landed on construct-herald main @ 1886d07 in the C7 rollout), regrades **9/9** (was 8/9, C7-only gap).

Delta is surgically narrow for Echelon's recompute: **rubric byte-unchanged** (`sha256:1374c7c4…93ce370`), one `content_hash` moved (`80f611e4…` → `486d3e35…`), one check flipped. EXPECTED.md + README updated with the before/after.

Part of `cycle-construct-grounding-c7` Sprint 408; repost to echelon-core#178 follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)