### PR TITLE
feat(ordering): CR-206 collection-report list/detail projections

### DIFF
--- a/packages/services/ordering/bin/http.ts
+++ b/packages/services/ordering/bin/http.ts
@@ -13,6 +13,7 @@ import {
 import { ReProbeWorker } from '../src/reprobe-worker.js';
 import { createCatalogResolveProbePort } from '../src/catalog-resolve-probe.js';
 import { mountCollectionResolutionRoutes } from '../src/resolution-http.js';
+import { mountCollectionReportRoutes } from '../src/collection-report-http.js';
 import { createResolutionStore } from '../src/resolution-store-factory.js';
 import { CollectionResolutionService } from '../src/resolution-service.js';
 import { sonarResolveProbeFromEnv } from '../src/sonar-resolve-probe-client.js';
@@ -64,6 +65,7 @@ const app = createIntakeApp({
     kitchen_enqueue: Boolean(enqueue),
     write_routes: writeRoutes,
     collection_resolutions: true,
+    collection_reports: true,
     resolve_probe: resolutionProbeMode,
   },
 });
@@ -74,6 +76,13 @@ mountCollectionResolutionRoutes(app, {
   store: resolutionStore,
   sonar: sonarProbe,
   service: resolutionService,
+  serviceToken: writeRoutes === 'token' ? serviceToken : undefined,
+});
+
+// CR-206: authenticated collection-report list/detail projections.
+mountCollectionReportRoutes(app, {
+  store,
+  resolutionStore,
   serviceToken: writeRoutes === 'token' ? serviceToken : undefined,
 });
 

--- a/packages/services/ordering/migrations/005_collection_report_list.sql
+++ b/packages/services/ordering/migrations/005_collection_report_list.sql
@@ -1,0 +1,19 @@
+-- CR-206 — cursor list for collection-report orders by community.
+-- community_ref lives on inputs JSON (resolution binding).
+
+CREATE INDEX IF NOT EXISTS orders_collection_report_community_cursor_idx
+  ON orders (
+    ((inputs ->> 'community_ref')),
+    created_at_unix DESC,
+    order_id DESC
+  )
+  WHERE product = 'collection-report';
+
+CREATE INDEX IF NOT EXISTS orders_collection_report_subject_cursor_idx
+  ON orders (
+    placed_by,
+    ((inputs ->> 'community_ref')),
+    created_at_unix DESC,
+    order_id DESC
+  )
+  WHERE product = 'collection-report';

--- a/packages/services/ordering/src/__tests__/collection-report-http.test.ts
+++ b/packages/services/ordering/src/__tests__/collection-report-http.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import { Hono } from "hono";
+
+import { mountCollectionReportRoutes } from "../collection-report-http.js";
+import { InMemoryOrderStore } from "../store.js";
+import { ORDER_LIFECYCLE_SUBJECTS } from "@freeside/ordering-protocol";
+
+const TOKEN = "test-service-token";
+
+function digest() {
+  return {
+    algorithm: "sha-256" as const,
+    domain: "collection-resolution.candidate-snapshot",
+    major_version: 1,
+    digest: "ab".repeat(32),
+  };
+}
+
+async function seed(
+  store: InMemoryOrderStore,
+  opts: {
+    order_id: string;
+    placed_by: string;
+    community_ref: string;
+    state?: "placed" | "producing" | "fulfilled" | "failed";
+    created_at_unix?: number;
+  },
+) {
+  const placed_at = opts.created_at_unix ?? 1_700_000_000;
+  await store.placeOrder(
+    {
+      order_id: opts.order_id,
+      product: "collection-report",
+      placed_by: opts.placed_by,
+      inputs: {
+        schema_version: 1,
+        resolution_id: `res-${opts.order_id}`,
+        candidate_snapshot_digest: digest(),
+        community_ref: opts.community_ref,
+      },
+      placed_at_unix: placed_at,
+      inputs_digest: "digest",
+    },
+    { subject: ORDER_LIFECYCLE_SUBJECTS.placed, payload: { order_id: opts.order_id } },
+  );
+
+  if (opts.state === "producing" || opts.state === "fulfilled" || opts.state === "failed") {
+    await store.transition(opts.order_id, "placed", "routing");
+    await store.transition(opts.order_id, "routing", "producing");
+  }
+  if (opts.state === "fulfilled") {
+    await store.transition(opts.order_id, "producing", "fulfilled", {
+      patch: { result_ref: `artifact://${opts.order_id}` },
+    });
+  }
+  if (opts.state === "failed") {
+    await store.transition(opts.order_id, "producing", "failed", {
+      patch: { refusal: { code: "capacity_rejected", reason: "full" } },
+    });
+  }
+
+  // Force created_at for cursor ordering when requested.
+  if (opts.created_at_unix !== undefined) {
+    const record = await store.get(opts.order_id);
+    if (record) {
+      (record as { created_at_unix: number }).created_at_unix = opts.created_at_unix;
+    }
+  }
+}
+
+function appWith(store: InMemoryOrderStore) {
+  const app = new Hono();
+  mountCollectionReportRoutes(app, { store, serviceToken: TOKEN });
+  return app;
+}
+
+describe("CR-206 collection-report HTTP", () => {
+  it("requires bearer token", async () => {
+    const store = new InMemoryOrderStore({ now: () => 1_700_000_000 });
+    const app = appWith(store);
+    const res = await app.request(
+      "/v1/collection-reports?community_ref=mibera&subject_id=user-a",
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("lists only the subject+community rows with safe projection", async () => {
+    const store = new InMemoryOrderStore({ now: () => 1_700_000_000 });
+    await seed(store, {
+      order_id: "ord-a",
+      placed_by: "user-a",
+      community_ref: "mibera",
+      state: "fulfilled",
+      created_at_unix: 100,
+    });
+    await seed(store, {
+      order_id: "ord-b",
+      placed_by: "user-a",
+      community_ref: "mibera",
+      state: "placed",
+      created_at_unix: 90,
+    });
+    await seed(store, {
+      order_id: "ord-other-user",
+      placed_by: "user-b",
+      community_ref: "mibera",
+      state: "placed",
+      created_at_unix: 110,
+    });
+    await seed(store, {
+      order_id: "ord-other-community",
+      placed_by: "user-a",
+      community_ref: "other",
+      state: "placed",
+      created_at_unix: 120,
+    });
+
+    const app = appWith(store);
+    const res = await app.request(
+      "/v1/collection-reports?community_ref=mibera&subject_id=user-a&limit=10",
+      { headers: { authorization: `Bearer ${TOKEN}` } },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      items: Array<{
+        order_id: string;
+        user_status: string;
+        open_action: string | null;
+        placed_by?: string;
+        inputs?: unknown;
+      }>;
+      next_cursor: string | null;
+    };
+    expect(body.items.map((i) => i.order_id)).toEqual(["ord-a", "ord-b"]);
+    expect(body.items[0]?.user_status).toBe("ready");
+    expect(body.items[0]?.open_action).toBe("open_artifact");
+    expect(body.items[1]?.user_status).toBe("requested");
+    expect(body.items[0]).not.toHaveProperty("placed_by");
+    expect(body.items[0]).not.toHaveProperty("inputs");
+  });
+
+  it("denies cross-subject detail", async () => {
+    const store = new InMemoryOrderStore({ now: () => 1_700_000_000 });
+    await seed(store, {
+      order_id: "ord-a",
+      placed_by: "user-a",
+      community_ref: "mibera",
+      state: "placed",
+    });
+    const app = appWith(store);
+    const res = await app.request(
+      "/v1/collection-reports/ord-a?community_ref=mibera&subject_id=user-b",
+      { headers: { authorization: `Bearer ${TOKEN}` } },
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("pages with immutable created_at+order_id cursor", async () => {
+    const store = new InMemoryOrderStore({ now: () => 1_700_000_000 });
+    await seed(store, {
+      order_id: "ord-3",
+      placed_by: "user-a",
+      community_ref: "mibera",
+      created_at_unix: 30,
+    });
+    await seed(store, {
+      order_id: "ord-2",
+      placed_by: "user-a",
+      community_ref: "mibera",
+      created_at_unix: 20,
+    });
+    await seed(store, {
+      order_id: "ord-1",
+      placed_by: "user-a",
+      community_ref: "mibera",
+      created_at_unix: 10,
+    });
+
+    const app = appWith(store);
+    const page1 = await app.request(
+      "/v1/collection-reports?community_ref=mibera&subject_id=user-a&limit=2",
+      { headers: { authorization: `Bearer ${TOKEN}` } },
+    );
+    const body1 = (await page1.json()) as {
+      items: Array<{ order_id: string }>;
+      next_cursor: string;
+    };
+    expect(body1.items.map((i) => i.order_id)).toEqual(["ord-3", "ord-2"]);
+    expect(body1.next_cursor).toBeTruthy();
+
+    const page2 = await app.request(
+      `/v1/collection-reports?community_ref=mibera&subject_id=user-a&limit=2&cursor=${encodeURIComponent(body1.next_cursor)}`,
+      { headers: { authorization: `Bearer ${TOKEN}` } },
+    );
+    const body2 = (await page2.json()) as {
+      items: Array<{ order_id: string }>;
+      next_cursor: string | null;
+    };
+    expect(body2.items.map((i) => i.order_id)).toEqual(["ord-1"]);
+    expect(body2.next_cursor).toBeNull();
+  });
+});

--- a/packages/services/ordering/src/collection-report-http.ts
+++ b/packages/services/ordering/src/collection-report-http.ts
@@ -1,0 +1,180 @@
+/**
+ * CR-206 — authenticated collection-report list/detail HTTP edge.
+ *
+ *   GET /v1/collection-reports
+ *   GET /v1/collection-reports/:order_id
+ *
+ * Auth: Bearer SERVICE_TOKEN (Dashboard BFF). Authorization scope is supplied
+ * in the query string and re-checked against community_ref (never trusted alone).
+ *
+ * Deferred vs full CR-206: identity-row paging, encrypted export, CR-015
+ * disclosure fences, artifact byte retrieval + audit. This cut unblocks
+ * Dashboard CR-304 table + detail status projections.
+ */
+
+import { Hono, type Context } from "hono";
+import { z } from "zod";
+
+import type { OrderStore } from "./store.js";
+import type { ResolutionStore } from "./resolution-store.js";
+import {
+  decodeCursor,
+  encodeCursor,
+  toCollectionReportListItem,
+  type CollectionReportListItem,
+  type CollectionReportListResponse,
+} from "./collection-report-projection.js";
+
+export interface CollectionReportHttpDeps {
+  readonly store: OrderStore;
+  readonly resolutionStore?: ResolutionStore;
+  readonly serviceToken?: string;
+}
+
+const ScopeQuerySchema = z
+  .object({
+    community_ref: z.string().min(1).max(128),
+    subject_id: z.string().min(1).max(256),
+    cursor: z.string().min(1).max(512).optional(),
+    limit: z.coerce.number().int().min(1).max(100).optional(),
+  })
+  .strict();
+
+function requireBearer(c: Context, token: string | undefined): boolean {
+  if (!token) return true;
+  return c.req.header("authorization") === `Bearer ${token}`;
+}
+
+function errorJson(
+  c: Context,
+  status: 400 | 401 | 403 | 404,
+  code: string,
+): Response {
+  return c.json(
+    { schema_version: 1, code },
+    status,
+    { "Cache-Control": "no-store" },
+  );
+}
+
+async function collectionSummary(
+  resolutionStore: ResolutionStore | undefined,
+  resolutionId: string,
+): Promise<{ name: string | null; symbol: string | null }> {
+  if (!resolutionStore || resolutionId.length === 0) {
+    return { name: null, symbol: null };
+  }
+  try {
+    const record = await resolutionStore.get(resolutionId);
+    if (!record) return { name: null, symbol: null };
+    const selectedDigest = record.selected_collection_id?.digest;
+    const candidates = record.candidate_snapshot.candidates;
+    const match =
+      selectedDigest !== undefined
+        ? (candidates.find((c) => c.identity.collection_id.digest === selectedDigest) ??
+          candidates[0])
+        : candidates[0];
+    return {
+      name: match?.identity.name ?? null,
+      symbol: match?.identity.symbol ?? null,
+    };
+  } catch {
+    return { name: null, symbol: null };
+  }
+}
+
+export function mountCollectionReportRoutes(
+  app: Hono,
+  deps: CollectionReportHttpDeps,
+): void {
+  app.get("/v1/collection-reports", async (c) => {
+    if (!requireBearer(c, deps.serviceToken)) {
+      return errorJson(c, 401, "unauthorized");
+    }
+
+    const parsed = ScopeQuerySchema.safeParse({
+      community_ref: c.req.query("community_ref"),
+      subject_id: c.req.query("subject_id"),
+      cursor: c.req.query("cursor") ?? undefined,
+      limit: c.req.query("limit") ?? undefined,
+    });
+    if (!parsed.success) {
+      return errorJson(c, 400, "invalid_request");
+    }
+
+    const cursor = decodeCursor(parsed.data.cursor);
+    if (parsed.data.cursor !== undefined && cursor === undefined) {
+      return errorJson(c, 400, "invalid_request");
+    }
+
+    const limit = parsed.data.limit ?? 25;
+    const rows = await deps.store.listCollectionReports({
+      community_ref: parsed.data.community_ref,
+      placed_by: parsed.data.subject_id,
+      limit: limit + 1,
+      ...(cursor !== undefined ? { cursor } : {}),
+    });
+
+    const page = rows.slice(0, limit);
+    const items: CollectionReportListItem[] = [];
+    for (const row of page) {
+      const inputs = row.inputs as { resolution_id?: string };
+      const summary = await collectionSummary(
+        deps.resolutionStore,
+        typeof inputs.resolution_id === "string" ? inputs.resolution_id : "",
+      );
+      const item = toCollectionReportListItem(row, summary);
+      if (item) items.push(item);
+    }
+
+    const last = page[page.length - 1];
+    const next_cursor =
+      rows.length > limit && last !== undefined
+        ? encodeCursor(last.created_at_unix, last.order_id)
+        : null;
+
+    const body: CollectionReportListResponse = {
+      schema_version: 1,
+      items,
+      next_cursor,
+    };
+    return c.json(body, 200, { "Cache-Control": "no-store" });
+  });
+
+  app.get("/v1/collection-reports/:order_id", async (c) => {
+    if (!requireBearer(c, deps.serviceToken)) {
+      return errorJson(c, 401, "unauthorized");
+    }
+
+    const community_ref = c.req.query("community_ref");
+    const subject_id = c.req.query("subject_id");
+    if (
+      typeof community_ref !== "string" ||
+      community_ref.length === 0 ||
+      typeof subject_id !== "string" ||
+      subject_id.length === 0
+    ) {
+      return errorJson(c, 400, "invalid_request");
+    }
+
+    const record = await deps.store.get(c.req.param("order_id"));
+    if (!record || record.product !== "collection-report") {
+      return errorJson(c, 404, "not_found");
+    }
+    if (record.placed_by !== subject_id) {
+      return errorJson(c, 403, "forbidden");
+    }
+    const inputs = record.inputs as { community_ref?: unknown; resolution_id?: unknown };
+    if (inputs.community_ref !== community_ref) {
+      return errorJson(c, 403, "forbidden");
+    }
+
+    const summary = await collectionSummary(
+      deps.resolutionStore,
+      typeof inputs.resolution_id === "string" ? inputs.resolution_id : "",
+    );
+    const item = toCollectionReportListItem(record, summary);
+    if (!item) return errorJson(c, 404, "not_found");
+    return c.json(item, 200, { "Cache-Control": "no-store" });
+  });
+}

--- a/packages/services/ordering/src/collection-report-projection.ts
+++ b/packages/services/ordering/src/collection-report-projection.ts
@@ -1,0 +1,157 @@
+/**
+ * CR-206 — safe collection-report list/detail projections for Dashboard BFF.
+ *
+ * Redacts raw inputs, digests, refusal internals, and operator audit.
+ * User-visible status maps from order lifecycle (sprint CR-202/CR-304 vocabulary).
+ */
+
+import type { OrderRecord } from "./store.js";
+
+export type CollectionReportUserStatus =
+  | "requested"
+  | "preparing_collection_data"
+  | "building_report"
+  | "ready"
+  | "needs_attention";
+
+export type ArtifactAvailability =
+  | "none"
+  | "available"
+  | "expired"
+  | "deleted"
+  | "quarantined";
+
+export interface CollectionReportListItem {
+  readonly schema_version: 1;
+  readonly order_id: string;
+  readonly community_ref: string;
+  readonly resolution_id: string;
+  readonly user_status: CollectionReportUserStatus;
+  readonly action_needed_code: string | null;
+  readonly artifact_availability: ArtifactAvailability;
+  readonly open_action: "open_artifact" | null;
+  readonly collection_summary: {
+    readonly name: string | null;
+    readonly symbol: string | null;
+  };
+  readonly placed_at_unix: number;
+  readonly updated_at_unix: number;
+  readonly created_at_unix: number;
+}
+
+export interface CollectionReportListResponse {
+  readonly schema_version: 1;
+  readonly items: readonly CollectionReportListItem[];
+  readonly next_cursor: string | null;
+}
+
+export function mapUserStatus(record: OrderRecord): CollectionReportUserStatus {
+  switch (record.state) {
+    case "placed":
+    case "routing":
+      return "requested";
+    case "producing": {
+      const fulfillment = record.fulfillment as
+        | { readonly phase?: string; readonly stage?: string }
+        | undefined;
+      const phase = fulfillment?.phase ?? fulfillment?.stage ?? "";
+      if (
+        typeof phase === "string" &&
+        (phase.includes("build") || phase.includes("render") || phase.includes("report"))
+      ) {
+        return "building_report";
+      }
+      return "preparing_collection_data";
+    }
+    case "fulfilled":
+      return "ready";
+    case "failed":
+      return "needs_attention";
+    default: {
+      const _exhaustive: never = record.state;
+      return _exhaustive;
+    }
+  }
+}
+
+export function mapArtifactAvailability(record: OrderRecord): ArtifactAvailability {
+  if (record.state !== "fulfilled") return "none";
+  if (typeof record.result_ref === "string" && record.result_ref.length > 0) {
+    return "available";
+  }
+  // Fulfilled without a retrievable artifact — history stays, open is withheld.
+  return "expired";
+}
+
+export function mapActionNeeded(record: OrderRecord): string | null {
+  if (record.state === "failed") {
+    const refusal = record.refusal as { readonly code?: string } | undefined;
+    if (typeof refusal?.code === "string" && refusal.code.length > 0) {
+      return refusal.code;
+    }
+    return "needs_attention";
+  }
+  return null;
+}
+
+export function toCollectionReportListItem(
+  record: OrderRecord,
+  collection: { readonly name: string | null; readonly symbol: string | null } = {
+    name: null,
+    symbol: null,
+  },
+): CollectionReportListItem | null {
+  if (record.product !== "collection-report") return null;
+  const inputs = record.inputs as {
+    readonly community_ref?: unknown;
+    readonly resolution_id?: unknown;
+  };
+  if (typeof inputs.community_ref !== "string" || inputs.community_ref.length === 0) {
+    return null;
+  }
+  if (typeof inputs.resolution_id !== "string" || inputs.resolution_id.length === 0) {
+    return null;
+  }
+
+  const artifact_availability = mapArtifactAvailability(record);
+  return {
+    schema_version: 1,
+    order_id: record.order_id,
+    community_ref: inputs.community_ref,
+    resolution_id: inputs.resolution_id,
+    user_status: mapUserStatus(record),
+    action_needed_code: mapActionNeeded(record),
+    artifact_availability,
+    open_action: artifact_availability === "available" ? "open_artifact" : null,
+    collection_summary: {
+      name: collection.name,
+      symbol: collection.symbol,
+    },
+    placed_at_unix: record.placed_at_unix,
+    updated_at_unix: record.updated_at_unix,
+    created_at_unix: record.created_at_unix,
+  };
+}
+
+export function encodeCursor(createdAtUnix: number, orderId: string): string {
+  return Buffer.from(`${createdAtUnix}:${orderId}`, "utf8").toString("base64url");
+}
+
+export function decodeCursor(
+  raw: string | undefined,
+): { readonly created_at_unix: number; readonly order_id: string } | undefined {
+  if (raw === undefined || raw.trim() === "") return undefined;
+  try {
+    const decoded = Buffer.from(raw, "base64url").toString("utf8");
+    const sep = decoded.indexOf(":");
+    if (sep <= 0) return undefined;
+    const created = Number(decoded.slice(0, sep));
+    const orderId = decoded.slice(sep + 1);
+    if (!Number.isSafeInteger(created) || created < 0 || orderId.length === 0) {
+      return undefined;
+    }
+    return { created_at_unix: created, order_id: orderId };
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/services/ordering/src/store-postgres.ts
+++ b/packages/services/ordering/src/store-postgres.ts
@@ -72,6 +72,7 @@ export class PostgresOrderStore implements OrderStore {
       '001_orders.sql',
       '002_probe_meta.sql',
       '004_collection_resolutions.sql',
+      '005_collection_report_list.sql',
     ]) {
       const sql = readFileSync(join(__dirname, '../migrations', file), 'utf8');
       await this.pool.query(sql);
@@ -276,6 +277,47 @@ export class PostgresOrderStore implements OrderStore {
 
   async listByState(state: OrderState): Promise<OrderRecord[]> {
     const res = await this.pool.query('SELECT * FROM orders WHERE state = $1', [state]);
+    return res.rows.map(rowToRecord);
+  }
+
+  async listCollectionReports(query: {
+    readonly community_ref: string;
+    readonly placed_by: string;
+    readonly limit: number;
+    readonly cursor?: { readonly created_at_unix: number; readonly order_id: string };
+  }): Promise<OrderRecord[]> {
+    if (query.cursor) {
+      const res = await this.pool.query(
+        `SELECT * FROM orders
+         WHERE product = 'collection-report'
+           AND placed_by = $1
+           AND (inputs ->> 'community_ref') = $2
+           AND (
+             created_at_unix < $3
+             OR (created_at_unix = $3 AND order_id < $4)
+           )
+         ORDER BY created_at_unix DESC, order_id DESC
+         LIMIT $5`,
+        [
+          query.placed_by,
+          query.community_ref,
+          query.cursor.created_at_unix,
+          query.cursor.order_id,
+          query.limit,
+        ],
+      );
+      return res.rows.map(rowToRecord);
+    }
+
+    const res = await this.pool.query(
+      `SELECT * FROM orders
+       WHERE product = 'collection-report'
+         AND placed_by = $1
+         AND (inputs ->> 'community_ref') = $2
+       ORDER BY created_at_unix DESC, order_id DESC
+       LIMIT $3`,
+      [query.placed_by, query.community_ref, query.limit],
+    );
     return res.rows.map(rowToRecord);
   }
 }

--- a/packages/services/ordering/src/store.ts
+++ b/packages/services/ordering/src/store.ts
@@ -120,6 +120,17 @@ export interface OrderStore {
   markPublished(seq: number): Promise<void>;
   /** Kitchen worker — orders in a given lifecycle state. */
   listByState(state: OrderState): Promise<OrderRecord[]>;
+
+  /**
+   * CR-206 — cursor page of collection-report orders for one subject + community.
+   * Cursor is exclusive `(created_at_unix, order_id)` descending.
+   */
+  listCollectionReports(query: {
+    readonly community_ref: string;
+    readonly placed_by: string;
+    readonly limit: number;
+    readonly cursor?: { readonly created_at_unix: number; readonly order_id: string };
+  }): Promise<OrderRecord[]>;
 }
 
 export class OrderNotFoundError extends Error {
@@ -227,5 +238,32 @@ export class InMemoryOrderStore implements OrderStore {
 
   async listByState(state: OrderState): Promise<OrderRecord[]> {
     return [...this.orders.values()].filter((r) => r.state === state);
+  }
+
+  async listCollectionReports(query: {
+    readonly community_ref: string;
+    readonly placed_by: string;
+    readonly limit: number;
+    readonly cursor?: { readonly created_at_unix: number; readonly order_id: string };
+  }): Promise<OrderRecord[]> {
+    const rows = [...this.orders.values()].filter((r) => {
+      if (r.product !== "collection-report") return false;
+      if (r.placed_by !== query.placed_by) return false;
+      const community = (r.inputs as { community_ref?: unknown }).community_ref;
+      if (community !== query.community_ref) return false;
+      if (query.cursor) {
+        if (r.created_at_unix < query.cursor.created_at_unix) return true;
+        if (r.created_at_unix > query.cursor.created_at_unix) return false;
+        return r.order_id < query.cursor.order_id;
+      }
+      return true;
+    });
+    rows.sort((a, b) => {
+      if (a.created_at_unix !== b.created_at_unix) {
+        return b.created_at_unix - a.created_at_unix;
+      }
+      return a.order_id < b.order_id ? 1 : a.order_id > b.order_id ? -1 : 0;
+    });
+    return rows.slice(0, query.limit);
   }
 }


### PR DESCRIPTION
## Summary
- Adds authenticated `GET /v1/collection-reports` and `GET /v1/collection-reports/:order_id` for Dashboard Reports (CR-304).
- Subject + community ACL (query scope re-checked against stored `placed_by` / `inputs.community_ref`).
- Cursor pagination on immutable `(created_at_unix, order_id)`; safe user-status mapping (`requested` → `needs_attention`).
- Healthz exposes `collection_reports: true`. Index migration `005_collection_report_list.sql`.

## Out of scope (full CR-206)
Identity-row paging, encrypted export, CR-015 disclosure fences, artifact byte retrieval audit — deferred.

## Test plan
- [x] `vitest` `collection-report-http.test.ts` (auth, ACL, cursor, safe projection)
- [ ] Deploy Ordering; healthz shows `collection_reports: true`
- [ ] Smoke list with Bearer + subject/community after a placed collection-report order


Made with [Cursor](https://cursor.com)