### PR TITLE
fix(ordering): normalize resolve-probe diagnostics schema_version

### DIFF
--- a/packages/services/ordering/src/sonar-resolve-probe-client.ts
+++ b/packages/services/ordering/src/sonar-resolve-probe-client.ts
@@ -80,10 +80,22 @@ export function createHttpSonarResolveProbePort(
           throw new SonarResolveProbeUnavailableError(502, "sonar probe missing fields");
         }
 
+        const diagnosticsRaw = body.diagnostics as Record<string, unknown>;
+        // Kitchen bounded-core diagnostics omit schema_version; Ordering
+        // CandidateSnapshot requires it. Normalize at the service boundary.
+        const diagnostics = {
+          schema_version: 1 as const,
+          searched: Array.isArray(diagnosticsRaw?.searched) ? diagnosticsRaw.searched : [],
+          timed_out: Array.isArray(diagnosticsRaw?.timed_out) ? diagnosticsRaw.timed_out : [],
+          unavailable: Array.isArray(diagnosticsRaw?.unavailable)
+            ? diagnosticsRaw.unavailable
+            : [],
+        } as CandidateSnapshot["diagnostics"];
+
         return {
           capability_snapshot_version: body.capability_snapshot_version as CapabilityRegistryVersion,
           candidates: body.candidates as ReadonlyArray<CollectionCandidate>,
-          diagnostics: body.diagnostics as CandidateSnapshot["diagnostics"],
+          diagnostics,
         };
       } finally {
         clearTimeout(timer);


### PR DESCRIPTION
## Summary
- Normalize Kitchen probe diagnostics to include `schema_version: 1` before snapshot seal

## Test plan
- [ ] Production create via `COLLECTION_RESOLVE_PROBE_MODE=http` returns 200 for Azuki


Made with [Cursor](https://cursor.com)