### PR TITLE
feat(governance): project user intent and construct expertise

### DIFF
--- a/.github/workflows/flow-moment-governance.yml
+++ b/.github/workflows/flow-moment-governance.yml
@@ -53,5 +53,5 @@ jobs:
         run: node tools/flow-moment.mjs render product/flow-moments/audit-community-composition.flow.json > /tmp/audit-flow-receipt.md
       - name: Prove the system receipt renders from source
         run: node tools/system-component.mjs render product/system-components/loa-freeside.system.json > /tmp/loa-freeside-system-receipt.md
-      - name: Prove the construct operator receipt renders from deterministic seams
+      - name: Smoke render construct receipt (partial is visible, not accepted)
         run: node tools/construct-operator.mjs render --snapshot tools/fixtures/construct-operator.snapshot.json > /tmp/loa-freeside-construct-receipt.md

--- a/.github/workflows/flow-moment-governance.yml
+++ b/.github/workflows/flow-moment-governance.yml
@@ -19,6 +19,9 @@ on:
       - "spec/product/flow-moment-plan.md"
       - "spec/product/flow-moment-implementation-report.md"
       - "product/system-components/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
       - ".github/workflows/flow-moment-governance.yml"
       - ".github/workflows/reusable-flow-moment-governance.yml"
   workflow_dispatch:

--- a/.github/workflows/flow-moment-governance.yml
+++ b/.github/workflows/flow-moment-governance.yml
@@ -1,0 +1,47 @@
+name: Flow Moment Governance
+
+on:
+  pull_request:
+    paths:
+      - "product/flow-moments/**"
+      - "spec/product/flow-moment.schema.json"
+      - "spec/product/system-component.schema.json"
+      - "tools/flow-moment.mjs"
+      - "tools/flow-moment.test.mjs"
+      - "tools/system-component.mjs"
+      - "tools/system-component.test.mjs"
+      - "tools/hivemind/hivemind-labels.v1.0.json"
+      - "docs/product/flow-moment-contract.md"
+      - "spec/product/flow-moment-plan.md"
+      - "spec/product/flow-moment-implementation-report.md"
+      - "product/system-components/**"
+      - ".github/workflows/flow-moment-governance.yml"
+      - ".github/workflows/reusable-flow-moment-governance.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  continuity-contract:
+    name: Validate user-flow moments
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+      - name: Install validator dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Prove promotion gates fail closed
+        run: node --test tools/flow-moment.test.mjs tools/system-component.test.mjs
+      - name: Validate every flow-moment record
+        run: node tools/flow-moment.mjs validate product/flow-moments
+      - name: Validate every system-component manifest
+        run: node tools/system-component.mjs validate product/system-components
+      - name: Prove the continuity receipt renders from source
+        run: node tools/flow-moment.mjs render product/flow-moments/audit-community-composition.flow.json > /tmp/audit-flow-receipt.md
+      - name: Prove the system receipt renders from source
+        run: node tools/system-component.mjs render product/system-components/loa-freeside.system.json > /tmp/loa-freeside-system-receipt.md

--- a/.github/workflows/flow-moment-governance.yml
+++ b/.github/workflows/flow-moment-governance.yml
@@ -8,6 +8,7 @@ on:
       - "spec/product/system-component.schema.json"
       - "tools/flow-moment.mjs"
       - "tools/flow-moment.test.mjs"
+      - "tools/markdown-text.mjs"
       - "tools/system-component.mjs"
       - "tools/system-component.test.mjs"
       - "tools/construct-operator.mjs"
@@ -34,9 +35,9 @@ jobs:
     name: Validate user-flow moments
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
           cache: pnpm

--- a/.github/workflows/flow-moment-governance.yml
+++ b/.github/workflows/flow-moment-governance.yml
@@ -10,6 +10,10 @@ on:
       - "tools/flow-moment.test.mjs"
       - "tools/system-component.mjs"
       - "tools/system-component.test.mjs"
+      - "tools/construct-operator.mjs"
+      - "tools/construct-operator.test.mjs"
+      - "tools/fixtures/construct-operator.snapshot.json"
+      - "grimoires/territory.yaml"
       - "tools/hivemind/hivemind-labels.v1.0.json"
       - "docs/product/flow-moment-contract.md"
       - "spec/product/flow-moment-plan.md"
@@ -36,7 +40,7 @@ jobs:
       - name: Install validator dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Prove promotion gates fail closed
-        run: node --test tools/flow-moment.test.mjs tools/system-component.test.mjs
+        run: node --test tools/flow-moment.test.mjs tools/system-component.test.mjs tools/construct-operator.test.mjs
       - name: Validate every flow-moment record
         run: node tools/flow-moment.mjs validate product/flow-moments
       - name: Validate every system-component manifest
@@ -45,3 +49,5 @@ jobs:
         run: node tools/flow-moment.mjs render product/flow-moments/audit-community-composition.flow.json > /tmp/audit-flow-receipt.md
       - name: Prove the system receipt renders from source
         run: node tools/system-component.mjs render product/system-components/loa-freeside.system.json > /tmp/loa-freeside-system-receipt.md
+      - name: Prove the construct operator receipt renders from deterministic seams
+        run: node tools/construct-operator.mjs render --snapshot tools/fixtures/construct-operator.snapshot.json > /tmp/loa-freeside-construct-receipt.md

--- a/.github/workflows/reusable-flow-moment-governance.yml
+++ b/.github/workflows/reusable-flow-moment-governance.yml
@@ -43,6 +43,8 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
+          cache: pnpm
+          cache-dependency-path: .flow-governance/pnpm-lock.yaml
       - name: Install governance validator dependencies
         working-directory: .flow-governance
         run: pnpm install --frozen-lockfile --ignore-scripts --ignore-workspace

--- a/.github/workflows/reusable-flow-moment-governance.yml
+++ b/.github/workflows/reusable-flow-moment-governance.yml
@@ -23,6 +23,14 @@ jobs:
     steps:
       - name: Checkout consumer repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Require an immutable governance commit
+        env:
+          GOVERNANCE_REF: ${{ inputs.governance-ref }}
+        run: |
+          if [[ ! "$GOVERNANCE_REF" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "governance-ref must be a full lowercase 40-character commit SHA" >&2
+            exit 1
+          fi
       - name: Checkout pinned governance contract
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/.github/workflows/reusable-flow-moment-governance.yml
+++ b/.github/workflows/reusable-flow-moment-governance.yml
@@ -38,7 +38,11 @@ jobs:
       - name: Install governance validator dependencies
         working-directory: .flow-governance
         run: pnpm install --frozen-lockfile --ignore-scripts --ignore-workspace
-      - name: Validate system component intent
+      - name: Validate portable system component intent
+        if: ${{ ! inputs.validate-flow-moments }}
+        run: node .flow-governance/tools/system-component.mjs validate product/system-components --portable
+      - name: Validate system component intent with canonical flow records
+        if: ${{ inputs.validate-flow-moments }}
         run: node .flow-governance/tools/system-component.mjs validate product/system-components
       - name: Validate repo-local user-flow moments
         if: ${{ inputs.validate-flow-moments }}

--- a/.github/workflows/reusable-flow-moment-governance.yml
+++ b/.github/workflows/reusable-flow-moment-governance.yml
@@ -1,0 +1,45 @@
+name: Reusable Flow Moment Governance
+
+on:
+  workflow_call:
+    inputs:
+      governance-ref:
+        description: Immutable loa-freeside commit containing the schema and validators
+        required: true
+        type: string
+      validate-flow-moments:
+        description: Validate repo-local product/flow-moments records in addition to the system manifest
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  continuity-contract:
+    name: Validate product and system intent
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout consumer repository
+        uses: actions/checkout@v4
+      - name: Checkout pinned governance contract
+        uses: actions/checkout@v4
+        with:
+          repository: 0xHoneyJar/loa-freeside
+          ref: ${{ inputs.governance-ref }}
+          path: .flow-governance
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: .flow-governance/package.json
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install governance validator dependencies
+        working-directory: .flow-governance
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Validate system component intent
+        run: node .flow-governance/tools/system-component.mjs validate product/system-components
+      - name: Validate repo-local user-flow moments
+        if: ${{ inputs.validate-flow-moments }}
+        run: node .flow-governance/tools/flow-moment.mjs validate product/flow-moments

--- a/.github/workflows/reusable-flow-moment-governance.yml
+++ b/.github/workflows/reusable-flow-moment-governance.yml
@@ -22,17 +22,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout consumer repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Checkout pinned governance contract
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: 0xHoneyJar/loa-freeside
           ref: ${{ inputs.governance-ref }}
           path: .flow-governance
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           package_json_file: .flow-governance/package.json
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
       - name: Install governance validator dependencies

--- a/.github/workflows/reusable-flow-moment-governance.yml
+++ b/.github/workflows/reusable-flow-moment-governance.yml
@@ -37,7 +37,7 @@ jobs:
           node-version: "22"
       - name: Install governance validator dependencies
         working-directory: .flow-governance
-        run: pnpm install --frozen-lockfile --ignore-scripts
+        run: pnpm install --frozen-lockfile --ignore-scripts --ignore-workspace
       - name: Validate system component intent
         run: node .flow-governance/tools/system-component.mjs validate product/system-components
       - name: Validate repo-local user-flow moments

--- a/docs/product/flow-moment-contract.md
+++ b/docs/product/flow-moment-contract.md
@@ -35,7 +35,7 @@ A Gold component can appear inside a falsified flow. A Silver prototype can prod
 - Exposed research requires a feature-flag reference and an evidence contract.
 - Default-on research requires a learning reference and an operator decision.
 - Gold requires Silver metadata, a taste owner, 14 production days, active use, no regressions, and evidence references.
-- Gold age is evaluated against the record's explicit `as_of` date. Advancing the maturity clock is therefore a reviewable record change, not an ambient CI clock.
+- Gold age is evaluated against the record's explicit `as_of` date. Advancing the maturity clock is therefore a reviewable record change, not an ambient CI clock; validation also refuses an `as_of` later than the validator's observed UTC date.
 - CI validates claims and evidence pointers. It cannot decide whether the taste is good or the hypothesis is true.
 
 ## Evidence privacy
@@ -61,6 +61,9 @@ Product telemetry, website feedback, tickets, Discord, interviews, partner obser
 - a thin workflow caller pinned to an immutable `loa-freeside` governance commit.
 
 This makes drift reviewable without vendoring the contract into every API or product repository.
+The `governance-ref` input must be a full lowercase 40-character commit SHA; branches
+and tags are rejected before the governance checkout so a caller's verifier cannot move
+without a reviewed caller change.
 By default, the reusable workflow validates a portable system manifest: flow IDs and
 `flow:<id>` references must agree, but the consumer does not need to vendor Freeside's
 canonical `.flow.json` records. Set `validate-flow-moments: true` only when the consumer

--- a/docs/product/flow-moment-contract.md
+++ b/docs/product/flow-moment-contract.md
@@ -18,6 +18,8 @@ node tools/system-component.mjs render product/system-components/loa-freeside.sy
 
 The system manifest captures the engineering operator, component object, consumer question, stable responsibility, trust surface, actions, ownership boundary, and handoff. It links to a canonical `FM-*` record when the relationship is real. An unmapped component must say why instead of inventing a user-truth relationship.
 
+JSON Schema is the portable shape contract; it rejects structurally invalid records and exact duplicate array items. The repository CLIs are the canonical acceptance layer because identity invariants such as duplicate signal IDs and duplicate `flow_moment_id` values cannot be expressed by portable JSON Schema alone. CI and cross-repository consumers must run the appropriate CLI rather than treating schema-only validation as semantic acceptance.
+
 ## Three independent axes
 
 | Axis | Answers | States |
@@ -85,7 +87,7 @@ Mechanical gates read the atlas's structured `ratification_status`; the neighbor
 `loa-freeside` ratifies the first bounded territory at `grimoires/territory.yaml`. The joined operator receipt derives from the existing system component, the live Constructs producer, and that region-owned declaration:
 
 ```bash
-# Deterministic fixture seam used by CI
+# Deterministic smoke-render seam used by CI; partial remains visible by design
 node tools/construct-operator.mjs render \
   --snapshot tools/fixtures/construct-operator.snapshot.json
 
@@ -96,4 +98,4 @@ node tools/construct-operator.mjs render \
 ```
 
 Live mode invokes only `capabilities`, `atlas`, and `info --rung local`. Mutation verbs are displayed in a separate set but are never executed. Until the territory is committed on the region's default branch and the producer can prove stationing, the overall receipt stays `partial` rather than presenting a working-tree declaration as ratified expertise.
-Release gates may add `--require-ok` to reject `partial`; ordinary operator inspection deliberately renders partial receipts so missing or unratified state remains visible.
+The checked-in fixture step is a smoke-render check, not a release-acceptance gate: its purpose is to prove that incomplete expertise remains inspectable. Release gates add `--require-ok` to reject `partial`; ordinary operator inspection deliberately renders partial receipts so missing or unratified state remains visible.

--- a/docs/product/flow-moment-contract.md
+++ b/docs/product/flow-moment-contract.md
@@ -19,6 +19,7 @@ node tools/system-component.mjs render product/system-components/loa-freeside.sy
 The system manifest captures the engineering operator, component object, consumer question, stable responsibility, trust surface, actions, ownership boundary, and handoff. It links to a canonical `FM-*` record when the relationship is real. An unmapped component must say why instead of inventing a user-truth relationship.
 
 JSON Schema is the portable shape contract; it rejects structurally invalid records and exact duplicate array items. The repository CLIs are the canonical acceptance layer because identity invariants such as duplicate signal IDs and duplicate `flow_moment_id` values cannot be expressed by portable JSON Schema alone. CI and cross-repository consumers must run the appropriate CLI rather than treating schema-only validation as semantic acceptance.
+Flow components make referential integrity explicit: `resolution: local` requires a `component:<component_id>` reference that resolves exactly once in `product/system-components`; `resolution: external` requires a non-component provenance reference and is not presented as locally verified.
 
 ## Three independent axes
 

--- a/docs/product/flow-moment-contract.md
+++ b/docs/product/flow-moment-contract.md
@@ -60,6 +60,11 @@ Product telemetry, website feedback, tickets, Discord, interviews, partner obser
 - a thin workflow caller pinned to an immutable `loa-freeside` governance commit.
 
 This makes drift reviewable without vendoring the contract into every API or product repository.
+By default, the reusable workflow validates a portable system manifest: flow IDs and
+`flow:<id>` references must agree, but the consumer does not need to vendor Freeside's
+canonical `.flow.json` records. Set `validate-flow-moments: true` only when the consumer
+owns repo-local flow records; that enables both full flow validation and exact canonical
+reference resolution.
 
 ## Construct expertise on the operator surface
 

--- a/docs/product/flow-moment-contract.md
+++ b/docs/product/flow-moment-contract.md
@@ -35,6 +35,7 @@ A Gold component can appear inside a falsified flow. A Silver prototype can prod
 - Exposed research requires a feature-flag reference and an evidence contract.
 - Default-on research requires a learning reference and an operator decision.
 - Gold requires Silver metadata, a taste owner, 14 production days, active use, no regressions, and evidence references.
+- Gold age is evaluated against the record's explicit `as_of` date. Advancing the maturity clock is therefore a reviewable record change, not an ambient CI clock.
 - CI validates claims and evidence pointers. It cannot decide whether the taste is good or the hypothesis is true.
 
 ## Evidence privacy
@@ -92,3 +93,4 @@ node tools/construct-operator.mjs render \
 ```
 
 Live mode invokes only `capabilities`, `atlas`, and `info --rung local`. Mutation verbs are displayed in a separate set but are never executed. Until the territory is committed on the region's default branch and the producer can prove stationing, the overall receipt stays `partial` rather than presenting a working-tree declaration as ratified expertise.
+Release gates may add `--require-ok` to reject `partial`; ordinary operator inspection deliberately renders partial receipts so missing or unratified state remains visible.

--- a/docs/product/flow-moment-contract.md
+++ b/docs/product/flow-moment-contract.md
@@ -60,3 +60,30 @@ Product telemetry, website feedback, tickets, Discord, interviews, partner obser
 - a thin workflow caller pinned to an immutable `loa-freeside` governance commit.
 
 This makes drift reviewable without vendoring the contract into every API or product repository.
+
+## Construct expertise on the operator surface
+
+Constructs join the continuity surface through a region-owned territory, not through free-text tags on every system component. The three planes stay mechanically separate:
+
+| Plane | Source | What it may claim |
+|---|---|---|
+| Orientation | `constructs info <slug> --json --rung local` → `orientation` | Prose that helps an operator frame the problem. Always `authoritative: false`. |
+| Mechanics | The same info payload → `mechanics`, plus `constructs capabilities --json` | Declared skills, commands, runtime requirements, verb mutation class, determinism, and provenance. It grants no authority. |
+| Authority | `grimoires/territory.yaml` projected through `constructs atlas --json`, then the graduated-trust ledger | The region's ceiling intersected with earned evidence. Unknown earned state collapses to `observe`. |
+
+Mechanical gates read the atlas's structured `ratification_status`; the neighboring `ratification` sentence is operator orientation and is never parsed as state.
+
+`loa-freeside` ratifies the first bounded territory at `grimoires/territory.yaml`. The joined operator receipt derives from the existing system component, the live Constructs producer, and that region-owned declaration:
+
+```bash
+# Deterministic fixture seam used by CI
+node tools/construct-operator.mjs render \
+  --snapshot tools/fixtures/construct-operator.snapshot.json
+
+# Live operator-local projection (producer path may also be set as CONSTRUCTS_CLI)
+CONSTRUCTS_DIR="$HOME/.loa/constructs/packs" \
+node tools/construct-operator.mjs render \
+  --constructs-cli /path/to/loa-constructs/packages/constructs-cli/bin/constructs.mjs
+```
+
+Live mode invokes only `capabilities`, `atlas`, and `info --rung local`. Mutation verbs are displayed in a separate set but are never executed. Until the territory is committed on the region's default branch and the producer can prove stationing, the overall receipt stays `partial` rather than presenting a working-tree declaration as ratified expertise.

--- a/docs/product/flow-moment-contract.md
+++ b/docs/product/flow-moment-contract.md
@@ -1,0 +1,62 @@
+# User-flow moment contract
+
+The user-flow moment is Freeside's stable join between product intent and implementation. It answers what progress a user is trying to make at one point in the journey, what we hypothesize will help, how the experience is exposed, and what evidence would support or falsify the hypothesis.
+
+It is deliberately not another decision or learning ledger. Each record points to existing issues, ADRs, Learning Memos, feature flags, components, and evidence. Agents render a disposable continuity receipt from those sources:
+
+```bash
+node tools/flow-moment.mjs validate product/flow-moments
+node tools/flow-moment.mjs render product/flow-moments/audit-community-composition.flow.json
+```
+
+System buildings and front-facing products consume those moments through a thinner manifest:
+
+```bash
+node tools/system-component.mjs validate product/system-components
+node tools/system-component.mjs render product/system-components/loa-freeside.system.json
+```
+
+The system manifest captures the engineering operator, component object, consumer question, stable responsibility, trust surface, actions, ownership boundary, and handoff. It links to a canonical `FM-*` record when the relationship is real. An unmapped component must say why instead of inventing a user-truth relationship.
+
+## Three independent axes
+
+| Axis | Answers | States |
+|---|---|---|
+| Hivemind learning status | Does the flow moment help the user progress? | `cant-make-a-conclusion`, `smol-evidence`, `directionally-correct`, `strongly-validated`, `hypothesis-failed` |
+| Component maturity | Can an agent safely reuse this implementation pattern? | `uncaptured`, `silver`, `gold`, `retired` |
+| Exposure | Who sees the experience, and why? | `dark`, `internal`, `partner`, `default-on`, `retiring`, `retired` |
+
+A Gold component can appear inside a falsified flow. A Silver prototype can produce strong user evidence. Component promotion never changes Hivemind learning status.
+
+## Promotion rules
+
+- A product thesis starts as an unproven hypothesis.
+- Dark research may be recorded before a flag is wired.
+- Exposed research requires a feature-flag reference and an evidence contract.
+- Default-on research requires a learning reference and an operator decision.
+- Gold requires Silver metadata, a taste owner, 14 production days, active use, no regressions, and evidence references.
+- CI validates claims and evidence pointers. It cannot decide whether the taste is good or the hypothesis is true.
+
+## Evidence privacy
+
+Product telemetry, website feedback, tickets, Discord, interviews, partner observations, and personal DMs may all orient learning. Raw private messages do not belong in the repository. Summarize them in operator voice, retain a provenance reference, and use direct quotations only when consented and redacted.
+
+## Adding a moment
+
+1. Copy an existing `product/flow-moments/*.flow.json` record.
+2. Give the moment a stable `FM-*` identifier.
+3. State the actor's entry state, desired progress, dream outcome, hypothesis, and falsification conditions.
+4. Attach the canonical Hivemind classification without adding an action field.
+5. Define behavioral and qualitative signals before exposure.
+6. Attach exemplars with both what to adopt and what to reject.
+7. Keep components `uncaptured` until their design intent is actually captured.
+8. Run validation and render the receipt before requesting review.
+
+## Cross-repository adoption
+
+`loa-freeside` owns the schemas and validators. Consumer repositories own only:
+
+- `product/system-components/<repo>.system.json`, containing their local responsibility and real flow links; and
+- a thin workflow caller pinned to an immutable `loa-freeside` governance commit.
+
+This makes drift reviewable without vendoring the contract into every API or product repository.

--- a/grimoires/territory.yaml
+++ b/grimoires/territory.yaml
@@ -34,6 +34,8 @@ scopes:
   - "tools/system-component.test.mjs"
   - "tools/construct-operator.mjs"
   - "tools/construct-operator.test.mjs"
+  - "tools/fixtures/construct-operator.snapshot.json"
+  - "tools/hivemind/hivemind-labels.v1.0.json"
 
 # Structural architecture and machine-readable projection are the bounded
 # expertise needed by this region. Both are observations at birth.

--- a/grimoires/territory.yaml
+++ b/grimoires/territory.yaml
@@ -1,0 +1,43 @@
+# Freeside product-governance territory.
+#
+# This file is owned by this region. loa-constructs indexes and validates it,
+# but does not author the loadout. A declared authority_tier is a ceiling, not
+# a grant; every construct below is observe-only until earned authority exists.
+
+schema_version: "1.0"
+region: loa-freeside
+maintainers:
+  - "@janitooor"
+  - "@zkSoju"
+
+outcomes:
+  - id: user-intent-continuity
+    description: "System components remain joined to explicit user-flow moments, evidence state, and ownership boundaries across context windows and repository seams."
+
+  - id: expertise-boundary-integrity
+    description: "Construct prose is visibly non-authoritative, mechanical claims resolve to producer-owned contracts, and declared expertise never silently becomes permission."
+
+  - id: operator-projection-legibility
+    description: "An operator can inspect user intent, system responsibility, construct mechanics, provenance, and effective authority in one derived receipt."
+
+scopes:
+  - "product/**"
+  - "spec/product/**"
+  - "docs/product/**"
+  - "tools/flow-moment.mjs"
+  - "tools/flow-moment.test.mjs"
+  - "tools/system-component.mjs"
+  - "tools/system-component.test.mjs"
+  - "tools/construct-operator.mjs"
+  - "tools/construct-operator.test.mjs"
+
+# Structural architecture and machine-readable projection are the bounded
+# expertise needed by this region. Both are observations at birth.
+loadout:
+  - construct: the-arcade
+    outcomes: [user-intent-continuity, expertise-boundary-integrity]
+    authority_tier: observe
+
+  - construct: beacon
+    outcomes: [operator-projection-legibility]
+    authority_tier: observe

--- a/grimoires/territory.yaml
+++ b/grimoires/territory.yaml
@@ -21,9 +21,13 @@ outcomes:
     description: "An operator can inspect user intent, system responsibility, construct mechanics, provenance, and effective authority in one derived receipt."
 
 scopes:
+  # The declaration is part of its own governed blast radius: changes to the
+  # region boundary must travel through the same review surface as its tools.
+  - "grimoires/territory.yaml"
   - "product/**"
   - "spec/product/**"
   - "docs/product/**"
+  - "tools/markdown-text.mjs"
   - "tools/flow-moment.mjs"
   - "tools/flow-moment.test.mjs"
   - "tools/system-component.mjs"

--- a/product/flow-moments/audit-community-composition.flow.json
+++ b/product/flow-moments/audit-community-composition.flow.json
@@ -4,6 +4,7 @@
   "flow_moment_id": "FM-AUDIT-COMPOSITION",
   "title": "Understand how the community is composed and changing",
   "record_state": "active",
+  "as_of": "2026-07-14",
   "hivemind": {
     "schema_version": "1.0",
     "artifact_type": "experiment-design",

--- a/product/flow-moments/audit-community-composition.flow.json
+++ b/product/flow-moments/audit-community-composition.flow.json
@@ -131,6 +131,7 @@
   "components": [
     {
       "ref": "github:0xHoneyJar/freeside-dashboard#111",
+      "resolution": "external",
       "maturity": "uncaptured"
     }
   ],

--- a/product/flow-moments/audit-community-composition.flow.json
+++ b/product/flow-moments/audit-community-composition.flow.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "../../spec/product/flow-moment.schema.json",
+  "schema_version": "1.0",
+  "flow_moment_id": "FM-AUDIT-COMPOSITION",
+  "title": "Understand how the community is composed and changing",
+  "record_state": "active",
+  "hivemind": {
+    "schema_version": "1.0",
+    "artifact_type": "experiment-design",
+    "workstream": "experimentation",
+    "priority": "high",
+    "product_area": "Audit",
+    "jtbd": {
+      "category": "functional",
+      "description": "Understand how my community is composed and changing so I can make informed decisions"
+    },
+    "learning_status": "cant-make-a-conclusion",
+    "source": "team-internal"
+  },
+  "actor": {
+    "role": "Community manager",
+    "context": "They understand community operations, but their member truth is fragmented across Discord, social platforms, and onchain activity."
+  },
+  "entry_state": "The manager sees activity and identities in separate tools and cannot distinguish durable community movement from noise.",
+  "desired_progress": "Form a coherent, evidence-backed view of who makes up the community and how that composition is moving.",
+  "dream_outcome": "Stay close enough to rapidly changing reality to make more informed community decisions.",
+  "hypothesis": {
+    "statement": "If Freeside composes fragmented social and onchain signals into predefined cohorts with fact-level receipts, community managers will understand how their community is composed and changing quickly enough to make more informed decisions.",
+    "falsifiable_by": [
+      "Managers cannot identify a meaningful composition or movement signal during an exposed session.",
+      "Managers treat cohort labels as opaque scores and cannot explain the supporting facts.",
+      "The surfaced view does not change or sharpen any subsequent community decision."
+    ]
+  },
+  "experience": {
+    "promise": "Surface signal from fragmented community noise without requiring the manager to become a data analyst.",
+    "recommendation_boundary": "Freeside may suggest options when it shows the reason, supporting facts, and uncertainty; the manager chooses whether to inspect, save, export, or activate and Freeside does not silently act.",
+    "actions": ["inspect", "save", "export", "activate"],
+    "surfaces": [
+      "github:0xHoneyJar/freeside-dashboard#110",
+      "github:0xHoneyJar/freeside-dashboard#111",
+      "github:0xHoneyJar/freeside-dashboard#112"
+    ]
+  },
+  "evidence_contract": {
+    "signals": [
+      {
+        "id": "time_to_supported_insight",
+        "kind": "behavioral",
+        "question": "Can the manager identify a supported fact about composition or movement without assembling the analysis themselves?",
+        "success_indicator": "The manager identifies at least one fact-backed composition or movement signal during the first exposed session.",
+        "failure_indicator": "The manager leaves the session without a supported observation or needs the team to interpret the interface for them.",
+        "source_types": ["product-telemetry", "partner-observation"]
+      },
+      {
+        "id": "receipt_comprehension",
+        "kind": "qualitative",
+        "question": "Does the manager understand why a member or cohort appears where it does?",
+        "success_indicator": "The manager can restate the reason using the displayed facts and says the classification feels credible.",
+        "failure_indicator": "The manager describes the result as an unexplained score, asks how it was invented, or distrusts it after inspecting the facts.",
+        "source_types": ["user-interview", "website-feedback", "discord-support-or-feedback", "dm-to-team-member"]
+      },
+      {
+        "id": "decision_usefulness",
+        "kind": "qualitative",
+        "question": "Did the surfaced signal sharpen a real community decision?",
+        "success_indicator": "The manager cites the view when choosing what to investigate, whom to speak with, or which cohort to save or export.",
+        "failure_indicator": "The view is interesting but does not change what the manager understands or considers doing.",
+        "source_types": ["user-interview", "partner-observation", "dm-to-team-member"]
+      }
+    ],
+    "observations": [],
+    "learning_refs": [],
+    "privacy": {
+      "customer_text_handling": "no-raw-private-text-in-repo",
+      "provenance_required": true
+    }
+  },
+  "exposure": {
+    "kind": "research",
+    "state": "dark",
+    "audience": "Internal communities first, followed by bounded partner walkthroughs.",
+    "owner": "Freeside product",
+    "review_trigger": "After three partner walkthroughs or thirty exposed sessions, whichever comes first.",
+    "success_criteria": [
+      "At least two managers identify a supported composition or movement signal without team interpretation.",
+      "Managers can explain at least one cohort placement using the displayed receipt facts."
+    ],
+    "failure_criteria": [
+      "Managers consistently require an analyst or team member to interpret the view.",
+      "Managers cannot connect the surfaced composition or movement to a real decision."
+    ],
+    "decision_refs": []
+  },
+  "boundaries": {
+    "does": [
+      "Compose fragmented identity, social, and onchain evidence into a legible view.",
+      "Expose facts and provenance that let a manager inspect why a result exists.",
+      "Offer reversible tools and evidence-backed options."
+    ],
+    "does_not": [
+      "Present the operator thesis as settled user truth.",
+      "Expose hidden scores or weights as an authority claim.",
+      "Silently contact members, launch campaigns, or take consequential action."
+    ]
+  },
+  "exemplars": [
+    {
+      "product": "Clay People",
+      "workflow_moment": "Inspect one person across connected sources and prior interactions.",
+      "ref": "operator-reference:mobbin/clay-people-2026-07-14",
+      "adopt": "Person-centered profile, low-density timeline, connected sources, and familiar CRM navigation.",
+      "reject": "Email-first contact-manager assumptions and decorative integration imagery as product evidence."
+    },
+    {
+      "product": "Customer.io Segments",
+      "workflow_moment": "Narrow an audience using understandable attribute and behavior rules.",
+      "ref": "https://docs.customer.io/messaging/segmentation/segments/",
+      "adopt": "Plain-language grouping logic and immediate visibility into the population produced by the rules.",
+      "reject": "Exposing a full advanced segment builder before the Audit MVP proves that managers need it."
+    },
+    {
+      "product": "Common Room Contacts",
+      "workflow_moment": "Understand a community member through unified identity and activity context.",
+      "ref": "https://www.commonroom.io/docs/using-common-room/contacts/",
+      "adopt": "Unified member intelligence with inspectable source activity and cohort navigation.",
+      "reject": "Prescribing an outreach action before the manager has understood the evidence."
+    }
+  ],
+  "components": [
+    {
+      "ref": "github:0xHoneyJar/freeside-dashboard#111",
+      "maturity": "uncaptured"
+    }
+  ],
+  "decision_refs": [
+    "bead:arrakis-ydw0u",
+    "github:0xHoneyJar/freeside-dashboard#110",
+    "github:0xHoneyJar/freeside-dashboard#112"
+  ]
+}

--- a/product/system-components/loa-freeside.system.json
+++ b/product/system-components/loa-freeside.system.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "../../spec/product/system-component.schema.json",
+  "schema_version": "1.0",
+  "component_id": "loa-freeside",
+  "repository": "github:0xHoneyJar/loa-freeside",
+  "layer": "orchestrator",
+  "operator": {
+    "role": "Freeside platform engineer",
+    "job": "Compose stable buildings and BFF contracts without crossing their domain boundaries or forcing a product surface into the same implementation session."
+  },
+  "object": {
+    "kind": "backend-for-frontend",
+    "description": "The platform composition layer that assembles Freeside buildings into consumer-ready contracts and operational services."
+  },
+  "question": "Can a front-facing product consume a coherent Freeside capability through a stable contract without learning every producer's internal model?",
+  "responsibility": "Compose and operate platform capabilities, shared contracts, and BFF seams while keeping building ownership and evidence provenance explicit.",
+  "consumers": [
+    {
+      "name": "freeside-dashboard",
+      "need": "Stable composed reads and honest source states for community-manager product surfaces."
+    },
+    {
+      "name": "freeside-characters",
+      "need": "Stable identity, activity, and world capabilities without reimplementing platform logic inside character code."
+    },
+    {
+      "name": "API and agent consumers",
+      "need": "Reviewable contracts, typed failures, and a clear handoff when a producer capability is missing."
+    }
+  ],
+  "trust": {
+    "contract_status": "partial",
+    "contract_refs": [
+      "file:README.md",
+      "file:packages/README.md",
+      "file:packages/routes"
+    ],
+    "evidence_refs": [
+      "file:spec/product/flow-moment.schema.json",
+      "file:product/flow-moments/audit-community-composition.flow.json"
+    ],
+    "note": "The platform exposes multiple stable contracts, but it is not one monolithic API and each composed route still requires an explicit producer-to-consumer seam."
+  },
+  "actions": ["inspect", "compose", "integrate", "handoff", "operate"],
+  "boundaries": {
+    "owns": [
+      "Platform composition, shared contracts, and operational BFF seams.",
+      "Typed failure and provenance across composed building outputs."
+    ],
+    "does_not_own": [
+      "The internal domain logic of an extracted API building.",
+      "Front-facing information architecture, copy, or component taste.",
+      "A community manager's consequential decision or action."
+    ],
+    "missing_capability_handoff": "Record the missing producer capability as a typed issue or order; do not implement it silently in the BFF or presentation layer."
+  },
+  "flow_moments": [
+    {
+      "flow_moment_id": "FM-AUDIT-COMPOSITION",
+      "canonical_ref": "flow:FM-AUDIT-COMPOSITION",
+      "role": "composer",
+      "contribution": "Compose identity, activity, holdings, and audit evidence into a stable contract that a product surface can render without re-deriving producer semantics."
+    }
+  ]
+}

--- a/spec/product/flow-moment-implementation-report.md
+++ b/spec/product/flow-moment-implementation-report.md
@@ -54,7 +54,7 @@ node tools/system-component.mjs render product/system-components/loa-freeside.sy
 node tools/construct-operator.mjs render --snapshot tools/fixtures/construct-operator.snapshot.json
 ```
 
-Result: 47 tests passed; 1 real flow record and 1 canonical system-component manifest passed; all three receipts rendered; the live producer validated the Freeside territory and returned both stationings as expected dry-runs pending default-branch ratification. Targeted lint and workflow parsing pass. Portable consumer validation no longer requires canonical flow records unless `validate-flow-moments: true`, both validator CLIs reject ambiguous positional targets, and the reusable install remains isolated from a caller's pnpm workspace.
+Result: 50 tests passed; 1 real flow record and 1 canonical system-component manifest passed; all three receipts rendered; the live producer validated the Freeside territory and returned both stationings as expected dry-runs pending default-branch ratification. Targeted lint and workflow parsing pass. Portable consumer validation no longer requires canonical flow records unless `validate-flow-moments: true`, local component references resolve exactly, both validator CLIs reject ambiguous positional targets, receipt validation dates are replayable, malformed producer names fail with field-specific errors, and the reusable install remains isolated from a caller's pnpm workspace.
 
 ## Known limitations
 

--- a/spec/product/flow-moment-implementation-report.md
+++ b/spec/product/flow-moment-implementation-report.md
@@ -20,7 +20,7 @@ The implementation does not create another decision or learning ledger. `product
 - **T-4 Tests:** `tools/flow-moment.test.mjs` covers valid unproven state, Hivemind's actionless boundary, flag exposure, default-on evidence, typed provenance, evidence claims, Gold maturity, date bypass, and receipt rendering.
 - **T-5 CI:** `.github/workflows/flow-moment-governance.yml:35` validates every flow record after proving the red paths.
 - **T-6 Estate adoption:** `spec/product/system-component.schema.json`, `tools/system-component.mjs`, and the reusable workflow let each API or product declare a local responsibility without copying the canonical flow schema.
-- **T-7 Constructs info contract:** a stacked `loa-constructs` change adds `info_schema_version: 1.0`, separates non-authoritative `orientation` from declared `mechanics`, exposes per-skill capability metadata, and supports pinned local provenance.
+- **T-7 Constructs info contract:** `loa-constructs#276` adds `info_schema_version: 1.0`, separates non-authoritative `orientation` from declared `mechanics`, exposes per-skill capability metadata, and supports pinned local provenance.
 - **T-8 Freeside territory ratification:** `grimoires/territory.yaml` declares three product-governance outcomes and stations The Arcade + Beacon at an observe-only ceiling over an explicit file blast radius.
 - **T-9 Operator expertise projection:** `tools/construct-operator.mjs` joins the system-component record, territory atlas, construct info, and CLI capabilities into deterministic JSON or Markdown.
 - **T-10 Deterministic seams and CI:** `tools/construct-operator.test.mjs` and its checked-in producer snapshot prove prose/authority separation, mechanical unavailability, structured ratification, fail-closed authority, read/write verb separation, and byte-stable rendering.
@@ -52,7 +52,7 @@ node tools/system-component.mjs render product/system-components/loa-freeside.sy
 node tools/construct-operator.mjs render --snapshot tools/fixtures/construct-operator.snapshot.json
 ```
 
-Result: 26 tests passed; 1 real flow record and 1 canonical system-component manifest passed; all three receipts rendered; the live producer validated the Freeside territory and returned both stationings as expected dry-runs pending default-branch ratification. Targeted lint and workflow parsing pass. The reusable install remains isolated from a caller's pnpm workspace.
+Result: 38 tests passed; 1 real flow record and 1 canonical system-component manifest passed; all three receipts rendered; the live producer validated the Freeside territory and returned both stationings as expected dry-runs pending default-branch ratification. Targeted lint and workflow parsing pass. Portable consumer validation no longer requires canonical flow records unless `validate-flow-moments: true`, and the reusable install remains isolated from a caller's pnpm workspace.
 
 ## Known limitations
 
@@ -62,7 +62,7 @@ Result: 26 tests passed; 1 real flow record and 1 canonical system-component man
 - Consumer repositories call the reusable workflow and validator checkout by immutable commit SHA so contract changes cannot arrive implicitly.
 - Component `github:0xHoneyJar/freeside-dashboard#111` remains honestly `uncaptured`; this slice does not claim Silver or Gold adoption in the dashboard.
 - The older standalone Hivemind shell validator is unchanged; the flow validator uses full JSON Schema validation for the nested Hivemind object.
-- The live operator projection depends on the stacked `loa-constructs` info-contract change. CI uses a deterministic snapshot until that producer contract is merged and can be pinned by release.
+- The live operator projection depends on the `loa-constructs#276` info-contract change. CI uses a deterministic snapshot until that producer contract is merged and can be pinned by release.
 - The territory is deliberately unratified on this feature branch. Producer dry-runs report the untracked/non-default-branch blockers; no station receipt is written before merge.
 - The CLI receipt is the first operator projection. The deployed Hono operator dashboard can consume this JSON later, but this slice does not introduce a cross-repository runtime dependency into that service.
 

--- a/spec/product/flow-moment-implementation-report.md
+++ b/spec/product/flow-moment-implementation-report.md
@@ -54,7 +54,7 @@ node tools/system-component.mjs render product/system-components/loa-freeside.sy
 node tools/construct-operator.mjs render --snapshot tools/fixtures/construct-operator.snapshot.json
 ```
 
-Result: 45 tests passed; 1 real flow record and 1 canonical system-component manifest passed; all three receipts rendered; the live producer validated the Freeside territory and returned both stationings as expected dry-runs pending default-branch ratification. Targeted lint and workflow parsing pass. Portable consumer validation no longer requires canonical flow records unless `validate-flow-moments: true`, and the reusable install remains isolated from a caller's pnpm workspace.
+Result: 47 tests passed; 1 real flow record and 1 canonical system-component manifest passed; all three receipts rendered; the live producer validated the Freeside territory and returned both stationings as expected dry-runs pending default-branch ratification. Targeted lint and workflow parsing pass. Portable consumer validation no longer requires canonical flow records unless `validate-flow-moments: true`, both validator CLIs reject ambiguous positional targets, and the reusable install remains isolated from a caller's pnpm workspace.
 
 ## Known limitations
 

--- a/spec/product/flow-moment-implementation-report.md
+++ b/spec/product/flow-moment-implementation-report.md
@@ -43,7 +43,7 @@ node tools/system-component.mjs validate product/system-components
 node tools/system-component.mjs render product/system-components/loa-freeside.system.json
 ```
 
-Result: 15 tests passed; 1 real flow record and 1 canonical system-component manifest passed; both receipts rendered; targeted lint passed; both workflow YAML files parsed.
+Result: 16 tests passed; 1 real flow record and 1 canonical system-component manifest passed; both receipts rendered; targeted lint passed; both workflow YAML files parsed. The reusable install is isolated from a caller's pnpm workspace.
 
 ## Known limitations
 

--- a/spec/product/flow-moment-implementation-report.md
+++ b/spec/product/flow-moment-implementation-report.md
@@ -10,7 +10,7 @@
 
 Implemented the first executable vertical slice of the user-flow-moment continuity contract. The Audit composition-and-movement thesis is now represented as an explicitly unproven, falsifiable Hivemind experiment; a validator separates outcome evidence, exposure state, and component maturity; and path-scoped CI proves invalid promotion claims fail closed.
 
-The implementation does not create another decision or learning ledger. `product/flow-moments/*.flow.json` is the typed join, and the operator-facing continuity receipt is generated from it.
+The implementation does not create another decision or learning ledger. `product/flow-moments/*.flow.json` is the typed user-flow join, `grimoires/territory.yaml` is the region-owned expertise declaration, and every operator receipt is derived from those sources plus producer-owned Constructs JSON.
 
 ## Tasks completed
 
@@ -20,6 +20,10 @@ The implementation does not create another decision or learning ledger. `product
 - **T-4 Tests:** `tools/flow-moment.test.mjs` covers valid unproven state, Hivemind's actionless boundary, flag exposure, default-on evidence, typed provenance, evidence claims, Gold maturity, date bypass, and receipt rendering.
 - **T-5 CI:** `.github/workflows/flow-moment-governance.yml:35` validates every flow record after proving the red paths.
 - **T-6 Estate adoption:** `spec/product/system-component.schema.json`, `tools/system-component.mjs`, and the reusable workflow let each API or product declare a local responsibility without copying the canonical flow schema.
+- **T-7 Constructs info contract:** a stacked `loa-constructs` change adds `info_schema_version: 1.0`, separates non-authoritative `orientation` from declared `mechanics`, exposes per-skill capability metadata, and supports pinned local provenance.
+- **T-8 Freeside territory ratification:** `grimoires/territory.yaml` declares three product-governance outcomes and stations The Arcade + Beacon at an observe-only ceiling over an explicit file blast radius.
+- **T-9 Operator expertise projection:** `tools/construct-operator.mjs` joins the system-component record, territory atlas, construct info, and CLI capabilities into deterministic JSON or Markdown.
+- **T-10 Deterministic seams and CI:** `tools/construct-operator.test.mjs` and its checked-in producer snapshot prove prose/authority separation, mechanical unavailability, structured ratification, fail-closed authority, read/write verb separation, and byte-stable rendering.
 - **Documentation:** `docs/product/flow-moment-contract.md:12` explains the three independent axes and adoption workflow.
 
 ## Technical highlights
@@ -31,19 +35,24 @@ The implementation does not create another decision or learning ledger. `product
 - Requires both behavioral and qualitative evidence for `strongly-validated`.
 - Requires Silver intent metadata and a 14-day, evidence-backed production floor for Gold.
 - Fails when no records are found, preventing a green check that validated nothing.
+- Refuses a construct whose prose claims authority or whose mechanics claim an authority effect.
+- Treats missing construct details and unchecked territory ratification as `partial`, not success.
+- Reads detailed expertise from the producer's pinned local rung; Freeside does not maintain a parallel construct catalog or territory schema.
+- Separates Constructs mutation verbs structurally and never invokes them from the operator receipt.
 
 ## Testing summary
 
 ```bash
-pnpm exec oxlint tools/flow-moment.mjs tools/flow-moment.test.mjs tools/system-component.mjs tools/system-component.test.mjs
-node --test tools/flow-moment.test.mjs tools/system-component.test.mjs
+pnpm exec oxlint tools/flow-moment.mjs tools/flow-moment.test.mjs tools/system-component.mjs tools/system-component.test.mjs tools/construct-operator.mjs tools/construct-operator.test.mjs
+node --test tools/flow-moment.test.mjs tools/system-component.test.mjs tools/construct-operator.test.mjs
 node tools/flow-moment.mjs validate product/flow-moments --today 2026-07-14
 node tools/flow-moment.mjs render product/flow-moments/audit-community-composition.flow.json
 node tools/system-component.mjs validate product/system-components
 node tools/system-component.mjs render product/system-components/loa-freeside.system.json
+node tools/construct-operator.mjs render --snapshot tools/fixtures/construct-operator.snapshot.json
 ```
 
-Result: 16 tests passed; 1 real flow record and 1 canonical system-component manifest passed; both receipts rendered; targeted lint passed; both workflow YAML files parsed. The reusable install is isolated from a caller's pnpm workspace.
+Result: 26 tests passed; 1 real flow record and 1 canonical system-component manifest passed; all three receipts rendered; the live producer validated the Freeside territory and returned both stationings as expected dry-runs pending default-branch ratification. Targeted lint and workflow parsing pass. The reusable install remains isolated from a caller's pnpm workspace.
 
 ## Known limitations
 
@@ -53,11 +62,16 @@ Result: 16 tests passed; 1 real flow record and 1 canonical system-component man
 - Consumer repositories call the reusable workflow and validator checkout by immutable commit SHA so contract changes cannot arrive implicitly.
 - Component `github:0xHoneyJar/freeside-dashboard#111` remains honestly `uncaptured`; this slice does not claim Silver or Gold adoption in the dashboard.
 - The older standalone Hivemind shell validator is unchanged; the flow validator uses full JSON Schema validation for the nested Hivemind object.
+- The live operator projection depends on the stacked `loa-constructs` info-contract change. CI uses a deterministic snapshot until that producer contract is merged and can be pinned by release.
+- The territory is deliberately unratified on this feature branch. Producer dry-runs report the untracked/non-default-branch blockers; no station receipt is written before merge.
+- The CLI receipt is the first operator projection. The deployed Hono operator dashboard can consume this JSON later, but this slice does not introduce a cross-repository runtime dependency into that service.
 
 ## Reviewer verification
 
-1. Run the six commands above.
+1. Run the seven commands above.
 2. Change the exemplar exposure from `dark` to `internal` without adding `flag_ref`; validation must fail.
 3. Add an action field under `hivemind`; validation must fail.
 4. Claim Gold with a production date fewer than 14 days old; validation must fail.
 5. Render the receipt and verify that actor, hypothesis, evidence, exemplars, boundaries, exposure, and component maturity are all present.
+6. Set `orientation.authoritative` to `true` in the construct snapshot; the operator test must fail closed.
+7. Run the live projection against the producer CLI and verify that orientation, declared mechanics, pinned provenance, and observe-only effective authority render as separate fields.

--- a/spec/product/flow-moment-implementation-report.md
+++ b/spec/product/flow-moment-implementation-report.md
@@ -54,7 +54,7 @@ node tools/system-component.mjs render product/system-components/loa-freeside.sy
 node tools/construct-operator.mjs render --snapshot tools/fixtures/construct-operator.snapshot.json
 ```
 
-Result: 50 tests passed; 1 real flow record and 1 canonical system-component manifest passed; all three receipts rendered; the live producer validated the Freeside territory and returned both stationings as expected dry-runs pending default-branch ratification. Targeted lint and workflow parsing pass. Portable consumer validation no longer requires canonical flow records unless `validate-flow-moments: true`, local component references resolve exactly, both validator CLIs reject ambiguous positional targets, receipt validation dates are replayable, malformed producer names fail with field-specific errors, and the reusable install remains isolated from a caller's pnpm workspace.
+Result: 51 tests passed; 1 real flow record and 1 canonical system-component manifest passed; all three receipts rendered; the live producer validated the Freeside territory and returned both stationings as expected dry-runs pending default-branch ratification. Targeted lint and workflow parsing pass. Portable consumer validation no longer requires canonical flow records unless `validate-flow-moments: true`, local component references resolve exactly against the target repository, both validator CLIs reject ambiguous positional targets, receipt validation dates are replayable, malformed producer names fail with field-specific errors, and the reusable install remains isolated from a caller's pnpm workspace.
 
 ## Known limitations
 

--- a/spec/product/flow-moment-implementation-report.md
+++ b/spec/product/flow-moment-implementation-report.md
@@ -50,7 +50,7 @@ Result: 15 tests passed; 1 real flow record and 1 canonical system-component man
 - The Audit moment remains `dark`; this slice does not invent or wire a dashboard feature flag.
 - External `github:`, `bead:`, and URL references are type-checked but not fetched over the network in CI.
 - CI blocks invalid records and promotion claims when flow-governance files change. It does not yet require every product-code PR to declare a flow moment.
-- Consumer repositories call the reusable workflow by immutable commit SHA. Their first CI runs also verify that the organization permits reusable-workflow access to `0xHoneyJar/loa-freeside`.
+- Consumer repositories call the reusable workflow and validator checkout by immutable commit SHA so contract changes cannot arrive implicitly.
 - Component `github:0xHoneyJar/freeside-dashboard#111` remains honestly `uncaptured`; this slice does not claim Silver or Gold adoption in the dashboard.
 - The older standalone Hivemind shell validator is unchanged; the flow validator uses full JSON Schema validation for the nested Hivemind object.
 

--- a/spec/product/flow-moment-implementation-report.md
+++ b/spec/product/flow-moment-implementation-report.md
@@ -34,7 +34,7 @@ The implementation does not create another decision or learning ledger. `product
 - Requires learning and operator-decision references before research becomes default-on.
 - Requires both behavioral and qualitative evidence for `strongly-validated`.
 - Requires Silver intent metadata and a 14-day, evidence-backed production floor for Gold.
-- Evaluates the Gold production floor against a record-owned `as_of` date, keeping a commit's result deterministic.
+- Evaluates the Gold production floor against a record-owned `as_of` date, while refusing dates beyond the validator's observed UTC date.
 - Fails when no records are found, preventing a green check that validated nothing.
 - Refuses a construct whose prose claims authority or whose mechanics claim an authority effect.
 - Treats missing construct details and unchecked territory ratification as `partial`, not success.
@@ -54,7 +54,7 @@ node tools/system-component.mjs render product/system-components/loa-freeside.sy
 node tools/construct-operator.mjs render --snapshot tools/fixtures/construct-operator.snapshot.json
 ```
 
-Result: 43 tests passed; 1 real flow record and 1 canonical system-component manifest passed; all three receipts rendered; the live producer validated the Freeside territory and returned both stationings as expected dry-runs pending default-branch ratification. Targeted lint and workflow parsing pass. Portable consumer validation no longer requires canonical flow records unless `validate-flow-moments: true`, and the reusable install remains isolated from a caller's pnpm workspace.
+Result: 45 tests passed; 1 real flow record and 1 canonical system-component manifest passed; all three receipts rendered; the live producer validated the Freeside territory and returned both stationings as expected dry-runs pending default-branch ratification. Targeted lint and workflow parsing pass. Portable consumer validation no longer requires canonical flow records unless `validate-flow-moments: true`, and the reusable install remains isolated from a caller's pnpm workspace.
 
 ## Known limitations
 

--- a/spec/product/flow-moment-implementation-report.md
+++ b/spec/product/flow-moment-implementation-report.md
@@ -1,0 +1,63 @@
+# Implementation report — User-flow moment continuity
+
+**Track:** `flow-moment-continuity`
+
+**Task:** `arrakis-ydw0u`
+
+**Date:** 2026-07-14
+
+## Executive summary
+
+Implemented the first executable vertical slice of the user-flow-moment continuity contract. The Audit composition-and-movement thesis is now represented as an explicitly unproven, falsifiable Hivemind experiment; a validator separates outcome evidence, exposure state, and component maturity; and path-scoped CI proves invalid promotion claims fail closed.
+
+The implementation does not create another decision or learning ledger. `product/flow-moments/*.flow.json` is the typed join, and the operator-facing continuity receipt is generated from it.
+
+## Tasks completed
+
+- **T-1 Contract:** `spec/product/flow-moment.schema.json:1` composes the canonical Hivemind schema and makes `flow_moment_id` the join (`:30`).
+- **T-2 Audit exemplar:** `product/flow-moments/audit-community-composition.flow.json:4` records the operator-approved hypothesis at `cant-make-a-conclusion`, with behavioral and qualitative falsification signals.
+- **T-3 Validator and receipt:** `tools/flow-moment.mjs:55` enforces semantic promotion rules; `:149` renders the continuity receipt.
+- **T-4 Tests:** `tools/flow-moment.test.mjs` covers valid unproven state, Hivemind's actionless boundary, flag exposure, default-on evidence, typed provenance, evidence claims, Gold maturity, date bypass, and receipt rendering.
+- **T-5 CI:** `.github/workflows/flow-moment-governance.yml:35` validates every flow record after proving the red paths.
+- **T-6 Estate adoption:** `spec/product/system-component.schema.json`, `tools/system-component.mjs`, and the reusable workflow let each API or product declare a local responsibility without copying the canonical flow schema.
+- **Documentation:** `docs/product/flow-moment-contract.md:12` explains the three independent axes and adoption workflow.
+
+## Technical highlights
+
+- Uses JSON Schema 2020-12 with `additionalProperties: false` throughout.
+- Wraps rather than modifies the canonical Hivemind label schema.
+- Allows a dark hypothesis before flag implementation, but requires a flag reference for any exposed state.
+- Requires learning and operator-decision references before research becomes default-on.
+- Requires both behavioral and qualitative evidence for `strongly-validated`.
+- Requires Silver intent metadata and a 14-day, evidence-backed production floor for Gold.
+- Fails when no records are found, preventing a green check that validated nothing.
+
+## Testing summary
+
+```bash
+pnpm exec oxlint tools/flow-moment.mjs tools/flow-moment.test.mjs tools/system-component.mjs tools/system-component.test.mjs
+node --test tools/flow-moment.test.mjs tools/system-component.test.mjs
+node tools/flow-moment.mjs validate product/flow-moments --today 2026-07-14
+node tools/flow-moment.mjs render product/flow-moments/audit-community-composition.flow.json
+node tools/system-component.mjs validate product/system-components
+node tools/system-component.mjs render product/system-components/loa-freeside.system.json
+```
+
+Result: 15 tests passed; 1 real flow record and 1 canonical system-component manifest passed; both receipts rendered; targeted lint passed; both workflow YAML files parsed.
+
+## Known limitations
+
+- The Audit moment remains `dark`; this slice does not invent or wire a dashboard feature flag.
+- External `github:`, `bead:`, and URL references are type-checked but not fetched over the network in CI.
+- CI blocks invalid records and promotion claims when flow-governance files change. It does not yet require every product-code PR to declare a flow moment.
+- Consumer repositories call the reusable workflow by immutable commit SHA. Their first CI runs also verify that the organization permits reusable-workflow access to `0xHoneyJar/loa-freeside`.
+- Component `github:0xHoneyJar/freeside-dashboard#111` remains honestly `uncaptured`; this slice does not claim Silver or Gold adoption in the dashboard.
+- The older standalone Hivemind shell validator is unchanged; the flow validator uses full JSON Schema validation for the nested Hivemind object.
+
+## Reviewer verification
+
+1. Run the six commands above.
+2. Change the exemplar exposure from `dark` to `internal` without adding `flag_ref`; validation must fail.
+3. Add an action field under `hivemind`; validation must fail.
+4. Claim Gold with a production date fewer than 14 days old; validation must fail.
+5. Render the receipt and verify that actor, hypothesis, evidence, exemplars, boundaries, exposure, and component maturity are all present.

--- a/spec/product/flow-moment-implementation-report.md
+++ b/spec/product/flow-moment-implementation-report.md
@@ -34,11 +34,13 @@ The implementation does not create another decision or learning ledger. `product
 - Requires learning and operator-decision references before research becomes default-on.
 - Requires both behavioral and qualitative evidence for `strongly-validated`.
 - Requires Silver intent metadata and a 14-day, evidence-backed production floor for Gold.
+- Evaluates the Gold production floor against a record-owned `as_of` date, keeping a commit's result deterministic.
 - Fails when no records are found, preventing a green check that validated nothing.
 - Refuses a construct whose prose claims authority or whose mechanics claim an authority effect.
 - Treats missing construct details and unchecked territory ratification as `partial`, not success.
 - Reads detailed expertise from the producer's pinned local rung; Freeside does not maintain a parallel construct catalog or territory schema.
 - Separates Constructs mutation verbs structurally and never invokes them from the operator receipt.
+- Offers `--require-ok` for release gates while preserving visible `partial` receipts during operator inspection.
 
 ## Testing summary
 
@@ -52,7 +54,7 @@ node tools/system-component.mjs render product/system-components/loa-freeside.sy
 node tools/construct-operator.mjs render --snapshot tools/fixtures/construct-operator.snapshot.json
 ```
 
-Result: 38 tests passed; 1 real flow record and 1 canonical system-component manifest passed; all three receipts rendered; the live producer validated the Freeside territory and returned both stationings as expected dry-runs pending default-branch ratification. Targeted lint and workflow parsing pass. Portable consumer validation no longer requires canonical flow records unless `validate-flow-moments: true`, and the reusable install remains isolated from a caller's pnpm workspace.
+Result: 43 tests passed; 1 real flow record and 1 canonical system-component manifest passed; all three receipts rendered; the live producer validated the Freeside territory and returned both stationings as expected dry-runs pending default-branch ratification. Targeted lint and workflow parsing pass. Portable consumer validation no longer requires canonical flow records unless `validate-flow-moments: true`, and the reusable install remains isolated from a caller's pnpm workspace.
 
 ## Known limitations
 

--- a/spec/product/flow-moment-plan.md
+++ b/spec/product/flow-moment-plan.md
@@ -1,0 +1,82 @@
+# Build plan — User-flow moment continuity
+
+| | |
+|---|---|
+| **Named track** | `flow-moment-continuity` (parallel; does not replace the active Shadow Audit cycle) |
+| **Status** | Active — operator authorized 2026-07-14 |
+| **Domain** | Shared product-governance substrate |
+| **Tracking** | `arrakis-ydw0u` |
+
+This is a compact PRD + SDD + sprint gate for a bounded parallel track. It stays outside the active Loa cycle so the build does not merge two rooms or rewrite Shadow Audit state.
+
+## Product requirement
+
+Product intent currently survives in issue comments, flags, ADRs, components, and operator memory, but a fresh agent cannot reliably join those surfaces. This produces two failures: an implementation remains after its job is forgotten, or a product hypothesis is presented as truth before evidence exists.
+
+The Audit hypothesis is:
+
+> Teams that understand how their community is composed and changing can stay closer to rapidly changing reality and make more informed decisions. Freeside surfaces the signal from fragmented social and onchain noise.
+
+This remains a hypothesis until behavioral or qualitative evidence supports or falsifies it.
+
+### Goals
+
+| ID | Goal | Metric |
+|---|---|---|
+| **G-1** | Make the user-flow moment the stable join across issues, evidence, exemplars, components, and rollout state | One executable schema with no additional properties |
+| **G-2** | Preserve the Audit hypothesis without presenting it as settled user truth | Audit exemplar starts at `cant-make-a-conclusion` and names falsification conditions |
+| **G-3** | Keep component maturity separate from product-outcome confidence | Silver/Gold checks never mutate or imply Hivemind learning status |
+| **G-4** | Give research flags an evidence contract | Any exposed research flow names flag, audience, owner, review trigger, and success/failure signals |
+| **G-5** | Prevent false graduation claims | CI fails invalid default-on research and invalid Gold claims, with tests proving the red path |
+| **G-6** | Avoid another hand-maintained ledger | The agent continuity receipt is rendered from the executable flow record |
+| **G-7** | Carry intent across system buildings and front-facing products without schema forks | Each active consumer owns one validated system-component manifest pinned to the canonical workflow |
+
+### Non-goals
+
+- Changing the canonical Hivemind label schema.
+- Adding actions or recommendations to the Hivemind label layer.
+- Deciding that a hypothesis is true, taste is good, or a user should take an action.
+- Replacing issues, ADRs, TDRs, Learning Memos, feature flags, or component annotations.
+- Modifying the active Shadow Audit sprint or ledger.
+
+## Architecture
+
+```text
+Hivemind truth/confidence ─┐
+Issue and decision refs ───┤
+Exemplars ─────────────────┤
+Components + maturity ─────┼─► flow-moment record ─► continuity receipt
+Research flag state ───────┤             │
+Evidence contract/results ─┘             └─► CI promotion gates
+```
+
+The flow record points to existing sources and renders a disposable receipt. The local schema wraps the canonical Hivemind schema and requires all seven dimensions without extending its actionless object.
+
+### Promotion invariants
+
+1. A dark research hypothesis may exist before a flag is implemented.
+2. Exposed research requires a flag reference.
+3. Default-on research requires an operator decision and a learning reference.
+4. Evidence-confidence claims require captured observations.
+5. Silver requires intent, feel, inspiration, and rejected directions.
+6. Gold adds a taste owner, 14 production days, active use, no regressions, and evidence references.
+7. Component maturity never promotes outcome confidence.
+
+### Failure semantics
+
+- Invalid JSON, schema drift, or invalid promotion: exit `1` with field-level evidence.
+- No records found: exit `1`; green must prove that something was validated.
+- A valid unproven hypothesis: exit `0`; honest uncertainty is not a validation failure.
+
+## Sprint slice
+
+| Task | Goals | Acceptance criteria |
+|---|---|---|
+| **T-1 Contract** | G-1, G-3, G-4 | Strict schema composes Hivemind and models flow, evidence, exposure, exemplars, and maturity |
+| **T-2 Audit exemplar** | G-2 | Community-composition moment is unproven and falsifiable |
+| **T-3 Validator and receipt** | G-3, G-4, G-6 | CLI validates promotion invariants and renders continuity from source |
+| **T-4 Red-path tests** | G-5 | Invalid Hivemind extension, exposed research without flag, unsupported default-on, and premature Gold all fail |
+| **T-5 CI** | G-5 | Path-scoped workflow runs tests, validates records, and renders the exemplar |
+| **T-6 Estate adoption** | G-7 | Reusable workflow validates thin component manifests across active APIs and front-facing products |
+
+The slice is complete when targeted tests pass, the Audit record validates, at least four invalid promotions are proven red, and no active-cycle artifact changes.

--- a/spec/product/flow-moment-plan.md
+++ b/spec/product/flow-moment-plan.md
@@ -30,6 +30,9 @@ This remains a hypothesis until behavioral or qualitative evidence supports or f
 | **G-5** | Prevent false graduation claims | CI fails invalid default-on research and invalid Gold claims, with tests proving the red path |
 | **G-6** | Avoid another hand-maintained ledger | The agent continuity receipt is rendered from the executable flow record |
 | **G-7** | Carry intent across system buildings and front-facing products without schema forks | Each active consumer owns one validated system-component manifest pinned to the canonical workflow |
+| **G-8** | Make construct expertise legible without confusing prose with execution | The operator projection labels orientation as non-authoritative prose and sources callable mechanics from `constructs info` / `constructs capabilities` JSON |
+| **G-9** | Let each Freeside region compose expertise without granting authority by declaration | One region-owned territory manifest binds constructs to outcomes; every effective authority starts at `observe` |
+| **G-10** | Give the operator one joined view of user intent, system responsibility, and stationed expertise | A deterministic receipt joins the system-component manifest, territory atlas, construct info, and CLI contract without copying their source records |
 
 ### Non-goals
 
@@ -38,6 +41,8 @@ This remains a hypothesis until behavioral or qualitative evidence supports or f
 - Deciding that a hypothesis is true, taste is good, or a user should take an action.
 - Replacing issues, ADRs, TDRs, Learning Memos, feature flags, or component annotations.
 - Modifying the active Shadow Audit sprint or ledger.
+- Treating a construct persona, description, or recommendation as executable authority.
+- Copying the Constructs command contract or territory schema into Freeside.
 
 ## Architecture
 
@@ -52,6 +57,21 @@ Evidence contract/results ─┘             └─► CI promotion gates
 
 The flow record points to existing sources and renders a disposable receipt. The local schema wraps the canonical Hivemind schema and requires all seven dimensions without extending its actionless object.
 
+Construct expertise joins at a separate altitude:
+
+```text
+system component + flow moments ───────────────┐
+region-owned territory (outcomes + loadout) ───┼─► operator expertise receipt
+constructs info (orientation + mechanics) ─────┤
+constructs capabilities (execution contract) ──┘
+
+orientation = prose, non-authoritative
+mechanics   = declared callable surface, provenance-carrying
+authority   = territory ceiling ∩ earned tier; unknown collapses to observe
+```
+
+The invariant is that no prose field can promote a mechanical claim or an authority tier. Freeside renders producer-owned JSON and a region-owned territory declaration; it does not maintain a parallel construct catalog.
+
 ### Promotion invariants
 
 1. A dark research hypothesis may exist before a flag is implemented.
@@ -61,6 +81,9 @@ The flow record points to existing sources and renders a disposable receipt. The
 5. Silver requires intent, feel, inspiration, and rejected directions.
 6. Gold adds a taste owner, 14 production days, active use, no regressions, and evidence references.
 7. Component maturity never promotes outcome confidence.
+8. Construct orientation never grants permission or proves a capability.
+9. A mechanical claim must name the producer contract and its provenance or render as unavailable.
+10. A territory declaration is a ceiling; missing earned-authority evidence always renders effective authority as `observe`.
 
 ### Failure semantics
 
@@ -78,5 +101,9 @@ The flow record points to existing sources and renders a disposable receipt. The
 | **T-4 Red-path tests** | G-5 | Invalid Hivemind extension, exposed research without flag, unsupported default-on, and premature Gold all fail |
 | **T-5 CI** | G-5 | Path-scoped workflow runs tests, validates records, and renders the exemplar |
 | **T-6 Estate adoption** | G-7 | Reusable workflow validates thin component manifests across active APIs and front-facing products |
+| **T-7 Constructs info contract** | G-8 | Producer JSON separates non-authoritative orientation from declared skills, commands, and runtime metadata while preserving provenance |
+| **T-8 Freeside territory ratification** | G-9 | `loa-freeside` owns one bounded product-governance territory with an observe-only construct loadout |
+| **T-9 Operator expertise projection** | G-8, G-9, G-10 | Read-only CLI joins system intent, territory, construct info, and command capabilities into JSON or Markdown |
+| **T-10 Deterministic seams and CI** | G-8, G-10 | Fixtures prove unavailable mechanics, prose/authority separation, drift visibility, and byte-stable rendering |
 
-The slice is complete when targeted tests pass, the Audit record validates, at least four invalid promotions are proven red, and no active-cycle artifact changes.
+The slice is complete when targeted tests pass, the Audit record validates, at least four invalid promotions are proven red, the territory resolves through the producer CLI, the joined receipt renders from both live and fixture seams, and no active-cycle artifact changes.

--- a/spec/product/flow-moment.schema.json
+++ b/spec/product/flow-moment.schema.json
@@ -1,0 +1,413 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://freeside.dev/schemas/product/flow-moment.schema.json",
+  "title": "Freeside User-Flow Moment",
+  "description": "Executable join between Hivemind user truth, a falsifiable product hypothesis, exposure, evidence, exemplars, decisions, and component maturity.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "flow_moment_id",
+    "title",
+    "record_state",
+    "hivemind",
+    "actor",
+    "entry_state",
+    "desired_progress",
+    "dream_outcome",
+    "hypothesis",
+    "experience",
+    "evidence_contract",
+    "exposure",
+    "boundaries",
+    "exemplars",
+    "components",
+    "decision_refs"
+  ],
+  "properties": {
+    "$schema": { "type": "string" },
+    "schema_version": { "const": "1.0" },
+    "flow_moment_id": {
+      "type": "string",
+      "pattern": "^FM-[A-Z0-9]+(?:-[A-Z0-9]+)*$"
+    },
+    "title": { "$ref": "#/$defs/nonEmptyString" },
+    "record_state": {
+      "type": "string",
+      "enum": ["draft", "active", "retired"]
+    },
+    "hivemind": {
+      "allOf": [
+        { "$ref": "https://loa.dev/hivemind/labels.schema.json" },
+        {
+          "required": [
+            "schema_version",
+            "artifact_type",
+            "workstream",
+            "priority",
+            "product_area",
+            "jtbd",
+            "learning_status",
+            "source"
+          ]
+        }
+      ]
+    },
+    "actor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "context"],
+      "properties": {
+        "role": { "$ref": "#/$defs/nonEmptyString" },
+        "context": { "$ref": "#/$defs/nonEmptyString" }
+      }
+    },
+    "entry_state": { "$ref": "#/$defs/nonEmptyString" },
+    "desired_progress": { "$ref": "#/$defs/nonEmptyString" },
+    "dream_outcome": { "$ref": "#/$defs/nonEmptyString" },
+    "hypothesis": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["statement", "falsifiable_by"],
+      "properties": {
+        "statement": { "$ref": "#/$defs/nonEmptyString" },
+        "falsifiable_by": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/nonEmptyString" }
+        }
+      }
+    },
+    "experience": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["promise", "recommendation_boundary", "actions", "surfaces"],
+      "properties": {
+        "promise": { "$ref": "#/$defs/nonEmptyString" },
+        "recommendation_boundary": { "$ref": "#/$defs/nonEmptyString" },
+        "actions": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/nonEmptyString" }
+        },
+        "surfaces": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/reference" }
+        }
+      }
+    },
+    "evidence_contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["signals", "observations", "learning_refs", "privacy"],
+      "properties": {
+        "signals": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "$ref": "#/$defs/signal" }
+        },
+        "observations": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/observation" }
+        },
+        "learning_refs": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/reference" }
+        },
+        "privacy": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["customer_text_handling", "provenance_required"],
+          "properties": {
+            "customer_text_handling": {
+              "type": "string",
+              "enum": [
+                "no-raw-private-text-in-repo",
+                "consented-redacted-quotation",
+                "aggregate-only"
+              ]
+            },
+            "provenance_required": { "const": true }
+          }
+        }
+      }
+    },
+    "exposure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "state",
+        "audience",
+        "owner",
+        "review_trigger",
+        "success_criteria",
+        "failure_criteria",
+        "decision_refs"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["release", "research", "permission"]
+        },
+        "state": {
+          "type": "string",
+          "enum": ["dark", "internal", "partner", "default-on", "retiring", "retired"]
+        },
+        "flag_ref": { "$ref": "#/$defs/reference" },
+        "audience": { "$ref": "#/$defs/nonEmptyString" },
+        "owner": { "$ref": "#/$defs/nonEmptyString" },
+        "review_trigger": { "$ref": "#/$defs/nonEmptyString" },
+        "success_criteria": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/nonEmptyString" }
+        },
+        "failure_criteria": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/nonEmptyString" }
+        },
+        "decision_refs": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/reference" }
+        }
+      }
+    },
+    "boundaries": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["does", "does_not"],
+      "properties": {
+        "does": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/nonEmptyString" }
+        },
+        "does_not": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/nonEmptyString" }
+        }
+      }
+    },
+    "exemplars": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/exemplar" }
+    },
+    "components": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/component" }
+    },
+    "decision_refs": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/reference" }
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "\\S"
+    },
+    "reference": {
+      "type": "string",
+      "minLength": 3,
+      "pattern": "^[a-z][a-z0-9+.-]*:\\S+$"
+    },
+    "signal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "question", "success_indicator", "failure_indicator", "source_types"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$"
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["behavioral", "qualitative", "operational"]
+        },
+        "question": { "$ref": "#/$defs/nonEmptyString" },
+        "success_indicator": { "$ref": "#/$defs/nonEmptyString" },
+        "failure_indicator": { "$ref": "#/$defs/nonEmptyString" },
+        "source_types": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/evidenceSourceType" }
+        }
+      }
+    },
+    "evidenceSourceType": {
+      "type": "string",
+      "enum": [
+        "product-telemetry",
+        "website-feedback",
+        "customer-ticket",
+        "discord-support-or-feedback",
+        "user-interview",
+        "dm-to-team-member",
+        "partner-observation"
+      ]
+    },
+    "observation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "captured_at", "signal_ids", "summary", "source_type", "ref"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^OBS-[A-Z0-9]+(?:-[A-Z0-9]+)*$"
+        },
+        "captured_at": { "type": "string", "format": "date-time" },
+        "signal_ids": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string" }
+        },
+        "summary": { "$ref": "#/$defs/nonEmptyString" },
+        "source_type": { "$ref": "#/$defs/evidenceSourceType" },
+        "ref": { "$ref": "#/$defs/reference" }
+      }
+    },
+    "exemplar": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["product", "workflow_moment", "ref", "adopt", "reject"],
+      "properties": {
+        "product": { "$ref": "#/$defs/nonEmptyString" },
+        "workflow_moment": { "$ref": "#/$defs/nonEmptyString" },
+        "ref": { "$ref": "#/$defs/reference" },
+        "adopt": { "$ref": "#/$defs/nonEmptyString" },
+        "reject": { "$ref": "#/$defs/nonEmptyString" }
+      }
+    },
+    "component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ref", "maturity"],
+      "properties": {
+        "ref": { "$ref": "#/$defs/reference" },
+        "maturity": {
+          "type": "string",
+          "enum": ["uncaptured", "silver", "gold", "retired"]
+        },
+        "intent": { "$ref": "#/$defs/nonEmptyString" },
+        "feel": { "$ref": "#/$defs/nonEmptyString" },
+        "inspiration": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/reference" }
+        },
+        "rejected": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/nonEmptyString" }
+        },
+        "graduation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "taste_owner",
+            "production_since",
+            "no_regressions",
+            "active_use",
+            "evidence_refs"
+          ],
+          "properties": {
+            "taste_owner": { "$ref": "#/$defs/nonEmptyString" },
+            "production_since": { "type": "string", "format": "date" },
+            "no_regressions": { "const": true },
+            "active_use": { "const": true },
+            "evidence_refs": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/reference" }
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "maturity": { "enum": ["silver", "gold"] }
+            },
+            "required": ["maturity"]
+          },
+          "then": {
+            "required": ["intent", "feel", "inspiration", "rejected"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "maturity": { "const": "gold" }
+            },
+            "required": ["maturity"]
+          },
+          "then": {
+            "required": ["graduation"]
+          }
+        }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "exposure": {
+            "properties": {
+              "state": {
+                "enum": ["internal", "partner", "default-on", "retiring", "retired"]
+              }
+            },
+            "required": ["state"]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "exposure": { "required": ["flag_ref"] }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "exposure": {
+            "properties": {
+              "kind": { "const": "research" },
+              "state": { "const": "default-on" }
+            },
+            "required": ["kind", "state"]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "exposure": {
+            "properties": {
+              "decision_refs": { "minItems": 1 }
+            }
+          },
+          "evidence_contract": {
+            "properties": {
+              "learning_refs": { "minItems": 1 }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/spec/product/flow-moment.schema.json
+++ b/spec/product/flow-moment.schema.json
@@ -298,9 +298,13 @@
     "component": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["ref", "maturity"],
+      "required": ["ref", "resolution", "maturity"],
       "properties": {
         "ref": { "$ref": "#/$defs/reference" },
+        "resolution": {
+          "type": "string",
+          "enum": ["local", "external"]
+        },
         "maturity": {
           "type": "string",
           "enum": ["uncaptured", "silver", "gold", "retired"]
@@ -361,6 +365,24 @@
           },
           "then": {
             "required": ["graduation"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "resolution": { "const": "local" } },
+            "required": ["resolution"]
+          },
+          "then": {
+            "properties": { "ref": { "pattern": "^component:[a-z0-9][a-z0-9-]*$" } }
+          }
+        },
+        {
+          "if": {
+            "properties": { "resolution": { "const": "external" } },
+            "required": ["resolution"]
+          },
+          "then": {
+            "properties": { "ref": { "not": { "pattern": "^component:" } } }
           }
         }
       ]

--- a/spec/product/flow-moment.schema.json
+++ b/spec/product/flow-moment.schema.json
@@ -220,7 +220,7 @@
     "reference": {
       "type": "string",
       "minLength": 3,
-      "pattern": "^[a-z][a-z0-9+.-]*:\\S+$"
+      "pattern": "^(?![\\s\\S]*\\s)[a-z][a-z0-9+.-]*:\\S+$"
     },
     "signal": {
       "type": "object",

--- a/spec/product/flow-moment.schema.json
+++ b/spec/product/flow-moment.schema.json
@@ -224,15 +224,16 @@
       "minLength": 3,
       "pattern": "^(?![\\s\\S]*\\s)[a-z][a-z0-9+.-]*:\\S+$"
     },
+    "signalId": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$"
+    },
     "signal": {
       "type": "object",
       "additionalProperties": false,
       "required": ["id", "kind", "question", "success_indicator", "failure_indicator", "source_types"],
       "properties": {
-        "id": {
-          "type": "string",
-          "pattern": "^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$"
-        },
+        "id": { "$ref": "#/$defs/signalId" },
         "kind": {
           "type": "string",
           "enum": ["behavioral", "qualitative", "operational"]
@@ -274,7 +275,7 @@
           "type": "array",
           "minItems": 1,
           "uniqueItems": true,
-          "items": { "type": "string" }
+          "items": { "$ref": "#/$defs/signalId" }
         },
         "summary": { "$ref": "#/$defs/nonEmptyString" },
         "source_type": { "$ref": "#/$defs/evidenceSourceType" },

--- a/spec/product/flow-moment.schema.json
+++ b/spec/product/flow-moment.schema.json
@@ -10,6 +10,7 @@
     "flow_moment_id",
     "title",
     "record_state",
+    "as_of",
     "hivemind",
     "actor",
     "entry_state",
@@ -36,6 +37,7 @@
       "type": "string",
       "enum": ["draft", "active", "retired"]
     },
+    "as_of": { "type": "string", "format": "date" },
     "hivemind": {
       "allOf": [
         { "$ref": "https://loa.dev/hivemind/labels.schema.json" },

--- a/spec/product/flow-moment.schema.json
+++ b/spec/product/flow-moment.schema.json
@@ -108,6 +108,7 @@
         "signals": {
           "type": "array",
           "minItems": 2,
+          "uniqueItems": true,
           "items": { "$ref": "#/$defs/signal" }
         },
         "observations": {

--- a/spec/product/system-component.schema.json
+++ b/spec/product/system-component.schema.json
@@ -173,7 +173,7 @@
     "reference": {
       "type": "string",
       "minLength": 3,
-      "pattern": "^[a-z][a-z0-9+.-]*:\\S+$"
+      "pattern": "^(?![\\s\\S]*\\s)[a-z][a-z0-9+.-]*:\\S+$"
     }
   },
   "oneOf": [

--- a/spec/product/system-component.schema.json
+++ b/spec/product/system-component.schema.json
@@ -1,0 +1,189 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://freeside.dev/schemas/product/system-component.schema.json",
+  "title": "Freeside System Component Intent",
+  "description": "A thin BFF and product-surface adoption contract that joins a component's stable responsibility to real user-flow moments without copying those moments.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema_version",
+    "component_id",
+    "repository",
+    "layer",
+    "operator",
+    "object",
+    "question",
+    "responsibility",
+    "consumers",
+    "trust",
+    "actions",
+    "boundaries",
+    "flow_moments"
+  ],
+  "properties": {
+    "$schema": { "type": "string" },
+    "schema_version": { "const": "1.0" },
+    "component_id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+    },
+    "repository": {
+      "type": "string",
+      "pattern": "^github:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+    },
+    "layer": {
+      "type": "string",
+      "enum": ["building", "bff", "surface", "agent-surface", "orchestrator"]
+    },
+    "operator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "job"],
+      "properties": {
+        "role": { "$ref": "#/$defs/nonEmptyString" },
+        "job": { "$ref": "#/$defs/nonEmptyString" }
+      }
+    },
+    "object": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "description"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["system-component", "backend-for-frontend", "product-surface", "agent-product"]
+        },
+        "description": { "$ref": "#/$defs/nonEmptyString" }
+      }
+    },
+    "question": { "$ref": "#/$defs/nonEmptyString" },
+    "responsibility": { "$ref": "#/$defs/nonEmptyString" },
+    "consumers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "need"],
+        "properties": {
+          "name": { "$ref": "#/$defs/nonEmptyString" },
+          "need": { "$ref": "#/$defs/nonEmptyString" }
+        }
+      }
+    },
+    "trust": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contract_status", "contract_refs", "evidence_refs", "note"],
+      "properties": {
+        "contract_status": {
+          "type": "string",
+          "enum": ["declared", "partial", "missing"]
+        },
+        "contract_refs": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/reference" }
+        },
+        "evidence_refs": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/reference" }
+        },
+        "note": { "$ref": "#/$defs/nonEmptyString" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "contract_status": { "enum": ["declared", "partial"] } },
+            "required": ["contract_status"]
+          },
+          "then": {
+            "properties": { "contract_refs": { "minItems": 1 } }
+          }
+        },
+        {
+          "if": {
+            "properties": { "contract_status": { "const": "missing" } },
+            "required": ["contract_status"]
+          },
+          "then": {
+            "properties": { "contract_refs": { "maxItems": 0 } }
+          }
+        }
+      ]
+    },
+    "actions": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/nonEmptyString" }
+    },
+    "boundaries": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owns", "does_not_own", "missing_capability_handoff"],
+      "properties": {
+        "owns": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/nonEmptyString" }
+        },
+        "does_not_own": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/nonEmptyString" }
+        },
+        "missing_capability_handoff": { "$ref": "#/$defs/nonEmptyString" }
+      }
+    },
+    "flow_moments": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["flow_moment_id", "canonical_ref", "role", "contribution"],
+        "properties": {
+          "flow_moment_id": {
+            "type": "string",
+            "pattern": "^FM-[A-Z0-9]+(?:-[A-Z0-9]+)*$"
+          },
+          "canonical_ref": {
+            "type": "string",
+            "pattern": "^flow:FM-[A-Z0-9]+(?:-[A-Z0-9]+)*$"
+          },
+          "role": {
+            "type": "string",
+            "enum": ["producer", "composer", "surface", "feedback", "orchestrator"]
+          },
+          "contribution": { "$ref": "#/$defs/nonEmptyString" }
+        }
+      }
+    },
+    "unmapped_reason": { "$ref": "#/$defs/nonEmptyString" }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "\\S"
+    },
+    "reference": {
+      "type": "string",
+      "minLength": 3,
+      "pattern": "^[a-z][a-z0-9+.-]*:\\S+$"
+    }
+  },
+  "oneOf": [
+    {
+      "properties": { "flow_moments": { "minItems": 1 } },
+      "not": { "required": ["unmapped_reason"] }
+    },
+    {
+      "properties": { "flow_moments": { "maxItems": 0 } },
+      "required": ["unmapped_reason"]
+    }
+  ]
+}

--- a/tools/construct-operator.mjs
+++ b/tools/construct-operator.mjs
@@ -288,7 +288,7 @@ function skillLine(skill) {
 
 export function renderConstructOperatorSurface(surface) {
   const flows = surface.component.flow_moments
-    .map((flow) => `- **${flow.flow_moment_id}** (${escapeMarkdownText(flow.role)}): ${escapeMarkdownText(flow.contribution)}`)
+    .map((flow) => `- **${escapeMarkdownText(flow.flow_moment_id)}** (${escapeMarkdownText(flow.role)}): ${escapeMarkdownText(flow.contribution)}`)
     .join("\n");
   const constructs = surface.constructs.map((construct) => {
     const orientation = construct.orientation.available
@@ -297,7 +297,7 @@ export function renderConstructOperatorSurface(surface) {
     const mechanics = construct.mechanics.available
       ? (construct.mechanics.skills.length > 0 ? construct.mechanics.skills.map(skillLine).join("\n") : "- No skills declared")
       : `- Unavailable: ${escapeMarkdownText(construct.mechanics.reason)}`;
-    return `### ${escapeMarkdownText(construct.slug)}\n\n**Orientation — prose, no authority**\n\n${escapeMarkdownText(orientation)}\n\n**Mechanical declaration — callable surface, no authority**\n\n${mechanics}\n\n**Authority — territory + earned evidence**\n\nCeiling: **${construct.authority.ceiling}** · Earned: **${construct.authority.earned}** · Effective: **${construct.authority.effective}**\n\nAnswers for: ${construct.answers_for.map((outcome) => outcome.id).join(", ")}`;
+    return `### ${escapeMarkdownText(construct.slug)}\n\n**Orientation — prose, no authority**\n\n${escapeMarkdownText(orientation)}\n\n**Mechanical declaration — callable surface, no authority**\n\n${mechanics}\n\n**Authority — territory + earned evidence**\n\nCeiling: **${construct.authority.ceiling}** · Earned: **${construct.authority.earned}** · Effective: **${construct.authority.effective}**\n\nAnswers for: ${construct.answers_for.map((outcome) => escapeMarkdownText(outcome.id)).join(", ")}`;
   }).join("\n\n");
   const reads = surface.execution_contract.read_verbs.map((verb) => `\`${escapeMarkdownText(verb.name)}\``).join(", ");
   const mutations = surface.execution_contract.mutation_verbs.map((verb) => `\`${escapeMarkdownText(verb.name)}\``).join(", ");

--- a/tools/construct-operator.mjs
+++ b/tools/construct-operator.mjs
@@ -25,6 +25,23 @@ function byName(a, b) {
   return a.name.localeCompare(b.name);
 }
 
+function duplicateValues(values) {
+  const seen = new Set();
+  return [...new Set(values.filter((value) => {
+    if (seen.has(value)) return true;
+    seen.add(value);
+    return false;
+  }))];
+}
+
+function escapeMarkdownText(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replace(/([\\`*_[\]{}()#+\-.!|])/g, "\\$1");
+}
+
 function normalizeExecutionContract(capabilities) {
   requireObject(capabilities, "constructs capabilities");
   if (!Array.isArray(capabilities.verbs)) {
@@ -117,11 +134,16 @@ function normalizeConstructInfo(slug, payload) {
           slug: skill.slug,
           path: skill.path ?? null,
           metadata_status: skill.metadata_status ?? "unknown",
+          entry: skill.entry ?? null,
           capabilities: skill.capabilities ?? null,
         })).toSorted((a, b) => a.slug.localeCompare(b.slug))
         : [],
       commands: Array.isArray(mechanics.commands)
-        ? mechanics.commands.map((command) => ({ name: command.name, path: command.path ?? null })).toSorted(byName)
+        ? mechanics.commands.map((command) => ({
+          name: command.name,
+          path: command.path ?? null,
+          path_status: command.path_status ?? "unknown",
+        })).toSorted(byName)
         : [],
     },
     provenance: payload.provenance ?? null,
@@ -188,12 +210,40 @@ export function buildConstructOperatorSurface({ component, snapshot, regionId })
   const region = (atlas.regions ?? []).find((candidate) => candidate.region === selectedRegion);
   if (!region) throw new Error(`construct atlas has no region named ${selectedRegion}`);
 
-  const outcomes = new Map((region.outcomes ?? []).map((outcome) => [outcome.id, outcome.description]));
-  const constructs = (region.loadout ?? []).map((stationing) => {
+  if (!Array.isArray(region.outcomes)) throw new Error(`construct atlas ${selectedRegion}: outcomes must be an array`);
+  if (!Array.isArray(region.loadout)) throw new Error(`construct atlas ${selectedRegion}: loadout must be an array`);
+  const duplicateOutcomeIds = duplicateValues(region.outcomes.map((outcome) => outcome?.id));
+  if (duplicateOutcomeIds.length > 0) {
+    throw new Error(`construct atlas ${selectedRegion}: duplicate outcome ids: ${duplicateOutcomeIds.join(", ")}`);
+  }
+  const duplicateConstructs = duplicateValues(region.loadout.map((stationing) => stationing?.construct));
+  if (duplicateConstructs.length > 0) {
+    throw new Error(`construct atlas ${selectedRegion}: duplicate construct stationings: ${duplicateConstructs.join(", ")}`);
+  }
+  const outcomes = new Map(region.outcomes.map((outcome) => {
+    requireObject(outcome, `construct atlas ${selectedRegion}.outcome`);
+    if (typeof outcome.id !== "string" || typeof outcome.description !== "string") {
+      throw new Error(`construct atlas ${selectedRegion}: every outcome requires string id and description`);
+    }
+    return [outcome.id, outcome.description];
+  }));
+  const constructs = region.loadout.map((stationing) => {
+    requireObject(stationing, `construct atlas ${selectedRegion}.stationing`);
+    if (typeof stationing.construct !== "string" || !Array.isArray(stationing.outcomes)) {
+      throw new Error(`construct atlas ${selectedRegion}: every stationing requires construct and outcomes`);
+    }
+    const repeated = duplicateValues(stationing.outcomes);
+    if (repeated.length > 0) {
+      throw new Error(`constructs atlas ${stationing.construct}: duplicate outcome ids: ${repeated.join(", ")}`);
+    }
+    const unknown = stationing.outcomes.filter((id) => !outcomes.has(id));
+    if (unknown.length > 0) {
+      throw new Error(`constructs atlas ${stationing.construct}: unknown outcome ids: ${unknown.join(", ")}`);
+    }
     const info = normalizeConstructInfo(stationing.construct, snapshot.info?.[stationing.construct]);
     info.answers_for = [...stationing.outcomes].toSorted().map((id) => ({
       id,
-      description: outcomes.get(id) ?? null,
+      description: outcomes.get(id),
     }));
     info.authority = normalizeAuthority(stationing);
     info.installed = stationing.installed === true;
@@ -253,7 +303,7 @@ export function renderConstructOperatorSurface(surface) {
     const mechanics = construct.mechanics.available
       ? (construct.mechanics.skills.length > 0 ? construct.mechanics.skills.map(skillLine).join("\n") : "- No skills declared")
       : `- Unavailable: ${construct.mechanics.reason}`;
-    return `### ${construct.slug}\n\n**Orientation — prose, no authority**\n\n${orientation}\n\n**Mechanical declaration — callable surface, no authority**\n\n${mechanics}\n\n**Authority — territory + earned evidence**\n\nCeiling: **${construct.authority.ceiling}** · Earned: **${construct.authority.earned}** · Effective: **${construct.authority.effective}**\n\nAnswers for: ${construct.answers_for.map((outcome) => outcome.id).join(", ")}`;
+    return `### ${construct.slug}\n\n**Orientation — prose, no authority**\n\n${escapeMarkdownText(orientation)}\n\n**Mechanical declaration — callable surface, no authority**\n\n${mechanics}\n\n**Authority — territory + earned evidence**\n\nCeiling: **${construct.authority.ceiling}** · Earned: **${construct.authority.earned}** · Effective: **${construct.authority.effective}**\n\nAnswers for: ${construct.answers_for.map((outcome) => outcome.id).join(", ")}`;
   }).join("\n\n");
   const reads = surface.execution_contract.read_verbs.map((verb) => `\`${verb.name}\``).join(", ");
   const mutations = surface.execution_contract.mutation_verbs.map((verb) => `\`${verb.name}\``).join(", ");

--- a/tools/construct-operator.mjs
+++ b/tools/construct-operator.mjs
@@ -348,9 +348,14 @@ export function captureLiveSnapshot({ cli, cwd = ROOT, regionId }) {
 
 function usage() {
   return `Usage:
-  node tools/construct-operator.mjs render [--system <file>] [--region <id>] (--snapshot <file> | --constructs-cli <path>) [--json]
+  node tools/construct-operator.mjs render [--system <file>] [--region <id>] (--snapshot <file> | --constructs-cli <path>) [--json] [--require-ok]
 
 Live mode runs read-only Constructs verbs only: capabilities, atlas, and info --rung local.`;
+}
+
+function rejectUnknownFlags(args, allowed) {
+  const unknown = args.find((arg) => arg.startsWith("--") && !allowed.has(arg));
+  if (unknown) throw new Error(`unknown option ${unknown}`);
 }
 
 function flagValue(args, name) {
@@ -366,6 +371,14 @@ async function main(args) {
     console.error(usage());
     return 1;
   }
+  rejectUnknownFlags(args.slice(1), new Set([
+    "--system",
+    "--region",
+    "--snapshot",
+    "--constructs-cli",
+    "--json",
+    "--require-ok",
+  ]));
   const systemPath = flagValue(args, "--system") ?? DEFAULT_SYSTEM;
   const component = readJson(systemPath);
   const regionId = flagValue(args, "--region") ?? component.component_id;
@@ -382,7 +395,12 @@ async function main(args) {
   const surface = buildConstructOperatorSurface({ component, snapshot, regionId });
   if (args.includes("--json")) process.stdout.write(`${JSON.stringify(surface, null, 2)}\n`);
   else process.stdout.write(renderConstructOperatorSurface(surface));
-  return surface.status === "drift" ? 5 : 0;
+  if (surface.status === "drift") return 5;
+  if (args.includes("--require-ok") && surface.status !== "ok") {
+    console.error(`construct-operator: --require-ok rejected status ${surface.status}`);
+    return 1;
+  }
+  return 0;
 }
 
 const isDirect = process.argv[1]

--- a/tools/construct-operator.mjs
+++ b/tools/construct-operator.mjs
@@ -1,0 +1,352 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { validateSystemComponent } from "./system-component.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const DEFAULT_SYSTEM = "product/system-components/loa-freeside.system.json";
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(path.resolve(file), "utf8"));
+}
+
+function requireObject(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value;
+}
+
+function byName(a, b) {
+  return a.name.localeCompare(b.name);
+}
+
+function normalizeExecutionContract(capabilities) {
+  requireObject(capabilities, "constructs capabilities");
+  if (!Array.isArray(capabilities.verbs)) {
+    throw new Error("constructs capabilities.verbs must be an array");
+  }
+  const verbs = capabilities.verbs.map((verb) => ({
+    name: verb.name,
+    summary: verb.summary,
+    flags: Array.isArray(verb.flags) ? [...verb.flags] : [],
+  }));
+  const mutationNames = new Set(
+    capabilities.verbs.filter((verb) => verb.mutation === true).map((verb) => verb.name),
+  );
+  return {
+    tool: capabilities.tool,
+    version: capabilities.version,
+    contract_version: capabilities.contract_version,
+    determinism: capabilities.determinism,
+    info_contract: capabilities.info_contract ?? null,
+    atlas_contract: capabilities.atlas_contract ?? null,
+    read_verbs: verbs.filter((verb) => !mutationNames.has(verb.name)).toSorted(byName),
+    mutation_verbs: verbs.filter((verb) => mutationNames.has(verb.name)).toSorted(byName),
+    exit_codes: capabilities.exit_codes,
+  };
+}
+
+function unavailableConstruct(slug, reason) {
+  return {
+    slug,
+    orientation: {
+      available: false,
+      kind: "unavailable",
+      authoritative: false,
+      description: null,
+      reason,
+    },
+    mechanics: {
+      available: false,
+      kind: "unavailable",
+      authority_effect: "none",
+      reason,
+      skills: [],
+      commands: [],
+    },
+    provenance: null,
+    drift: [],
+  };
+}
+
+function normalizeConstructInfo(slug, payload) {
+  if (!payload || payload.error) {
+    return unavailableConstruct(slug, payload?.error?.message ?? "construct info was not available");
+  }
+  const data = requireObject(payload.data, `constructs info ${slug}.data`);
+  if (data.info_schema_version !== "1.0") {
+    throw new Error(`constructs info ${slug}: producer does not expose info_schema_version 1.0`);
+  }
+  const orientation = requireObject(data.orientation, `constructs info ${slug}.orientation`);
+  if (orientation.kind !== "prose" || orientation.authoritative !== false) {
+    throw new Error(`constructs info ${slug}: orientation must be non-authoritative prose`);
+  }
+  const mechanics = requireObject(data.mechanics, `constructs info ${slug}.mechanics`);
+  if (mechanics.authority_effect !== "none") {
+    throw new Error(`constructs info ${slug}: mechanics cannot grant authority`);
+  }
+  if (!new Set(["declared", "unavailable"]).has(mechanics.kind)) {
+    throw new Error(`constructs info ${slug}: unknown mechanics kind ${JSON.stringify(mechanics.kind)}`);
+  }
+
+  return {
+    slug,
+    orientation: {
+      available: true,
+      kind: "prose",
+      authoritative: false,
+      description: orientation.description ?? "",
+      short_description: orientation.short_description ?? null,
+      domains: Array.isArray(orientation.domains) ? [...orientation.domains].toSorted() : [],
+      persona_ref: orientation.persona_ref ?? null,
+      expertise_ref: orientation.expertise_ref ?? null,
+    },
+    mechanics: {
+      available: mechanics.kind === "declared",
+      kind: mechanics.kind,
+      authority_effect: "none",
+      reason: mechanics.reason ?? null,
+      source_refs: Array.isArray(mechanics.source_refs) ? [...mechanics.source_refs].toSorted() : [],
+      skills: Array.isArray(mechanics.skills)
+        ? mechanics.skills.map((skill) => ({
+          slug: skill.slug,
+          path: skill.path ?? null,
+          metadata_status: skill.metadata_status ?? "unknown",
+          capabilities: skill.capabilities ?? null,
+        })).toSorted((a, b) => a.slug.localeCompare(b.slug))
+        : [],
+      commands: Array.isArray(mechanics.commands)
+        ? mechanics.commands.map((command) => ({ name: command.name, path: command.path ?? null })).toSorted(byName)
+        : [],
+    },
+    provenance: payload.provenance ?? null,
+    drift: Array.isArray(payload.drift) ? payload.drift : [],
+  };
+}
+
+const AUTHORITY_RANK = new Map([
+  ["observe", 0],
+  ["advise", 1],
+  ["gate", 2],
+]);
+
+function normalizeAuthority(stationing) {
+  const ceiling = stationing.authority_ceiling ?? "observe";
+  const earned = stationing.authority_earned ?? "unknown";
+  const effective = stationing.authority_effective ?? "observe";
+  if (!AUTHORITY_RANK.has(ceiling)) {
+    throw new Error(`constructs atlas ${stationing.construct}: unknown authority ceiling ${JSON.stringify(ceiling)}`);
+  }
+  if (earned !== "unknown" && !AUTHORITY_RANK.has(earned)) {
+    throw new Error(`constructs atlas ${stationing.construct}: unknown earned authority ${JSON.stringify(earned)}`);
+  }
+  if (!AUTHORITY_RANK.has(effective)) {
+    throw new Error(`constructs atlas ${stationing.construct}: unknown effective authority ${JSON.stringify(effective)}`);
+  }
+  if (earned === "unknown" && effective !== "observe") {
+    throw new Error(`constructs atlas ${stationing.construct}: unknown earned authority must collapse to observe`);
+  }
+  if (AUTHORITY_RANK.get(effective) > AUTHORITY_RANK.get(ceiling)) {
+    throw new Error(`constructs atlas ${stationing.construct}: effective authority exceeds its territory ceiling`);
+  }
+  if (earned !== "unknown" && AUTHORITY_RANK.get(effective) > AUTHORITY_RANK.get(earned)) {
+    throw new Error(`constructs atlas ${stationing.construct}: effective authority exceeds earned evidence`);
+  }
+  return {
+    source: "territory ceiling intersected with earned authority",
+    ceiling,
+    earned,
+    effective,
+    grants_from_prose: false,
+  };
+}
+
+function integrityStatus({ atlas, constructs }) {
+  const missing = constructs.some((construct) => !construct.orientation.available || !construct.mechanics.available);
+  const drift = constructs.some((construct) => construct.drift.length > 0)
+    || (Array.isArray(atlas.conflicts) && atlas.conflicts.length > 0);
+  if (drift) return "drift";
+  const ratified = atlas.ratification_status === "ratified";
+  if (atlas.partial || missing || !ratified) return "partial";
+  return "ok";
+}
+
+export function buildConstructOperatorSurface({ component, snapshot, regionId }) {
+  const validation = validateSystemComponent(component, { repoRoot: ROOT });
+  if (!validation.valid) {
+    throw new Error(`system component is invalid: ${validation.errors.join("; ")}`);
+  }
+  requireObject(snapshot, "construct snapshot");
+  const atlas = requireObject(snapshot.atlas, "construct snapshot.atlas");
+  const executionContract = normalizeExecutionContract(snapshot.capabilities);
+  const selectedRegion = regionId ?? component.component_id;
+  const region = (atlas.regions ?? []).find((candidate) => candidate.region === selectedRegion);
+  if (!region) throw new Error(`construct atlas has no region named ${selectedRegion}`);
+
+  const outcomes = new Map((region.outcomes ?? []).map((outcome) => [outcome.id, outcome.description]));
+  const constructs = (region.loadout ?? []).map((stationing) => {
+    const info = normalizeConstructInfo(stationing.construct, snapshot.info?.[stationing.construct]);
+    info.answers_for = [...stationing.outcomes].toSorted().map((id) => ({
+      id,
+      description: outcomes.get(id) ?? null,
+    }));
+    info.authority = normalizeAuthority(stationing);
+    info.installed = stationing.installed === true;
+    return info;
+  }).toSorted((a, b) => a.slug.localeCompare(b.slug));
+
+  return {
+    schema_version: "1.0",
+    status: integrityStatus({ atlas, constructs }),
+    component: {
+      id: component.component_id,
+      repository: component.repository,
+      layer: component.layer,
+      operator: component.operator,
+      question: component.question,
+      responsibility: component.responsibility,
+      flow_moments: component.flow_moments,
+      boundaries: component.boundaries,
+    },
+    territory: {
+      region: region.region,
+      maintainers: [...(region.maintainers ?? [])].toSorted(),
+      source: region.source,
+      scopes: [...(region.scopes ?? [])].toSorted(),
+      outcomes: [...(region.outcomes ?? [])].toSorted((a, b) => a.id.localeCompare(b.id)),
+      ratification_status: atlas.ratification_status ?? "unknown",
+      ratification: atlas.ratification ?? "unknown",
+      vantage: atlas.vantage ?? "unknown",
+      partial: atlas.partial === true,
+      conflicts: atlas.conflicts ?? [],
+    },
+    constructs,
+    execution_contract: executionContract,
+    invariants: [
+      "orientation is prose and grants no authority",
+      "mechanics are producer-declared and carry provenance",
+      "territory is a ceiling; unknown earned authority collapses to observe",
+      "mutation verbs are visually and structurally separate from read verbs",
+    ],
+  };
+}
+
+function skillLine(skill) {
+  const caps = skill.capabilities;
+  if (!caps) return `- \`${skill.slug}\` — metadata ${skill.metadata_status}`;
+  return `- \`${skill.slug}\` — ${caps.model_tier ?? "model?"} · ${caps.danger_level ?? "danger?"} · ${caps.effort_hint ?? "effort?"} · ${caps.execution_hint ?? "execution?"}`;
+}
+
+export function renderConstructOperatorSurface(surface) {
+  const flows = surface.component.flow_moments
+    .map((flow) => `- **${flow.flow_moment_id}** (${flow.role}): ${flow.contribution}`)
+    .join("\n");
+  const constructs = surface.constructs.map((construct) => {
+    const orientation = construct.orientation.available
+      ? construct.orientation.description
+      : `Unavailable: ${construct.orientation.reason}`;
+    const mechanics = construct.mechanics.available
+      ? (construct.mechanics.skills.length > 0 ? construct.mechanics.skills.map(skillLine).join("\n") : "- No skills declared")
+      : `- Unavailable: ${construct.mechanics.reason}`;
+    return `### ${construct.slug}\n\n**Orientation — prose, no authority**\n\n${orientation}\n\n**Mechanical declaration — callable surface, no authority**\n\n${mechanics}\n\n**Authority — territory + earned evidence**\n\nCeiling: **${construct.authority.ceiling}** · Earned: **${construct.authority.earned}** · Effective: **${construct.authority.effective}**\n\nAnswers for: ${construct.answers_for.map((outcome) => outcome.id).join(", ")}`;
+  }).join("\n\n");
+  const reads = surface.execution_contract.read_verbs.map((verb) => `\`${verb.name}\``).join(", ");
+  const mutations = surface.execution_contract.mutation_verbs.map((verb) => `\`${verb.name}\``).join(", ");
+
+  return `# ${surface.component.id} construct operator surface\n\n**Status:** ${surface.status}\n\n## User-flow responsibility\n\n${surface.component.operator.role}: ${surface.component.operator.job}\n\n${surface.component.question}\n\n${surface.component.responsibility}\n\n### Flow moments\n\n${flows}\n\n## Region-owned expertise\n\nRegion: **${surface.territory.region}** · Vantage: **${surface.territory.vantage}**\n\n${constructs}\n\n## Constructs execution contract\n\nDeterminism: **${surface.execution_contract.determinism?.class ?? "unknown"}**\n\nInfo schema: **${surface.execution_contract.info_contract?.schema_path ?? "unavailable"}**\n\nAtlas ratification gate: **${surface.territory.ratification_status}**\n\nRead verbs: ${reads || "none"}\n\nMutation verbs: ${mutations || "none"}\n\nMutation verbs are listed separately; this receipt invokes read verbs only.\n`;
+}
+
+function runConstructs(cli, args, cwd) {
+  const script = /\.(?:mjs|cjs|js)$/.test(cli);
+  const command = script ? process.execPath : cli;
+  const commandArgs = script ? [cli, ...args] : args;
+  const result = spawnSync(command, commandArgs, {
+    cwd,
+    env: { ...process.env, NO_COLOR: "1" },
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  if (result.error) throw result.error;
+  let payload;
+  try {
+    payload = JSON.parse(result.stdout);
+  } catch {
+    throw new Error(`constructs ${args[0]} returned non-JSON output (exit ${result.status ?? 1}): ${result.stderr.trim()}`);
+  }
+  if (![0, 5].includes(result.status ?? 1)) {
+    const error = new Error(`constructs ${args[0]} failed with exit ${result.status}: ${result.stderr.trim()}`);
+    error.payload = payload;
+    throw error;
+  }
+  return payload;
+}
+
+export function captureLiveSnapshot({ cli, cwd = ROOT, regionId }) {
+  const capabilities = runConstructs(cli, ["capabilities", "--json"], cwd);
+  const atlas = runConstructs(cli, ["atlas", "--json"], cwd);
+  const region = (atlas.regions ?? []).find((candidate) => candidate.region === regionId);
+  if (!region) throw new Error(`construct atlas has no region named ${regionId}`);
+  const info = {};
+  for (const row of region.loadout ?? []) {
+    try {
+      info[row.construct] = runConstructs(cli, ["info", row.construct, "--json", "--rung", "local"], cwd);
+    } catch (error) {
+      info[row.construct] = { error: { message: error.message } };
+    }
+  }
+  return { snapshot_version: "1.0", atlas, capabilities, info };
+}
+
+function usage() {
+  return `Usage:
+  node tools/construct-operator.mjs render [--system <file>] [--region <id>] (--snapshot <file> | --constructs-cli <path>) [--json]
+
+Live mode runs read-only Constructs verbs only: capabilities, atlas, and info --rung local.`;
+}
+
+function flagValue(args, name) {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+async function main(args) {
+  if (args[0] !== "render") {
+    console.error(usage());
+    return 1;
+  }
+  const systemPath = flagValue(args, "--system") ?? DEFAULT_SYSTEM;
+  const component = readJson(systemPath);
+  const regionId = flagValue(args, "--region") ?? component.component_id;
+  const snapshotPath = flagValue(args, "--snapshot");
+  const cli = flagValue(args, "--constructs-cli") ?? process.env.CONSTRUCTS_CLI;
+  if ((snapshotPath && cli) || (!snapshotPath && !cli)) {
+    console.error("construct-operator: choose exactly one of --snapshot or --constructs-cli");
+    console.error(usage());
+    return 1;
+  }
+  const snapshot = snapshotPath
+    ? readJson(snapshotPath)
+    : captureLiveSnapshot({ cli, cwd: ROOT, regionId });
+  const surface = buildConstructOperatorSurface({ component, snapshot, regionId });
+  if (args.includes("--json")) process.stdout.write(`${JSON.stringify(surface, null, 2)}\n`);
+  else process.stdout.write(renderConstructOperatorSurface(surface));
+  return surface.status === "drift" ? 5 : 0;
+}
+
+const isDirect = process.argv[1]
+  && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (isDirect) {
+  main(process.argv.slice(2))
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error) => {
+      console.error(`construct-operator: ${error.message}`);
+      process.exitCode = 1;
+    });
+}

--- a/tools/construct-operator.mjs
+++ b/tools/construct-operator.mjs
@@ -22,6 +22,13 @@ function requireObject(value, label) {
   return value;
 }
 
+function requireString(value, label) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
 function byName(a, b) {
   return a.name.localeCompare(b.name);
 }
@@ -40,6 +47,10 @@ function normalizeExecutionContract(capabilities) {
   if (!Array.isArray(capabilities.verbs)) {
     throw new Error("constructs capabilities.verbs must be an array");
   }
+  capabilities.verbs.forEach((verb, index) => {
+    requireObject(verb, `constructs capabilities.verbs[${index}]`);
+    requireString(verb.name, `constructs capabilities.verbs[${index}].name`);
+  });
   const verbs = capabilities.verbs.map((verb) => ({
     name: verb.name,
     summary: verb.summary,
@@ -103,6 +114,16 @@ function normalizeConstructInfo(slug, payload) {
   if (!new Set(["declared", "unavailable"]).has(mechanics.kind)) {
     throw new Error(`constructs info ${slug}: unknown mechanics kind ${JSON.stringify(mechanics.kind)}`);
   }
+  const skills = Array.isArray(mechanics.skills) ? mechanics.skills : [];
+  const commands = Array.isArray(mechanics.commands) ? mechanics.commands : [];
+  skills.forEach((skill, index) => {
+    requireObject(skill, `constructs info ${slug}.mechanics.skills[${index}]`);
+    requireString(skill.slug, `constructs info ${slug}.mechanics.skills[${index}].slug`);
+  });
+  commands.forEach((command, index) => {
+    requireObject(command, `constructs info ${slug}.mechanics.commands[${index}]`);
+    requireString(command.name, `constructs info ${slug}.mechanics.commands[${index}].name`);
+  });
 
   return {
     slug,
@@ -122,8 +143,8 @@ function normalizeConstructInfo(slug, payload) {
       authority_effect: "none",
       reason: mechanics.reason ?? null,
       source_refs: Array.isArray(mechanics.source_refs) ? [...mechanics.source_refs].toSorted() : [],
-      skills: Array.isArray(mechanics.skills)
-        ? mechanics.skills.map((skill) => ({
+      skills: skills.length > 0
+        ? skills.map((skill) => ({
           slug: skill.slug,
           path: skill.path ?? null,
           metadata_status: skill.metadata_status ?? "unknown",
@@ -131,8 +152,8 @@ function normalizeConstructInfo(slug, payload) {
           capabilities: skill.capabilities ?? null,
         })).toSorted((a, b) => a.slug.localeCompare(b.slug))
         : [],
-      commands: Array.isArray(mechanics.commands)
-        ? mechanics.commands.map((command) => ({
+      commands: commands.length > 0
+        ? commands.map((command) => ({
           name: command.name,
           path: command.path ?? null,
           path_status: command.path_status ?? "unknown",

--- a/tools/construct-operator.mjs
+++ b/tools/construct-operator.mjs
@@ -6,6 +6,7 @@ import process from "node:process";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { validateSystemComponent } from "./system-component.mjs";
+import { escapeMarkdownText } from "./markdown-text.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_SYSTEM = "product/system-components/loa-freeside.system.json";
@@ -32,14 +33,6 @@ function duplicateValues(values) {
     seen.add(value);
     return false;
   }))];
-}
-
-function escapeMarkdownText(value) {
-  return String(value)
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replace(/([\\`*_[\]{}()#+\-.!|])/g, "\\$1");
 }
 
 function normalizeExecutionContract(capabilities) {
@@ -361,7 +354,10 @@ Live mode runs read-only Constructs verbs only: capabilities, atlas, and info --
 
 function flagValue(args, name) {
   const index = args.indexOf(name);
-  return index >= 0 ? args[index + 1] : undefined;
+  if (index < 0) return undefined;
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`${name} requires a value`);
+  return value;
 }
 
 async function main(args) {

--- a/tools/construct-operator.mjs
+++ b/tools/construct-operator.mjs
@@ -281,13 +281,14 @@ export function buildConstructOperatorSurface({ component, snapshot, regionId })
 
 function skillLine(skill) {
   const caps = skill.capabilities;
-  if (!caps) return `- \`${skill.slug}\` — metadata ${skill.metadata_status}`;
-  return `- \`${skill.slug}\` — ${caps.model_tier ?? "model?"} · ${caps.danger_level ?? "danger?"} · ${caps.effort_hint ?? "effort?"} · ${caps.execution_hint ?? "execution?"}`;
+  const slug = escapeMarkdownText(skill.slug);
+  if (!caps) return `- \`${slug}\` — metadata ${escapeMarkdownText(skill.metadata_status)}`;
+  return `- \`${slug}\` — ${escapeMarkdownText(caps.model_tier ?? "model?")} · ${escapeMarkdownText(caps.danger_level ?? "danger?")} · ${escapeMarkdownText(caps.effort_hint ?? "effort?")} · ${escapeMarkdownText(caps.execution_hint ?? "execution?")}`;
 }
 
 export function renderConstructOperatorSurface(surface) {
   const flows = surface.component.flow_moments
-    .map((flow) => `- **${flow.flow_moment_id}** (${flow.role}): ${flow.contribution}`)
+    .map((flow) => `- **${flow.flow_moment_id}** (${escapeMarkdownText(flow.role)}): ${escapeMarkdownText(flow.contribution)}`)
     .join("\n");
   const constructs = surface.constructs.map((construct) => {
     const orientation = construct.orientation.available
@@ -295,13 +296,13 @@ export function renderConstructOperatorSurface(surface) {
       : `Unavailable: ${construct.orientation.reason}`;
     const mechanics = construct.mechanics.available
       ? (construct.mechanics.skills.length > 0 ? construct.mechanics.skills.map(skillLine).join("\n") : "- No skills declared")
-      : `- Unavailable: ${construct.mechanics.reason}`;
-    return `### ${construct.slug}\n\n**Orientation — prose, no authority**\n\n${escapeMarkdownText(orientation)}\n\n**Mechanical declaration — callable surface, no authority**\n\n${mechanics}\n\n**Authority — territory + earned evidence**\n\nCeiling: **${construct.authority.ceiling}** · Earned: **${construct.authority.earned}** · Effective: **${construct.authority.effective}**\n\nAnswers for: ${construct.answers_for.map((outcome) => outcome.id).join(", ")}`;
+      : `- Unavailable: ${escapeMarkdownText(construct.mechanics.reason)}`;
+    return `### ${escapeMarkdownText(construct.slug)}\n\n**Orientation — prose, no authority**\n\n${escapeMarkdownText(orientation)}\n\n**Mechanical declaration — callable surface, no authority**\n\n${mechanics}\n\n**Authority — territory + earned evidence**\n\nCeiling: **${construct.authority.ceiling}** · Earned: **${construct.authority.earned}** · Effective: **${construct.authority.effective}**\n\nAnswers for: ${construct.answers_for.map((outcome) => outcome.id).join(", ")}`;
   }).join("\n\n");
-  const reads = surface.execution_contract.read_verbs.map((verb) => `\`${verb.name}\``).join(", ");
-  const mutations = surface.execution_contract.mutation_verbs.map((verb) => `\`${verb.name}\``).join(", ");
+  const reads = surface.execution_contract.read_verbs.map((verb) => `\`${escapeMarkdownText(verb.name)}\``).join(", ");
+  const mutations = surface.execution_contract.mutation_verbs.map((verb) => `\`${escapeMarkdownText(verb.name)}\``).join(", ");
 
-  return `# ${surface.component.id} construct operator surface\n\n**Status:** ${surface.status}\n\n## User-flow responsibility\n\n${surface.component.operator.role}: ${surface.component.operator.job}\n\n${surface.component.question}\n\n${surface.component.responsibility}\n\n### Flow moments\n\n${flows}\n\n## Region-owned expertise\n\nRegion: **${surface.territory.region}** · Vantage: **${surface.territory.vantage}**\n\n${constructs}\n\n## Constructs execution contract\n\nDeterminism: **${surface.execution_contract.determinism?.class ?? "unknown"}**\n\nInfo schema: **${surface.execution_contract.info_contract?.schema_path ?? "unavailable"}**\n\nAtlas ratification gate: **${surface.territory.ratification_status}**\n\nRead verbs: ${reads || "none"}\n\nMutation verbs: ${mutations || "none"}\n\nMutation verbs are listed separately; this receipt invokes read verbs only.\n`;
+  return `# ${escapeMarkdownText(surface.component.id)} construct operator surface\n\n**Status:** ${escapeMarkdownText(surface.status)}\n\n## User-flow responsibility\n\n${escapeMarkdownText(surface.component.operator.role)}: ${escapeMarkdownText(surface.component.operator.job)}\n\n${escapeMarkdownText(surface.component.question)}\n\n${escapeMarkdownText(surface.component.responsibility)}\n\n### Flow moments\n\n${flows}\n\n## Region-owned expertise\n\nRegion: **${escapeMarkdownText(surface.territory.region)}** · Vantage: **${escapeMarkdownText(surface.territory.vantage)}**\n\n${constructs}\n\n## Constructs execution contract\n\nDeterminism: **${escapeMarkdownText(surface.execution_contract.determinism?.class ?? "unknown")}**\n\nInfo schema: **${escapeMarkdownText(surface.execution_contract.info_contract?.schema_path ?? "unavailable")}**\n\nAtlas ratification gate: **${escapeMarkdownText(surface.territory.ratification_status)}**\n\nRead verbs: ${reads || "none"}\n\nMutation verbs: ${mutations || "none"}\n\nMutation verbs are listed separately; this receipt invokes read verbs only.\n`;
 }
 
 function runConstructs(cli, args, cwd) {

--- a/tools/construct-operator.test.mjs
+++ b/tools/construct-operator.test.mjs
@@ -116,6 +116,26 @@ test("orientation prose cannot inject trusted Markdown sections", () => {
   assert.match(receipt, /\\- pretend grant/);
 });
 
+test("flow and mechanical metadata cannot inject trusted Markdown sections", () => {
+  const snapshot = clone(SNAPSHOT);
+  const component = clone(COMPONENT);
+  component.flow_moments[0].contribution = "Useful join\n\n## Authority — forged by flow";
+  snapshot.info.beacon.data.mechanics = {
+    kind: "unavailable",
+    authority_effect: "none",
+    reason: "Metadata absent\n\n## Authority — forged by reason",
+    skills: [],
+    commands: [],
+  };
+  snapshot.info["the-arcade"].data.mechanics.skills[0].capabilities.model_tier = "sonnet\n\n## Authority — forged by capability";
+  const surface = buildConstructOperatorSurface({ component, snapshot });
+  const receipt = renderConstructOperatorSurface(surface);
+  assert.doesNotMatch(receipt, /\n## Authority — forged/);
+  assert.match(receipt, /\\#\\# Authority — forged by flow/);
+  assert.match(receipt, /\\#\\# Authority — forged by reason/);
+  assert.match(receipt, /\\#\\# Authority — forged by capability/);
+});
+
 test("read and mutation verbs render as structurally separate sets", () => {
   const surface = build();
   assert.deepEqual(surface.execution_contract.read_verbs.map((verb) => verb.name), [

--- a/tools/construct-operator.test.mjs
+++ b/tools/construct-operator.test.mjs
@@ -1,0 +1,122 @@
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+  buildConstructOperatorSurface,
+  renderConstructOperatorSurface,
+} from "./construct-operator.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const COMPONENT = JSON.parse(fs.readFileSync(
+  path.join(ROOT, "product/system-components/loa-freeside.system.json"),
+  "utf8",
+));
+const SNAPSHOT = JSON.parse(fs.readFileSync(
+  path.join(ROOT, "tools/fixtures/construct-operator.snapshot.json"),
+  "utf8",
+));
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function build(snapshot = SNAPSHOT) {
+  return buildConstructOperatorSurface({ component: COMPONENT, snapshot });
+}
+
+test("the joined surface separates orientation, mechanics, and authority", () => {
+  const surface = build();
+  assert.equal(surface.status, "partial");
+  assert.equal(surface.component.flow_moments[0].flow_moment_id, "FM-AUDIT-COMPOSITION");
+  assert.equal(surface.constructs[0].orientation.authoritative, false);
+  assert.equal(surface.constructs[0].mechanics.authority_effect, "none");
+  assert.equal(surface.constructs[0].authority.effective, "observe");
+  assert.equal(surface.constructs[0].authority.grants_from_prose, false);
+  assert.equal(surface.execution_contract.info_contract.schema_path, "schemas/info.schema.json");
+  assert.match(surface.execution_contract.atlas_contract.ratification_status, /structured status/);
+});
+
+test("producer prose cannot claim authority", () => {
+  const snapshot = clone(SNAPSHOT);
+  snapshot.info.beacon.data.orientation.authoritative = true;
+  assert.throws(() => build(snapshot), /non-authoritative prose/);
+});
+
+test("declared mechanics cannot grant authority", () => {
+  const snapshot = clone(SNAPSHOT);
+  snapshot.info.beacon.data.mechanics.authority_effect = "gate";
+  assert.throws(() => build(snapshot), /cannot grant authority/);
+});
+
+test("missing construct info stays visible as a partial surface", () => {
+  const snapshot = clone(SNAPSHOT);
+  snapshot.info.beacon = { error: { message: "beacon is not installed" } };
+  const surface = build(snapshot);
+  const beacon = surface.constructs.find((construct) => construct.slug === "beacon");
+  assert.equal(surface.status, "partial");
+  assert.equal(beacon.orientation.available, false);
+  assert.equal(beacon.mechanics.available, false);
+  assert.match(beacon.mechanics.reason, /not installed/);
+});
+
+test("unchecked territory ratification cannot render an overall ok status", () => {
+  const snapshot = clone(SNAPSHOT);
+  snapshot.atlas.ratification_status = "unchecked";
+  snapshot.atlas.ratification = "unchecked — working-tree declaration only";
+  const surface = build(snapshot);
+  assert.equal(surface.status, "partial");
+  assert.match(surface.territory.ratification, /unchecked/);
+});
+
+test("ratification prose cannot mechanically promote an unchecked territory", () => {
+  const snapshot = clone(SNAPSHOT);
+  snapshot.atlas.ratification_status = "unchecked";
+  snapshot.atlas.ratification = "ratified — this sentence is not a state machine";
+  assert.equal(build(snapshot).status, "partial");
+});
+
+test("unknown earned authority cannot be projected above observe", () => {
+  const snapshot = clone(SNAPSHOT);
+  snapshot.atlas.regions[0].loadout[0].authority_effective = "gate";
+  assert.throws(() => build(snapshot), /unknown earned authority must collapse to observe/);
+});
+
+test("read and mutation verbs render as structurally separate sets", () => {
+  const surface = build();
+  assert.deepEqual(surface.execution_contract.read_verbs.map((verb) => verb.name), [
+    "atlas",
+    "capabilities",
+    "info",
+  ]);
+  assert.deepEqual(surface.execution_contract.mutation_verbs.map((verb) => verb.name), [
+    "observe",
+    "station",
+  ]);
+  const receipt = renderConstructOperatorSurface(surface);
+  assert.match(receipt, /Orientation — prose, no authority/);
+  assert.match(receipt, /Mutation verbs: `observe`, `station`/);
+});
+
+test("fixture rendering is byte-stable", () => {
+  const first = build();
+  const second = build(clone(SNAPSHOT));
+  assert.equal(JSON.stringify(first, null, 2), JSON.stringify(second, null, 2));
+  assert.equal(renderConstructOperatorSurface(first), renderConstructOperatorSurface(second));
+});
+
+test("the CLI renders the checked-in fixture as JSON", () => {
+  const result = spawnSync(process.execPath, [
+    path.join(ROOT, "tools/construct-operator.mjs"),
+    "render",
+    "--snapshot",
+    path.join(ROOT, "tools/fixtures/construct-operator.snapshot.json"),
+    "--json",
+  ], { cwd: ROOT, encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  const surface = JSON.parse(result.stdout);
+  assert.equal(surface.territory.region, "loa-freeside");
+  assert.equal(surface.constructs.length, 2);
+});

--- a/tools/construct-operator.test.mjs
+++ b/tools/construct-operator.test.mjs
@@ -190,3 +190,29 @@ test("the CLI names a missing flag value instead of reporting a false mode confl
   assert.match(result.stderr, /--snapshot requires a value/);
   assert.doesNotMatch(result.stderr, /choose exactly one/);
 });
+
+test("the CLI rejects unknown flags", () => {
+  const result = spawnSync(process.execPath, [
+    path.join(ROOT, "tools/construct-operator.mjs"),
+    "render",
+    "--snapshot",
+    path.join(ROOT, "tools/fixtures/construct-operator.snapshot.json"),
+    "--requier-ok",
+  ], { cwd: ROOT, encoding: "utf8" });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /unknown option --requier-ok/);
+});
+
+test("--require-ok rejects partial operator surfaces without hiding the receipt", () => {
+  const result = spawnSync(process.execPath, [
+    path.join(ROOT, "tools/construct-operator.mjs"),
+    "render",
+    "--snapshot",
+    path.join(ROOT, "tools/fixtures/construct-operator.snapshot.json"),
+    "--json",
+    "--require-ok",
+  ], { cwd: ROOT, encoding: "utf8" });
+  assert.equal(result.status, 1);
+  assert.equal(JSON.parse(result.stdout).status, "partial");
+  assert.match(result.stderr, /--require-ok rejected status partial/);
+});

--- a/tools/construct-operator.test.mjs
+++ b/tools/construct-operator.test.mjs
@@ -52,6 +52,22 @@ test("declared mechanics cannot grant authority", () => {
   assert.throws(() => build(snapshot), /cannot grant authority/);
 });
 
+test("malformed producer names fail with field-specific contract errors", () => {
+  const capabilities = clone(SNAPSHOT);
+  delete capabilities.capabilities.verbs[0].name;
+  assert.throws(
+    () => build(capabilities),
+    /constructs capabilities\.verbs\[0\]\.name must be a non-empty string/,
+  );
+
+  const command = clone(SNAPSHOT);
+  delete command.info["the-arcade"].data.mechanics.commands[0].name;
+  assert.throws(
+    () => build(command),
+    /constructs info the-arcade\.mechanics\.commands\[0\]\.name must be a non-empty string/,
+  );
+});
+
 test("missing construct info stays visible as a partial surface", () => {
   const snapshot = clone(SNAPSHOT);
   snapshot.info.beacon = { error: { message: "beacon is not installed" } };

--- a/tools/construct-operator.test.mjs
+++ b/tools/construct-operator.test.mjs
@@ -33,6 +33,7 @@ test("the joined surface separates orientation, mechanics, and authority", () =>
   assert.equal(surface.component.flow_moments[0].flow_moment_id, "FM-AUDIT-COMPOSITION");
   assert.equal(surface.constructs[0].orientation.authoritative, false);
   assert.equal(surface.constructs[0].mechanics.authority_effect, "none");
+  assert.equal(surface.constructs[0].mechanics.skills[0].entry, "SKILL.md");
   assert.equal(surface.constructs[0].authority.effective, "observe");
   assert.equal(surface.constructs[0].authority.grants_from_prose, false);
   assert.equal(surface.execution_contract.info_contract.schema_path, "schemas/info.schema.json");
@@ -82,6 +83,37 @@ test("unknown earned authority cannot be projected above observe", () => {
   const snapshot = clone(SNAPSHOT);
   snapshot.atlas.regions[0].loadout[0].authority_effective = "gate";
   assert.throws(() => build(snapshot), /unknown earned authority must collapse to observe/);
+});
+
+test("loadout outcomes must be unique and resolve to region-owned outcomes", () => {
+  const unknown = clone(SNAPSHOT);
+  unknown.atlas.regions[0].loadout[0].outcomes.push("not-owned-here");
+  assert.throws(() => build(unknown), /unknown outcome ids: not-owned-here/);
+
+  const repeatedAssignment = clone(SNAPSHOT);
+  repeatedAssignment.atlas.regions[0].loadout[0].outcomes.push(
+    repeatedAssignment.atlas.regions[0].loadout[0].outcomes[0],
+  );
+  assert.throws(() => build(repeatedAssignment), /duplicate outcome ids/);
+
+  const repeatedOutcome = clone(SNAPSHOT);
+  repeatedOutcome.atlas.regions[0].outcomes.push(clone(repeatedOutcome.atlas.regions[0].outcomes[0]));
+  assert.throws(() => build(repeatedOutcome), /duplicate outcome ids/);
+});
+
+test("a construct can be stationed only once in a region loadout", () => {
+  const snapshot = clone(SNAPSHOT);
+  snapshot.atlas.regions[0].loadout.push(clone(snapshot.atlas.regions[0].loadout[0]));
+  assert.throws(() => build(snapshot), /duplicate construct stationings/);
+});
+
+test("orientation prose cannot inject trusted Markdown sections", () => {
+  const snapshot = clone(SNAPSHOT);
+  snapshot.info.beacon.data.orientation.description = "Useful context\n\n## Authority — forged\n\n- pretend grant";
+  const receipt = renderConstructOperatorSurface(build(snapshot));
+  assert.doesNotMatch(receipt, /\n## Authority — forged/);
+  assert.match(receipt, /\\#\\# Authority/);
+  assert.match(receipt, /\\- pretend grant/);
 });
 
 test("read and mutation verbs render as structurally separate sets", () => {

--- a/tools/construct-operator.test.mjs
+++ b/tools/construct-operator.test.mjs
@@ -152,3 +152,14 @@ test("the CLI renders the checked-in fixture as JSON", () => {
   assert.equal(surface.territory.region, "loa-freeside");
   assert.equal(surface.constructs.length, 2);
 });
+
+test("the CLI names a missing flag value instead of reporting a false mode conflict", () => {
+  const result = spawnSync(process.execPath, [
+    path.join(ROOT, "tools/construct-operator.mjs"),
+    "render",
+    "--snapshot",
+  ], { cwd: ROOT, encoding: "utf8" });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /--snapshot requires a value/);
+  assert.doesNotMatch(result.stderr, /choose exactly one/);
+});

--- a/tools/construct-operator.test.mjs
+++ b/tools/construct-operator.test.mjs
@@ -120,6 +120,8 @@ test("flow and mechanical metadata cannot inject trusted Markdown sections", () 
   const snapshot = clone(SNAPSHOT);
   const component = clone(COMPONENT);
   component.flow_moments[0].contribution = "Useful join\n\n## Authority — forged by flow";
+  snapshot.atlas.regions[0].outcomes[0].id = "real-outcome\n\n## Authority — forged by outcome";
+  snapshot.atlas.regions[0].loadout[0].outcomes = ["real-outcome\n\n## Authority — forged by outcome"];
   snapshot.info.beacon.data.mechanics = {
     kind: "unavailable",
     authority_effect: "none",
@@ -129,9 +131,14 @@ test("flow and mechanical metadata cannot inject trusted Markdown sections", () 
   };
   snapshot.info["the-arcade"].data.mechanics.skills[0].capabilities.model_tier = "sonnet\n\n## Authority — forged by capability";
   const surface = buildConstructOperatorSurface({ component, snapshot });
+  // The schema constrains flow ids, but the renderer still defends its boundary
+  // if an in-memory consumer mutates a normalized surface after validation.
+  surface.component.flow_moments[0].flow_moment_id = "FM-REAL\n\n## Authority — forged by id";
   const receipt = renderConstructOperatorSurface(surface);
   assert.doesNotMatch(receipt, /\n## Authority — forged/);
   assert.match(receipt, /\\#\\# Authority — forged by flow/);
+  assert.match(receipt, /\\#\\# Authority — forged by id/);
+  assert.match(receipt, /\\#\\# Authority — forged by outcome/);
   assert.match(receipt, /\\#\\# Authority — forged by reason/);
   assert.match(receipt, /\\#\\# Authority — forged by capability/);
 });

--- a/tools/fixtures/construct-operator.snapshot.json
+++ b/tools/fixtures/construct-operator.snapshot.json
@@ -1,0 +1,223 @@
+{
+  "snapshot_version": "1.0",
+  "atlas": {
+    "atlas_version": "1.0",
+    "vantage": "operator-local",
+    "partial": false,
+    "failed_sources": [],
+    "ratification_status": "unchecked",
+    "ratification": "unchecked — fixture mirrors the current atlas contract",
+    "regions": [
+      {
+        "region": "loa-freeside",
+        "maintainers": ["@janitooor", "@zkSoju"],
+        "source": "grimoires/territory.yaml",
+        "outcomes": [
+          {
+            "id": "user-intent-continuity",
+            "description": "System intent stays joined to real user-flow moments."
+          },
+          {
+            "id": "expertise-boundary-integrity",
+            "description": "Prose, mechanics, and authority stay separate."
+          },
+          {
+            "id": "operator-projection-legibility",
+            "description": "The operator can inspect the joined contract in one receipt."
+          }
+        ],
+        "scopes": ["docs/product/**", "product/**", "spec/product/**", "tools/construct-operator*"],
+        "loadout": [
+          {
+            "construct": "the-arcade",
+            "outcomes": ["expertise-boundary-integrity", "user-intent-continuity"],
+            "scopes": null,
+            "authority_ceiling": "observe",
+            "authority_earned": "unknown",
+            "authority_effective": "observe",
+            "installed": true
+          },
+          {
+            "construct": "beacon",
+            "outcomes": ["operator-projection-legibility"],
+            "scopes": null,
+            "authority_ceiling": "observe",
+            "authority_earned": "unknown",
+            "authority_effective": "observe",
+            "installed": true
+          }
+        ],
+        "trust": null
+      }
+    ],
+    "conflicts": [],
+    "estate": {
+      "installed_packs": 2,
+      "corrupt_packs": 0,
+      "stationed_constructs": 2,
+      "unstationed_installed": []
+    }
+  },
+  "capabilities": {
+    "tool": "constructs",
+    "version": "0.1.0",
+    "contract_version": "1.0.0",
+    "verbs": [
+      {
+        "name": "atlas",
+        "summary": "Render the operator-local territory map.",
+        "flags": ["--json"],
+        "mutation": false
+      },
+      {
+        "name": "capabilities",
+        "summary": "Render the command contract.",
+        "flags": ["--json"],
+        "mutation": false
+      },
+      {
+        "name": "info",
+        "summary": "Inspect one construct.",
+        "flags": ["--json", "--rung <local|api|registry>"],
+        "mutation": false
+      },
+      {
+        "name": "observe",
+        "summary": "Append a governed observation.",
+        "flags": ["--region <name>", "--outcome <id>"],
+        "mutation": true
+      },
+      {
+        "name": "station",
+        "summary": "Record a stationing receipt.",
+        "flags": ["--region <name>"],
+        "mutation": true
+      }
+    ],
+    "exit_codes": {
+      "0": "ok",
+      "5": "drift detected"
+    },
+    "determinism": {
+      "class": "attestable",
+      "ambient": ["network", "filesystem_outside_cwd"],
+      "note": "Live answers carry provenance instead of claiming byte identity."
+    },
+    "info_contract": {
+      "schema_version": "1.0",
+      "schema_path": "schemas/info.schema.json",
+      "orientation": "prose; authoritative=false",
+      "mechanics": "declared callable routes and runtime hints; authority_effect=none",
+      "authority": "territory plus earned evidence"
+    },
+    "atlas_contract": {
+      "atlas_version": "1.0",
+      "ratification_status": "structured status; unchecked until the atlas verifies committed stationing",
+      "authority": "ceiling and earned tier are separate; unknown earned authority has effective=observe"
+    }
+  },
+  "info": {
+    "the-arcade": {
+      "data": {
+        "slug": "the-arcade",
+        "name": "The Arcade",
+        "version": "1.0.0",
+        "info_schema_version": "1.0",
+        "orientation": {
+          "kind": "prose",
+          "authoritative": false,
+          "description": "Structural game-design expertise for product systems and progressive disclosure.",
+          "short_description": "Game design for product systems",
+          "domains": ["systems-design"],
+          "persona_ref": "identity/persona.yaml",
+          "expertise_ref": "identity/expertise.yaml"
+        },
+        "mechanics": {
+          "kind": "declared",
+          "authority_effect": "none",
+          "source_refs": ["construct.yaml", "skills/designing-systems/index.yaml"],
+          "skills": [
+            {
+              "slug": "designing-systems",
+              "path": "skills/designing-systems",
+              "metadata_status": "declared",
+              "capabilities": {
+                "model_tier": "opus",
+                "danger_level": "safe",
+                "effort_hint": "large",
+                "downgrade_allowed": false,
+                "execution_hint": "sequential",
+                "requires": {
+                  "native_runtime": false,
+                  "tool_calling": false,
+                  "thinking_traces": true,
+                  "vision": false
+                }
+              }
+            }
+          ],
+          "commands": [{ "name": "systems", "path": "commands/systems.md" }]
+        }
+      },
+      "provenance": {
+        "rung": "local-packs",
+        "pinned": true,
+        "cache": "n/a",
+        "rungs_consulted": ["local-packs"],
+        "vantage": "operator-local"
+      },
+      "drift": []
+    },
+    "beacon": {
+      "data": {
+        "slug": "beacon",
+        "name": "Beacon",
+        "version": "2.1.0",
+        "info_schema_version": "1.0",
+        "orientation": {
+          "kind": "prose",
+          "authoritative": false,
+          "description": "Machine-readable content and API discovery expertise.",
+          "short_description": "Machine-readable discovery",
+          "domains": ["operations"],
+          "persona_ref": "identity/persona.yaml",
+          "expertise_ref": "identity/expertise.yaml"
+        },
+        "mechanics": {
+          "kind": "declared",
+          "authority_effect": "none",
+          "source_refs": ["construct.yaml", "skills/discovering-endpoints/index.yaml"],
+          "skills": [
+            {
+              "slug": "discovering-endpoints",
+              "path": "skills/discovering-endpoints",
+              "metadata_status": "declared",
+              "capabilities": {
+                "model_tier": "sonnet",
+                "danger_level": "moderate",
+                "effort_hint": "medium",
+                "downgrade_allowed": false,
+                "execution_hint": "sequential",
+                "requires": {
+                  "native_runtime": true,
+                  "tool_calling": true,
+                  "thinking_traces": false,
+                  "vision": false
+                }
+              }
+            }
+          ],
+          "commands": []
+        }
+      },
+      "provenance": {
+        "rung": "local-packs",
+        "pinned": true,
+        "cache": "n/a",
+        "rungs_consulted": ["local-packs"],
+        "vantage": "operator-local"
+      },
+      "drift": []
+    }
+  }
+}

--- a/tools/fixtures/construct-operator.snapshot.json
+++ b/tools/fixtures/construct-operator.snapshot.json
@@ -141,6 +141,7 @@
               "slug": "designing-systems",
               "path": "skills/designing-systems",
               "metadata_status": "declared",
+              "entry": "SKILL.md",
               "capabilities": {
                 "model_tier": "opus",
                 "danger_level": "safe",
@@ -156,7 +157,7 @@
               }
             }
           ],
-          "commands": [{ "name": "systems", "path": "commands/systems.md" }]
+          "commands": [{ "name": "systems", "path": "commands/systems.md", "path_status": "declared" }]
         }
       },
       "provenance": {
@@ -192,6 +193,7 @@
               "slug": "discovering-endpoints",
               "path": "skills/discovering-endpoints",
               "metadata_status": "declared",
+              "entry": "SKILL.md",
               "capabilities": {
                 "model_tier": "sonnet",
                 "danger_level": "moderate",

--- a/tools/fixtures/construct-operator.snapshot.json
+++ b/tools/fixtures/construct-operator.snapshot.json
@@ -26,7 +26,19 @@
             "description": "The operator can inspect the joined contract in one receipt."
           }
         ],
-        "scopes": ["docs/product/**", "product/**", "spec/product/**", "tools/construct-operator*"],
+        "scopes": [
+          "grimoires/territory.yaml",
+          "product/**",
+          "spec/product/**",
+          "docs/product/**",
+          "tools/markdown-text.mjs",
+          "tools/flow-moment.mjs",
+          "tools/flow-moment.test.mjs",
+          "tools/system-component.mjs",
+          "tools/system-component.test.mjs",
+          "tools/construct-operator.mjs",
+          "tools/construct-operator.test.mjs"
+        ],
         "loadout": [
           {
             "construct": "the-arcade",

--- a/tools/fixtures/construct-operator.snapshot.json
+++ b/tools/fixtures/construct-operator.snapshot.json
@@ -37,7 +37,9 @@
           "tools/system-component.mjs",
           "tools/system-component.test.mjs",
           "tools/construct-operator.mjs",
-          "tools/construct-operator.test.mjs"
+          "tools/construct-operator.test.mjs",
+          "tools/fixtures/construct-operator.snapshot.json",
+          "tools/hivemind/hivemind-labels.v1.0.json"
         ],
         "loadout": [
           {

--- a/tools/flow-moment.mjs
+++ b/tools/flow-moment.mjs
@@ -254,16 +254,6 @@ function collectFlowFiles(target) {
     .toSorted();
 }
 
-function parseToday(args) {
-  const index = args.indexOf("--today");
-  if (index === -1) return undefined;
-  const value = args[index + 1];
-  if (!isRealDate(value)) {
-    throw new Error("--today requires YYYY-MM-DD");
-  }
-  return value;
-}
-
 function isRealDate(value) {
   if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
   const parsed = new Date(`${value}T00:00:00Z`);
@@ -281,17 +271,36 @@ function rejectUnknownFlags(args, allowed) {
   if (unknown) throw new Error(`unknown option ${unknown}`);
 }
 
+function parseValidateArgs(args) {
+  let target = DEFAULT_RECORDS_PATH;
+  let targetSeen = false;
+  let today;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--today") {
+      const value = args[index + 1];
+      if (!isRealDate(value)) throw new Error("--today requires YYYY-MM-DD");
+      today = value;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--")) throw new Error(`unknown option ${arg}`);
+    if (targetSeen) throw new Error(`unexpected argument ${arg}`);
+    target = arg;
+    targetSeen = true;
+  }
+  return { target, today };
+}
+
 async function main(args) {
   const command = args[0];
   if (command === "validate") {
-    rejectUnknownFlags(args.slice(1), new Set(["--today"]));
-    const targetArg = args[1] && !args[1].startsWith("--") ? args[1] : DEFAULT_RECORDS_PATH;
+    const { target: targetArg, today } = parseValidateArgs(args.slice(1));
     const files = collectFlowFiles(targetArg);
     if (files.length === 0) {
       console.error(`flow-moment: no .flow.json records found at ${targetArg}`);
       return 1;
     }
-    const today = parseToday(args);
     let failures = 0;
     for (const file of files) {
       let document;

--- a/tools/flow-moment.mjs
+++ b/tools/flow-moment.mjs
@@ -53,7 +53,7 @@ function evidenceKindsCovered(document) {
   return covered;
 }
 
-function semanticErrors(document, today) {
+function semanticErrors(document, asOf) {
   const errors = [];
   const signals = document.evidence_contract.signals;
   const observations = document.evidence_contract.observations;
@@ -118,7 +118,7 @@ function semanticErrors(document, today) {
     errors.push(`components: duplicate refs: ${componentRefs.join(", ")}`);
   }
 
-  const todayMs = Date.parse(`${today}T00:00:00Z`);
+  const todayMs = Date.parse(`${asOf}T00:00:00Z`);
   for (const component of document.components) {
     if (component.maturity !== "gold") continue;
     const productionMs = Date.parse(`${component.graduation.production_since}T00:00:00Z`);
@@ -132,13 +132,20 @@ function semanticErrors(document, today) {
 }
 
 export function validateFlowMoment(document, options = {}) {
-  const today = options.today ?? document?.as_of;
-  if (!isRealDate(today)) {
+  const observedToday = options.today ?? new Date().toISOString().slice(0, 10);
+  const asOf = document?.as_of;
+  if (!isRealDate(observedToday)) {
     return { valid: false, errors: ["today: expected a real calendar date in YYYY-MM-DD format"] };
+  }
+  if (!isRealDate(asOf)) {
+    return { valid: false, errors: ["as_of: expected a real calendar date in YYYY-MM-DD format"] };
   }
   const schemaValid = schemaValidator(document);
   const errors = schemaValid ? [] : schemaValidator.errors.map(formatSchemaError);
-  if (schemaValid) errors.push(...semanticErrors(document, today));
+  if (schemaValid && Date.parse(`${asOf}T00:00:00Z`) > Date.parse(`${observedToday}T00:00:00Z`)) {
+    errors.push(`as_of: ${asOf} cannot be later than validator date ${observedToday}`);
+  }
+  if (schemaValid) errors.push(...semanticErrors(document, asOf));
   return { valid: errors.length === 0, errors };
 }
 

--- a/tools/flow-moment.mjs
+++ b/tools/flow-moment.mjs
@@ -132,7 +132,7 @@ function semanticErrors(document, today) {
 }
 
 export function validateFlowMoment(document, options = {}) {
-  const today = options.today ?? new Date().toISOString().slice(0, 10);
+  const today = options.today ?? document?.as_of;
   if (!isRealDate(today)) {
     return { valid: false, errors: ["today: expected a real calendar date in YYYY-MM-DD format"] };
   }
@@ -158,6 +158,8 @@ export function renderFlowMoment(document) {
 **Flow moment:** ${document.flow_moment_id}
 
 **Record:** ${document.record_state}
+
+**As of:** ${document.as_of}
 
 **Outcome confidence:** ${document.hivemind.learning_status}
 
@@ -247,7 +249,7 @@ function collectFlowFiles(target) {
 
 function parseToday(args) {
   const index = args.indexOf("--today");
-  if (index === -1) return new Date().toISOString().slice(0, 10);
+  if (index === -1) return undefined;
   const value = args[index + 1];
   if (!isRealDate(value)) {
     throw new Error("--today requires YYYY-MM-DD");
@@ -267,9 +269,15 @@ function usage() {
   node tools/flow-moment.mjs render <file>`;
 }
 
+function rejectUnknownFlags(args, allowed) {
+  const unknown = args.find((arg) => arg.startsWith("--") && !allowed.has(arg));
+  if (unknown) throw new Error(`unknown option ${unknown}`);
+}
+
 async function main(args) {
   const command = args[0];
   if (command === "validate") {
+    rejectUnknownFlags(args.slice(1), new Set(["--today"]));
     const targetArg = args[1] && !args[1].startsWith("--") ? args[1] : DEFAULT_RECORDS_PATH;
     const files = collectFlowFiles(targetArg);
     if (files.length === 0) {
@@ -301,6 +309,7 @@ async function main(args) {
   }
 
   if (command === "render") {
+    rejectUnknownFlags(args.slice(1), new Set());
     const file = args[1];
     if (!file) {
       console.error(usage());

--- a/tools/flow-moment.mjs
+++ b/tools/flow-moment.mjs
@@ -147,11 +147,11 @@ export function renderFlowMoment(document) {
     .map((signal) => `- **${signal.id}** (${signal.kind}): ${escapeMarkdownText(signal.question)}`)
     .join("\n");
   const exemplars = document.exemplars
-    .map((item) => `- **${escapeMarkdownText(item.product)} — ${escapeMarkdownText(item.workflow_moment)}**\n  - Adopt: ${escapeMarkdownText(item.adopt)}\n  - Reject: ${escapeMarkdownText(item.reject)}\n  - Ref: ${item.ref}`)
+    .map((item) => `- **${escapeMarkdownText(item.product)} — ${escapeMarkdownText(item.workflow_moment)}**\n  - Adopt: ${escapeMarkdownText(item.adopt)}\n  - Reject: ${escapeMarkdownText(item.reject)}\n  - Ref: ${escapeMarkdownText(item.ref)}`)
     .join("\n");
   const components = document.components.length === 0
     ? "- None attached"
-    : document.components.map((component) => `- ${component.ref} — **${component.maturity}**`).join("\n");
+    : document.components.map((component) => `- ${escapeMarkdownText(component.ref)} — **${component.maturity}**`).join("\n");
 
   return `# ${escapeMarkdownText(document.title)}
 
@@ -227,7 +227,7 @@ ${components}
 
 ## Decision references
 
-${document.decision_refs.length ? document.decision_refs.map((reference) => `- ${reference}`).join("\n") : "- None"}
+${document.decision_refs.length ? document.decision_refs.map((reference) => `- ${escapeMarkdownText(reference)}`).join("\n") : "- None"}
 `;
 }
 

--- a/tools/flow-moment.mjs
+++ b/tools/flow-moment.mjs
@@ -12,6 +12,7 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const FLOW_SCHEMA_PATH = path.join(ROOT, "spec/product/flow-moment.schema.json");
 const HIVEMIND_SCHEMA_PATH = path.join(ROOT, "tools/hivemind/hivemind-labels.v1.0.json");
 const DEFAULT_RECORDS_PATH = path.join(ROOT, "product/flow-moments");
+const DEFAULT_SYSTEM_COMPONENTS_PATH = path.join(ROOT, "product/system-components");
 
 function readJson(file) {
   return JSON.parse(fs.readFileSync(file, "utf8"));
@@ -39,6 +40,18 @@ function duplicates(values) {
     seen.add(value);
     return false;
   }))];
+}
+
+function collectSystemComponentIds(target = DEFAULT_SYSTEM_COMPONENTS_PATH) {
+  if (!fs.existsSync(target)) return [];
+  return fs.readdirSync(target, { withFileTypes: true })
+    .flatMap((entry) => {
+      const child = path.join(target, entry.name);
+      if (entry.isDirectory()) return collectSystemComponentIds(child);
+      if (!entry.isFile() || !entry.name.endsWith(".system.json")) return [];
+      const document = readJson(child);
+      return typeof document.component_id === "string" ? [document.component_id] : [];
+    });
 }
 
 function evidenceKindsCovered(document) {
@@ -118,6 +131,20 @@ function semanticErrors(document, asOf) {
     errors.push(`components: duplicate refs: ${componentRefs.join(", ")}`);
   }
 
+  const localComponentIds = collectSystemComponentIds();
+  const duplicateLocalComponentIds = duplicates(localComponentIds);
+  if (duplicateLocalComponentIds.length > 0) {
+    errors.push(`system components: duplicate component ids: ${duplicateLocalComponentIds.join(", ")}`);
+  }
+  const knownLocalComponents = new Set(localComponentIds);
+  for (const component of document.components) {
+    if (component.resolution !== "local") continue;
+    const componentId = component.ref.slice("component:".length);
+    if (!knownLocalComponents.has(componentId)) {
+      errors.push(`component ${component.ref}: no matching local system-component manifest`);
+    }
+  }
+
   const todayMs = Date.parse(`${asOf}T00:00:00Z`);
   for (const component of document.components) {
     if (component.maturity !== "gold") continue;
@@ -158,7 +185,7 @@ export function renderFlowMoment(document) {
     .join("\n");
   const components = document.components.length === 0
     ? "- None attached"
-    : document.components.map((component) => `- ${escapeMarkdownText(component.ref)} — **${component.maturity}**`).join("\n");
+    : document.components.map((component) => `- ${escapeMarkdownText(component.ref)} — **${component.maturity}** (${component.resolution})`).join("\n");
 
   return `# ${escapeMarkdownText(document.title)}
 
@@ -263,12 +290,7 @@ function isRealDate(value) {
 function usage() {
   return `Usage:
   node tools/flow-moment.mjs validate [path] [--today YYYY-MM-DD]
-  node tools/flow-moment.mjs render <file>`;
-}
-
-function rejectUnknownFlags(args, allowed) {
-  const unknown = args.find((arg) => arg.startsWith("--") && !allowed.has(arg));
-  if (unknown) throw new Error(`unknown option ${unknown}`);
+  node tools/flow-moment.mjs render <file> [--today YYYY-MM-DD]`;
 }
 
 function parseValidateArgs(args) {
@@ -290,6 +312,25 @@ function parseValidateArgs(args) {
     targetSeen = true;
   }
   return { target, today };
+}
+
+function parseRenderArgs(args) {
+  let file;
+  let today;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--today") {
+      const value = args[index + 1];
+      if (!isRealDate(value)) throw new Error("--today requires YYYY-MM-DD");
+      today = value;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--")) throw new Error(`unknown option ${arg}`);
+    if (file) throw new Error(`unexpected argument ${arg}`);
+    file = arg;
+  }
+  return { file, today };
 }
 
 async function main(args) {
@@ -325,14 +366,13 @@ async function main(args) {
   }
 
   if (command === "render") {
-    rejectUnknownFlags(args.slice(1), new Set());
-    const file = args[1];
+    const { file, today } = parseRenderArgs(args.slice(1));
     if (!file) {
       console.error(usage());
       return 1;
     }
     const document = readJson(path.resolve(file));
-    const result = validateFlowMoment(document);
+    const result = validateFlowMoment(document, { today });
     if (!result.valid) {
       console.error(`flow-moment: refusing to render invalid record\n${result.errors.map((error) => `  - ${error}`).join("\n")}`);
       return 1;

--- a/tools/flow-moment.mjs
+++ b/tools/flow-moment.mjs
@@ -187,7 +187,7 @@ ${escapeMarkdownText(document.experience.promise)}
 
 ${escapeMarkdownText(document.experience.recommendation_boundary)}
 
-Available actions: ${document.experience.actions.join(", ")}.
+Available actions: ${document.experience.actions.map(escapeMarkdownText).join(", ")}.
 
 ## Evidence contract
 

--- a/tools/flow-moment.mjs
+++ b/tools/flow-moment.mjs
@@ -6,6 +6,7 @@ import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import Ajv2020 from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
+import { escapeMarkdownText, markdownBulletList } from "./markdown-text.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const FLOW_SCHEMA_PATH = path.join(ROOT, "spec/product/flow-moment.schema.json");
@@ -141,23 +142,18 @@ export function validateFlowMoment(document, options = {}) {
   return { valid: errors.length === 0, errors };
 }
 
-function bulletList(items, empty = "None") {
-  if (!items || items.length === 0) return `- ${empty}`;
-  return items.map((item) => `- ${item}`).join("\n");
-}
-
 export function renderFlowMoment(document) {
   const signals = document.evidence_contract.signals
-    .map((signal) => `- **${signal.id}** (${signal.kind}): ${signal.question}`)
+    .map((signal) => `- **${signal.id}** (${signal.kind}): ${escapeMarkdownText(signal.question)}`)
     .join("\n");
   const exemplars = document.exemplars
-    .map((item) => `- **${item.product} — ${item.workflow_moment}**\n  - Adopt: ${item.adopt}\n  - Reject: ${item.reject}\n  - Ref: ${item.ref}`)
+    .map((item) => `- **${escapeMarkdownText(item.product)} — ${escapeMarkdownText(item.workflow_moment)}**\n  - Adopt: ${escapeMarkdownText(item.adopt)}\n  - Reject: ${escapeMarkdownText(item.reject)}\n  - Ref: ${item.ref}`)
     .join("\n");
   const components = document.components.length === 0
     ? "- None attached"
     : document.components.map((component) => `- ${component.ref} — **${component.maturity}**`).join("\n");
 
-  return `# ${document.title}
+  return `# ${escapeMarkdownText(document.title)}
 
 **Flow moment:** ${document.flow_moment_id}
 
@@ -169,27 +165,27 @@ export function renderFlowMoment(document) {
 
 ## Operator and progress
 
-**Actor:** ${document.actor.role} — ${document.actor.context}
+**Actor:** ${escapeMarkdownText(document.actor.role)} — ${escapeMarkdownText(document.actor.context)}
 
-**Entry state:** ${document.entry_state}
+**Entry state:** ${escapeMarkdownText(document.entry_state)}
 
-**Desired progress:** ${document.desired_progress}
+**Desired progress:** ${escapeMarkdownText(document.desired_progress)}
 
-**Dream outcome:** ${document.dream_outcome}
+**Dream outcome:** ${escapeMarkdownText(document.dream_outcome)}
 
 ## Product hypothesis
 
-${document.hypothesis.statement}
+${escapeMarkdownText(document.hypothesis.statement)}
 
 Falsified or revised when:
 
-${bulletList(document.hypothesis.falsifiable_by)}
+${markdownBulletList(document.hypothesis.falsifiable_by)}
 
 ## Experience boundary
 
-${document.experience.promise}
+${escapeMarkdownText(document.experience.promise)}
 
-${document.experience.recommendation_boundary}
+${escapeMarkdownText(document.experience.recommendation_boundary)}
 
 Available actions: ${document.experience.actions.join(", ")}.
 
@@ -203,23 +199,23 @@ Learning references: ${document.evidence_contract.learning_refs.length}.
 
 ## Exposure contract
 
-**Audience:** ${document.exposure.audience}
+**Audience:** ${escapeMarkdownText(document.exposure.audience)}
 
-**Owner:** ${document.exposure.owner}
+**Owner:** ${escapeMarkdownText(document.exposure.owner)}
 
-**Review trigger:** ${document.exposure.review_trigger}
+**Review trigger:** ${escapeMarkdownText(document.exposure.review_trigger)}
 
-**Flag:** ${document.exposure.flag_ref ?? "not wired; dark hypotheses may remain unflagged"}
+**Flag:** ${escapeMarkdownText(document.exposure.flag_ref ?? "not wired; dark hypotheses may remain unflagged")}
 
 ## Boundaries
 
 Does:
 
-${bulletList(document.boundaries.does)}
+${markdownBulletList(document.boundaries.does)}
 
 Does not:
 
-${bulletList(document.boundaries.does_not)}
+${markdownBulletList(document.boundaries.does_not)}
 
 ## Exemplars
 
@@ -231,7 +227,7 @@ ${components}
 
 ## Decision references
 
-${bulletList(document.decision_refs)}
+${document.decision_refs.length ? document.decision_refs.map((reference) => `- ${reference}`).join("\n") : "- None"}
 `;
 }
 

--- a/tools/flow-moment.mjs
+++ b/tools/flow-moment.mjs
@@ -66,7 +66,7 @@ function evidenceKindsCovered(document) {
   return covered;
 }
 
-function semanticErrors(document, asOf) {
+function semanticErrors(document, asOf, systemComponentsPath) {
   const errors = [];
   const signals = document.evidence_contract.signals;
   const observations = document.evidence_contract.observations;
@@ -131,7 +131,7 @@ function semanticErrors(document, asOf) {
     errors.push(`components: duplicate refs: ${componentRefs.join(", ")}`);
   }
 
-  const localComponentIds = collectSystemComponentIds();
+  const localComponentIds = collectSystemComponentIds(systemComponentsPath);
   const duplicateLocalComponentIds = duplicates(localComponentIds);
   if (duplicateLocalComponentIds.length > 0) {
     errors.push(`system components: duplicate component ids: ${duplicateLocalComponentIds.join(", ")}`);
@@ -160,6 +160,7 @@ function semanticErrors(document, asOf) {
 
 export function validateFlowMoment(document, options = {}) {
   const observedToday = options.today ?? new Date().toISOString().slice(0, 10);
+  const systemComponentsPath = options.systemComponentsPath ?? DEFAULT_SYSTEM_COMPONENTS_PATH;
   const asOf = document?.as_of;
   if (!isRealDate(observedToday)) {
     return { valid: false, errors: ["today: expected a real calendar date in YYYY-MM-DD format"] };
@@ -172,7 +173,7 @@ export function validateFlowMoment(document, options = {}) {
   if (schemaValid && Date.parse(`${asOf}T00:00:00Z`) > Date.parse(`${observedToday}T00:00:00Z`)) {
     errors.push(`as_of: ${asOf} cannot be later than validator date ${observedToday}`);
   }
-  if (schemaValid) errors.push(...semanticErrors(document, asOf));
+  if (schemaValid) errors.push(...semanticErrors(document, asOf, systemComponentsPath));
   return { valid: errors.length === 0, errors };
 }
 
@@ -337,6 +338,7 @@ async function main(args) {
   const command = args[0];
   if (command === "validate") {
     const { target: targetArg, today } = parseValidateArgs(args.slice(1));
+    const systemComponentsPath = path.resolve("product/system-components");
     const files = collectFlowFiles(targetArg);
     if (files.length === 0) {
       console.error(`flow-moment: no .flow.json records found at ${targetArg}`);
@@ -352,7 +354,7 @@ async function main(args) {
         console.error(`FAIL ${path.relative(ROOT, file)}: invalid JSON: ${error.message}`);
         continue;
       }
-      const result = validateFlowMoment(document, { today });
+      const result = validateFlowMoment(document, { today, systemComponentsPath });
       if (result.valid) {
         console.log(`PASS ${path.relative(ROOT, file)}`);
       } else {
@@ -372,7 +374,10 @@ async function main(args) {
       return 1;
     }
     const document = readJson(path.resolve(file));
-    const result = validateFlowMoment(document, { today });
+    const result = validateFlowMoment(document, {
+      today,
+      systemComponentsPath: path.resolve("product/system-components"),
+    });
     if (!result.valid) {
       console.error(`flow-moment: refusing to render invalid record\n${result.errors.map((error) => `  - ${error}`).join("\n")}`);
       return 1;

--- a/tools/flow-moment.mjs
+++ b/tools/flow-moment.mjs
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const FLOW_SCHEMA_PATH = path.join(ROOT, "spec/product/flow-moment.schema.json");
+const HIVEMIND_SCHEMA_PATH = path.join(ROOT, "tools/hivemind/hivemind-labels.v1.0.json");
+const DEFAULT_RECORDS_PATH = path.join(ROOT, "product/flow-moments");
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function createSchemaValidator() {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const hivemindSchema = readJson(HIVEMIND_SCHEMA_PATH);
+  ajv.addSchema(hivemindSchema, hivemindSchema.$id);
+  return ajv.compile(readJson(FLOW_SCHEMA_PATH));
+}
+
+const schemaValidator = createSchemaValidator();
+
+function formatSchemaError(error) {
+  const location = error.instancePath || "/";
+  return `schema ${location}: ${error.message}`;
+}
+
+function duplicates(values) {
+  const seen = new Set();
+  return [...new Set(values.filter((value) => {
+    if (seen.has(value)) return true;
+    seen.add(value);
+    return false;
+  }))];
+}
+
+function evidenceKindsCovered(document) {
+  const signals = new Map(document.evidence_contract.signals.map((signal) => [signal.id, signal]));
+  const covered = new Set();
+  for (const observation of document.evidence_contract.observations) {
+    for (const signalId of observation.signal_ids) {
+      const signal = signals.get(signalId);
+      if (signal) covered.add(signal.kind);
+    }
+  }
+  return covered;
+}
+
+function semanticErrors(document, today) {
+  const errors = [];
+  const signals = document.evidence_contract.signals;
+  const observations = document.evidence_contract.observations;
+  const signalIds = new Set(signals.map((signal) => signal.id));
+
+  const duplicateSignals = duplicates(signals.map((signal) => signal.id));
+  if (duplicateSignals.length > 0) {
+    errors.push(`evidence_contract.signals: duplicate ids: ${duplicateSignals.join(", ")}`);
+  }
+
+  const signalKinds = new Set(signals.map((signal) => signal.kind));
+  if (!signalKinds.has("behavioral") || !signalKinds.has("qualitative")) {
+    errors.push("evidence_contract.signals: research requires at least one behavioral and one qualitative signal");
+  }
+
+  const duplicateObservations = duplicates(observations.map((observation) => observation.id));
+  if (duplicateObservations.length > 0) {
+    errors.push(`evidence_contract.observations: duplicate ids: ${duplicateObservations.join(", ")}`);
+  }
+
+  for (const observation of observations) {
+    for (const signalId of observation.signal_ids) {
+      const signal = signals.find((candidate) => candidate.id === signalId);
+      if (!signalIds.has(signalId)) {
+        errors.push(`observation ${observation.id}: unknown signal id '${signalId}'`);
+      } else if (!signal.source_types.includes(observation.source_type)) {
+        errors.push(`observation ${observation.id}: source '${observation.source_type}' is not declared for signal '${signalId}'`);
+      }
+    }
+  }
+
+  const learningStatus = document.hivemind.learning_status;
+  const learningRefs = document.evidence_contract.learning_refs;
+  const coveredKinds = evidenceKindsCovered(document);
+
+  if (learningStatus === "smol-evidence" && observations.length < 1) {
+    errors.push("hivemind.learning_status: smol-evidence requires at least one captured observation");
+  }
+  if (["directionally-correct", "hypothesis-failed"].includes(learningStatus)) {
+    if (observations.length < 1 || learningRefs.length < 1) {
+      errors.push(`hivemind.learning_status: ${learningStatus} requires an observation and a learning reference`);
+    }
+  }
+  if (learningStatus === "strongly-validated") {
+    if (observations.length < 2 || learningRefs.length < 1) {
+      errors.push("hivemind.learning_status: strongly-validated requires at least two observations and a learning reference");
+    }
+    if (!coveredKinds.has("behavioral") || !coveredKinds.has("qualitative")) {
+      errors.push("hivemind.learning_status: strongly-validated must cover behavioral and qualitative signals");
+    }
+  }
+
+  const exposure = document.exposure;
+  if (exposure.kind === "research" && exposure.state === "default-on") {
+    if (!["directionally-correct", "strongly-validated"].includes(learningStatus)) {
+      errors.push("exposure: default-on research requires directionally-correct or strongly-validated outcome evidence");
+    }
+  }
+
+  const componentRefs = duplicates(document.components.map((component) => component.ref));
+  if (componentRefs.length > 0) {
+    errors.push(`components: duplicate refs: ${componentRefs.join(", ")}`);
+  }
+
+  const todayMs = Date.parse(`${today}T00:00:00Z`);
+  for (const component of document.components) {
+    if (component.maturity !== "gold") continue;
+    const productionMs = Date.parse(`${component.graduation.production_since}T00:00:00Z`);
+    const ageDays = Math.floor((todayMs - productionMs) / 86_400_000);
+    if (ageDays < 14) {
+      errors.push(`component ${component.ref}: Gold requires 14 production days; found ${ageDays}`);
+    }
+  }
+
+  return errors;
+}
+
+export function validateFlowMoment(document, options = {}) {
+  const today = options.today ?? new Date().toISOString().slice(0, 10);
+  if (!isRealDate(today)) {
+    return { valid: false, errors: ["today: expected a real calendar date in YYYY-MM-DD format"] };
+  }
+  const schemaValid = schemaValidator(document);
+  const errors = schemaValid ? [] : schemaValidator.errors.map(formatSchemaError);
+  if (schemaValid) errors.push(...semanticErrors(document, today));
+  return { valid: errors.length === 0, errors };
+}
+
+function bulletList(items, empty = "None") {
+  if (!items || items.length === 0) return `- ${empty}`;
+  return items.map((item) => `- ${item}`).join("\n");
+}
+
+export function renderFlowMoment(document) {
+  const signals = document.evidence_contract.signals
+    .map((signal) => `- **${signal.id}** (${signal.kind}): ${signal.question}`)
+    .join("\n");
+  const exemplars = document.exemplars
+    .map((item) => `- **${item.product} — ${item.workflow_moment}**\n  - Adopt: ${item.adopt}\n  - Reject: ${item.reject}\n  - Ref: ${item.ref}`)
+    .join("\n");
+  const components = document.components.length === 0
+    ? "- None attached"
+    : document.components.map((component) => `- ${component.ref} — **${component.maturity}**`).join("\n");
+
+  return `# ${document.title}
+
+**Flow moment:** ${document.flow_moment_id}
+
+**Record:** ${document.record_state}
+
+**Outcome confidence:** ${document.hivemind.learning_status}
+
+**Exposure:** ${document.exposure.kind} / ${document.exposure.state}
+
+## Operator and progress
+
+**Actor:** ${document.actor.role} — ${document.actor.context}
+
+**Entry state:** ${document.entry_state}
+
+**Desired progress:** ${document.desired_progress}
+
+**Dream outcome:** ${document.dream_outcome}
+
+## Product hypothesis
+
+${document.hypothesis.statement}
+
+Falsified or revised when:
+
+${bulletList(document.hypothesis.falsifiable_by)}
+
+## Experience boundary
+
+${document.experience.promise}
+
+${document.experience.recommendation_boundary}
+
+Available actions: ${document.experience.actions.join(", ")}.
+
+## Evidence contract
+
+${signals}
+
+Captured observations: ${document.evidence_contract.observations.length}.
+
+Learning references: ${document.evidence_contract.learning_refs.length}.
+
+## Exposure contract
+
+**Audience:** ${document.exposure.audience}
+
+**Owner:** ${document.exposure.owner}
+
+**Review trigger:** ${document.exposure.review_trigger}
+
+**Flag:** ${document.exposure.flag_ref ?? "not wired; dark hypotheses may remain unflagged"}
+
+## Boundaries
+
+Does:
+
+${bulletList(document.boundaries.does)}
+
+Does not:
+
+${bulletList(document.boundaries.does_not)}
+
+## Exemplars
+
+${exemplars}
+
+## Components
+
+${components}
+
+## Decision references
+
+${bulletList(document.decision_refs)}
+`;
+}
+
+function collectFlowFiles(target) {
+  const resolved = path.resolve(target);
+  if (!fs.existsSync(resolved)) return [];
+  const stat = fs.statSync(resolved);
+  if (stat.isFile()) return resolved.endsWith(".flow.json") ? [resolved] : [];
+  return fs.readdirSync(resolved, { withFileTypes: true })
+    .flatMap((entry) => {
+      const child = path.join(resolved, entry.name);
+      if (entry.isDirectory()) return collectFlowFiles(child);
+      return entry.isFile() && entry.name.endsWith(".flow.json") ? [child] : [];
+    })
+    .toSorted();
+}
+
+function parseToday(args) {
+  const index = args.indexOf("--today");
+  if (index === -1) return new Date().toISOString().slice(0, 10);
+  const value = args[index + 1];
+  if (!isRealDate(value)) {
+    throw new Error("--today requires YYYY-MM-DD");
+  }
+  return value;
+}
+
+function isRealDate(value) {
+  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsed.valueOf()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+function usage() {
+  return `Usage:
+  node tools/flow-moment.mjs validate [path] [--today YYYY-MM-DD]
+  node tools/flow-moment.mjs render <file>`;
+}
+
+async function main(args) {
+  const command = args[0];
+  if (command === "validate") {
+    const targetArg = args[1] && !args[1].startsWith("--") ? args[1] : DEFAULT_RECORDS_PATH;
+    const files = collectFlowFiles(targetArg);
+    if (files.length === 0) {
+      console.error(`flow-moment: no .flow.json records found at ${targetArg}`);
+      return 1;
+    }
+    const today = parseToday(args);
+    let failures = 0;
+    for (const file of files) {
+      let document;
+      try {
+        document = readJson(file);
+      } catch (error) {
+        failures += 1;
+        console.error(`FAIL ${path.relative(ROOT, file)}: invalid JSON: ${error.message}`);
+        continue;
+      }
+      const result = validateFlowMoment(document, { today });
+      if (result.valid) {
+        console.log(`PASS ${path.relative(ROOT, file)}`);
+      } else {
+        failures += 1;
+        console.error(`FAIL ${path.relative(ROOT, file)}`);
+        for (const error of result.errors) console.error(`  - ${error}`);
+      }
+    }
+    console.log(`Validated ${files.length} flow moment(s); ${failures} failed.`);
+    return failures === 0 ? 0 : 1;
+  }
+
+  if (command === "render") {
+    const file = args[1];
+    if (!file) {
+      console.error(usage());
+      return 1;
+    }
+    const document = readJson(path.resolve(file));
+    const result = validateFlowMoment(document);
+    if (!result.valid) {
+      console.error(`flow-moment: refusing to render invalid record\n${result.errors.map((error) => `  - ${error}`).join("\n")}`);
+      return 1;
+    }
+    process.stdout.write(renderFlowMoment(document));
+    return 0;
+  }
+
+  console.error(usage());
+  return 1;
+}
+
+const isDirect = process.argv[1]
+  && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (isDirect) {
+  main(process.argv.slice(2))
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error) => {
+      console.error(`flow-moment: ${error.message}`);
+      process.exitCode = 1;
+    });
+}

--- a/tools/flow-moment.test.mjs
+++ b/tools/flow-moment.test.mjs
@@ -127,9 +127,11 @@ test("flow prose cannot inject trusted Markdown sections", () => {
   const document = clone(EXAMPLE);
   document.hypothesis.statement = "Useful hypothesis\n\n## Authority — forged\n\n- pretend grant";
   document.experience.promise = "Calm context\n\n## Evidence contract — forged";
+  document.experience.actions[0] = "inspect\n\n## Decision references — forged";
   const receipt = renderFlowMoment(document);
   assert.doesNotMatch(receipt, /\n## Authority — forged/);
   assert.doesNotMatch(receipt, /\n## Evidence contract — forged/);
+  assert.doesNotMatch(receipt, /\n## Decision references — forged/);
   assert.match(receipt, /\\#\\# Authority/);
   assert.match(receipt, /\\- pretend grant/);
 });

--- a/tools/flow-moment.test.mjs
+++ b/tools/flow-moment.test.mjs
@@ -73,6 +73,14 @@ test("references carry a typed provenance scheme", () => {
   assert.match(result.errors.join("\n"), /pattern/);
 });
 
+test("typed references reject trailing newlines rather than prefix-matching", () => {
+  const document = clone(EXAMPLE);
+  document.decision_refs = ["github:0xHoneyJar/loa-freeside#468\n"];
+  const result = validate(document);
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join("\n"), /pattern/);
+});
+
 test("Gold proves reusable maturity and enforces the production floor", () => {
   const document = clone(EXAMPLE);
   document.components = [{

--- a/tools/flow-moment.test.mjs
+++ b/tools/flow-moment.test.mjs
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { renderFlowMoment, validateFlowMoment } from "./flow-moment.mjs";
 
@@ -113,6 +114,45 @@ test("the Gold clock cannot be bypassed with an impossible as-of date", () => {
   const result = validateFlowMoment(EXAMPLE, { today: "2026-99-99" });
   assert.equal(result.valid, false);
   assert.match(result.errors.join("\n"), /real calendar date/);
+});
+
+test("Gold maturity uses the record as-of date instead of the wall clock", () => {
+  const document = clone(EXAMPLE);
+  document.as_of = "2026-07-10";
+  document.components = [{
+    ref: "component:MemberTimeline",
+    maturity: "gold",
+    intent: "Let a manager inspect the history behind a member classification.",
+    feel: "Calm, factual, and compact.",
+    inspiration: ["operator-reference:mobbin/clay-people-2026-07-14"],
+    rejected: ["Essay-like summary without event provenance."],
+    graduation: {
+      taste_owner: "Freeside product",
+      production_since: "2026-07-01",
+      no_regressions: true,
+      active_use: true,
+      evidence_refs: ["github:0xHoneyJar/freeside-dashboard#111"],
+    },
+  }];
+  const premature = validateFlowMoment(document);
+  assert.equal(premature.valid, false);
+  assert.match(premature.errors.join("\n"), /requires 14 production days/);
+
+  document.as_of = "2026-07-15";
+  const mature = validateFlowMoment(document);
+  assert.equal(mature.valid, true, mature.errors.join("\n"));
+});
+
+test("the flow CLI rejects unknown flags", () => {
+  const result = spawnSync(process.execPath, [
+    path.join(ROOT, "tools/flow-moment.mjs"),
+    "validate",
+    "product/flow-moments",
+    "--todays",
+    TODAY,
+  ], { cwd: ROOT, encoding: "utf8" });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /unknown option --todays/);
 });
 
 test("the generated receipt carries intent without becoming another ledger", () => {

--- a/tools/flow-moment.test.mjs
+++ b/tools/flow-moment.test.mjs
@@ -134,13 +134,36 @@ test("Gold maturity uses the record as-of date instead of the wall clock", () =>
       evidence_refs: ["github:0xHoneyJar/freeside-dashboard#111"],
     },
   }];
-  const premature = validateFlowMoment(document);
+  const premature = validateFlowMoment(document, { today: "2026-07-15" });
   assert.equal(premature.valid, false);
   assert.match(premature.errors.join("\n"), /requires 14 production days/);
 
   document.as_of = "2026-07-15";
-  const mature = validateFlowMoment(document);
+  const mature = validateFlowMoment(document, { today: "2026-07-15" });
   assert.equal(mature.valid, true, mature.errors.join("\n"));
+});
+
+test("a record cannot self-certify maturity against a future as-of date", () => {
+  const document = clone(EXAMPLE);
+  document.as_of = "2026-07-16";
+  const result = validateFlowMoment(document, { today: "2026-07-15" });
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join("\n"), /cannot be later than validator date/);
+});
+
+test("observation signal references use the canonical signal id grammar", () => {
+  const document = clone(EXAMPLE);
+  document.evidence_contract.observations = [{
+    id: "OBS-FIRST",
+    captured_at: "2026-07-14T12:00:00Z",
+    signal_ids: ["Not_A_Signal"],
+    summary: "A bounded observation.",
+    source_type: "partner-observation",
+    ref: "github:0xHoneyJar/loa-freeside#468",
+  }];
+  const result = validate(document);
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join("\n"), /pattern/);
 });
 
 test("the flow CLI rejects unknown flags", () => {

--- a/tools/flow-moment.test.mjs
+++ b/tools/flow-moment.test.mjs
@@ -85,7 +85,8 @@ test("typed references reject trailing newlines rather than prefix-matching", ()
 test("Gold proves reusable maturity and enforces the production floor", () => {
   const document = clone(EXAMPLE);
   document.components = [{
-    ref: "component:MemberTimeline",
+    ref: "component:loa-freeside",
+    resolution: "local",
     maturity: "gold",
     intent: "Let a manager inspect the history behind a member classification.",
     feel: "Calm, factual, and compact.",
@@ -120,7 +121,8 @@ test("Gold maturity uses the record as-of date instead of the wall clock", () =>
   const document = clone(EXAMPLE);
   document.as_of = "2026-07-10";
   document.components = [{
-    ref: "component:MemberTimeline",
+    ref: "component:loa-freeside",
+    resolution: "local",
     maturity: "gold",
     intent: "Let a manager inspect the history behind a member classification.",
     feel: "Calm, factual, and compact.",
@@ -166,6 +168,31 @@ test("observation signal references use the canonical signal id grammar", () => 
   assert.match(result.errors.join("\n"), /pattern/);
 });
 
+test("local component references resolve exactly and external references stay explicit", () => {
+  const local = clone(EXAMPLE);
+  local.components = [{
+    ref: "component:loa-freeside",
+    resolution: "local",
+    maturity: "uncaptured",
+  }];
+  assert.equal(validate(local).valid, true);
+
+  local.components[0].ref = "component:missing-building";
+  const missing = validate(local);
+  assert.equal(missing.valid, false);
+  assert.match(missing.errors.join("\n"), /no matching local system-component manifest/);
+
+  const mislabeled = clone(EXAMPLE);
+  mislabeled.components[0] = {
+    ref: "component:loa-freeside",
+    resolution: "external",
+    maturity: "uncaptured",
+  };
+  const external = validate(mislabeled);
+  assert.equal(external.valid, false);
+  assert.match(external.errors.join("\n"), /must NOT be valid/);
+});
+
 test("the flow CLI rejects unknown flags", () => {
   const result = spawnSync(process.execPath, [
     path.join(ROOT, "tools/flow-moment.mjs"),
@@ -189,6 +216,18 @@ test("the flow CLI rejects ambiguous positional targets", () => {
   ], { cwd: ROOT, encoding: "utf8" });
   assert.equal(result.status, 1);
   assert.match(result.stderr, /unexpected argument product\/flow-moments/);
+});
+
+test("flow receipt rendering accepts an explicit validation date", () => {
+  const result = spawnSync(process.execPath, [
+    path.join(ROOT, "tools/flow-moment.mjs"),
+    "render",
+    "--today",
+    "2026-07-13",
+    "product/flow-moments/audit-community-composition.flow.json",
+  ], { cwd: ROOT, encoding: "utf8" });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /cannot be later than validator date 2026-07-13/);
 });
 
 test("the generated receipt carries intent without becoming another ledger", () => {

--- a/tools/flow-moment.test.mjs
+++ b/tools/flow-moment.test.mjs
@@ -178,6 +178,19 @@ test("the flow CLI rejects unknown flags", () => {
   assert.match(result.stderr, /unknown option --todays/);
 });
 
+test("the flow CLI rejects ambiguous positional targets", () => {
+  const result = spawnSync(process.execPath, [
+    path.join(ROOT, "tools/flow-moment.mjs"),
+    "validate",
+    "--today",
+    TODAY,
+    "product/flow-moments",
+    "product/flow-moments",
+  ], { cwd: ROOT, encoding: "utf8" });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /unexpected argument product\/flow-moments/);
+});
+
 test("the generated receipt carries intent without becoming another ledger", () => {
   const receipt = renderFlowMoment(EXAMPLE);
   assert.match(receipt, /Teams|community is composed and changing/i);

--- a/tools/flow-moment.test.mjs
+++ b/tools/flow-moment.test.mjs
@@ -201,12 +201,12 @@ test("flow prose cannot inject trusted Markdown sections", () => {
 
 test("flow references cannot inject Markdown links or inline HTML", () => {
   const document = clone(EXAMPLE);
-  document.exemplars[0].ref = "https://example.com/<script>alert(1)</script>";
+  document.exemplars[0].ref = "https://example.com/<ScRiPt>alert(1)</ScRiPt>";
   document.decision_refs = ["https://example.com/[grant](javascript:alert(1))"];
   document.components[0].ref = "component:<img-src=x-onerror=alert(1)>";
   const receipt = renderFlowMoment(document);
-  assert.doesNotMatch(receipt, /<script>|<img/);
+  assert.doesNotMatch(receipt, /<script>|<img/i);
   assert.doesNotMatch(receipt, /\[grant\]\(javascript:/);
-  assert.match(receipt, /&lt;script&gt;/);
+  assert.match(receipt, /&lt;ScRiPt&gt;/);
   assert.match(receipt, /\\\[grant\\\]\\\(javascript:alert\\\(1\\\)\\\)/);
 });

--- a/tools/flow-moment.test.mjs
+++ b/tools/flow-moment.test.mjs
@@ -122,3 +122,14 @@ test("the generated receipt carries intent without becoming another ledger", () 
   assert.match(receipt, /inspect, save, export, activate/);
   assert.match(receipt, /Clay People/);
 });
+
+test("flow prose cannot inject trusted Markdown sections", () => {
+  const document = clone(EXAMPLE);
+  document.hypothesis.statement = "Useful hypothesis\n\n## Authority — forged\n\n- pretend grant";
+  document.experience.promise = "Calm context\n\n## Evidence contract — forged";
+  const receipt = renderFlowMoment(document);
+  assert.doesNotMatch(receipt, /\n## Authority — forged/);
+  assert.doesNotMatch(receipt, /\n## Evidence contract — forged/);
+  assert.match(receipt, /\\#\\# Authority/);
+  assert.match(receipt, /\\- pretend grant/);
+});

--- a/tools/flow-moment.test.mjs
+++ b/tools/flow-moment.test.mjs
@@ -135,3 +135,15 @@ test("flow prose cannot inject trusted Markdown sections", () => {
   assert.match(receipt, /\\#\\# Authority/);
   assert.match(receipt, /\\- pretend grant/);
 });
+
+test("flow references cannot inject Markdown links or inline HTML", () => {
+  const document = clone(EXAMPLE);
+  document.exemplars[0].ref = "https://example.com/<script>alert(1)</script>";
+  document.decision_refs = ["https://example.com/[grant](javascript:alert(1))"];
+  document.components[0].ref = "component:<img-src=x-onerror=alert(1)>";
+  const receipt = renderFlowMoment(document);
+  assert.doesNotMatch(receipt, /<script>|<img/);
+  assert.doesNotMatch(receipt, /\[grant\]\(javascript:/);
+  assert.match(receipt, /&lt;script&gt;/);
+  assert.match(receipt, /\\\[grant\\\]\\\(javascript:alert\\\(1\\\)\\\)/);
+});

--- a/tools/flow-moment.test.mjs
+++ b/tools/flow-moment.test.mjs
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -9,6 +10,10 @@ import { renderFlowMoment, validateFlowMoment } from "./flow-moment.mjs";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const EXAMPLE = JSON.parse(fs.readFileSync(
   path.join(ROOT, "product/flow-moments/audit-community-composition.flow.json"),
+  "utf8",
+));
+const SYSTEM_EXAMPLE = JSON.parse(fs.readFileSync(
+  path.join(ROOT, "product/system-components/loa-freeside.system.json"),
   "utf8",
 ));
 const TODAY = "2026-07-14";
@@ -191,6 +196,41 @@ test("local component references resolve exactly and external references stay ex
   const external = validate(mislabeled);
   assert.equal(external.valid, false);
   assert.match(external.errors.join("\n"), /must NOT be valid/);
+});
+
+test("the reusable flow CLI resolves local components from the consumer repository", () => {
+  const consumerRoot = fs.mkdtempSync(path.join(os.tmpdir(), "flow-consumer-"));
+  try {
+    fs.mkdirSync(path.join(consumerRoot, "product/flow-moments"), { recursive: true });
+    fs.mkdirSync(path.join(consumerRoot, "product/system-components"), { recursive: true });
+    const flow = clone(EXAMPLE);
+    flow.components = [{
+      ref: "component:consumer-widget",
+      resolution: "local",
+      maturity: "uncaptured",
+    }];
+    const component = clone(SYSTEM_EXAMPLE);
+    component.component_id = "consumer-widget";
+    fs.writeFileSync(
+      path.join(consumerRoot, "product/flow-moments/consumer.flow.json"),
+      `${JSON.stringify(flow, null, 2)}\n`,
+    );
+    fs.writeFileSync(
+      path.join(consumerRoot, "product/system-components/consumer.system.json"),
+      `${JSON.stringify(component, null, 2)}\n`,
+    );
+    const result = spawnSync(process.execPath, [
+      path.join(ROOT, "tools/flow-moment.mjs"),
+      "validate",
+      "product/flow-moments",
+      "--today",
+      TODAY,
+    ], { cwd: consumerRoot, encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Validated 1 flow moment\(s\); 0 failed/);
+  } finally {
+    fs.rmSync(consumerRoot, { recursive: true, force: true });
+  }
 });
 
 test("the flow CLI rejects unknown flags", () => {

--- a/tools/flow-moment.test.mjs
+++ b/tools/flow-moment.test.mjs
@@ -1,0 +1,116 @@
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { renderFlowMoment, validateFlowMoment } from "./flow-moment.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const EXAMPLE = JSON.parse(fs.readFileSync(
+  path.join(ROOT, "product/flow-moments/audit-community-composition.flow.json"),
+  "utf8",
+));
+const TODAY = "2026-07-14";
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function validate(document) {
+  return validateFlowMoment(document, { today: TODAY });
+}
+
+test("the Audit community-composition hypothesis is valid but unproven", () => {
+  const result = validate(EXAMPLE);
+  assert.equal(result.valid, true, result.errors.join("\n"));
+  assert.equal(EXAMPLE.hivemind.learning_status, "cant-make-a-conclusion");
+  assert.equal(EXAMPLE.exposure.state, "dark");
+});
+
+test("the Hivemind label layer remains actionless", () => {
+  const document = clone(EXAMPLE);
+  document.hivemind.action = "launch-campaign";
+  const result = validate(document);
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join("\n"), /additional properties|must NOT have additional properties/i);
+});
+
+test("exposed research requires a real feature-flag reference", () => {
+  const document = clone(EXAMPLE);
+  document.exposure.state = "internal";
+  const result = validate(document);
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join("\n"), /flag_ref/);
+
+  document.exposure.flag_ref = "env:FREESIDE_AUDIT_COMPOSITION";
+  const repaired = validate(document);
+  assert.equal(repaired.valid, true, repaired.errors.join("\n"));
+});
+
+test("default-on research cannot outrun its evidence and operator decision", () => {
+  const document = clone(EXAMPLE);
+  document.exposure.state = "default-on";
+  document.exposure.flag_ref = "env:FREESIDE_AUDIT_COMPOSITION";
+  const result = validate(document);
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join("\n"), /decision_refs|learning_refs|outcome evidence/);
+});
+
+test("evidence confidence claims require observations", () => {
+  const document = clone(EXAMPLE);
+  document.hivemind.learning_status = "strongly-validated";
+  document.evidence_contract.learning_refs = ["github:0xHoneyJar/loa-freeside#learning"];
+  const result = validate(document);
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join("\n"), /two observations|behavioral and qualitative/);
+});
+
+test("references carry a typed provenance scheme", () => {
+  const document = clone(EXAMPLE);
+  document.decision_refs = ["some issue somebody mentioned"];
+  const result = validate(document);
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join("\n"), /pattern/);
+});
+
+test("Gold proves reusable maturity and enforces the production floor", () => {
+  const document = clone(EXAMPLE);
+  document.components = [{
+    ref: "component:MemberTimeline",
+    maturity: "gold",
+    intent: "Let a manager inspect the history behind a member classification.",
+    feel: "Calm, factual, and compact.",
+    inspiration: ["operator-reference:mobbin/clay-people-2026-07-14"],
+    rejected: ["Essay-like summary without event provenance."],
+    graduation: {
+      taste_owner: "Freeside product",
+      production_since: "2026-07-10",
+      no_regressions: true,
+      active_use: true,
+      evidence_refs: ["github:0xHoneyJar/freeside-dashboard#111"],
+    },
+  }];
+
+  const premature = validate(document);
+  assert.equal(premature.valid, false);
+  assert.match(premature.errors.join("\n"), /requires 14 production days/);
+
+  document.components[0].graduation.production_since = "2026-06-01";
+  const mature = validate(document);
+  assert.equal(mature.valid, true, mature.errors.join("\n"));
+  assert.equal(document.hivemind.learning_status, "cant-make-a-conclusion");
+});
+
+test("the Gold clock cannot be bypassed with an impossible as-of date", () => {
+  const result = validateFlowMoment(EXAMPLE, { today: "2026-99-99" });
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join("\n"), /real calendar date/);
+});
+
+test("the generated receipt carries intent without becoming another ledger", () => {
+  const receipt = renderFlowMoment(EXAMPLE);
+  assert.match(receipt, /Teams|community is composed and changing/i);
+  assert.match(receipt, /cant-make-a-conclusion/);
+  assert.match(receipt, /inspect, save, export, activate/);
+  assert.match(receipt, /Clay People/);
+});

--- a/tools/markdown-text.mjs
+++ b/tools/markdown-text.mjs
@@ -1,0 +1,16 @@
+/**
+ * Render untrusted prose as Markdown text without allowing it to create trusted
+ * headings, lists, links, or inline HTML in derived operator receipts.
+ */
+export function escapeMarkdownText(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replace(/([\\`*_[\]{}()#+\-.!|])/g, "\\$1");
+}
+
+export function markdownBulletList(items, empty = "None") {
+  if (!items || items.length === 0) return `- ${escapeMarkdownText(empty)}`;
+  return items.map((item) => `- ${escapeMarkdownText(item)}`).join("\n");
+}

--- a/tools/system-component.mjs
+++ b/tools/system-component.mjs
@@ -202,12 +202,27 @@ function rejectUnknownFlags(args, allowed) {
   if (unknown) throw new Error(`unknown option ${unknown}`);
 }
 
+function parseValidateArgs(args) {
+  let target = DEFAULT_PATH;
+  let targetSeen = false;
+  let portable = false;
+  for (const arg of args) {
+    if (arg === "--portable") {
+      portable = true;
+      continue;
+    }
+    if (arg.startsWith("--")) throw new Error(`unknown option ${arg}`);
+    if (targetSeen) throw new Error(`unexpected argument ${arg}`);
+    target = arg;
+    targetSeen = true;
+  }
+  return { target, portable };
+}
+
 async function main(args) {
   const command = args[0];
   if (command === "validate") {
-    rejectUnknownFlags(args.slice(1), new Set(["--portable"]));
-    const portable = args.includes("--portable");
-    const target = args.slice(1).find((arg) => !arg.startsWith("--")) ?? DEFAULT_PATH;
+    const { target, portable } = parseValidateArgs(args.slice(1));
     const files = collectFiles(target);
     if (files.length === 0) {
       console.error(`system-component: no .system.json manifests found at ${target}`);

--- a/tools/system-component.mjs
+++ b/tools/system-component.mjs
@@ -6,6 +6,7 @@ import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import Ajv2020 from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
+import { escapeMarkdownText } from "./markdown-text.mjs";
 
 const GOVERNANCE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const SCHEMA_PATH = path.join(GOVERNANCE_ROOT, "spec/product/system-component.schema.json");
@@ -122,9 +123,9 @@ export function validateSystemComponent(document, options = {}) {
 
 export function renderSystemComponent(document) {
   const flows = document.flow_moments.length === 0
-    ? `- Unmapped: ${document.unmapped_reason}`
+    ? `- Unmapped: ${escapeMarkdownText(document.unmapped_reason)}`
     : document.flow_moments
-      .map((moment) => `- **${moment.flow_moment_id}** (${moment.role}): ${moment.contribution}`)
+      .map((moment) => `- **${moment.flow_moment_id}** (${escapeMarkdownText(moment.role)}): ${escapeMarkdownText(moment.contribution)}`)
       .join("\n");
 
   return `# ${document.component_id}
@@ -135,23 +136,23 @@ export function renderSystemComponent(document) {
 
 ## Operator
 
-${document.operator.role}: ${document.operator.job}
+${escapeMarkdownText(document.operator.role)}: ${escapeMarkdownText(document.operator.job)}
 
 ## Object and question
 
-${document.object.description}
+${escapeMarkdownText(document.object.description)}
 
-${document.question}
+${escapeMarkdownText(document.question)}
 
 ## Stable responsibility
 
-${document.responsibility}
+${escapeMarkdownText(document.responsibility)}
 
 ## Trust
 
 Contract status: **${document.trust.contract_status}**
 
-${document.trust.note}
+${escapeMarkdownText(document.trust.note)}
 
 ## Flow moments
 
@@ -161,13 +162,13 @@ ${flows}
 
 Owns:
 
-${document.boundaries.owns.map((item) => `- ${item}`).join("\n")}
+${document.boundaries.owns.map((item) => `- ${escapeMarkdownText(item)}`).join("\n")}
 
 Does not own:
 
-${document.boundaries.does_not_own.map((item) => `- ${item}`).join("\n")}
+${document.boundaries.does_not_own.map((item) => `- ${escapeMarkdownText(item)}`).join("\n")}
 
-Missing capability: ${document.boundaries.missing_capability_handoff}
+Missing capability: ${escapeMarkdownText(document.boundaries.missing_capability_handoff)}
 `;
 }
 

--- a/tools/system-component.mjs
+++ b/tools/system-component.mjs
@@ -71,7 +71,7 @@ function collectFlowMomentRecords(repoRoot) {
   return { records, errors };
 }
 
-function semanticErrors(document, repoRoot) {
+function semanticErrors(document, repoRoot, { requireCanonicalFlowRecords }) {
   const errors = [];
   const flowIds = document.flow_moments.map((moment) => moment.flow_moment_id);
   const duplicateFlows = duplicates(flowIds);
@@ -85,16 +85,18 @@ function semanticErrors(document, repoRoot) {
     }
   }
 
-  const flowRecords = collectFlowMomentRecords(repoRoot);
-  errors.push(...flowRecords.errors);
-  const flowCounts = new Map();
-  for (const record of flowRecords.records) {
-    flowCounts.set(record.id, (flowCounts.get(record.id) ?? 0) + 1);
-  }
-  for (const moment of document.flow_moments) {
-    const count = flowCounts.get(moment.flow_moment_id) ?? 0;
-    if (count !== 1) {
-      errors.push(`flow_moment ${moment.flow_moment_id}: canonical_ref must resolve to exactly one .flow.json record; found ${count}`);
+  if (requireCanonicalFlowRecords) {
+    const flowRecords = collectFlowMomentRecords(repoRoot);
+    errors.push(...flowRecords.errors);
+    const flowCounts = new Map();
+    for (const record of flowRecords.records) {
+      flowCounts.set(record.id, (flowCounts.get(record.id) ?? 0) + 1);
+    }
+    for (const moment of document.flow_moments) {
+      const count = flowCounts.get(moment.flow_moment_id) ?? 0;
+      if (count !== 1) {
+        errors.push(`flow_moment ${moment.flow_moment_id}: canonical_ref must resolve to exactly one .flow.json record; found ${count}`);
+      }
     }
   }
 
@@ -115,9 +117,12 @@ function semanticErrors(document, repoRoot) {
 
 export function validateSystemComponent(document, options = {}) {
   const repoRoot = path.resolve(options.repoRoot ?? process.cwd());
+  const requireCanonicalFlowRecords = options.requireCanonicalFlowRecords ?? true;
   const schemaValid = schemaValidator(document);
   const errors = schemaValid ? [] : schemaValidator.errors.map(formatSchemaError);
-  if (schemaValid) errors.push(...semanticErrors(document, repoRoot));
+  if (schemaValid) {
+    errors.push(...semanticErrors(document, repoRoot, { requireCanonicalFlowRecords }));
+  }
   return { valid: errors.length === 0, errors };
 }
 
@@ -188,14 +193,15 @@ function collectFiles(target) {
 
 function usage() {
   return `Usage:
-  node tools/system-component.mjs validate [path]
+  node tools/system-component.mjs validate [path] [--portable]
   node tools/system-component.mjs render <file>`;
 }
 
 async function main(args) {
   const command = args[0];
   if (command === "validate") {
-    const target = args[1] ?? DEFAULT_PATH;
+    const portable = args.includes("--portable");
+    const target = args.slice(1).find((arg) => !arg.startsWith("--")) ?? DEFAULT_PATH;
     const files = collectFiles(target);
     if (files.length === 0) {
       console.error(`system-component: no .system.json manifests found at ${target}`);
@@ -211,7 +217,10 @@ async function main(args) {
         console.error(`FAIL ${path.relative(process.cwd(), file)}: invalid JSON: ${error.message}`);
         continue;
       }
-      const result = validateSystemComponent(document, { repoRoot: process.cwd() });
+      const result = validateSystemComponent(document, {
+        repoRoot: process.cwd(),
+        requireCanonicalFlowRecords: !portable,
+      });
       if (result.valid) {
         console.log(`PASS ${path.relative(process.cwd(), file)}`);
       } else {

--- a/tools/system-component.mjs
+++ b/tools/system-component.mjs
@@ -43,6 +43,33 @@ function allReferences(document) {
   ];
 }
 
+function collectFlowMomentRecords(repoRoot) {
+  const recordsRoot = path.join(repoRoot, "product", "flow-moments");
+  const records = [];
+  const errors = [];
+  if (!fs.existsSync(recordsRoot)) return { records, errors };
+
+  const visit = (directory) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const child = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(child);
+      } else if (entry.isFile() && entry.name.endsWith(".flow.json")) {
+        try {
+          const flow = readJson(child);
+          if (typeof flow.flow_moment_id === "string") {
+            records.push({ id: flow.flow_moment_id, file: child });
+          }
+        } catch (error) {
+          errors.push(`flow record ${path.relative(repoRoot, child)}: invalid JSON: ${error.message}`);
+        }
+      }
+    }
+  };
+  visit(recordsRoot);
+  return { records, errors };
+}
+
 function semanticErrors(document, repoRoot) {
   const errors = [];
   const flowIds = document.flow_moments.map((moment) => moment.flow_moment_id);
@@ -54,6 +81,19 @@ function semanticErrors(document, repoRoot) {
   for (const moment of document.flow_moments) {
     if (moment.canonical_ref !== `flow:${moment.flow_moment_id}`) {
       errors.push(`flow_moment ${moment.flow_moment_id}: canonical_ref must be flow:${moment.flow_moment_id}`);
+    }
+  }
+
+  const flowRecords = collectFlowMomentRecords(repoRoot);
+  errors.push(...flowRecords.errors);
+  const flowCounts = new Map();
+  for (const record of flowRecords.records) {
+    flowCounts.set(record.id, (flowCounts.get(record.id) ?? 0) + 1);
+  }
+  for (const moment of document.flow_moments) {
+    const count = flowCounts.get(moment.flow_moment_id) ?? 0;
+    if (count !== 1) {
+      errors.push(`flow_moment ${moment.flow_moment_id}: canonical_ref must resolve to exactly one .flow.json record; found ${count}`);
     }
   }
 

--- a/tools/system-component.mjs
+++ b/tools/system-component.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+
+const GOVERNANCE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SCHEMA_PATH = path.join(GOVERNANCE_ROOT, "spec/product/system-component.schema.json");
+const DEFAULT_PATH = "product/system-components";
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function createValidator() {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  return ajv.compile(readJson(SCHEMA_PATH));
+}
+
+const schemaValidator = createValidator();
+
+function formatSchemaError(error) {
+  return `schema ${error.instancePath || "/"}: ${error.message}`;
+}
+
+function duplicates(values) {
+  const seen = new Set();
+  return [...new Set(values.filter((value) => {
+    if (seen.has(value)) return true;
+    seen.add(value);
+    return false;
+  }))];
+}
+
+function allReferences(document) {
+  return [
+    ...document.trust.contract_refs,
+    ...document.trust.evidence_refs,
+  ];
+}
+
+function semanticErrors(document, repoRoot) {
+  const errors = [];
+  const flowIds = document.flow_moments.map((moment) => moment.flow_moment_id);
+  const duplicateFlows = duplicates(flowIds);
+  if (duplicateFlows.length > 0) {
+    errors.push(`flow_moments: duplicate ids: ${duplicateFlows.join(", ")}`);
+  }
+
+  for (const moment of document.flow_moments) {
+    if (moment.canonical_ref !== `flow:${moment.flow_moment_id}`) {
+      errors.push(`flow_moment ${moment.flow_moment_id}: canonical_ref must be flow:${moment.flow_moment_id}`);
+    }
+  }
+
+  for (const reference of allReferences(document)) {
+    if (!reference.startsWith("file:")) continue;
+    const relative = reference.slice("file:".length).split("#", 1)[0];
+    const resolved = path.resolve(repoRoot, relative);
+    const insideRepo = resolved === repoRoot || resolved.startsWith(`${repoRoot}${path.sep}`);
+    if (!insideRepo) {
+      errors.push(`reference ${reference}: local path escapes the repository root`);
+    } else if (!fs.existsSync(resolved)) {
+      errors.push(`reference ${reference}: local contract or evidence does not exist`);
+    }
+  }
+
+  return errors;
+}
+
+export function validateSystemComponent(document, options = {}) {
+  const repoRoot = path.resolve(options.repoRoot ?? process.cwd());
+  const schemaValid = schemaValidator(document);
+  const errors = schemaValid ? [] : schemaValidator.errors.map(formatSchemaError);
+  if (schemaValid) errors.push(...semanticErrors(document, repoRoot));
+  return { valid: errors.length === 0, errors };
+}
+
+export function renderSystemComponent(document) {
+  const flows = document.flow_moments.length === 0
+    ? `- Unmapped: ${document.unmapped_reason}`
+    : document.flow_moments
+      .map((moment) => `- **${moment.flow_moment_id}** (${moment.role}): ${moment.contribution}`)
+      .join("\n");
+
+  return `# ${document.component_id}
+
+**Layer:** ${document.layer}
+
+**Repository:** ${document.repository}
+
+## Operator
+
+${document.operator.role}: ${document.operator.job}
+
+## Object and question
+
+${document.object.description}
+
+${document.question}
+
+## Stable responsibility
+
+${document.responsibility}
+
+## Trust
+
+Contract status: **${document.trust.contract_status}**
+
+${document.trust.note}
+
+## Flow moments
+
+${flows}
+
+## Boundary
+
+Owns:
+
+${document.boundaries.owns.map((item) => `- ${item}`).join("\n")}
+
+Does not own:
+
+${document.boundaries.does_not_own.map((item) => `- ${item}`).join("\n")}
+
+Missing capability: ${document.boundaries.missing_capability_handoff}
+`;
+}
+
+function collectFiles(target) {
+  const resolved = path.resolve(target);
+  if (!fs.existsSync(resolved)) return [];
+  const stat = fs.statSync(resolved);
+  if (stat.isFile()) return resolved.endsWith(".system.json") ? [resolved] : [];
+  return fs.readdirSync(resolved, { withFileTypes: true })
+    .flatMap((entry) => {
+      const child = path.join(resolved, entry.name);
+      if (entry.isDirectory()) return collectFiles(child);
+      return entry.isFile() && entry.name.endsWith(".system.json") ? [child] : [];
+    })
+    .toSorted();
+}
+
+function usage() {
+  return `Usage:
+  node tools/system-component.mjs validate [path]
+  node tools/system-component.mjs render <file>`;
+}
+
+async function main(args) {
+  const command = args[0];
+  if (command === "validate") {
+    const target = args[1] ?? DEFAULT_PATH;
+    const files = collectFiles(target);
+    if (files.length === 0) {
+      console.error(`system-component: no .system.json manifests found at ${target}`);
+      return 1;
+    }
+    let failures = 0;
+    for (const file of files) {
+      let document;
+      try {
+        document = readJson(file);
+      } catch (error) {
+        failures += 1;
+        console.error(`FAIL ${path.relative(process.cwd(), file)}: invalid JSON: ${error.message}`);
+        continue;
+      }
+      const result = validateSystemComponent(document, { repoRoot: process.cwd() });
+      if (result.valid) {
+        console.log(`PASS ${path.relative(process.cwd(), file)}`);
+      } else {
+        failures += 1;
+        console.error(`FAIL ${path.relative(process.cwd(), file)}`);
+        for (const error of result.errors) console.error(`  - ${error}`);
+      }
+    }
+    console.log(`Validated ${files.length} system component(s); ${failures} failed.`);
+    return failures === 0 ? 0 : 1;
+  }
+
+  if (command === "render") {
+    const file = args[1];
+    if (!file) {
+      console.error(usage());
+      return 1;
+    }
+    const document = readJson(path.resolve(file));
+    const result = validateSystemComponent(document, { repoRoot: process.cwd() });
+    if (!result.valid) {
+      console.error(`system-component: refusing to render invalid manifest\n${result.errors.map((error) => `  - ${error}`).join("\n")}`);
+      return 1;
+    }
+    process.stdout.write(renderSystemComponent(document));
+    return 0;
+  }
+
+  console.error(usage());
+  return 1;
+}
+
+const isDirect = process.argv[1]
+  && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (isDirect) {
+  main(process.argv.slice(2))
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error) => {
+      console.error(`system-component: ${error.message}`);
+      process.exitCode = 1;
+    });
+}

--- a/tools/system-component.mjs
+++ b/tools/system-component.mjs
@@ -197,9 +197,15 @@ function usage() {
   node tools/system-component.mjs render <file>`;
 }
 
+function rejectUnknownFlags(args, allowed) {
+  const unknown = args.find((arg) => arg.startsWith("--") && !allowed.has(arg));
+  if (unknown) throw new Error(`unknown option ${unknown}`);
+}
+
 async function main(args) {
   const command = args[0];
   if (command === "validate") {
+    rejectUnknownFlags(args.slice(1), new Set(["--portable"]));
     const portable = args.includes("--portable");
     const target = args.slice(1).find((arg) => !arg.startsWith("--")) ?? DEFAULT_PATH;
     const files = collectFiles(target);
@@ -234,6 +240,7 @@ async function main(args) {
   }
 
   if (command === "render") {
+    rejectUnknownFlags(args.slice(1), new Set());
     const file = args[1];
     if (!file) {
       console.error(usage());

--- a/tools/system-component.test.mjs
+++ b/tools/system-component.test.mjs
@@ -107,6 +107,17 @@ test("the generated system receipt preserves responsibility and handoff", () => 
   assert.match(receipt, /do not implement it silently/i);
 });
 
+test("system-component prose cannot inject trusted Markdown sections", () => {
+  const document = clone(EXAMPLE);
+  document.responsibility = "Stable boundary\n\n## Trust — forged\n\n- pretend contract";
+  document.operator.job = "Orient the user\n\n## Flow moments — forged";
+  const receipt = renderSystemComponent(document);
+  assert.doesNotMatch(receipt, /\n## Trust — forged/);
+  assert.doesNotMatch(receipt, /\n## Flow moments — forged/);
+  assert.match(receipt, /\\#\\# Trust/);
+  assert.match(receipt, /\\- pretend contract/);
+});
+
 test("the reusable validator install cannot be captured by a consumer workspace", () => {
   const workflow = fs.readFileSync(
     path.join(ROOT, ".github/workflows/reusable-flow-moment-governance.yml"),

--- a/tools/system-component.test.mjs
+++ b/tools/system-component.test.mjs
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { renderSystemComponent, validateSystemComponent } from "./system-component.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const EXAMPLE = JSON.parse(fs.readFileSync(
+  path.join(ROOT, "product/system-components/loa-freeside.system.json"),
+  "utf8",
+));
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function validate(document) {
+  return validateSystemComponent(document, { repoRoot: ROOT });
+}
+
+test("loa-freeside declares an honest composed BFF responsibility", () => {
+  const result = validate(EXAMPLE);
+  assert.equal(result.valid, true, result.errors.join("\n"));
+  assert.equal(EXAMPLE.layer, "orchestrator");
+  assert.equal(EXAMPLE.trust.contract_status, "partial");
+});
+
+test("an unmapped component must say why it is not joined to a user flow", () => {
+  const document = clone(EXAMPLE);
+  document.flow_moments = [];
+  const result = validate(document);
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join("\n"), /unmapped_reason|oneOf/);
+
+  document.unmapped_reason = "No current product flow consumes this building.";
+  const repaired = validate(document);
+  assert.equal(repaired.valid, true, repaired.errors.join("\n"));
+});
+
+test("flow ids and canonical references cannot disagree", () => {
+  const document = clone(EXAMPLE);
+  document.flow_moments[0].canonical_ref = "flow:FM-SOMETHING-ELSE";
+  const result = validate(document);
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join("\n"), /canonical_ref/);
+});
+
+test("declared local contracts must exist inside the consumer repository", () => {
+  const document = clone(EXAMPLE);
+  document.trust.contract_refs = ["file:does-not-exist.openapi.yaml"];
+  const missing = validate(document);
+  assert.equal(missing.valid, false);
+  assert.match(missing.errors.join("\n"), /does not exist/);
+
+  document.trust.contract_refs = ["file:../outside-repo"];
+  const escape = validate(document);
+  assert.equal(escape.valid, false);
+  assert.match(escape.errors.join("\n"), /escapes the repository root/);
+});
+
+test("missing contract status cannot carry a flattering contract reference", () => {
+  const document = clone(EXAMPLE);
+  document.trust.contract_status = "missing";
+  const result = validate(document);
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join("\n"), /more than 0 items|maxItems/);
+});
+
+test("the generated system receipt preserves responsibility and handoff", () => {
+  const receipt = renderSystemComponent(EXAMPLE);
+  assert.match(receipt, /Stable responsibility/);
+  assert.match(receipt, /FM-AUDIT-COMPOSITION/);
+  assert.match(receipt, /do not implement it silently/i);
+});

--- a/tools/system-component.test.mjs
+++ b/tools/system-component.test.mjs
@@ -95,7 +95,7 @@ test("portable validation preserves typed flow links without requiring local can
   assert.equal(portable.valid, true, portable.errors.join("\n"));
   const { stdout, stderr } = await run(
     process.execPath,
-    [SYSTEM_CLI, "validate", "product/system-components", "--portable"],
+    [SYSTEM_CLI, "validate", "--portable", "product/system-components"],
     { cwd: repo },
   );
   assert.equal(stderr, "");
@@ -180,4 +180,16 @@ test("the system-component CLI rejects unknown flags", () => {
   ], { cwd: ROOT, encoding: "utf8" });
   assert.equal(result.status, 1);
   assert.match(result.stderr, /unknown option --portabl/);
+});
+
+test("the system-component CLI rejects ambiguous positional targets", () => {
+  const result = spawnSync(process.execPath, [
+    SYSTEM_CLI,
+    "validate",
+    "--portable",
+    "product/system-components",
+    "product/system-components",
+  ], { cwd: ROOT, encoding: "utf8" });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /unexpected argument product\/system-components/);
 });

--- a/tools/system-component.test.mjs
+++ b/tools/system-component.test.mjs
@@ -168,6 +168,7 @@ test("the reusable validator install cannot be captured by a consumer workspace"
   );
   assert.match(workflow, /--portable/);
   assert.match(workflow, /inputs\.validate-flow-moments/);
+  assert.match(workflow, /governance-ref must be a full lowercase 40-character commit SHA/);
 });
 
 test("the system-component CLI rejects unknown flags", () => {

--- a/tools/system-component.test.mjs
+++ b/tools/system-component.test.mjs
@@ -73,3 +73,14 @@ test("the generated system receipt preserves responsibility and handoff", () => 
   assert.match(receipt, /FM-AUDIT-COMPOSITION/);
   assert.match(receipt, /do not implement it silently/i);
 });
+
+test("the reusable validator install cannot be captured by a consumer workspace", () => {
+  const workflow = fs.readFileSync(
+    path.join(ROOT, ".github/workflows/reusable-flow-moment-governance.yml"),
+    "utf8",
+  );
+  assert.match(
+    workflow,
+    /pnpm install --frozen-lockfile --ignore-scripts --ignore-workspace/,
+  );
+});

--- a/tools/system-component.test.mjs
+++ b/tools/system-component.test.mjs
@@ -2,12 +2,16 @@ import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import { renderSystemComponent, validateSystemComponent } from "./system-component.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const run = promisify(execFile);
+const SYSTEM_CLI = path.join(ROOT, "tools/system-component.mjs");
 const EXAMPLE = JSON.parse(fs.readFileSync(
   path.join(ROOT, "product/system-components/loa-freeside.system.json"),
   "utf8",
@@ -71,6 +75,41 @@ test("every canonical flow reference resolves exactly once", async (t) => {
   assert.match(result.errors.join("\n"), /exactly one.*found 2/);
 });
 
+test("portable validation preserves typed flow links without requiring local canonical records", async (t) => {
+  const repo = await mkdtemp(path.join(tmpdir(), "portable-system-component-"));
+  t.after(() => rm(repo, { recursive: true, force: true }));
+  await mkdir(path.join(repo, "product", "system-components"), { recursive: true });
+  await writeFile(path.join(repo, "README.md"), "# Consumer\n");
+  const document = clone(EXAMPLE);
+  document.trust.contract_refs = ["file:README.md"];
+  document.trust.evidence_refs = [];
+  await writeFile(
+    path.join(repo, "product", "system-components", "consumer.system.json"),
+    JSON.stringify(document),
+  );
+
+  const portable = validateSystemComponent(document, {
+    repoRoot: repo,
+    requireCanonicalFlowRecords: false,
+  });
+  assert.equal(portable.valid, true, portable.errors.join("\n"));
+  const { stdout, stderr } = await run(
+    process.execPath,
+    [SYSTEM_CLI, "validate", "product/system-components", "--portable"],
+    { cwd: repo },
+  );
+  assert.equal(stderr, "");
+  assert.match(stdout, /Validated 1 system component\(s\); 0 failed/);
+
+  document.flow_moments[0].canonical_ref = "flow:FM-SOMETHING-ELSE";
+  const inconsistent = validateSystemComponent(document, {
+    repoRoot: repo,
+    requireCanonicalFlowRecords: false,
+  });
+  assert.equal(inconsistent.valid, false);
+  assert.match(inconsistent.errors.join("\n"), /canonical_ref/);
+});
+
 test("declared local contracts must exist inside the consumer repository", () => {
   const document = clone(EXAMPLE);
   document.trust.contract_refs = ["file:does-not-exist.openapi.yaml"];
@@ -127,4 +166,6 @@ test("the reusable validator install cannot be captured by a consumer workspace"
     workflow,
     /pnpm install --frozen-lockfile --ignore-scripts --ignore-workspace/,
   );
+  assert.match(workflow, /--portable/);
+  assert.match(workflow, /inputs\.validate-flow-moments/);
 });

--- a/tools/system-component.test.mjs
+++ b/tools/system-component.test.mjs
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -168,4 +168,15 @@ test("the reusable validator install cannot be captured by a consumer workspace"
   );
   assert.match(workflow, /--portable/);
   assert.match(workflow, /inputs\.validate-flow-moments/);
+});
+
+test("the system-component CLI rejects unknown flags", () => {
+  const result = spawnSync(process.execPath, [
+    SYSTEM_CLI,
+    "validate",
+    "product/system-components",
+    "--portabl",
+  ], { cwd: ROOT, encoding: "utf8" });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /unknown option --portabl/);
 });

--- a/tools/system-component.test.mjs
+++ b/tools/system-component.test.mjs
@@ -2,6 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { renderSystemComponent, validateSystemComponent } from "./system-component.mjs";
 
@@ -46,6 +48,29 @@ test("flow ids and canonical references cannot disagree", () => {
   assert.match(result.errors.join("\n"), /canonical_ref/);
 });
 
+test("every canonical flow reference resolves exactly once", async (t) => {
+  const missing = clone(EXAMPLE);
+  missing.flow_moments[0].flow_moment_id = "FM-NOT-THERE";
+  missing.flow_moments[0].canonical_ref = "flow:FM-NOT-THERE";
+  const absent = validate(missing);
+  assert.equal(absent.valid, false);
+  assert.match(absent.errors.join("\n"), /exactly one.*found 0/);
+
+  const repo = await mkdtemp(path.join(tmpdir(), "flow-resolution-"));
+  t.after(() => rm(repo, { recursive: true, force: true }));
+  await mkdir(path.join(repo, "product", "flow-moments"), { recursive: true });
+  await writeFile(path.join(repo, "README.md"), "# Fixture\n");
+  const flow = JSON.stringify({ flow_moment_id: "FM-AUDIT-COMPOSITION" });
+  await writeFile(path.join(repo, "product", "flow-moments", "one.flow.json"), flow);
+  await writeFile(path.join(repo, "product", "flow-moments", "two.flow.json"), flow);
+  const duplicate = clone(EXAMPLE);
+  duplicate.trust.contract_refs = ["file:README.md"];
+  duplicate.trust.evidence_refs = [];
+  const result = validateSystemComponent(duplicate, { repoRoot: repo });
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join("\n"), /exactly one.*found 2/);
+});
+
 test("declared local contracts must exist inside the consumer repository", () => {
   const document = clone(EXAMPLE);
   document.trust.contract_refs = ["file:does-not-exist.openapi.yaml"];
@@ -65,6 +90,14 @@ test("missing contract status cannot carry a flattering contract reference", () 
   const result = validate(document);
   assert.equal(result.valid, false);
   assert.match(result.errors.join("\n"), /more than 0 items|maxItems/);
+});
+
+test("typed references reject trailing whitespace and newlines", () => {
+  const document = clone(EXAMPLE);
+  document.trust.contract_refs = ["file:README.md\n"];
+  const result = validate(document);
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join("\n"), /pattern/);
 });
 
 test("the generated system receipt preserves responsibility and handoff", () => {


### PR DESCRIPTION
## Summary

- add a typed flow-moment contract that keeps product thesis, exposure, and component maturity independent
- add a canonical system-component contract and reusable validation workflow for API/BFF and front-facing product consumers
- ratify the first `loa-freeside` product-governance territory with The Arcade and Beacon at an observe-only ceiling
- add a construct-aware operator receipt joining user-flow responsibility, region outcomes, producer-declared expertise, provenance, and effective authority

## Why

Teams closest to rapidly changing reality can make the most informed decisions when the system surfaces signal without flattening every claim into “truth.” This gives agents continuity across context windows while preserving the force chain:

- product thesis remains a hypothesis until evidence arrives
- construct orientation is prose and cannot grant authority
- construct mechanics come from producer-owned contracts
- territory is only a ceiling; unknown earned authority collapses to `observe`

The result is a derived operator surface, not another decision or learning ledger.

## Contract shape

| Plane | Source | Guarantee |
|---|---|---|
| User intent | flow moments + system components | operator, question, responsibility, evidence, boundaries, handoff |
| Orientation | Constructs info | prose with `authoritative: false` |
| Mechanics | Constructs info + capabilities | declared skills/commands/runtime hints with provenance and no authority effect |
| Authority | territory + earned evidence | fail-closed effective tier; explanatory prose is never parsed as state |

## Stack and adoption

- depends on 0xHoneyJar/loa-constructs#276, stacked on its CLI producer PR #275
- this PR remains the canonical dependency for follow-up consumer PRs in the active Freeside APIs, `freeside-dashboard`, and `freeside-characters`
- consumers pin the reusable governance workflow by immutable commit rather than copying schemas

## Verification

- `node --test tools/flow-moment.test.mjs tools/system-component.test.mjs tools/construct-operator.test.mjs` — 51 passed
- validated 1 canonical flow-moment record and 1 canonical system-component manifest
- rendered flow, system, and construct operator receipts
- targeted Oxlint passed
- workflow YAML parsed successfully
- live join against the local Constructs producer returned The Arcade + Beacon with declared mechanics, structured `ratification_status: unchecked`, and `unknown -> observe` authority
- producer suite: 176 tests and 7/7 deterministic vectors

## Reviewer focus

- weakest link: territory stationing is intentionally unratified on a feature branch, so the live operator receipt must remain `partial` until the producer can prove committed default-branch state
- confirm ratification prose cannot mechanically promote state
- confirm Hivemind remains actionless and product actions stay in the flow contract
- confirm missing mechanics, producer drift, and impossible authority combinations fail closed