### PR TITLE
fix(platform/ordering): hardening slice — choke-point health gate, slug guard, persistent-404 backstop (#441)

### DIFF
--- a/packages/services/ordering/bin/fulfillment-orchestrator.ts
+++ b/packages/services/ordering/bin/fulfillment-orchestrator.ts
@@ -6,6 +6,7 @@
  * explicitly deployed; env-config is reused from the intake service.
  */
 import { createFulfillmentOrchestratorWorker, orchestratorEnabled } from '../src/composition.js';
+import { reprobeIntervalMs } from '../src/reprobe-worker.js';
 
 if (!orchestratorEnabled()) {
   // eslint-disable-next-line no-console
@@ -17,7 +18,7 @@ const worker = await createFulfillmentOrchestratorWorker();
 worker.start();
 
 // eslint-disable-next-line no-console
-console.log(`fulfillment-orchestrator started (interval ${process.env.KITCHEN_REPROBE_INTERVAL_SEC ?? 900}s)`);
+console.log(`fulfillment-orchestrator started (interval ${reprobeIntervalMs() / 1000}s)`);
 
 process.on('SIGTERM', () => worker.stop());
 process.on('SIGINT', () => worker.stop());

--- a/packages/services/ordering/src/__tests__/community-onboarding-orchestrator.test.ts
+++ b/packages/services/ordering/src/__tests__/community-onboarding-orchestrator.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { ORDER_LIFECYCLE_SUBJECTS, INITIAL_COMMUNITY_ONBOARDING_INGREDIENTS } from '@freeside/ordering-protocol';
 import { OrderOrchestrator } from '../orchestrator.js';
 import { InMemoryOrderStore, type NewOrder } from '../store.js';
 import { ConfigCapabilityResolver, type CapabilityConfig } from '../resolver.js';
 import { StubTriagePorts } from '../triage-ports.js';
-import { canFulfillCommunityOnboarding, mergeProbedIngredients } from '../community-onboarding-orchestrator.js';
+import { canFulfillCommunityOnboarding, CommunityOnboardingOrchestrator, mergeProbedIngredients } from '../community-onboarding-orchestrator.js';
 import type { AuditPort } from '../audit-acl.js';
 import type { AuditServiceResult } from '@freeside/shadow-audit-service';
 import type { Cta } from '@freeside/shadow-audit-protocol';
@@ -172,5 +172,70 @@ describe('canFulfillCommunityOnboarding — metadata_snapshot gate (T-5)', () =>
 
   it('returns true when metadata_snapshot is optional (NF-6 disabled path)', () => {
     expect(canFulfillCommunityOnboarding({ ...base, metadata_snapshot: 'optional' }, fulfillment)).toBe(true);
+  });
+});
+
+// ── T-2: discord health gate in advanceIngredient (AC-3, AC-4) ────────────────
+
+function discordAdvanceHarness(discordHealth?: {
+  checkChannelHealth(chainId: string, contract: string): Promise<{ healthy: boolean; reason?: string }>;
+}) {
+  const store = new InMemoryOrderStore({ now: () => 1_700_000_000 });
+  const orchestrator = new CommunityOnboardingOrchestrator({
+    store,
+    resolver: new ConfigCapabilityResolver(TRIAGE_CAPS),
+    triage: new StubTriagePorts(),
+    now: () => 1_700_000_000_000,
+    discordHealth,
+  });
+  return { store, orchestrator };
+}
+
+async function placedAndProducing(store: ReturnType<typeof harness>['store'], orchestratorInstance: InstanceType<typeof CommunityOnboardingOrchestrator>) {
+  await store.placeOrder(communityOrder('ord_dc_1'), {
+    subject: ORDER_LIFECYCLE_SUBJECTS.placed,
+    payload: { order_id: 'ord_dc_1', product: 'community-onboarding', inputs_digest: 'b'.repeat(64) },
+  });
+  await orchestratorInstance.process('ord_dc_1', (await store.get('ord_dc_1'))!);
+  return store.get('ord_dc_1');
+}
+
+describe('CommunityOnboardingOrchestrator — discord health gate in advanceIngredient (T-2, AC-3, AC-4)', () => {
+  it('AC-3: advanceIngredient discord_observer→complete with unhealthy port returns ok:false and does not patch the store', async () => {
+    const spy = vi.fn().mockResolvedValue({ healthy: false, reason: 'channel archived' });
+    const { store, orchestrator } = discordAdvanceHarness({ checkChannelHealth: spy });
+    const initial = new InMemoryOrderStore({ now: () => 1_700_000_000 });
+    // Use own store, orchestrator has its own store.
+    await store.placeOrder(communityOrder('ord_dc_1'), {
+      subject: ORDER_LIFECYCLE_SUBJECTS.placed,
+      payload: { order_id: 'ord_dc_1', product: 'community-onboarding', inputs_digest: 'b'.repeat(64) },
+    });
+    await orchestrator.process('ord_dc_1', (await store.get('ord_dc_1'))!);
+    const recordBefore = await store.get('ord_dc_1');
+
+    const result = await orchestrator.advanceIngredient('ord_dc_1', 'discord_observer', 'complete');
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('discord channel-health check failed');
+    // Store must be IDENTICAL before and after the rejected advance.
+    const recordAfter = await store.get('ord_dc_1');
+    expect(recordAfter?.ingredients).toEqual(recordBefore?.ingredients);
+    expect(recordAfter?.operator_audit).toEqual(recordBefore?.operator_audit);
+    void initial;
+  });
+
+  it('AC-4: advanceIngredient discord_observer→optional passes unconditionally (no health check)', async () => {
+    const spy = vi.fn();
+    const { store, orchestrator } = discordAdvanceHarness({ checkChannelHealth: spy });
+    await store.placeOrder(communityOrder('ord_dc_2'), {
+      subject: ORDER_LIFECYCLE_SUBJECTS.placed,
+      payload: { order_id: 'ord_dc_2', product: 'community-onboarding', inputs_digest: 'b'.repeat(64) },
+    });
+    await orchestrator.process('ord_dc_2', (await store.get('ord_dc_2'))!);
+
+    const result = await orchestrator.advanceIngredient('ord_dc_2', 'discord_observer', 'optional');
+
+    expect(result.ok).toBe(true);
+    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/packages/services/ordering/src/__tests__/fulfillment-orchestrator-wiring.test.ts
+++ b/packages/services/ordering/src/__tests__/fulfillment-orchestrator-wiring.test.ts
@@ -94,6 +94,7 @@ async function wiringHarness(
     resolver: new ConfigCapabilityResolver(TRIAGE_CAPS),
     triage,
     now: () => NOW_MS,
+    discordHealth: opts?.discordHealth,  // T-2: gate lives in advanceIngredient
   });
   await store.placeOrder(order(), {
     subject: ORDER_LIFECYCLE_SUBJECTS.placed,

--- a/packages/services/ordering/src/__tests__/fulfillment-orchestrator.test.ts
+++ b/packages/services/ordering/src/__tests__/fulfillment-orchestrator.test.ts
@@ -477,17 +477,21 @@ describe('FulfillmentOrchestrator — discord channel-health gate (T-4)', () => 
 
   // ── AC-1: spy called exactly once (gate is in advanceIngredient) ─────────────
   it('AC-1: checkChannelHealth spy called once before orchestrator.advance for discord_observer', async () => {
-    const spy = vi.fn().mockResolvedValue({ healthy: true });
+    // ONE ordered log for both the health check and the emitted events, so the
+    // before-relation is actually asserted (not merely both-happened).
+    const callOrder: string[] = [];
+    const spy = vi.fn().mockImplementation(async () => {
+      callOrder.push('HEALTH_CHECK');
+      return { healthy: true };
+    });
     const { store, orchestrator } = await discordHarness({
       discordStatus: 'complete',
       discordHealth: { checkChannelHealth: spy },
     });
-    const eventsBeforeAdvance: string[] = [];
-    // Track order of events by intercepting emit — proxy the store's appendEvent.
-    const callOrder: string[] = [];
     const origAppend = store.appendEvent.bind(store);
     store.appendEvent = async (orderId, event) => {
-      callOrder.push(event.subject as string);
+      const ingredient = (event.payload as { ingredient?: string } | undefined)?.ingredient;
+      callOrder.push(`${event.subject as string}:${ingredient ?? '-'}`);
       return origAppend(orderId, event);
     };
 
@@ -495,11 +499,11 @@ describe('FulfillmentOrchestrator — discord channel-health gate (T-4)', () => 
 
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith('8453', CONTRACT);
-    const advIdx = callOrder.indexOf(ORCHESTRATOR_SUBJECTS.advance);
-    // Spy was called before the advance event was emitted (verified via call ordering).
+    const healthIdx = callOrder.indexOf('HEALTH_CHECK');
+    const advIdx = callOrder.indexOf(`${ORCHESTRATOR_SUBJECTS.advance}:discord_observer`);
+    expect(healthIdx).toBeGreaterThanOrEqual(0);
     expect(advIdx).toBeGreaterThanOrEqual(0);
-    expect(callOrder.some((s) => s === ORCHESTRATOR_SUBJECTS.advance)).toBe(true);
-    void eventsBeforeAdvance; // silence lint
+    expect(healthIdx).toBeLessThan(advIdx);
   });
 
   // ── AC-2: healthy=false → no advance, escalate instead ──────────────────────
@@ -541,19 +545,24 @@ describe('FulfillmentOrchestrator — canonicalSlug guard (T-1, AC-6, AC-7)', ()
   });
 
   it('AC-7: successful worlds dispatch (ok=true) correctly populates canonicalSlug', async () => {
-    const dispatch = new FakeDispatch('real-slug', undefined);
+    // Adoption is observable via slug_divergence: score dispatch returns a DIFFERENT
+    // slug in the same tick, so the divergence event can only fire if the worlds slug
+    // was actually adopted into canonicalSlug (previously this test asserted nothing
+    // beyond "worlds was dispatched" — FAGAN vacuity finding).
+    const dispatch = new FakeDispatch('real-slug', 'other-slug');
     const triage = new MutableTriage();
     triage.worldsStatus = 'in_progress';
     const { store, orchestrator } = await producingHarness({ triage, dispatch });
     triage.worldsStatus = 'pending';
-    triage.scoreStatus = 'complete';
+    triage.scoreStatus = 'pending';
     triage.sonarStatus = 'complete';
 
     await orchestrator.processOrder('ord_fo');
-    // worlds dispatched and returned real-slug — should be adopted (mark in_progress, no slug in store yet,
-    // but next tick after worlds complete the fulfillment would carry it).
-    // Verify no rogue-slug was adopted via the dispatch log.
     expect(dispatch.calls).toContain('worlds_manifest');
+    const divergences = await eventsOfKind(store, ORCHESTRATOR_SUBJECTS.slug_divergence);
+    expect(divergences).toHaveLength(1);
+    expect((divergences[0] as { worlds_slug?: string }).worlds_slug).toBe('real-slug');
+    expect((divergences[0] as { score_slug?: string }).score_slug).toBe('other-slug');
   });
 });
 

--- a/packages/services/ordering/src/__tests__/fulfillment-orchestrator.test.ts
+++ b/packages/services/ordering/src/__tests__/fulfillment-orchestrator.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   ORDER_LIFECYCLE_SUBJECTS,
   INITIAL_COMMUNITY_ONBOARDING_INGREDIENTS,
@@ -378,11 +378,14 @@ async function discordHarness(opts: {
   triage.shadowStatus = 'in_progress'; // operator not yet approved — shadow gate holds
 
   const store = new InMemoryOrderStore({ now: () => 1_700_000_000 });
+  // T-2: discord health gate lives in advanceIngredient — wire discordHealth to
+  // CommunityOnboardingOrchestrator, not just to FulfillmentOrchestrator.
   const onboarding = new CommunityOnboardingOrchestrator({
     store,
     resolver: new ConfigCapabilityResolver(TRIAGE_CAPS),
     triage,
     now: () => NOW_MS,
+    discordHealth: opts.discordHealth,
   });
   await store.placeOrder(order(), {
     subject: ORDER_LIFECYCLE_SUBJECTS.placed,
@@ -403,7 +406,7 @@ async function discordHarness(opts: {
     now: () => NOW_MS,
     discordHealth: opts.discordHealth,
   });
-  return { store, orchestrator };
+  return { store, orchestrator, onboarding };
 }
 
 describe('FulfillmentOrchestrator — discord channel-health gate (T-4)', () => {
@@ -470,6 +473,218 @@ describe('FulfillmentOrchestrator — discord channel-health gate (T-4)', () => 
     await orchestrator.processOrder('ord_fo');
     await orchestrator.processOrder('ord_fo');
     expect(await eventsOfKind(store, ORCHESTRATOR_SUBJECTS.escalate)).toHaveLength(1);
+  });
+
+  // ── AC-1: spy called exactly once (gate is in advanceIngredient) ─────────────
+  it('AC-1: checkChannelHealth spy called once before orchestrator.advance for discord_observer', async () => {
+    const spy = vi.fn().mockResolvedValue({ healthy: true });
+    const { store, orchestrator } = await discordHarness({
+      discordStatus: 'complete',
+      discordHealth: { checkChannelHealth: spy },
+    });
+    const eventsBeforeAdvance: string[] = [];
+    // Track order of events by intercepting emit — proxy the store's appendEvent.
+    const callOrder: string[] = [];
+    const origAppend = store.appendEvent.bind(store);
+    store.appendEvent = async (orderId, event) => {
+      callOrder.push(event.subject as string);
+      return origAppend(orderId, event);
+    };
+
+    await orchestrator.processOrder('ord_fo');
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith('8453', CONTRACT);
+    const advIdx = callOrder.indexOf(ORCHESTRATOR_SUBJECTS.advance);
+    // Spy was called before the advance event was emitted (verified via call ordering).
+    expect(advIdx).toBeGreaterThanOrEqual(0);
+    expect(callOrder.some((s) => s === ORCHESTRATOR_SUBJECTS.advance)).toBe(true);
+    void eventsBeforeAdvance; // silence lint
+  });
+
+  // ── AC-2: healthy=false → no advance, escalate instead ──────────────────────
+  it('AC-2: healthy=false emits orchestrator.escalate and no advance for discord_observer', async () => {
+    const spy = vi.fn().mockResolvedValue({ healthy: false, reason: 'channel closed' });
+    const { store, orchestrator } = await discordHarness({
+      discordStatus: 'complete',
+      discordHealth: { checkChannelHealth: spy },
+    });
+    await orchestrator.processOrder('ord_fo');
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const advances = await eventsOfKind(store, ORCHESTRATOR_SUBJECTS.advance);
+    expect(advances.some((a) => (a as { ingredient?: string }).ingredient === 'discord_observer')).toBe(false);
+    const escalations = await eventsOfKind(store, ORCHESTRATOR_SUBJECTS.escalate);
+    expect(escalations.some((e) => (e as { ingredient?: string }).ingredient === 'discord_observer')).toBe(true);
+  });
+});
+
+// ── T-1: canonicalSlug guard (AC-6, AC-7) ──────────────────────────────────
+
+class FailDispatch implements FulfillmentDispatchPort {
+  async ingestSonar(): Promise<DispatchResult> { return { ok: true }; }
+  async registerScore(): Promise<DispatchResult> { return { ok: true }; }
+  async manifestWorlds(): Promise<DispatchResult> { return { ok: false, world_slug: 'rogue-slug' }; }
+}
+
+describe('FulfillmentOrchestrator — canonicalSlug guard (T-1, AC-6, AC-7)', () => {
+  it('AC-6: failed worlds dispatch (ok=false) does NOT adopt its world_slug as canonicalSlug', async () => {
+    const triage = new MutableTriage();
+    triage.worldsStatus = 'in_progress';
+    const { store, orchestrator } = await producingHarness({ triage, dispatch: new FailDispatch() });
+    triage.worldsStatus = 'pending'; // next probe returns pending so dispatch fires
+
+    // worlds returns ok:false with world_slug='rogue-slug' — must NOT be adopted.
+    await orchestrator.processOrder('ord_fo');
+    const record = await store.get('ord_fo');
+    expect(record?.fulfillment?.world_slug).not.toBe('rogue-slug');
+  });
+
+  it('AC-7: successful worlds dispatch (ok=true) correctly populates canonicalSlug', async () => {
+    const dispatch = new FakeDispatch('real-slug', undefined);
+    const triage = new MutableTriage();
+    triage.worldsStatus = 'in_progress';
+    const { store, orchestrator } = await producingHarness({ triage, dispatch });
+    triage.worldsStatus = 'pending';
+    triage.scoreStatus = 'complete';
+    triage.sonarStatus = 'complete';
+
+    await orchestrator.processOrder('ord_fo');
+    // worlds dispatched and returned real-slug — should be adopted (mark in_progress, no slug in store yet,
+    // but next tick after worlds complete the fulfillment would carry it).
+    // Verify no rogue-slug was adopted via the dispatch log.
+    expect(dispatch.calls).toContain('worlds_manifest');
+  });
+});
+
+// ── T-3: persistent-404 backstop (AC-8, AC-9, AC-10, AC-11) ────────────────
+
+async function metadataTickHarness(opts: { withMetadataPort: boolean; maxTicks?: number }) {
+  const origEnv = process.env.METADATA_PROBE_MAX_PENDING_TICKS;
+  if (opts.maxTicks !== undefined) {
+    process.env.METADATA_PROBE_MAX_PENDING_TICKS = String(opts.maxTicks);
+  }
+
+  const triage = opts.withMetadataPort ? new TriageWithMeta() : new MutableTriage();
+  if (opts.withMetadataPort) {
+    (triage as TriageWithMeta).metadataStatus = 'pending';
+  }
+  (triage as MutableTriage).sonarStatus = 'in_progress';
+  (triage as MutableTriage).scoreStatus = 'complete';
+  (triage as MutableTriage).worldsStatus = 'in_progress';
+
+  const dispatch = new FullFakeDispatch('azuki', 'azuki');
+  const store = new InMemoryOrderStore({ now: () => 1_700_000_000 });
+  const onboarding = new CommunityOnboardingOrchestrator({
+    store,
+    resolver: new ConfigCapabilityResolver(TRIAGE_CAPS),
+    triage: opts.withMetadataPort ? (triage as TriageWithMeta) : (triage as MutableTriage),
+    now: () => NOW_MS,
+  });
+  await store.placeOrder(order(), {
+    subject: ORDER_LIFECYCLE_SUBJECTS.placed,
+    payload: { order_id: 'ord_fo', product: 'community-onboarding', inputs_digest: 'b'.repeat(64) },
+  });
+  await onboarding.process('ord_fo', (await store.get('ord_fo'))!);
+  const orchestrator = new FulfillmentOrchestrator({
+    store,
+    triage: opts.withMetadataPort ? (triage as TriageWithMeta) : (triage as MutableTriage),
+    onboarding,
+    dispatch,
+    github: null,
+    now: () => NOW_MS,
+    tokenLabel: 'test-token',
+  });
+
+  return { store, orchestrator, dispatch, restoreEnv: () => {
+    if (opts.maxTicks !== undefined) {
+      if (origEnv === undefined) delete process.env.METADATA_PROBE_MAX_PENDING_TICKS;
+      else process.env.METADATA_PROBE_MAX_PENDING_TICKS = origEnv;
+    }
+  }};
+}
+
+describe('FulfillmentOrchestrator — persistent-404 backstop (T-3, AC-8–AC-11)', () => {
+  afterEach(() => {
+    delete process.env.METADATA_PROBE_MAX_PENDING_TICKS;
+  });
+
+  it('AC-8: after N ticks metadata_snapshot self-resolves to optional with advance event', async () => {
+    // maxPendingTicks=2: tick1=dispatch(count→1), tick2=increment(count→2), tick3=self-resolve
+    process.env.METADATA_PROBE_MAX_PENDING_TICKS = '2';
+    const { store, orchestrator } = await metadataTickHarness({ withMetadataPort: true });
+
+    await orchestrator.processOrder('ord_fo'); // tick 1 — dispatch
+    await orchestrator.processOrder('ord_fo'); // tick 2 — increment
+    await orchestrator.processOrder('ord_fo'); // tick 3 — self-resolve
+
+    const record = await store.get('ord_fo');
+    expect(record?.ingredients?.metadata_snapshot).toBe('optional');
+    const advances = await eventsOfKind(store, ORCHESTRATOR_SUBJECTS.advance);
+    expect(advances.some((a) => (a as { ingredient?: string; status?: string }).ingredient === 'metadata_snapshot' && (a as { ingredient?: string; status?: string }).status === 'optional')).toBe(true);
+  });
+
+  it('AC-9: self-resolve operator_audit entry carries persistent-404-self-resolve callerNote', async () => {
+    process.env.METADATA_PROBE_MAX_PENDING_TICKS = '2';
+    const { store, orchestrator } = await metadataTickHarness({ withMetadataPort: true });
+
+    await orchestrator.processOrder('ord_fo');
+    await orchestrator.processOrder('ord_fo');
+    await orchestrator.processOrder('ord_fo');
+
+    const record = await store.get('ord_fo');
+    const audit = record?.operator_audit ?? [];
+    const selfResolve = audit.find((e) => (e as { caller_note?: string }).caller_note === 'fulfillment-orchestrator:persistent-404-self-resolve');
+    expect(selfResolve).toBeDefined();
+  });
+
+  it('AC-10: dispatch fires only once; ticks 2 and 3 emit zero additional metadata dispatch events', async () => {
+    process.env.METADATA_PROBE_MAX_PENDING_TICKS = '2';
+    const { store, orchestrator, dispatch } = await metadataTickHarness({ withMetadataPort: true });
+
+    await orchestrator.processOrder('ord_fo');
+    await orchestrator.processOrder('ord_fo');
+    await orchestrator.processOrder('ord_fo');
+
+    expect(dispatch.snapshotCalls).toHaveLength(1); // dispatched exactly once on tick 1
+    const dispatches = await eventsOfKind(store, ORCHESTRATOR_SUBJECTS.dispatch);
+    const metaDispatches = dispatches.filter((d) => (d as { ingredient?: string }).ingredient === 'metadata_snapshot');
+    expect(metaDispatches).toHaveLength(1);
+  });
+
+  it('AC-11: when triage.metadata absent the structural-absence path fires (not tick counter)', async () => {
+    // triage has NO metadata port — advance loop takes the structural-absence path.
+    const { store, orchestrator } = await metadataTickHarness({ withMetadataPort: false });
+
+    await orchestrator.processOrder('ord_fo');
+
+    const record = await store.get('ord_fo');
+    // Structural-absence path advances metadata to optional via callerNote='fulfillment-orchestrator'.
+    const audit = record?.operator_audit ?? [];
+    const structuralAbsence = audit.find(
+      (e) => (e as { caller_note?: string }).caller_note === 'fulfillment-orchestrator' &&
+        (e as { ingredient?: string }).ingredient === 'metadata_snapshot',
+    );
+    expect(structuralAbsence).toBeDefined();
+    // The persistent-404 callerNote must NOT appear.
+    const selfResolve = audit.find((e) => (e as { caller_note?: string }).caller_note === 'fulfillment-orchestrator:persistent-404-self-resolve');
+    expect(selfResolve).toBeUndefined();
+  });
+});
+
+// ── T-4a: dispatch-null suppresses all dispatch events (AC-12) ───────────────
+
+describe('FulfillmentOrchestrator — dispatch=null emits zero dispatch events (T-4a, AC-12)', () => {
+  it('AC-12: processOrder with dispatch=null emits no orchestrator.dispatch events', async () => {
+    const triage = new FixedTriage({ sonar: 'pending', score: 'pending', worlds: 'pending' });
+    const { store, orchestrator } = await producingHarness({ triage, dispatch: null });
+
+    await orchestrator.processOrder('ord_fo');
+
+    const dispatches = await eventsOfKind(store, ORCHESTRATOR_SUBJECTS.dispatch);
+    expect(dispatches).toHaveLength(0);
+    // Probe event still fires (dispatch suppression only, not probe).
+    expect(await eventsOfKind(store, ORCHESTRATOR_SUBJECTS.probe)).toHaveLength(1);
   });
 });
 

--- a/packages/services/ordering/src/__tests__/kitchen-triage-ports.test.ts
+++ b/packages/services/ordering/src/__tests__/kitchen-triage-ports.test.ts
@@ -7,7 +7,7 @@ import {
   resetShadowProducerlessWarning,
   shadowUnavailablePolicyFromEnv,
 } from '../kitchen-triage-ports.js';
-import { StubTriagePorts } from '../triage-ports.js';
+import { StubTriagePorts, type TriagePorts } from '../triage-ports.js';
 
 const CHAIN = '10';
 const CONTRACT = '0xED5AF388653567Af2F388e6224DcC93746104133';
@@ -152,6 +152,28 @@ describe('createKitchenTriagePorts darkness observability', () => {
     createKitchenTriagePorts();
     const producerless = warn.mock.calls.flat().filter((m) => String(m).includes('producer-less'));
     expect(producerless).toHaveLength(1);
+  });
+});
+
+// ── T-4b: fallback metadata wiring (AC-13, AC-14) ────────────────────────────
+
+describe('KitchenTriagePorts — fallback metadata wiring (T-4b, AC-13, AC-14)', () => {
+  it('AC-13: http=null with fallback.metadata port delegates probes to the fallback', async () => {
+    const stubValue = 'complete' as const;
+    const fallbackWithMeta: TriagePorts = {
+      ...new StubTriagePorts(),
+      metadata: { probe: async () => stubValue },
+    };
+    const ports = new KitchenTriagePorts(null, fallbackWithMeta);
+    expect(ports.metadata).toBeDefined();
+    await expect(ports.metadata!.probe(CHAIN, CONTRACT)).resolves.toBe(stubValue);
+  });
+
+  it('AC-14: http=null with fallback lacking metadata port yields triage.metadata === undefined', async () => {
+    // StubTriagePorts has no metadata property (TriagePorts.metadata is optional).
+    const fallbackWithoutMeta = new StubTriagePorts();
+    const ports = new KitchenTriagePorts(null, fallbackWithoutMeta);
+    expect(ports.metadata).toBeUndefined();
   });
 });
 

--- a/packages/services/ordering/src/community-onboarding-orchestrator.ts
+++ b/packages/services/ordering/src/community-onboarding-orchestrator.ts
@@ -45,6 +45,9 @@ const REPROBE_COOLDOWN_MS = Number(process.env.REPROBE_COOLDOWN_MS ?? 10_000);
 const REPROBE_PER_PROBE_TIMEOUT_MS = Number(process.env.REPROBE_PER_PROBE_TIMEOUT_MS ?? 10_000);
 const REPROBE_FANOUT = 3;
 
+// Once-per-process guard for the D13.3 port-absent warning (sits on the advance path).
+let warnedDiscordHealthAbsent = false;
+
 export function canFulfillCommunityOnboarding(
   ingredients: CommunityOnboardingIngredients,
   fulfillment?: CommunityOnboardingOutput,
@@ -277,18 +280,24 @@ export class CommunityOnboardingOrchestrator {
     // DISCORD CHANNEL-HEALTH GATE (T-2, FR-1) ────────────────────────────────
     // Fires only when advancing discord_observer to 'complete'. Advancing to 'optional' is
     // unconditional (PRD Assumption 5). Port absent → advance proceeds (D13.3 fallback).
-    if (ingredient === 'discord_observer' && status === 'complete' && this.deps.discordHealth) {
-      let health: DiscordChannelHealth;
-      try {
-        health = await this.deps.discordHealth.checkChannelHealth(
-          parsedInputs.data.chain_id,
-          parsedInputs.data.contract_address,
-        );
-      } catch (e) {
-        health = { healthy: false, reason: `probe error: ${e instanceof Error ? e.message : String(e)}` };
-      }
-      if (!health.healthy) {
-        return { ok: false, error: `discord channel-health check failed: ${health.reason ?? 'unhealthy'}` };
+    if (ingredient === 'discord_observer' && status === 'complete') {
+      if (this.deps.discordHealth) {
+        let health: DiscordChannelHealth;
+        try {
+          health = await this.deps.discordHealth.checkChannelHealth(
+            parsedInputs.data.chain_id,
+            parsedInputs.data.contract_address,
+          );
+        } catch (e) {
+          health = { healthy: false, reason: `probe error: ${e instanceof Error ? e.message : String(e)}` };
+        }
+        if (!health.healthy) {
+          return { ok: false, error: `discord channel-health check failed: ${health.reason ?? 'unhealthy'}` };
+        }
+      } else if (!warnedDiscordHealthAbsent) {
+        // D13.3 observability: the unguarded advance must not be silent (once per process).
+        warnedDiscordHealthAbsent = true;
+        console.warn('[community-onboarding] discord_observer: discordHealth port absent, advancing without channel-health check (D13.3)');
       }
     }
 

--- a/packages/services/ordering/src/community-onboarding-orchestrator.ts
+++ b/packages/services/ordering/src/community-onboarding-orchestrator.ts
@@ -18,7 +18,7 @@ import type { OrderStore, OrderRecord } from './store.js';
 import { type CapabilityResolver, type ResolvedEndpoint, CapabilityUnresolvedError } from './resolver.js';
 import type { PrivateOpsPublisher } from './private-ops.js';
 import type { ProcessResult } from './orchestrator.js';
-import type { TriagePorts } from './triage-ports.js';
+import type { DiscordChannelHealth, TriagePorts } from './triage-ports.js';
 import type { IngredientEnqueueService } from './ingredient-enqueue.js';
 import { fireEnqueue } from './ingredient-enqueue.js';
 import type { OperatorAuditEntry, OrderProbeMeta, ProbeSource } from './kitchen-types.js';
@@ -30,6 +30,10 @@ export interface CommunityOnboardingOrchestratorDeps {
   now: () => number;
   opsChannel?: PrivateOpsPublisher;
   enqueue?: IngredientEnqueueService;
+  /** Optional Discord channel-health port (T-2, FR-1). Gate fires on discord_observer→complete. */
+  discordHealth?: {
+    checkChannelHealth(chainId: string, contract: string): Promise<DiscordChannelHealth>;
+  };
 }
 
 type IngredientKey = keyof CommunityOnboardingIngredients;
@@ -267,6 +271,27 @@ export class CommunityOnboardingOrchestrator {
     if (record.product !== 'community-onboarding') return { ok: false, error: 'not a community-onboarding order' };
     if (isTerminal(record.state)) return { ok: false, error: 'order already terminal' };
 
+    const parsedInputs = CommunityOnboardingInputs.safeParse(record.inputs);
+    if (!parsedInputs.success) return { ok: false, error: 'invalid order inputs' };
+
+    // DISCORD CHANNEL-HEALTH GATE (T-2, FR-1) ────────────────────────────────
+    // Fires only when advancing discord_observer to 'complete'. Advancing to 'optional' is
+    // unconditional (PRD Assumption 5). Port absent → advance proceeds (D13.3 fallback).
+    if (ingredient === 'discord_observer' && status === 'complete' && this.deps.discordHealth) {
+      let health: DiscordChannelHealth;
+      try {
+        health = await this.deps.discordHealth.checkChannelHealth(
+          parsedInputs.data.chain_id,
+          parsedInputs.data.contract_address,
+        );
+      } catch (e) {
+        health = { healthy: false, reason: `probe error: ${e instanceof Error ? e.message : String(e)}` };
+      }
+      if (!health.healthy) {
+        return { ok: false, error: `discord channel-health check failed: ${health.reason ?? 'unhealthy'}` };
+      }
+    }
+
     const ingredients: CommunityOnboardingIngredients = {
       ...(record.ingredients ?? INITIAL_COMMUNITY_ONBOARDING_INGREDIENTS),
       [ingredient]: status,
@@ -280,9 +305,6 @@ export class CommunityOnboardingOrchestrator {
     ) {
       ingredients.shadow_preview = 'pending';
     }
-
-    const parsedInputs = CommunityOnboardingInputs.safeParse(record.inputs);
-    if (!parsedInputs.success) return { ok: false, error: 'invalid order inputs' };
 
     let fulfillment = record.fulfillment;
     if (worldSlug) {

--- a/packages/services/ordering/src/composition.ts
+++ b/packages/services/ordering/src/composition.ts
@@ -81,20 +81,23 @@ export function orchestratorEnabled(): boolean {
  * the HTTP probes and escalation from the GitHub port (both null-safe for CI/dev).
  */
 export async function createFulfillmentOrchestratorWorker(): Promise<FulfillmentOrchestratorWorker> {
-  const { store } = await createOrderingComposition();
+  const { store, enqueue } = await createOrderingComposition();
   const triage = createKitchenTriagePorts();
   const dispatch = triage instanceof KitchenTriagePorts ? triage.httpProbes : null;
   const discordHealth = triage instanceof KitchenTriagePorts ? triage.discordHealth : undefined;
 
   // Create a dedicated onboarding orchestrator with discordHealth wired in (T-2, FR-1).
   // The gate lives in advanceIngredient, so the orchestrator the fulfillment worker uses
-  // must carry the port — it cannot reuse the intake orchestrator's instance.
+  // must carry the port — it cannot reuse the intake orchestrator's instance. It MUST
+  // mirror the intake instance's side-effect deps (enqueue) or worker-driven advances
+  // silently lose ingredient enqueue behavior (FAGAN: dropped composition deps).
   const onboarding = new CommunityOnboardingOrchestrator({
     store,
     resolver: new ConfigCapabilityResolver(triageCapabilityConfig()),
     triage,
     now: () => Date.now(),
     discordHealth,
+    enqueue,
   });
 
   const fulfillment = new FulfillmentOrchestrator({

--- a/packages/services/ordering/src/composition.ts
+++ b/packages/services/ordering/src/composition.ts
@@ -13,6 +13,7 @@ import { IngredientEnqueueService } from './ingredient-enqueue.js';
 import { createKitchenTriagePorts, KitchenTriagePorts } from './kitchen-triage-ports.js';
 import { createOrderStore } from './store-factory.js';
 import { FulfillmentOrchestrator, FulfillmentOrchestratorWorker } from './fulfillment-orchestrator.js';
+import { CommunityOnboardingOrchestrator } from './community-onboarding-orchestrator.js';
 
 class NoopAudit implements AuditPort {
   async invoke(): Promise<AuditServiceResult> {
@@ -80,15 +81,26 @@ export function orchestratorEnabled(): boolean {
  * the HTTP probes and escalation from the GitHub port (both null-safe for CI/dev).
  */
 export async function createFulfillmentOrchestratorWorker(): Promise<FulfillmentOrchestratorWorker> {
-  const { store, orchestrator } = await createOrderingComposition();
+  const { store } = await createOrderingComposition();
   const triage = createKitchenTriagePorts();
   const dispatch = triage instanceof KitchenTriagePorts ? triage.httpProbes : null;
   const discordHealth = triage instanceof KitchenTriagePorts ? triage.discordHealth : undefined;
 
+  // Create a dedicated onboarding orchestrator with discordHealth wired in (T-2, FR-1).
+  // The gate lives in advanceIngredient, so the orchestrator the fulfillment worker uses
+  // must carry the port — it cannot reuse the intake orchestrator's instance.
+  const onboarding = new CommunityOnboardingOrchestrator({
+    store,
+    resolver: new ConfigCapabilityResolver(triageCapabilityConfig()),
+    triage,
+    now: () => Date.now(),
+    discordHealth,
+  });
+
   const fulfillment = new FulfillmentOrchestrator({
     store,
     triage,
-    onboarding: orchestrator.communityOnboarding,
+    onboarding,
     dispatch,
     github: createGitHubIssuePort(),
     now: () => Date.now(),

--- a/packages/services/ordering/src/composition.ts
+++ b/packages/services/ordering/src/composition.ts
@@ -66,6 +66,9 @@ export async function createOrderingComposition(): Promise<OrderingComposition> 
     now: () => Date.now(),
     triage,
     enqueue,
+    // The advanceIngredient health gate must have teeth on the INTAKE path too —
+    // without this, the service/merge write path bypasses the choke point (BB #443).
+    discordHealth: triage instanceof KitchenTriagePorts ? triage.discordHealth : undefined,
   });
 
   return { store, orchestrator, enqueue };

--- a/packages/services/ordering/src/fulfillment-orchestrator.ts
+++ b/packages/services/ordering/src/fulfillment-orchestrator.ts
@@ -19,7 +19,7 @@ import {
 } from './orchestrator-events.js';
 import { reprobeIntervalMs } from './reprobe-worker.js';
 import type { OrderStore } from './store.js';
-import type { DiscordChannelHealth, TriagePorts } from './triage-ports.js';
+import type { TriagePorts } from './triage-ports.js';
 
 type IngredientKey = keyof CommunityOnboardingIngredients;
 
@@ -36,8 +36,6 @@ const ALL_INGREDIENTS: readonly IngredientKey[] = [
 /** Dispatch order — WORLDS-FIRST so the canonical slug is sourced before score register (D-5). */
 const DISPATCH_ORDER: readonly EnqueueIngredientKey[] = ['worlds_manifest', 'score', 'sonar'];
 
-// Once-per-process guard for the D13.3 fallback warning (it sits in the per-tick advance loop).
-let warnedDiscordHealthAbsent = false;
 
 /**
  * The single decision table (SDD §4.1 / task 23.2). Ingredient status → orchestrator action:
@@ -109,6 +107,12 @@ export class FulfillmentOrchestrator {
    *  `idempotency_key` so a consumer can dedupe. */
   private readonly escalated = new Set<string>();
 
+  /** Consecutive pending-tick counter for metadata_snapshot (T-3, FR-3). Incremented each tick
+   *  that metadata stays 'pending' after the initial dispatch. Self-resolves to 'optional' when
+   *  count reaches maxPendingTicks. loa:shortcut: in-memory; stales harmlessly on restart. */
+  private readonly metadataPendingTicks = new Map<string, number>();
+  private readonly maxPendingTicks = Number(process.env.METADATA_PROBE_MAX_PENDING_TICKS ?? 3);
+
   async processOrder(orderId: string): Promise<void> {
     let record = await this.deps.store.get(orderId);
     if (!record || record.product !== 'community-onboarding' || isTerminal(record.state)) return;
@@ -138,48 +142,71 @@ export class FulfillmentOrchestrator {
     // DISPATCH (worlds-first) ────────────────────────────────────────────────
     let canonicalSlug = probe.worldSlug;
     const payload = this.payloadFor(orderId, inputs);
-    for (const ingredient of DISPATCH_ORDER) {
-      if (probe.statuses[ingredient] !== 'pending') continue;
-      const res = this.deps.dispatch ? await this.dispatchOne(ingredient, payload) : { ok: false };
-      await this.emit(orderId, ORCHESTRATOR_SUBJECTS.dispatch, OrchestratorDispatchSchema.parse({
-        order_id: orderId,
-        ingredient,
-        ok: res.ok,
-        idempotency_key: ingredientJobIdempotencyKey(orderId, ingredient),
-        at_unix: this.nowUnix(),
-      }));
-      if (ingredient === 'worlds_manifest' && res.world_slug) canonicalSlug = res.world_slug;
-      if (ingredient === 'score' && res.world_slug && canonicalSlug && res.world_slug !== canonicalSlug) {
-        await this.emit(orderId, ORCHESTRATOR_SUBJECTS.slug_divergence, SlugDivergenceSchema.parse({
+    if (this.deps.dispatch) {
+      for (const ingredient of DISPATCH_ORDER) {
+        if (probe.statuses[ingredient] !== 'pending') continue;
+        const res = await this.dispatchOne(ingredient, payload);
+        await this.emit(orderId, ORCHESTRATOR_SUBJECTS.dispatch, OrchestratorDispatchSchema.parse({
           order_id: orderId,
-          worlds_slug: canonicalSlug,
-          score_slug: res.world_slug,
+          ingredient,
+          ok: res.ok,
+          idempotency_key: ingredientJobIdempotencyKey(orderId, ingredient),
           at_unix: this.nowUnix(),
         }));
+        // T-1: adopt canonical slug only from a successful dispatch (res.ok guard prevents a
+        // failed dispatch from overwriting a previously probed slug with a transient error value).
+        if (ingredient === 'worlds_manifest' && res.ok && res.world_slug) canonicalSlug = res.world_slug;
+        if (ingredient === 'score' && res.world_slug && canonicalSlug && res.world_slug !== canonicalSlug) {
+          await this.emit(orderId, ORCHESTRATOR_SUBJECTS.slug_divergence, SlugDivergenceSchema.parse({
+            order_id: orderId,
+            worlds_slug: canonicalSlug,
+            score_slug: res.world_slug,
+            at_unix: this.nowUnix(),
+          }));
+        }
+        if (res.ok) await this.markInProgress(orderId, ingredient);
       }
-      if (res.ok) await this.markInProgress(orderId, ingredient);
-    }
 
-    // CONDITIONAL DISPATCH: metadata_snapshot (D12.3) ─────────────────────────
-    // Not in DISPATCH_ORDER — score must complete first. metadata port absence = no dispatch (NF-6).
-    if (
-      probe.statuses.metadata_snapshot === 'pending' &&
-      probe.statuses.score === 'complete' &&
-      this.deps.triage.metadata &&
-      this.deps.dispatch?.snapshotMetadata
-    ) {
-      const res = await this.deps.dispatch.snapshotMetadata(payload);
-      await this.emit(orderId, ORCHESTRATOR_SUBJECTS.dispatch, OrchestratorDispatchSchema.parse({
-        order_id: orderId,
-        ingredient: 'metadata_snapshot',
-        ok: res.ok,
-        // Hand-built: ingredientJobIdempotencyKey's EnqueueIngredientKey type does not
-        // include metadata_snapshot (dispatch here is direct HTTP, not kitchen enqueue).
-        // Same `${orderId}:${ingredient}` shape by construction.
-        idempotency_key: `${orderId}:metadata_snapshot`,
-        at_unix: this.nowUnix(),
-      }));
-      if (res.ok) await this.markInProgressKey(orderId, 'metadata_snapshot');
+      // CONDITIONAL DISPATCH: metadata_snapshot (D12.3, T-3) ───────────────────
+      // Not in DISPATCH_ORDER — score must complete first. Persistent-404 backstop: after
+      // maxPendingTicks ticks, self-resolve to 'optional' so the order is not stalled forever.
+      if (probe.statuses.metadata_snapshot === 'pending' && this.deps.triage.metadata) {
+        const pendingCount = this.metadataPendingTicks.get(orderId) ?? 0;
+        if (pendingCount >= this.maxPendingTicks) {
+          // Persistent-404 self-resolve (FR-3): enough ticks have passed, advance to optional.
+          const result = await this.deps.onboarding.advanceIngredient(
+            orderId, 'metadata_snapshot', 'optional', undefined,
+            { tokenLabel: this.deps.tokenLabel, callerNote: 'fulfillment-orchestrator:persistent-404-self-resolve' },
+          );
+          if (result.ok) {
+            await this.emit(orderId, ORCHESTRATOR_SUBJECTS.advance, OrchestratorAdvanceSchema.parse({
+              order_id: orderId,
+              ingredient: 'metadata_snapshot',
+              status: 'optional',
+              world_slug: undefined,
+              at_unix: this.nowUnix(),
+            }));
+          }
+          this.metadataPendingTicks.delete(orderId);
+        } else if (pendingCount === 0 && probe.statuses.score === 'complete' && this.deps.dispatch.snapshotMetadata) {
+          // First pending tick: dispatch normally (existing path, D12.3).
+          const res = await this.deps.dispatch.snapshotMetadata(payload);
+          await this.emit(orderId, ORCHESTRATOR_SUBJECTS.dispatch, OrchestratorDispatchSchema.parse({
+            order_id: orderId,
+            ingredient: 'metadata_snapshot',
+            ok: res.ok,
+            // Hand-built: ingredientJobIdempotencyKey's EnqueueIngredientKey type does not
+            // include metadata_snapshot (dispatch here is direct HTTP, not kitchen enqueue).
+            idempotency_key: `${orderId}:metadata_snapshot`,
+            at_unix: this.nowUnix(),
+          }));
+          if (res.ok) await this.markInProgressKey(orderId, 'metadata_snapshot');
+          this.metadataPendingTicks.set(orderId, 1);
+        } else if (pendingCount > 0) {
+          // Ticks 2..maxPendingTicks-1: no re-dispatch, just increment the counter.
+          this.metadataPendingTicks.set(orderId, pendingCount + 1);
+        }
+      }
     }
 
     // ADVANCE satisfied ingredients ─────────────────────────────────────────
@@ -222,33 +249,18 @@ export class FulfillmentOrchestrator {
         await this.escalate(orderId, ingredient, 'worlds returned complete without world_slug');
         continue;
       }
-      // DISCORD CHANNEL-HEALTH GATE (D13.4) ───────────────────────────────────
-      if (ingredient === 'discord_observer' && status === 'complete') {
-        if (this.deps.discordHealth) {
-          // A throwing health port must not abort the whole processOrder tick —
-          // fail closed: treat probe error as unhealthy and escalate (BB FO-003).
-          let health: DiscordChannelHealth;
-          try {
-            health = await this.deps.discordHealth.checkChannelHealth(inputs.chain_id, inputs.contract_address);
-          } catch (e) {
-            health = { healthy: false, reason: `probe error: ${e instanceof Error ? e.message : String(e)}` };
-          }
-          if (!health.healthy) {
-            await this.escalate(orderId, ingredient, `channel-health: ${health.reason ?? 'unhealthy'}`);
-            continue;
-          }
-        } else if (!warnedDiscordHealthAbsent) {
-          // discordHealth port absent + discord complete → documented fallback (D13.3, AC-10).
-          // Once per process: this branch sits in the per-tick advance loop.
-          warnedDiscordHealthAbsent = true;
-          console.warn('[fulfillment-orchestrator] discord_observer: discordHealth port absent, advancing without channel-health check (D13.3)');
-        }
-      }
+      // Discord channel-health gate now lives in CommunityOnboardingOrchestrator.advanceIngredient
+      // (T-2, FR-1). The gate returns { ok: false } when the health check fails; we escalate here.
       const slug = ingredient === 'worlds_manifest' ? canonicalSlug : undefined;
-      await this.deps.onboarding.advanceIngredient(orderId, ingredient, status, slug, {
+      const advResult = await this.deps.onboarding.advanceIngredient(orderId, ingredient, status, slug, {
         tokenLabel: this.deps.tokenLabel,
         callerNote: 'fulfillment-orchestrator',
       });
+      if (!advResult.ok) {
+        // Gate rejection (e.g., discord health check failed) or transient terminal race.
+        await this.escalate(orderId, ingredient, advResult.error ?? `${ingredient} advance rejected`);
+        continue;
+      }
       await this.emit(orderId, ORCHESTRATOR_SUBJECTS.advance, OrchestratorAdvanceSchema.parse({
         order_id: orderId,
         ingredient,

--- a/packages/services/ordering/src/fulfillment-orchestrator.ts
+++ b/packages/services/ordering/src/fulfillment-orchestrator.ts
@@ -19,7 +19,7 @@ import {
 } from './orchestrator-events.js';
 import { reprobeIntervalMs } from './reprobe-worker.js';
 import type { OrderStore } from './store.js';
-import type { TriagePorts } from './triage-ports.js';
+import type { DiscordChannelHealth, TriagePorts } from './triage-ports.js';
 
 type IngredientKey = keyof CommunityOnboardingIngredients;
 
@@ -84,7 +84,9 @@ export interface FulfillmentOrchestratorDeps {
   now: () => number;
   /** Credential label recorded on advance audit entries. */
   tokenLabel?: string;
-  /** Optional Discord channel-health port (D13.2). When absent, health gate is skipped with a warning (AC-10). */
+  /** @deprecated The channel-health gate moved to CommunityOnboardingOrchestrator.advanceIngredient
+   *  (T-2/FR-1 choke point) — wire discordHealth on the onboarding orchestrator instead. Kept so
+   *  existing composition call-sites keep typechecking; ignored here. */
   discordHealth?: {
     checkChannelHealth(chainId: string, contract: string): Promise<DiscordChannelHealth>;
   };
@@ -111,7 +113,12 @@ export class FulfillmentOrchestrator {
    *  that metadata stays 'pending' after the initial dispatch. Self-resolves to 'optional' when
    *  count reaches maxPendingTicks. loa:shortcut: in-memory; stales harmlessly on restart. */
   private readonly metadataPendingTicks = new Map<string, number>();
-  private readonly maxPendingTicks = Number(process.env.METADATA_PROBE_MAX_PENDING_TICKS ?? 3);
+  // Malformed env must not silently disable the backstop (NaN >= n is always false);
+  // clamp to >=1 so 0 cannot self-resolve before the first counted tick.
+  private readonly maxPendingTicks = (() => {
+    const raw = Number(process.env.METADATA_PROBE_MAX_PENDING_TICKS ?? 3);
+    return Number.isInteger(raw) && raw >= 1 ? raw : 3;
+  })();
 
   async processOrder(orderId: string): Promise<void> {
     let record = await this.deps.store.get(orderId);
@@ -156,7 +163,7 @@ export class FulfillmentOrchestrator {
         // T-1: adopt canonical slug only from a successful dispatch (res.ok guard prevents a
         // failed dispatch from overwriting a previously probed slug with a transient error value).
         if (ingredient === 'worlds_manifest' && res.ok && res.world_slug) canonicalSlug = res.world_slug;
-        if (ingredient === 'score' && res.world_slug && canonicalSlug && res.world_slug !== canonicalSlug) {
+        if (ingredient === 'score' && res.ok && res.world_slug && canonicalSlug && res.world_slug !== canonicalSlug) {
           await this.emit(orderId, ORCHESTRATOR_SUBJECTS.slug_divergence, SlugDivergenceSchema.parse({
             order_id: orderId,
             worlds_slug: canonicalSlug,
@@ -167,29 +174,36 @@ export class FulfillmentOrchestrator {
         if (res.ok) await this.markInProgress(orderId, ingredient);
       }
 
-      // CONDITIONAL DISPATCH: metadata_snapshot (D12.3, T-3) ───────────────────
-      // Not in DISPATCH_ORDER — score must complete first. Persistent-404 backstop: after
-      // maxPendingTicks ticks, self-resolve to 'optional' so the order is not stalled forever.
-      if (probe.statuses.metadata_snapshot === 'pending' && this.deps.triage.metadata) {
-        const pendingCount = this.metadataPendingTicks.get(orderId) ?? 0;
-        if (pendingCount >= this.maxPendingTicks) {
-          // Persistent-404 self-resolve (FR-3): enough ticks have passed, advance to optional.
-          const result = await this.deps.onboarding.advanceIngredient(
-            orderId, 'metadata_snapshot', 'optional', undefined,
-            { tokenLabel: this.deps.tokenLabel, callerNote: 'fulfillment-orchestrator:persistent-404-self-resolve' },
-          );
-          if (result.ok) {
-            await this.emit(orderId, ORCHESTRATOR_SUBJECTS.advance, OrchestratorAdvanceSchema.parse({
-              order_id: orderId,
-              ingredient: 'metadata_snapshot',
-              status: 'optional',
-              world_slug: undefined,
-              at_unix: this.nowUnix(),
-            }));
-          }
+    }
+
+    // METADATA_SNAPSHOT: conditional dispatch + persistent-404 backstop (D12.3, T-3) ──
+    // Deliberately OUTSIDE the `if (this.deps.dispatch)` guard: a dispatch-null
+    // composition is the canonical stall this backstop exists to break (FAGAN
+    // convergent major). Ticks are counted whenever metadata is pending with score
+    // complete, dispatch or not; dispatch itself fires at most once (first tick).
+    if (probe.statuses.metadata_snapshot === 'pending' && this.deps.triage.metadata) {
+      const pendingCount = this.metadataPendingTicks.get(orderId) ?? 0;
+      if (pendingCount >= this.maxPendingTicks) {
+        // Persistent-404 self-resolve (FR-3): enough ticks have passed, advance to optional.
+        const result = await this.deps.onboarding.advanceIngredient(
+          orderId, 'metadata_snapshot', 'optional', undefined,
+          { tokenLabel: this.deps.tokenLabel, callerNote: 'fulfillment-orchestrator:persistent-404-self-resolve' },
+        );
+        if (result.ok) {
+          await this.emit(orderId, ORCHESTRATOR_SUBJECTS.advance, OrchestratorAdvanceSchema.parse({
+            order_id: orderId,
+            ingredient: 'metadata_snapshot',
+            status: 'optional',
+            world_slug: undefined,
+            at_unix: this.nowUnix(),
+          }));
           this.metadataPendingTicks.delete(orderId);
-        } else if (pendingCount === 0 && probe.statuses.score === 'complete' && this.deps.dispatch.snapshotMetadata) {
-          // First pending tick: dispatch normally (existing path, D12.3).
+        }
+        // On failure the counter is KEPT: deleting would reset to 0 and re-fire the
+        // one-shot dispatch below on the next tick (FAGAN convergent major).
+      } else if (probe.statuses.score === 'complete') {
+        if (pendingCount === 0 && this.deps.dispatch?.snapshotMetadata) {
+          // First counted tick: dispatch once (existing path, D12.3).
           const res = await this.deps.dispatch.snapshotMetadata(payload);
           await this.emit(orderId, ORCHESTRATOR_SUBJECTS.dispatch, OrchestratorDispatchSchema.parse({
             order_id: orderId,
@@ -201,12 +215,14 @@ export class FulfillmentOrchestrator {
             at_unix: this.nowUnix(),
           }));
           if (res.ok) await this.markInProgressKey(orderId, 'metadata_snapshot');
-          this.metadataPendingTicks.set(orderId, 1);
-        } else if (pendingCount > 0) {
-          // Ticks 2..maxPendingTicks-1: no re-dispatch, just increment the counter.
-          this.metadataPendingTicks.set(orderId, pendingCount + 1);
         }
+        // Count the tick regardless of dispatch availability.
+        this.metadataPendingTicks.set(orderId, pendingCount + 1);
       }
+    } else {
+      // Metadata resolved (or port absent — the structural-absence path owns that):
+      // drop the counter so long-lived workers do not leak an entry per settled order.
+      this.metadataPendingTicks.delete(orderId);
     }
 
     // ADVANCE satisfied ingredients ─────────────────────────────────────────
@@ -257,7 +273,10 @@ export class FulfillmentOrchestrator {
         callerNote: 'fulfillment-orchestrator',
       });
       if (!advResult.ok) {
-        // Gate rejection (e.g., discord health check failed) or transient terminal race.
+        // Terminal race is benign — the order settled between our read and the call;
+        // escalating it would page an operator about a SUCCESS (FAGAN).
+        if (advResult.error === 'order already terminal') return;
+        // Gate rejection (e.g., discord health check failed): real, escalate.
         await this.escalate(orderId, ingredient, advResult.error ?? `${ingredient} advance rejected`);
         continue;
       }

--- a/packages/services/ordering/src/fulfillment-orchestrator.ts
+++ b/packages/services/ordering/src/fulfillment-orchestrator.ts
@@ -122,7 +122,12 @@ export class FulfillmentOrchestrator {
 
   async processOrder(orderId: string): Promise<void> {
     let record = await this.deps.store.get(orderId);
-    if (!record || record.product !== 'community-onboarding' || isTerminal(record.state)) return;
+    if (!record || record.product !== 'community-onboarding' || isTerminal(record.state)) {
+      // Order settled (or gone) with a pending metadata counter → drop the entry
+      // so long-lived workers do not leak one per terminal order (BB #443).
+      this.metadataPendingTicks.delete(orderId);
+      return;
+    }
 
     // Lifecycle: drive placed/routing → producing via the existing state machine (idempotent CAS).
     if (record.state === 'placed' || record.state === 'routing') {

--- a/packages/services/ordering/src/kitchen-triage-ports.ts
+++ b/packages/services/ordering/src/kitchen-triage-ports.ts
@@ -57,8 +57,11 @@ export class KitchenTriagePorts implements TriagePorts {
     } else if (!metadataEnabled) {
       // Deliberate opt-out: report 'optional' so canFulfill gate passes (D11.4).
       this.metadata = { probe: async () => 'optional' as const };
+    } else if (this.fallback.metadata) {
+      // HTTP probes off but fallback carries a metadata port — honor it (T-4b, FR-4b).
+      this.metadata = this.fallback.metadata;
     } else {
-      // HTTP probes off or score-api not configured: metadata port absent → NF-6 (stays pending).
+      // HTTP probes off and no fallback metadata port: absent → NF-6 (stays pending).
       this.metadata = undefined;
     }
 

--- a/packages/services/ordering/src/orchestrator.ts
+++ b/packages/services/ordering/src/orchestrator.ts
@@ -5,7 +5,7 @@ import { type CapabilityResolver } from './resolver.js';
 import { type AuditPort, type OperatedCommunityRegistry } from './audit-acl.js';
 import type { PrivateOpsPublisher } from './private-ops.js';
 import { AccessRiskAuditOrchestrator } from './access-risk-audit-orchestrator.js';
-import { CommunityOnboardingOrchestrator } from './community-onboarding-orchestrator.js';
+import { CommunityOnboardingOrchestrator, type CommunityOnboardingOrchestratorDeps } from './community-onboarding-orchestrator.js';
 import type { TriagePorts } from './triage-ports.js';
 import { StubTriagePorts } from './triage-ports.js';
 import type { IngredientEnqueueService } from './ingredient-enqueue.js';
@@ -37,6 +37,10 @@ export interface OrchestratorDeps {
   enqueue?: IngredientEnqueueService;
   /** Optional private ops channel (SDD §13 M-8). */
   opsChannel?: PrivateOpsPublisher;
+  /** Discord channel-health port — the advanceIngredient gate (T-2/FR-1) needs it on
+   *  EVERY CommunityOnboardingOrchestrator instance, intake included, or the choke
+   *  point has teeth only on the worker path. */
+  discordHealth?: CommunityOnboardingOrchestratorDeps['discordHealth'];
 }
 
 export class OrderOrchestrator {
@@ -60,6 +64,7 @@ export class OrderOrchestrator {
       ...shared,
       triage: deps.triage ?? new StubTriagePorts(),
       enqueue: deps.enqueue,
+      discordHealth: deps.discordHealth,
     });
   }
 


### PR DESCRIPTION
Spiral `spiral-20260705-d344e8` cycle-1 output + FAGAN council fixes. Closes the verified review-finding cluster on the fulfillment orchestrator.

## What
- **FO-001/PB-003 choke point**: discord channel-health gate moved INTO `CommunityOnboardingOrchestrator.advanceIngredient` — the single place `discord_observer` transitions to complete. Both write paths (worker + service/merge) now pass through it; fail-closed on throwing ports; D13.3 port-absent warn-once restored. Gate test starts from REAL initial ingredients (no fixture contortion).
- **PB-002**: canonicalSlug adopted only from `res.ok` dispatches; slug_divergence likewise.
- **Persistent-404 backstop**: metadata_snapshot pending with port present self-resolves to optional after N counted ticks (default 3, env-validated vs NaN, clamped ≥1) — counted regardless of dispatch availability (dispatch-null was the canonical stall); one-shot dispatch; counter survives failed self-resolve; no per-order leak.
- **Worker composition**: dedicated onboarding orchestrator mirrors intake deps (enqueue) — worker advances were silently dropping enqueue side-effects.
- **Escalation**: terminal-race advance failures no longer escalate (paged an operator about a success).
- +13 tests incl. AC-7 slug-adoption and AC-1 ordering (both previously vacuous per council).

## Review trail
- FAGAN council (claude 12 / gpt 2 / cursor 10 findings): all convergent majors fixed in `f896403c`, each verified against source first.
- Spiral harness again died at the evidence gate (5th instance, package-relative paths) — tracked upstream loa#1175; no gaming this round.

Suite: 185/186 — the 1 red (reprobe hung-probe timeout classification) is proven pre-existing. Domain: platform (packages/services/ordering only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)