### PR TITLE
Build local file: deps before compiling CLI; add build-local-deps helper and extend CLI smoke tests

### DIFF
--- a/packages/freeside-cli/package.json
+++ b/packages/freeside-cli/package.json
@@ -16,8 +16,8 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc -b && chmod +x dist/bin/freeside-cli.js",
-    "typecheck": "tsc --noEmit",
+    "build": "node scripts/build-local-deps.mjs && tsc -b && chmod +x dist/bin/freeside-cli.js",
+    "typecheck": "node scripts/build-local-deps.mjs && tsc --noEmit",
     "clean": "rm -rf dist",
     "test": "tsx --test tests/*.test.ts"
   },

--- a/packages/freeside-cli/scripts/build-local-deps.mjs
+++ b/packages/freeside-cli/scripts/build-local-deps.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { cpSync, existsSync, readFileSync, rmSync } from "node:fs";
+import { cpSync, existsSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
@@ -36,6 +36,12 @@ const refreshFileDependencyDist = (sourceRel, installedRel) => {
   // workspace links. Refresh only the built dist payload for the exact local
   // dependency package that Node will load when executing the compiled CLI.
   const installedDist = resolve(installedRoot, "dist");
+
+  // npm can materialize file: dependencies as symlinks. In that layout the
+  // installed dist is the source dist; deleting it would erase the build we
+  // just produced and make the following copy fail with ENOENT.
+  if (existsSync(installedDist) && realpathSync(installedDist) === realpathSync(sourceDist)) return;
+
   rmSync(installedDist, { recursive: true, force: true });
   cpSync(sourceDist, installedDist, { recursive: true });
 };

--- a/packages/freeside-cli/scripts/build-local-deps.mjs
+++ b/packages/freeside-cli/scripts/build-local-deps.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+import { cpSync, existsSync, readFileSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const cliRoot = resolve(here, "..");
+const repoRoot = resolve(cliRoot, "../..");
+
+const runBuild = (packageDir) => {
+  const result = spawnSync("pnpm", ["build"], { cwd: packageDir, stdio: "inherit" });
+  if (result.status !== 0) process.exit(result.status ?? 1);
+};
+
+const readPackage = (packageDir) =>
+  JSON.parse(readFileSync(resolve(packageDir, "package.json"), "utf-8"));
+
+const refreshFileDependencyDist = (sourceRel, installedRel) => {
+  const sourceRoot = resolve(repoRoot, sourceRel);
+  const installedRoot = resolve(repoRoot, installedRel);
+  const sourceDist = resolve(sourceRoot, "dist");
+
+  if (!existsSync(installedRoot) || !existsSync(sourceDist)) return;
+
+  const sourcePackage = readPackage(sourceRoot);
+  const installedPackage = readPackage(installedRoot);
+  if (sourcePackage.name !== installedPackage.name || sourcePackage.version !== installedPackage.version) {
+    throw new Error(
+      `Refusing to refresh ${installedRel}: expected ${sourcePackage.name}@${sourcePackage.version}, ` +
+        `found ${installedPackage.name}@${installedPackage.version}`,
+    );
+  }
+
+  // Local pnpm file: dependencies are materialized as package snapshots, not live
+  // workspace links. Refresh only the built dist payload for the exact local
+  // dependency package that Node will load when executing the compiled CLI.
+  const installedDist = resolve(installedRoot, "dist");
+  rmSync(installedDist, { recursive: true, force: true });
+  cpSync(sourceDist, installedDist, { recursive: true });
+};
+
+runBuild(resolve(repoRoot, "packages/beacon-schema"));
+refreshFileDependencyDist("packages/beacon-schema", "packages/freeside-registry/node_modules/@freeside/beacon-schema");
+refreshFileDependencyDist("packages/beacon-schema", "packages/freeside-cli/node_modules/@freeside/beacon-schema");
+
+runBuild(resolve(repoRoot, "packages/freeside-registry"));
+refreshFileDependencyDist("packages/freeside-registry", "packages/freeside-cli/node_modules/@freeside/freeside-registry");

--- a/packages/freeside-cli/scripts/build-local-deps.mjs
+++ b/packages/freeside-cli/scripts/build-local-deps.mjs
@@ -1,15 +1,31 @@
 #!/usr/bin/env node
 import { cpSync, existsSync, readFileSync, realpathSync, rmSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const cliRoot = resolve(here, "..");
 const repoRoot = resolve(cliRoot, "../..");
+const packageManagerExecPath = process.env.npm_execpath;
+
+if (!packageManagerExecPath) {
+  throw new Error("Cannot build local dependencies: npm_execpath is not set");
+}
+
+const assertWithin = (parent, child, label) => {
+  const rel = relative(parent, child);
+  if (rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))) return;
+  throw new Error(`Refusing ${label}: ${child} escapes ${parent}`);
+};
 
 const runBuild = (packageDir) => {
-  const result = spawnSync("pnpm", ["build"], { cwd: packageDir, stdio: "inherit" });
+  assertWithin(repoRoot, packageDir, "package build outside repository root");
+  const result = spawnSync(process.execPath, [packageManagerExecPath, "run", "build"], {
+    cwd: packageDir,
+    stdio: "inherit",
+  });
+  if (result.error) throw result.error;
   if (result.status !== 0) process.exit(result.status ?? 1);
 };
 
@@ -19,9 +35,17 @@ const readPackage = (packageDir) =>
 const refreshFileDependencyDist = (sourceRel, installedRel) => {
   const sourceRoot = resolve(repoRoot, sourceRel);
   const installedRoot = resolve(repoRoot, installedRel);
-  const sourceDist = resolve(sourceRoot, "dist");
+  assertWithin(repoRoot, sourceRoot, "source package outside repository root");
+  assertWithin(repoRoot, installedRoot, "installed package outside repository root");
 
-  if (!existsSync(installedRoot) || !existsSync(sourceDist)) return;
+  if (!existsSync(installedRoot)) {
+    throw new Error(`Expected installed local dependency is missing: ${installedRel}`);
+  }
+
+  const sourceDist = resolve(sourceRoot, "dist");
+  if (!existsSync(sourceDist)) {
+    throw new Error(`Expected source dist is missing after build: ${sourceRel}/dist`);
+  }
 
   const sourcePackage = readPackage(sourceRoot);
   const installedPackage = readPackage(installedRoot);
@@ -32,16 +56,19 @@ const refreshFileDependencyDist = (sourceRel, installedRel) => {
     );
   }
 
-  // Local pnpm file: dependencies are materialized as package snapshots, not live
-  // workspace links. Refresh only the built dist payload for the exact local
-  // dependency package that Node will load when executing the compiled CLI.
+  const sourceRootReal = realpathSync(sourceRoot);
+  const installedRootReal = realpathSync(installedRoot);
+  assertWithin(repoRoot, sourceRootReal, "resolved source package outside repository root");
+  assertWithin(repoRoot, installedRootReal, "resolved installed package outside repository root");
+
+  // npm can materialize file: dependencies as symlinks to the source package.
+  // In that layout the dependency already consumes the source dist directly.
+  if (sourceRootReal === installedRootReal) return;
+
+  // pnpm materializes file: dependencies as package snapshots. Refresh only the
+  // built dist payload for the exact local dependency package the CLI loads.
   const installedDist = resolve(installedRoot, "dist");
-
-  // npm can materialize file: dependencies as symlinks. In that layout the
-  // installed dist is the source dist; deleting it would erase the build we
-  // just produced and make the following copy fail with ENOENT.
-  if (existsSync(installedDist) && realpathSync(installedDist) === realpathSync(sourceDist)) return;
-
+  assertWithin(installedRoot, installedDist, "installed dist outside package root");
   rmSync(installedDist, { recursive: true, force: true });
   cpSync(sourceDist, installedDist, { recursive: true });
 };

--- a/packages/freeside-cli/tests/doctor.test.ts
+++ b/packages/freeside-cli/tests/doctor.test.ts
@@ -525,17 +525,56 @@ test("doctor() · BeaconV2 module → beacon_legacy_v2 warn, NOT error (G-4)", a
 
 // ─── built CLI smoke (G-6 exit code) ────────────────────────────────────────
 
-test("CLI · doctor --registry <bad> → exit 1 (sealed_schema_hash_drift)", () => {
+test("CLI · --help exits 0, prints usage, and has no module-load SyntaxError", () => {
+  if (!existsSync(CLI)) throw new Error(`CLI not built at ${CLI} — run \`pnpm build\` first`);
+  const output = execFileSync("node", [CLI, "--help"], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  assert.match(output, /Usage:/);
+  assert.match(output, /freeside-cli doctor/);
+  assert.doesNotMatch(output, /SyntaxError: The requested module/);
+});
+
+test("CLI · list exits 0 and prints registered modules", () => {
+  if (!existsSync(CLI)) throw new Error(`CLI not built at ${CLI} — run \`pnpm build\` first`);
+  const output = execFileSync("node", [CLI, "list"], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  assert.match(output, /Registered freeside-\* modules/);
+  assert.match(output, /score-api/);
+});
+
+test("CLI · doctor --registry <bad> → semantic sealed_schema_hash_drift failure", () => {
   if (!existsSync(CLI)) throw new Error(`CLI not built at ${CLI} — run \`pnpm build\` first`);
   let exitCode = 0;
+  let stdout = "";
+  let stderr = "";
   try {
-    execFileSync("node", [CLI, "doctor", "--registry", join(FIXTURES, "registry-fixture.yaml")], {
+    stdout = execFileSync("node", [CLI, "doctor", "--registry", join(FIXTURES, "registry-fixture.yaml")], {
+      encoding: "utf-8",
       stdio: ["ignore", "pipe", "pipe"],
     });
   } catch (e) {
-    exitCode = (e as { status?: number }).status ?? -1;
+    const err = e as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
+    exitCode = err.status ?? -1;
+    stdout = String(err.stdout ?? "");
+    stderr = String(err.stderr ?? "");
   }
   assert.equal(exitCode, 1, "expected exit 1 when a module has an error finding");
+  assert.doesNotMatch(stdout + "\n" + stderr, /SyntaxError: The requested module/);
+  const report = JSON.parse(stdout) as {
+    modules_checked?: number;
+    summary?: { error?: number };
+    findings?: Array<{ slug?: string; check?: string; severity?: string }>;
+  };
+  assert.equal(report.modules_checked, 2);
+  assert.ok((report.summary?.error ?? 0) > 0, "doctor should report semantic error findings");
+  assert.ok(
+    report.findings?.some((f) => f.slug === "bad-api" && f.check === "sealed_schema_hash_drift" && f.severity === "error"),
+    "doctor output should identify the expected sealed_schema_hash_drift error",
+  );
 });
 
 // ─── --cells-dir per-cell resolution + FL-B0 git-freshness (sprint-400 step 3) ──


### PR DESCRIPTION
### Motivation

- Ensure local `file:` dependencies have their compiled `dist` materialized into the installed package snapshots before building or typechecking the CLI so runtime module-load `SyntaxError` issues are avoided and CLI smoke tests can run against the built binary.

### Description

- Update `packages/freeside-cli/package.json` to prepend `node scripts/build-local-deps.mjs` to the `build` and `typecheck` scripts. 
- Add `packages/freeside-cli/scripts/build-local-deps.mjs` which runs `pnpm build` for local packages and copies their `dist` directories into the corresponding `node_modules` snapshot locations, with safety checks on package name/version. 
- Extend `packages/freeside-cli/tests/doctor.test.ts` to add CLI smoke tests for `--help` and `list`, and to capture `stdout`/`stderr` from the `doctor` invocation to assert the JSON report contents and absence of module `SyntaxError` output.

### Testing

- Ran the package test suite via `pnpm test` (which executes `tsx --test tests/*.test.ts`) and the tests completed successfully. 
- Executed the new helper with `node packages/freeside-cli/scripts/build-local-deps.mjs` to verify it builds local packages and refreshes `dist` into `node_modules` without errors. 
- Ran `pnpm build` for the CLI to verify the updated `build` and `typecheck` workflows complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54146534d08321ba0372e37c36236b)