### PR TITLE
docs: establish CR-000 Discord authority boundary

### DIFF
--- a/grimoires/loa/coordination/collection-report/cr-000/README.md
+++ b/grimoires/loa/coordination/collection-report/cr-000/README.md
@@ -1,0 +1,43 @@
+# CR-000 — Discord restricted-tier viability evidence room
+
+**Task:** Discord restricted-tier viability go/no-go
+**Cycle:** `collection-report`
+**Branch:** `coord/collection-report-coordinator-f09.10`
+**Room type:** bounded DIG/ARCH evidence room
+**Decision state:** `pending` (not Go, not No-go)
+
+This directory is the CR-000 coordination workspace. It records public-policy
+findings, repository non-secret evidence, private-evidence gaps, owner sign-off
+blocks, and the machine-readable pending authority template.
+
+It does **not** authorize restricted T2 work, alter production Discord
+permissions, or invent an owner signature.
+
+## Contents
+
+| Path | Purpose |
+|------|---------|
+| [`decision-record.md`](./decision-record.md) | Current state, deadline, findings, gaps, T0/T1/T2 consequences, sign-offs |
+| [`evidence-checklist.md`](./evidence-checklist.md) | Completable checklist for Discord application owner + privacy/security owner |
+| [`pending-authority-record.yaml`](./pending-authority-record.yaml) | Versioned pending Discord-policy authority template |
+| [`pending-authority-record.schema.json`](./pending-authority-record.schema.json) | JSON Schema for the authority record |
+| [`repository-evidence.md`](./repository-evidence.md) | Non-secret origin/main audit notes (no portal inference) |
+| [`link-validation.md`](./link-validation.md) | Primary-source link probe results |
+| [`sources.md`](./sources.md) | Pointers to grounded public-policy packet and masters |
+
+## Hard rules for this room
+
+1. Unknown / missing private evidence remains `pending` until the ratified
+   deadline. Pending does **not** become No-go early.
+2. Restricted T2 stays **disabled** while the decision is `pending`.
+3. T0 recognition and T1 public preparation remain intact regardless of CR-000.
+4. Do not fabricate Go, No-go, owner identity, approval, privileged-intent
+   portal state, user count, policy interpretation, or signatures.
+5. Do not infer Developer Portal state from code or environment-variable names.
+6. Do not change production bot permissions from this room.
+
+## Related masters
+
+- Coordinator PRD/SDD/sprint: `grimoires/loa/{prd,sdd,sprint}.md` (coordinator root)
+- Task manifest: `grimoires/loa/coordination/task-manifest.yaml`
+- Public-policy packet: `grimoires/loa/research/collection-report-cr000-source-packet.md`

--- a/grimoires/loa/coordination/collection-report/cr-000/decision-record.md
+++ b/grimoires/loa/coordination/collection-report/cr-000/decision-record.md
@@ -1,0 +1,270 @@
+# CR-000 Decision Record — Discord restricted-tier viability
+
+| Field | Value |
+|-------|-------|
+| Task ID | `CR-000` |
+| Title | Discord restricted-tier viability go/no-go |
+| Primary repository (sprint) | `loa-freeside/packages/services/shadow-audit` |
+| Coordination branch | `coord/collection-report-coordinator-f09.10` |
+| Audit tip (origin/main equivalent in this worktree) | `3782fd47e8a20cdaf6325621962bd0443e6781b8` |
+| Decision state | **`pending`** |
+| Restricted T2 status | **disabled** (fail-closed while pending) |
+| T0 / T1 status | **intact** (continue regardless of CR-000) |
+| Fabricated outcome | none — no Go, No-go, owner identity, approval, or signature |
+
+---
+
+## 1. Current decision state
+
+**`pending`**
+
+Meaning under sprint CR-000 / G-1:
+
+- Public Discord documentation has been collected into a grounded source packet.
+- Repository non-secret evidence about Discord integration and Shadow Audit
+  RoleSnapshot / Gateway boundaries has been audited.
+- Private Developer Portal evidence, owner identities, and dual signatures are
+  **absent**.
+- Therefore the decision is neither Go nor No-go.
+- Restricted-tier (T2) Gate Leak remains disabled.
+- Unknown/pending becomes No-go **only** at the ratified deadline below, not
+  earlier.
+
+---
+
+## 2. Issue-start time and 10-business-day deadline
+
+### 2.1 Issue start
+
+| Field | Value |
+|-------|-------|
+| `issue_start_at` | `2026-07-16T08:49:00Z` |
+| `issue_start_date_utc` | `2026-07-16` (Thursday) |
+| Basis | KRANZ autonomous dispatch CR-000 room open on this branch |
+
+### 2.2 Deterministic deadline semantics
+
+These rules are fixed for this record and must not be reinterpreted ad hoc:
+
+1. **Calendar:** UTC dates only.
+2. **Business day:** Monday–Friday. No holiday calendar is ratified in this
+   room; weekends are excluded and no holidays are skipped unless a later
+   signed amendment records an explicit holiday set.
+3. **Counting:** Count **10 weekdays strictly after** `issue_start_date_utc`.
+   The issue-start calendar day itself is not counted as one of the ten.
+4. **Deadline instant:** End of the 10th counted business day in UTC:
+   `YYYY-MM-DDT23:59:59Z`.
+5. **Late state rule:** If, at the deadline instant, the dual sign-offs are
+   missing, incomplete, or the decision remains `pending` / unknown, the
+   decision **automatically becomes `no-go` for T2**. This conversion happens
+   only at the deadline, never early.
+6. **Early No-go:** Allowed only if an authorized Discord application owner and
+   privacy/security owner **explicitly sign a No-go** before the deadline.
+7. **Early Go:** Allowed only if all required private evidence is attached and
+   both owners sign Go before the deadline. Public-policy notes alone are
+   insufficient.
+
+### 2.3 Computed deadline for this issue
+
+Counted business days after `2026-07-16`:
+
+1. `2026-07-17` (Fri)
+2. `2026-07-20` (Mon)
+3. `2026-07-21` (Tue)
+4. `2026-07-22` (Wed)
+5. `2026-07-23` (Thu)
+6. `2026-07-24` (Fri)
+7. `2026-07-27` (Mon)
+8. `2026-07-28` (Tue)
+9. `2026-07-29` (Wed)
+10. `2026-07-30` (Thu)
+
+| Field | Value |
+|-------|-------|
+| `decision_deadline_at` | `2026-07-30T23:59:59Z` |
+| Auto-consequence if still pending | `no-go` for T2; T0/T1 remain intact |
+
+---
+
+## 3. Current public-policy findings
+
+Source of truth for public Discord policy in this room:
+
+`grimoires/loa/research/collection-report-cr000-source-packet.md`
+(accessed `2026-07-16`; Exa route unavailable — `EXA_API_KEY` absent)
+
+Findings recorded from that packet (not from private portal state):
+
+| Topic | Public finding | Status |
+|-------|----------------|--------|
+| Privileged intent | `GUILD_MEMBERS` is privileged; Developer Portal enablement required; apps subject to review need approval; unauthorized use can close Gateway with `4014` | documented |
+| Member list / REST | Complete member list / guild member listing requires `GUILD_MEMBERS`; pages/chunks at most 1,000; request limited to one guild ID | documented |
+| Scale threshold (2026-06-11 guidance) | Apps under 10,000 guild-installed users may enable privileged intents without review; at 10,000, review is required with owner notice and 90 days to apply | documented (threshold only; **Freeside count = pending**) |
+| Developer Policy | API data only as necessary for stated functionality; no profiling of users/identities/relationships; respect opt-out; no mining/scraping | documented |
+| Developer Terms | Public current privacy policy required; update/delete API data when unnecessary or requested; encryption at rest + safeguards; material changes may need renewed App Review | documented |
+| Proposed Gate Leak purpose | Member-data joined to wallet identity for stale-access audit | **not established as authorized** by public docs alone |
+
+Safe interim interpretation (from packet; retained here):
+
+> Public documentation establishes technical dependence on `GUILD_MEMBERS`, but
+> does **not** establish that the current Freeside Discord application is
+> authorized for the proposed member-data-plus-wallet purpose.
+
+Link probe notes: see [`link-validation.md`](./link-validation.md).
+
+---
+
+## 4. Repository non-secret evidence (summary)
+
+Full citations: [`repository-evidence.md`](./repository-evidence.md).
+
+Proven from `origin/main` tip `3782fd47…` without reading secrets:
+
+| Area | What code/docs prove | What they do **not** prove |
+|------|----------------------|----------------------------|
+| Discord application integration | Sietch Discord service, worker, and `apps/ingestor` construct `discord.js` clients and login via `DISCORD_BOT_TOKEN`; slash-command registration takes a `clientId` argument | Live Application ID, team ownership, verification/review state |
+| Configured intents (code) | Multiple clients request `GatewayIntentBits.GuildMembers` (and other intents including `MessageContent` / `GuildPresences` in some entrypoints) | That privileged intents are enabled or approved in the Developer Portal |
+| Setup docs | `themes/sietch/docs/discord-setup.md` instructs operators to turn **Server Members Intent** ON in the portal | That production followed that checklist |
+| Guild / member scale | No production guild-installed user count in-repo; sandbox IaC lists a named sandbox server id only | Whether the app is under/over Discord’s 10,000-user review threshold |
+| Privacy policy | No verified live public privacy-policy URL describing Gate Leak member+wallet use; `https://0xhoneyjar.xyz/privacy` probed → final `404` | Existence/currency of the required public privacy policy |
+| Shadow Audit RoleSnapshot | `RoleSnapshot` schema + file-backed `ROLE_SNAPSHOT_PATH` loader; dogfood-full refuses without snapshot; k-anonymity via `AUDIT_K` | Live Gateway-bound `discord_role_snapshot.v1` producer authorization |
+| Planned Gateway boundary (SDD) | SDD requires privileged `GUILD_MEMBERS`, Gateway epoch/sequence completeness, and external gating before restricted producer use | That those permissions exist today |
+
+**Boundary rule:** environment-variable *names* (`DISCORD_BOT_TOKEN`,
+`DISCORD_GUILD_ID`, `ROLE_SNAPSHOT_PATH`, etc.) are configuration seams only.
+They are not evidence of portal toggles, review approval, or ownership.
+
+---
+
+## 5. Private evidence gaps (must stay `pending`)
+
+All of the following are **pending** human/private evidence:
+
+1. Discord Application ID for the production/relevant bot.
+2. Team / application owner identity (role filled by a named human).
+3. Bot verification / App Review state.
+4. Whether `GUILD_MEMBERS` is enabled in the Developer Portal.
+5. Whether privileged-intent review applies and, if so, approval/conditions.
+6. Exact submitted use case for member data + wallet join (Gate Leak).
+7. Current guild-installed user count vs Discord’s 10,000 threshold.
+8. Current public privacy-policy URL and whether it covers the proposed use,
+   retention, deletion, and safeguards.
+9. Discord application owner Go/No-go signature.
+10. Privacy/security owner determination and Go/No-go signature.
+11. Evidence digests for attached private artifacts (portal screenshots /
+    exports) — slots exist in the authority template, values empty.
+
+---
+
+## 6. Owners required (roles — identities pending)
+
+| Role | Responsibility | Named person | Status |
+|------|----------------|--------------|--------|
+| Discord application owner | Prove portal verification/intents/limits; sign Go/No-go; own renewal | `pending` | required |
+| Privacy / security owner | Determine Developer Terms/Policy fit for member+wallet purpose; sign Go/No-go | `pending` | required |
+| Shadow Audit maintainer (coordination) | Keep restricted producer fail-closed until Go authority version exists | role per sprint | not a substitute for the two signatures |
+
+No individual names are asserted by this room.
+
+---
+
+## 7. Explicit T0 / T1 / T2 consequences
+
+| Tier | Meaning (sprint) | CR-000 `pending` | CR-000 Go | CR-000 No-go (signed early or auto at deadline) |
+|------|------------------|------------------|-----------|--------------------------------------------------|
+| **T0 Recognition** | Collection question, candidates, support demand; no report order | **continues** | continues | **continues** |
+| **T1 Public preparation** | Controlled public-chain fixtures; no production Gate Leak artifact / identity data | **continues** | continues | **continues** |
+| **T2 Gate Leak release** | Production report orders, restricted evidence, artifact, Reports/attention | **disabled** | may proceed only with other G1B/G3/G4 gates | **stopped**; Gate Leak visibly unavailable with honest external-dependency reason; **no** aggregate-only fallback; **do not** alter existing bot production permissions |
+
+Checkpoint C0: T0/T1 continue regardless; T2 stops on No-go. While pending, treat
+T2 the same as not-yet-authorized: disabled.
+
+---
+
+## 8. Renewal and revocation behavior (authority lifecycle)
+
+When a Go authority record is later ratified (not now), sprint CR-000 requires:
+
+| Event | Behavior |
+|-------|----------|
+| Authority shape | Versioned Discord-policy authority record: owner, evidence digest, approved purposes/data classes, effective time, 90-day expiry or earlier review date, emergency revocation; version enters restricted work keys / projections |
+| Standing renewal | Discord application owner checks at day 60 and every 60 days while restricted program is active |
+| No-change renewal before expiry | New authority version; does **not** quarantine in-flight work |
+| Changed evidence on renewal | Requires fresh privacy/security approval |
+| Missed renewal | Same as expiry |
+| Expiry, ownership/terms/intent change, or revocation | Stop new restricted work; quarantine in-flight work; start disposal review until a new Go is ratified |
+| Denial / No-go | Leave T0/T1 intact; do not invent aggregate-only Gate Leak; do not touch existing bot production permissions |
+
+Until Go exists, the pending authority template holds empty digest/signature
+slots and `decision: pending`.
+
+---
+
+## 9. Machine-readable pending authority
+
+See [`pending-authority-record.yaml`](./pending-authority-record.yaml)
+Schema: [`pending-authority-record.schema.json`](./pending-authority-record.schema.json)
+
+Current authority version in that file: `cr000-pending-0`.
+It is **not** a Go record and must not enter restricted work keys as approval.
+
+---
+
+## 10. Sign-off blocks (exact — leave blank until humans sign)
+
+### 10.1 Discord application owner
+
+```
+Role: Discord application owner
+Name: ______________________________
+Contact: ___________________________
+Application ID attested: ___________
+Guild-installed user count band attested (under / at-or-over 10,000): ___________
+GUILD_MEMBERS portal state attested (enabled / not enabled / review-approved / review-pending / N/A): ___________
+Decision: [ ] Go   [ ] No-go
+Evidence attachments / digests referenced: ___________
+Signature: __________________________
+Signed at (UTC): ____________________
+```
+
+### 10.2 Privacy / security owner
+
+```
+Role: Privacy / security owner
+Name: ______________________________
+Contact: ___________________________
+Privacy policy URL attested current: ___________
+Member-data + wallet join purpose determination: [ ] permitted as proposed   [ ] not permitted   [ ] permitted only with conditions:
+Conditions (if any): ________________
+Retention / deletion / encryption determination recorded: [ ] yes   [ ] no
+Decision: [ ] Go   [ ] No-go
+Evidence attachments / digests referenced: ___________
+Signature: __________________________
+Signed at (UTC): ____________________
+```
+
+### 10.3 Joint ratification gate
+
+A Go is valid only when:
+
+1. Both blocks above are marked Go with non-empty names and UTC timestamps;
+2. Evidence checklist critical items are complete (see
+   [`evidence-checklist.md`](./evidence-checklist.md));
+3. `pending-authority-record.yaml` is upgraded to a non-pending version with
+   filled digests, purposes, effective/expiry times, renewal owner, and
+   revocation contacts;
+4. Restricted work keys may then reference that authority version.
+
+A No-go is valid when either owner signs No-go, or when the deadline auto-rule
+in §2 fires.
+
+---
+
+## 11. Record history
+
+| UTC | Event |
+|-----|-------|
+| `2026-07-16T08:49:00Z` | Issue start — CR-000 evidence room opened; decision = `pending`; T2 disabled |
+| `2026-07-16` | Public-policy packet grounded; repository audit written; authority template + checklist published |
+
+No Go/No-go ratification has occurred.

--- a/grimoires/loa/coordination/collection-report/cr-000/evidence-checklist.md
+++ b/grimoires/loa/coordination/collection-report/cr-000/evidence-checklist.md
@@ -1,0 +1,119 @@
+# CR-000 Evidence Checklist
+
+Complete this checklist using Discord Developer Portal access, privacy/legal
+review, and operational knowledge. Do **not** interpret the PRD/SDD/sprint to
+fill gaps — those masters define *what* must be decided; this list defines the
+evidence fields.
+
+**Decision state while any Critical item is incomplete:** `pending`
+**Restricted T2 while pending:** disabled
+**Deadline:** `2026-07-30T23:59:59Z` (see `decision-record.md` §2)
+
+Mark each item: `pending` | `complete` | `not_applicable` (N/A requires a
+written reason). Attach evidence digests in
+`pending-authority-record.yaml` when complete.
+
+---
+
+## A. Discord application identity (Critical — Application owner)
+
+| ID | Evidence item | How to obtain | Status | Value / attachment ref |
+|----|---------------|---------------|--------|------------------------|
+| A1 | Discord Application ID | Developer Portal → Application → Application ID | pending | |
+| A2 | Application / team owner name and contact | Developer Portal → Team / owner account | pending | |
+| A3 | Bot user ID / bot username tag | Portal → Bot, or live bot profile | pending | |
+| A4 | Which runtime(s) this application powers | Map portal app to deployed services (ingestor / Sietch / worker / other). Do not guess from env names alone. | pending | |
+| A5 | Verification / App Review status | Portal verification and any App Review history | pending | |
+
+---
+
+## B. Privileged intents (Critical — Application owner)
+
+| ID | Evidence item | How to obtain | Status | Value / attachment ref |
+|----|---------------|---------------|--------|------------------------|
+| B1 | Server Members Intent (`GUILD_MEMBERS`) toggle state in Portal | Portal → Bot → Privileged Gateway Intents | pending | |
+| B2 | Whether Discord requires privileged-intent review for this app | Compare guild-installed user count to Discord’s published threshold; record Portal review state | pending | |
+| B3 | If review required: approval status and date | Portal / Discord notice | pending | |
+| B4 | If approved: exact approved use case text | Copy from submission / approval record | pending | |
+| B5 | Approval conditions or restrictions | Approval correspondence | pending | |
+| B6 | Message Content Intent portal state (if used by any production client) | Portal → Bot | pending | |
+| B7 | Presence Intent portal state (if used by any production client) | Portal → Bot | pending | |
+| B8 | Confirmation that production permissions will **not** be changed by this CR-000 process unless separately authorized | Owner attestation | pending | |
+
+Note: Repository clients *request* `GuildMembers` in code. That is **not** an
+answer for B1–B5.
+
+---
+
+## C. Scale / limits (Critical — Application owner)
+
+| ID | Evidence item | How to obtain | Status | Value / attachment ref |
+|----|---------------|---------------|--------|------------------------|
+| C1 | Current guild-installed user count (Discord’s metric) | Developer Portal analytics / Discord-provided count | pending | |
+| C2 | Band relative to 10,000 guild-installed users | Derived from C1: `under_10000` or `at_or_over_10000` | pending | |
+| C3 | Largest target guild member count for Gate Leak V1 | Guild settings / ops export (no need to paste member PII here) | pending | |
+| C4 | Known Discord pagination / rate-limit constraints accepted for capture design | Ops note acknowledging 1,000-member pages and privileged-intent dependency | pending | |
+
+---
+
+## D. Privacy policy and data use (Critical — Privacy/security owner)
+
+| ID | Evidence item | How to obtain | Status | Value / attachment ref |
+|----|---------------|---------------|--------|------------------------|
+| D1 | Public privacy-policy URL that is current | Live URL that returns the policy document | pending | |
+| D2 | Policy covers Discord API data collection | Policy text citation (section heading) | pending | |
+| D3 | Policy covers joining Discord member/role data to wallet / identity links for audit | Policy text citation or explicit gap | pending | |
+| D4 | Retention period for restricted Gate Leak evidence / identity rows | Policy or internal retention schedule aligned to CR-007B when available | pending | |
+| D5 | Deletion / user opt-out / Discord-requested deletion process | Documented procedure owner + contact | pending | |
+| D6 | Encryption at rest and access safeguards for API data | Security owner note (systems, not secrets) | pending | |
+| D7 | Determination: proposed Gate Leak purpose is permitted under Discord Developer Terms/Policy as used by this application | Written determination | pending | |
+| D8 | If conditions apply, list them | Written conditions | pending | |
+
+---
+
+## E. Purpose / data classes for authority record (Critical — both owners)
+
+Fill the authority template fields; checklist tracks completeness only.
+
+| ID | Evidence item | Status | Notes |
+|----|---------------|--------|-------|
+| E1 | Approved purposes list drafted (or explicit denial) | pending | e.g. Gate Leak V1 stale-access audit among mapped-role members |
+| E2 | Approved data classes drafted (or explicit denial) | pending | e.g. guild id, role ids, discord user ids, linked wallets under consent, aggregate counts |
+| E3 | Explicitly excluded purposes/data classes listed | pending | e.g. profiling, marketing, cross-community sharing |
+| E4 | Effective time proposed | pending | |
+| E5 | Expiry or earlier review date proposed (≤ 90 days from effective) | pending | |
+| E6 | Renewal owner named (Discord application owner role) | pending | |
+| E7 | Emergency revocation contacts named | pending | |
+
+---
+
+## F. Shadow Audit / capture boundary readiness (Supporting — not a substitute for A–E)
+
+| ID | Evidence item | Status | Notes |
+|----|---------------|--------|-------|
+| F1 | Confirm current production Shadow Audit path for roles (file export vs live Gateway) | pending | Repo today: file-backed `ROLE_SNAPSHOT_PATH` |
+| F2 | Confirm no restricted T2 producer is enabled while CR-000 is pending | pending | Expect disabled |
+| F3 | Confirm dogfood/k-anonymity controls remain for any non-T2 audit paths | pending | `AUDIT_K` etc. are not CR-000 Go |
+
+---
+
+## G. Sign-off (Critical)
+
+| ID | Evidence item | Status |
+|----|---------------|--------|
+| G1 | Discord application owner completed §10.1 in `decision-record.md` | pending |
+| G2 | Privacy/security owner completed §10.2 in `decision-record.md` | pending |
+| G3 | Both decisions agree (both Go, or either/both No-go) | pending |
+| G4 | `pending-authority-record.yaml` updated to match signed outcome | pending |
+| G5 | If Go: authority version recorded for restricted work-key projection | pending |
+| G6 | If No-go or deadline auto-No-go: T2 remains disabled; T0/T1 confirmed intact | pending |
+
+---
+
+## Completion rule
+
+- **Go:** all Critical rows in A–E and G are `complete`, both owners signed Go,
+  authority record is non-pending with digests filled.
+- **No-go:** either owner signed No-go, **or** deadline `2026-07-30T23:59:59Z`
+  passed with Critical items still `pending`.
+- **Until then:** leave decision state `pending`; do not enable T2.

--- a/grimoires/loa/coordination/collection-report/cr-000/link-validation.md
+++ b/grimoires/loa/coordination/collection-report/cr-000/link-validation.md
@@ -1,0 +1,40 @@
+# CR-000 Primary-source link validation
+
+**Probed at:** `2026-07-16T08:51:26Z`–`2026-07-16T08:53:29Z` (approx.)
+**Method:** HTTP HEAD/GET status probes from this environment
+**Authority for policy text:** grounded packet
+`grimoires/loa/research/collection-report-cr000-source-packet.md`
+(Exa search route unavailable — `EXA_API_KEY` absent)
+
+## Discord documentation
+
+| URL | Probe result | Notes |
+|-----|--------------|-------|
+| https://docs.discord.com/developers/events/gateway | `200` | Reachable |
+| https://docs.discord.com/developers/events/gateway-events#request-guild-members | `200` | Reachable |
+| https://docs.discord.com/developers/resources/guild#list-guild-members | `200` | Reachable |
+| https://support-dev.discord.com/hc/en-us/articles/6205754771351-How-do-I-get-Privileged-Intents-for-my-bot | `403` | Bot/WAF block to this probe; text retained from grounded packet (updated 2026-06-11 per packet) |
+| https://support-dev.discord.com/hc/en-us/articles/8563934450327-Discord-Developer-Policy | `403` | Same; text retained from grounded packet |
+| https://support-dev.discord.com/hc/en-us/articles/8562894815383-Discord-Developer-Terms-of-Service | `403` | Same; text retained from grounded packet |
+
+## Candidate privacy-policy URL (not asserted as the app policy)
+
+| URL | Probe result | Notes |
+|-----|--------------|-------|
+| https://0xhoneyjar.xyz/privacy | `308` → final `404` at https://www.0xhoneyjar.xyz/privacy | Does **not** establish a current public privacy policy |
+| https://www.0xhoneyjar.xyz/privacy-policy | `404` | Not found |
+
+Owners must supply the actual public privacy-policy URL in the checklist (D1).
+
+## Workspace internal links
+
+| Path | Exists |
+|------|--------|
+| `decision-record.md` | yes |
+| `evidence-checklist.md` | yes |
+| `pending-authority-record.yaml` | yes |
+| `pending-authority-record.schema.json` | yes |
+| `repository-evidence.md` | yes |
+| `sources.md` | yes |
+| `../task-manifest.yaml` (coordinator) | yes (coordinator root) |
+| `grimoires/loa/research/collection-report-cr000-source-packet.md` | yes |

--- a/grimoires/loa/coordination/collection-report/cr-000/pending-authority-record.schema.json
+++ b/grimoires/loa/coordination/collection-report/cr-000/pending-authority-record.schema.json
@@ -1,0 +1,503 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bonfire.local/schemas/cr-000-discord-policy-authority.json",
+  "title": "CR-000 Discord policy authority record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "schema_version",
+    "record_kind",
+    "task_id",
+    "decision",
+    "owners",
+    "application",
+    "privileged_intents",
+    "scale",
+    "privacy_policy",
+    "approved_purposes",
+    "approved_data_classes",
+    "evidence_digests",
+    "timing",
+    "renewal",
+    "emergency_revocation",
+    "tier_consequences",
+    "signatures"
+  ],
+  "properties": {
+    "version": { "type": "string", "minLength": 1 },
+    "schema_version": { "type": "string", "minLength": 1 },
+    "record_kind": { "const": "discord_policy_authority" },
+    "task_id": { "const": "CR-000" },
+    "cycle": { "type": "string" },
+    "decision": {
+      "type": "string",
+      "enum": ["pending", "go", "no-go"]
+    },
+    "owners": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["discord_application_owner", "privacy_security_owner"],
+      "properties": {
+        "discord_application_owner": { "$ref": "#/$defs/owner" },
+        "privacy_security_owner": { "$ref": "#/$defs/owner" }
+      }
+    },
+    "application": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "application_id",
+        "bot_user_id",
+        "team_or_owner_attested",
+        "verification_or_review_state"
+      ],
+      "properties": {
+        "application_id": { "type": ["string", "null"] },
+        "bot_user_id": { "type": ["string", "null"] },
+        "team_or_owner_attested": { "type": ["string", "null"] },
+        "verification_or_review_state": {
+          "type": "string",
+          "enum": ["pending", "unverified", "verified", "review_pending", "review_approved", "review_denied", "unknown"]
+        },
+        "notes": { "type": "string" }
+      }
+    },
+    "privileged_intents": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["guild_members"],
+      "properties": {
+        "guild_members": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "portal_enabled",
+            "review_required",
+            "review_approved",
+            "approved_use_case_text",
+            "approval_conditions"
+          ],
+          "properties": {
+            "portal_enabled": { "$ref": "#/$defs/tri_pending_bool" },
+            "review_required": { "$ref": "#/$defs/tri_pending_bool" },
+            "review_approved": { "$ref": "#/$defs/tri_pending_bool" },
+            "approved_use_case_text": { "type": ["string", "null"] },
+            "approval_conditions": { "type": ["string", "null"] }
+          }
+        },
+        "message_content": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "portal_enabled": { "$ref": "#/$defs/tri_pending_bool" }
+          }
+        },
+        "presence": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "portal_enabled": { "$ref": "#/$defs/tri_pending_bool" }
+          }
+        }
+      }
+    },
+    "scale": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["guild_installed_user_count", "guild_installed_user_band"],
+      "properties": {
+        "guild_installed_user_count": { "type": ["integer", "null"], "minimum": 0 },
+        "guild_installed_user_band": {
+          "type": "string",
+          "enum": ["pending", "under_10000", "at_or_over_10000"]
+        },
+        "largest_target_guild_member_count": { "type": ["integer", "null"], "minimum": 0 },
+        "notes": { "type": "string" }
+      }
+    },
+    "privacy_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["public_url", "covers_discord_api_data", "covers_member_wallet_join_for_gate_leak"],
+      "properties": {
+        "public_url": { "type": ["string", "null"] },
+        "url_verified_at": { "type": ["string", "null"] },
+        "covers_discord_api_data": { "$ref": "#/$defs/tri_pending_bool" },
+        "covers_member_wallet_join_for_gate_leak": { "$ref": "#/$defs/tri_pending_bool" },
+        "retention_summary": { "type": ["string", "null"] },
+        "deletion_opt_out_summary": { "type": ["string", "null"] },
+        "encryption_safeguards_summary": { "type": ["string", "null"] }
+      }
+    },
+    "approved_purposes": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "approved_data_classes": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "excluded_purposes_or_data_classes": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "evidence_digests": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/digest" },
+      "required": [
+        "public_policy_packet",
+        "developer_portal_export",
+        "privileged_intent_approval",
+        "privacy_policy_snapshot",
+        "privacy_security_determination"
+      ],
+      "properties": {
+        "public_policy_packet": { "$ref": "#/$defs/digest" },
+        "developer_portal_export": { "$ref": "#/$defs/digest" },
+        "privileged_intent_approval": { "$ref": "#/$defs/digest" },
+        "privacy_policy_snapshot": { "$ref": "#/$defs/digest" },
+        "privacy_security_determination": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "timing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["issue_start_at", "decision_deadline_at", "effective_at", "expires_at"],
+      "properties": {
+        "issue_start_at": { "type": "string", "format": "date-time" },
+        "decision_deadline_at": { "type": "string", "format": "date-time" },
+        "effective_at": { "type": ["string", "null"], "format": "date-time" },
+        "expires_at": { "type": ["string", "null"], "format": "date-time" },
+        "review_by": { "type": ["string", "null"], "format": "date-time" },
+        "timezone_basis": { "type": "string" }
+      }
+    },
+    "renewal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "owner_role",
+        "owner_name",
+        "interval_days",
+        "missed_renewal_behavior",
+        "no_change_renewal_creates_new_version",
+        "changed_evidence_requires_privacy_security_reapproval"
+      ],
+      "properties": {
+        "owner_role": { "type": "string" },
+        "owner_name": { "type": ["string", "null"] },
+        "first_check_at": { "type": ["string", "null"] },
+        "interval_days": { "type": "integer", "minimum": 1 },
+        "missed_renewal_behavior": { "type": "string" },
+        "no_change_renewal_creates_new_version": { "type": "boolean" },
+        "changed_evidence_requires_privacy_security_reapproval": { "type": "boolean" }
+      }
+    },
+    "emergency_revocation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contacts", "triggers", "effects"],
+      "properties": {
+        "contacts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "role", "contact"],
+            "properties": {
+              "name": { "type": "string" },
+              "role": { "type": "string" },
+              "contact": { "type": "string" }
+            }
+          }
+        },
+        "triggers": { "type": "array", "items": { "type": "string" } },
+        "effects": { "type": "array", "items": { "type": "string" } },
+        "revoke_at": { "type": ["string", "null"] },
+        "revoked_by": { "type": ["string", "null"] },
+        "revocation_reason": { "type": ["string", "null"] }
+      }
+    },
+    "tier_consequences": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["t0_recognition", "t1_public_preparation", "t2_gate_leak_restricted"],
+      "properties": {
+        "t0_recognition": { "type": "string" },
+        "t1_public_preparation": { "type": "string" },
+        "t2_gate_leak_restricted": { "type": "string" }
+      }
+    },
+    "signatures": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["discord_application_owner", "privacy_security_owner"],
+      "properties": {
+        "discord_application_owner": { "$ref": "#/$defs/signature" },
+        "privacy_security_owner": { "$ref": "#/$defs/signature" }
+      }
+    },
+    "audit": { "type": "object" }
+  },
+  "$defs": {
+    "owner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "name", "contact", "status"],
+      "properties": {
+        "role": { "type": "string" },
+        "name": { "type": ["string", "null"] },
+        "contact": { "type": ["string", "null"] },
+        "status": { "type": "string", "enum": ["pending", "named", "signed"] }
+      }
+    },
+    "tri_pending_bool": {
+      "type": "string",
+      "enum": ["pending", "true", "false", "unknown"]
+    },
+    "digest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "value"],
+      "properties": {
+        "algorithm": { "type": "string" },
+        "value": { "type": ["string", "null"] },
+        "path": { "type": ["string", "null"] }
+      }
+    },
+    "signature": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["decision", "signed_at", "signature"],
+      "properties": {
+        "decision": {
+          "type": ["string", "null"],
+          "enum": ["go", "no-go", null]
+        },
+        "signed_at": { "type": ["string", "null"] },
+        "signature": { "type": ["string", "null"] }
+      }
+    },
+    "signed_owner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "name", "contact", "status"],
+      "properties": {
+        "role": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "contact": { "type": "string", "minLength": 1 },
+        "status": { "const": "signed" }
+      }
+    },
+    "go_signature": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["decision", "signed_at", "signature"],
+      "properties": {
+        "decision": { "const": "go" },
+        "signed_at": { "type": "string", "format": "date-time" },
+        "signature": { "type": "string", "minLength": 1 }
+      }
+    },
+    "completed_digest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "value", "path"],
+      "properties": {
+        "algorithm": { "const": "sha256" },
+        "value": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "path": { "type": "string", "minLength": 1 }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "decision": { "const": "go" } } },
+      "then": {
+        "properties": {
+          "approved_purposes": { "type": "array", "minItems": 1 },
+          "approved_data_classes": { "type": "array", "minItems": 1 },
+          "owners": {
+            "type": "object",
+            "properties": {
+              "discord_application_owner": { "$ref": "#/$defs/signed_owner" },
+              "privacy_security_owner": { "$ref": "#/$defs/signed_owner" }
+            }
+          },
+          "application": {
+            "type": "object",
+            "properties": {
+              "application_id": { "type": "string", "minLength": 1 },
+              "bot_user_id": { "type": "string", "minLength": 1 },
+              "team_or_owner_attested": { "type": "string", "minLength": 1 },
+              "verification_or_review_state": {
+                "enum": ["unverified", "verified", "review_approved"]
+              }
+            }
+          },
+          "privileged_intents": {
+            "type": "object",
+            "properties": {
+              "guild_members": {
+                "type": "object",
+                "properties": {
+                  "portal_enabled": { "const": "true" },
+                  "review_required": {
+                    "enum": ["true", "false"]
+                  },
+                  "review_approved": {
+                    "enum": ["true", "false"]
+                  }
+                },
+                "allOf": [
+                  {
+                    "if": {
+                      "properties": {
+                        "review_required": { "const": "true" }
+                      },
+                      "required": ["review_required"]
+                    },
+                    "then": {
+                      "properties": {
+                        "review_approved": { "const": "true" },
+                        "approved_use_case_text": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "scale": {
+            "type": "object",
+            "properties": {
+              "guild_installed_user_count": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "guild_installed_user_band": {
+                "enum": ["under_10000", "at_or_over_10000"]
+              },
+              "largest_target_guild_member_count": {
+                "type": "integer",
+                "minimum": 0
+              }
+            }
+          },
+          "privacy_policy": {
+            "type": "object",
+            "properties": {
+              "public_url": {
+                "type": "string",
+                "format": "uri",
+                "minLength": 1
+              },
+              "url_verified_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "covers_discord_api_data": { "const": "true" },
+              "covers_member_wallet_join_for_gate_leak": { "const": "true" },
+              "retention_summary": { "type": "string", "minLength": 1 },
+              "deletion_opt_out_summary": { "type": "string", "minLength": 1 },
+              "encryption_safeguards_summary": { "type": "string", "minLength": 1 }
+            }
+          },
+          "evidence_digests": {
+            "type": "object",
+            "properties": {
+              "public_policy_packet": { "$ref": "#/$defs/completed_digest" },
+              "developer_portal_export": { "$ref": "#/$defs/completed_digest" },
+              "privacy_policy_snapshot": { "$ref": "#/$defs/completed_digest" },
+              "privacy_security_determination": { "$ref": "#/$defs/completed_digest" }
+            }
+          },
+          "timing": {
+            "type": "object",
+            "properties": {
+              "effective_at": { "type": "string", "format": "date-time" },
+              "expires_at": { "type": "string", "format": "date-time" },
+              "review_by": { "type": "string", "format": "date-time" }
+            }
+          },
+          "renewal": {
+            "type": "object",
+            "properties": {
+              "owner_name": { "type": "string" }
+            }
+          },
+          "emergency_revocation": {
+            "type": "object",
+            "properties": {
+              "contacts": { "type": "array", "minItems": 1 }
+            }
+          },
+          "signatures": {
+            "type": "object",
+            "properties": {
+              "discord_application_owner": { "$ref": "#/$defs/go_signature" },
+              "privacy_security_owner": { "$ref": "#/$defs/go_signature" }
+            }
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "privileged_intents": {
+                  "type": "object",
+                  "properties": {
+                    "guild_members": {
+                      "type": "object",
+                      "properties": {
+                        "review_required": { "const": "true" }
+                      },
+                      "required": ["review_required"]
+                    }
+                  },
+                  "required": ["guild_members"]
+                }
+              },
+              "required": ["privileged_intents"]
+            },
+            "then": {
+              "properties": {
+                "evidence_digests": {
+                  "type": "object",
+                  "properties": {
+                    "privileged_intent_approval": {
+                      "$ref": "#/$defs/completed_digest"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "if": { "properties": { "decision": { "const": "pending" } } },
+      "then": {
+        "properties": {
+          "tier_consequences": {
+            "type": "object",
+            "properties": {
+              "t2_gate_leak_restricted": {
+                "type": "string",
+                "pattern": "disabled"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/grimoires/loa/coordination/collection-report/cr-000/pending-authority-record.yaml
+++ b/grimoires/loa/coordination/collection-report/cr-000/pending-authority-record.yaml
@@ -1,0 +1,176 @@
+# CR-000 pending Discord-policy authority record
+# Schema: ./pending-authority-record.schema.json
+# This file is NOT a Go. decision=pending. Do not project into restricted work keys as approval.
+
+version: "cr000-pending-0"
+schema_version: "1.0.0"
+record_kind: "discord_policy_authority"
+task_id: "CR-000"
+cycle: "collection-report"
+
+decision: "pending"
+# Allowed later values after human ratification only: "go" | "no-go"
+# While decision is pending, restricted T2 must remain disabled.
+
+owners:
+  discord_application_owner:
+    role: "Discord application owner"
+    name: null
+    contact: null
+    status: "pending"
+  privacy_security_owner:
+    role: "Privacy / security owner"
+    name: null
+    contact: null
+    status: "pending"
+
+application:
+  application_id: null
+  bot_user_id: null
+  team_or_owner_attested: null
+  verification_or_review_state: "pending"
+  # Do not infer from DISCORD_* env var names.
+  notes: "Private Developer Portal fields required."
+
+privileged_intents:
+  guild_members:
+    portal_enabled: "pending"
+    review_required: "pending"
+    review_approved: "pending"
+    approved_use_case_text: null
+    approval_conditions: null
+  message_content:
+    portal_enabled: "pending"
+  presence:
+    portal_enabled: "pending"
+
+scale:
+  guild_installed_user_count: null
+  guild_installed_user_band: "pending"
+  # pending | under_10000 | at_or_over_10000
+  largest_target_guild_member_count: null
+  notes: "Public Discord threshold guidance exists; Freeside count is private evidence."
+
+privacy_policy:
+  public_url: null
+  url_verified_at: null
+  covers_discord_api_data: "pending"
+  covers_member_wallet_join_for_gate_leak: "pending"
+  retention_summary: null
+  deletion_opt_out_summary: null
+  encryption_safeguards_summary: null
+
+approved_purposes: []
+# Populate only on Go, for example:
+# - "gate_leak_v1_stale_access_audit_mapped_role_members"
+
+approved_data_classes: []
+# Populate only on Go, for example:
+# - "discord_guild_id"
+# - "discord_role_ids"
+# - "discord_user_ids_in_mapped_roles"
+# - "authorized_community_wallet_links"
+# - "k_anonymized_aggregates"
+
+excluded_purposes_or_data_classes: []
+# Example exclusions when Go is drafted:
+# - "user_profiling"
+# - "relationship_graph_mining"
+# - "cross_community_identity_broadcast"
+
+evidence_digests:
+  # algorithm:value — leave null until artifacts exist
+  public_policy_packet:
+    algorithm: "sha256"
+    value: "03a65638c2449855c5131732a2e5635bb05f4069e9d7245ad6a3bfc5ac74c68d"
+    path: "grimoires/loa/research/collection-report-cr000-source-packet.md"
+  developer_portal_export:
+    algorithm: "sha256"
+    value: null
+    path: null
+  privileged_intent_approval:
+    algorithm: "sha256"
+    value: null
+    path: null
+  privacy_policy_snapshot:
+    algorithm: "sha256"
+    value: null
+    path: null
+  privacy_security_determination:
+    algorithm: "sha256"
+    value: null
+    path: null
+  repository_evidence_notes:
+    algorithm: "sha256"
+    value: "11944ae92c40388f9c3921b4ec81d4098f2b99e934b15917b689827935623df9"
+    path: "grimoires/loa/coordination/collection-report/cr-000/repository-evidence.md"
+
+timing:
+  issue_start_at: "2026-07-16T08:49:00Z"
+  decision_deadline_at: "2026-07-30T23:59:59Z"
+  effective_at: null
+  expires_at: null
+  # On Go: expires_at must be <= effective_at + 90 days, or earlier review date
+  review_by: null
+  timezone_basis: "UTC"
+
+renewal:
+  owner_role: "Discord application owner"
+  owner_name: null
+  first_check_at: null
+  # Sprint: standing renewal check at day 60 and every 60 days while active
+  interval_days: 60
+  missed_renewal_behavior: "identical_to_expiry"
+  no_change_renewal_creates_new_version: true
+  changed_evidence_requires_privacy_security_reapproval: true
+
+emergency_revocation:
+  contacts: []
+  # Each contact: { name, role, contact }
+  triggers:
+    - "authority_expiry"
+    - "missed_renewal"
+    - "ownership_change"
+    - "terms_or_policy_change"
+    - "privileged_intent_change_or_loss"
+    - "explicit_owner_revocation"
+  effects:
+    - "stop_new_restricted_work"
+    - "quarantine_in_flight_restricted_work"
+    - "start_disposal_review"
+    - "require_new_go_record_before_resume"
+  revoke_at: null
+  revoked_by: null
+  revocation_reason: null
+
+tier_consequences:
+  t0_recognition: "intact"
+  t1_public_preparation: "intact"
+  t2_gate_leak_restricted: "disabled_while_pending"
+  on_no_go:
+    t0_recognition: "intact"
+    t1_public_preparation: "intact"
+    t2_gate_leak_restricted: "stopped"
+    invent_aggregate_only_fallback: false
+    alter_existing_bot_production_permissions: false
+  on_deadline_still_pending: "auto_no_go_for_t2"
+
+signatures:
+  discord_application_owner:
+    decision: null
+    signed_at: null
+    signature: null
+  privacy_security_owner:
+    decision: null
+    signed_at: null
+    signature: null
+
+audit:
+  created_at: "2026-07-16T08:53:29Z"
+  created_by: "kranz-autonomous-dispatch-cr-000"
+  git_tip: "3782fd47e8a20cdaf6325621962bd0443e6781b8"
+  branch: "coord/collection-report-coordinator-f09.10"
+  notes:
+    - "Pending template only."
+    - "Public-policy packet grounded; private portal evidence absent."
+    - "Do not treat code-requested GuildMembers intents as portal approval."

--- a/grimoires/loa/coordination/collection-report/cr-000/repository-evidence.md
+++ b/grimoires/loa/coordination/collection-report/cr-000/repository-evidence.md
@@ -1,0 +1,174 @@
+# CR-000 Repository evidence audit (non-secret)
+
+**Git tip audited:** `3782fd47e8a20cdaf6325621962bd0443e6781b8`
+**Branch:** `coord/collection-report-coordinator-f09.10` (tracks `origin/main`)
+**Rule:** Do not infer Developer Portal toggles, review approval, ownership, or
+user counts from code or environment-variable names.
+
+---
+
+## 1. Discord application integration (code presence)
+
+### 1.1 Sietch Discord service
+
+`themes/sietch/src/services/discord.ts` constructs a `discord.js` `Client` and
+logs in with `config.discord.botToken`.
+
+Configured intents in that client:
+
+- `Guilds`
+- `GuildMembers`
+- `GuildMessages`
+- `GuildMessageReactions`
+- `DirectMessages`
+- `MessageContent`
+
+### 1.2 Sietch worker
+
+`themes/sietch/src/jobs/worker.ts` constructs a worker Discord client with:
+
+- `Guilds`
+- `GuildMembers`
+- `GuildPresences`
+
+Requires `DISCORD_BOT_TOKEN` to be configured for the worker service.
+
+### 1.3 Platform ingestor
+
+`apps/ingestor/src/client.ts` creates a zero-cache Discord client with:
+
+- `Guilds`
+- `GuildMembers`
+- `GuildMessages`
+- `MessageContent`
+
+Partials include `GuildMember`. Member cache managers are set to `0` (no member
+cache retention in-process).
+
+### 1.4 Slash-command registration
+
+`themes/sietch/src/discord/commands/index.ts` registers guild commands via
+`Routes.applicationGuildCommands(clientId, config.discord.guildId)`.
+
+`clientId` is a function argument — the repository does not hardcode a
+production Application ID in this path.
+
+### 1.5 Config seams (names only)
+
+`themes/sietch/src/config.ts` reads Discord configuration from environment
+variables including `DISCORD_BOT_TOKEN`, `DISCORD_GUILD_ID`, channel IDs, and
+role IDs.
+
+**Non-inference:** presence of these variable names does not prove portal
+intent state, ownership, verification, or live guild size.
+
+---
+
+## 2. Application ownership references
+
+| Source | What it says | Ownership proof? |
+|--------|--------------|------------------|
+| `themes/sietch/docs/discord-setup.md` | Manual steps to create an application in Discord Developer Portal; name example “Sietch Bot” | No — setup guide |
+| `themes/sietch/docs/ADMIN_SETUP_GUIDE.md` | References Developer Portal access for admins | No — ops guide |
+| `packages/cli/discord-server.yaml` | IaC sample for “Arrakis Sandbox” with server id `1460247581312549049` | No — sandbox config, not production owner or user count |
+
+**Application owner identity:** pending (private).
+
+---
+
+## 3. Configured intents vs portal approval
+
+| Fact | Proven? |
+|------|---------|
+| Code requests `GatewayIntentBits.GuildMembers` in multiple clients | Yes |
+| Setup doc tells humans to enable Server Members Intent in Portal | Yes (instructional) |
+| Portal currently has Server Members Intent enabled | **Not proven** |
+| Privileged-intent review approved for Gate Leak member+wallet use | **Not proven** |
+
+Unauthorized privileged intent use can fail closed at Discord (`4014` per public
+docs). Runtime success in some environments still would not equal CR-000 Go for
+the proposed restricted purpose.
+
+---
+
+## 4. Guild / member scale
+
+| Candidate signal | Assessment |
+|------------------|-------------|
+| Production guild-installed user count | Absent from repository |
+| Sandbox server id in `packages/cli/discord-server.yaml` | Not a scale metric |
+| SDD 50,000-member fixture requirement for capture proof | Design target for later CR-018 / release evidence — not a live count |
+
+**Scale band vs Discord’s 10,000 guild-installed-user threshold:** pending.
+
+---
+
+## 5. Privacy policy references and data use
+
+| Probe / source | Result |
+|----------------|--------|
+| In-repo “privacy” copy in Sietch embeds/docs | Product/community privacy language (e.g. no wallet addresses in public embeds); **not** a Discord Developer Terms privacy-policy URL for the bot application |
+| HTTP follow of `https://0xhoneyjar.xyz/privacy` | Final status `404` at `https://www.0xhoneyjar.xyz/privacy` (2026-07-16 probe) |
+| Policy text covering Gate Leak member+wallet join | **Not found** in this audit |
+
+**Public privacy-policy URL for the Discord application:** pending.
+
+Retention/deletion for restricted Gate Leak artifacts is specified as future
+policy work in the collection-report SDD (CR-007B and related) — not ratified
+here as CR-000 Go evidence.
+
+---
+
+## 6. Shadow Audit RoleSnapshot and Gateway boundaries
+
+### 6.1 Current RoleSnapshot (implemented)
+
+`packages/services/shadow-audit/src/role-snapshot.ts`:
+
+- Schema fields: `source`, `community`, `captured_at`, `export_method`,
+  `owner`, `freshness_threshold_seconds`, `entries[]`
+- Entries may include `discord_user_id`, optional `wallet`, and `role_ids`
+- Unmatched role-holders without wallets are flagged, not dropped
+
+`packages/services/shadow-audit/src/role-source.ts`:
+
+- Production adapter is **file-backed** (`ROLE_SNAPSHOT_PATH`)
+- Missing path → `undefined` → external-mode refusal downstream
+- Invalid file → throw (fail loud)
+
+`packages/services/shadow-audit/DEPLOY.md`:
+
+- Documents `ROLE_SNAPSHOT_PATH` and `AUDIT_K` (k-anonymity; `0` rejected)
+
+### 6.2 Protocol output boundary
+
+`packages/protocol/shadow-audit` audit output:
+
+- Anonymous callers get k-anonymized aggregates
+- Per-member records / comparison require authenticated community-bound callers
+- Methodology includes `role_snapshot_at`
+
+### 6.3 Planned Gateway-bound producer (SDD — not CR-000 approval)
+
+Collection-report SDD states the future `discord_role_snapshot.v1` producer is
+externally gated by:
+
+- current bot verification
+- approved privileged `GUILD_MEMBERS`
+- guild-size limits
+- Developer Terms/Policy for storing member data joined to wallet identity
+
+and requires Gateway epoch/sequence completeness attestations.
+
+**This repository audit does not show that Gateway-bound qualifying producer as
+an authorized live T2 path.** Current dogfood RoleSnapshot is an export/file
+port, not CR-000 Go.
+
+---
+
+## 7. What remains out of scope for repository evidence
+
+- Live Developer Portal screenshots or exports
+- Secrets, tokens, or `.env` contents (not read)
+- Inventing a Go because code already requests `GuildMembers`
+- Changing production bot permissions

--- a/grimoires/loa/coordination/collection-report/cr-000/sources.md
+++ b/grimoires/loa/coordination/collection-report/cr-000/sources.md
@@ -1,0 +1,27 @@
+# CR-000 Sources
+
+## Grounded public-policy packet (primary for Discord policy text)
+
+- `grimoires/loa/research/collection-report-cr000-source-packet.md`
+
+## Coordinator masters
+
+Paths relative to coordinator root
+`/Users/zksoju/bonfire/collection-report-coordinator/`:
+
+- `grimoires/loa/prd.md`
+- `grimoires/loa/sdd.md`
+- `grimoires/loa/sprint.md` — § CR-000, G-1, T0/T1/T2, C0
+- `grimoires/loa/coordination/task-manifest.yaml` — CR-000 under `loa-freeside`
+
+## Repository evidence tip
+
+- Git: `3782fd47e8a20cdaf6325621962bd0443e6781b8`
+- See `repository-evidence.md`
+
+## Explicit non-sources
+
+- Exa / k-hole search (unavailable this dispatch — no `EXA_API_KEY`)
+- Environment-variable values / secrets
+- Inferred Developer Portal state
+- Fabricated owner identities or signatures

--- a/grimoires/loa/research/collection-report-cr000-source-packet.md
+++ b/grimoires/loa/research/collection-report-cr000-source-packet.md
@@ -1,0 +1,62 @@
+# CR-000 Discord policy source packet
+
+Accessed: 2026-07-16
+
+This packet contains current public-policy evidence only. It does not establish
+the private state of the Freeside Discord application, record an owner
+signature, or provide privacy/security approval.
+
+## Primary Discord sources
+
+- [Gateway intents](https://docs.discord.com/developers/events/gateway)
+  - `GUILD_MEMBERS` is privileged.
+  - It must be enabled in the Developer Portal.
+  - Applications subject to review must be approved before using it.
+  - Unauthorized privileged intent use can close the Gateway connection with
+    code `4014`.
+- [Gateway member requests](https://docs.discord.com/developers/events/gateway-events#request-guild-members)
+  - Requesting the complete member list requires `GUILD_MEMBERS`.
+  - Member chunks contain at most 1,000 members.
+  - A request is limited to one guild ID.
+- [Guild members REST API](https://docs.discord.com/developers/resources/guild#list-guild-members)
+  - Listing guild members requires the `GUILD_MEMBERS` privileged intent.
+  - A page contains at most 1,000 members.
+- [Privileged intent access](https://support-dev.discord.com/hc/en-us/articles/6205754771351-How-do-I-get-Privileged-Intents-for-my-bot)
+  - Discord updated this guidance on 2026-06-11.
+  - Applications accessible to fewer than 10,000 guild-installed users can
+    enable privileged intents in the Developer Portal without review.
+  - At 10,000 users, review is required for continued access; Discord says the
+    owner receives notice and has 90 days to apply.
+  - Review asks for the intent, use case, and security/privacy information.
+- [Developer Policy](https://support-dev.discord.com/hc/en-us/articles/8563934450327-Discord-Developer-Policy)
+  - API data may only be used as necessary for stated functionality.
+  - Discord API data may not be used to profile users, their identities, or
+    their relationships.
+  - Applications must respect user opt-out/removal and must not mine or scrape
+    Discord data.
+- [Developer Terms](https://support-dev.discord.com/hc/en-us/articles/8562894815383-Discord-Developer-Terms-of-Service)
+  - The application must maintain a public, current privacy policy.
+  - API data must be updated or deleted when no longer necessary, requested by
+    Discord, requested by the user, or required by law.
+  - API data must be protected with encryption at rest and reasonable
+    administrative, physical, and technical safeguards.
+  - Material changes to reviewed functionality or API-data use require renewed
+    App Review approval where applicable.
+
+## Evidence still unavailable
+
+- Application ID, team/application owner, and verification/review state.
+- Current guild-installed user count under Discord's 2026 threshold.
+- Whether `GUILD_MEMBERS` is enabled and, if review applies, approved.
+- The exact Developer Portal use-case submission and any approval conditions.
+- Current public privacy-policy URL and whether it describes the proposed use.
+- Discord application owner signature.
+- Privacy/security owner determination and signature.
+
+## Safe interim interpretation
+
+Public documentation establishes that the proposed workflow is technically
+possible only with `GUILD_MEMBERS`, but it does not establish that the current
+Freeside application is authorized for the proposed member-data-plus-wallet
+purpose. Until the private evidence and signatures exist, restricted T2 remains
+disabled. T0 recognition and T1 public preparation are unaffected.


### PR DESCRIPTION
## Summary
- grounds Discord privileged-intent and policy evidence
- publishes a fail-closed pending authority record and evidence checklist
- keeps T0/T1 intact while T2 remains disabled
- defines a deterministic July 30 UTC decision deadline

## Validation
- strict Draft 2020-12 AJV validation passes
- incomplete synthetic Go record is rejected
- complete dual-signature synthetic Go record validates
- independent Cheval review: PASS / KEEP_OPEN_PENDING

## Important
This PR does not claim Go or No-go, does not identify owners, and does not authorize restricted T2 work. CR-000 remains open pending real private evidence and human signatures.

Tracks #472.