### PR TITLE
feat(ordering): CR-305 report attention receipts and mark-seen

### DIFF
--- a/packages/services/ordering/bin/http.ts
+++ b/packages/services/ordering/bin/http.ts
@@ -14,10 +14,13 @@ import { ReProbeWorker } from '../src/reprobe-worker.js';
 import { createCatalogResolveProbePort } from '../src/catalog-resolve-probe.js';
 import { mountCollectionResolutionRoutes } from '../src/resolution-http.js';
 import { mountCollectionReportRoutes } from '../src/collection-report-http.js';
+import { mountReportAttentionRoutes } from '../src/report-attention-http.js';
 import { createResolutionStore } from '../src/resolution-store-factory.js';
 import { CollectionResolutionService } from '../src/resolution-service.js';
 import { sonarResolveProbeFromEnv } from '../src/sonar-resolve-probe-client.js';
 import { PostgresOrderStore } from '../src/store-postgres.js';
+import { InMemoryReportAttentionStore } from '../src/report-attention-store.js';
+import { PostgresReportAttentionStore } from '../src/report-attention-store-postgres.js';
 
 const { store, orchestrator, enqueue } = await createOrderingComposition();
 
@@ -66,9 +69,15 @@ const app = createIntakeApp({
     write_routes: writeRoutes,
     collection_resolutions: true,
     collection_reports: true,
+    report_attention: true,
     resolve_probe: resolutionProbeMode,
   },
 });
+
+const attentionStore =
+  store instanceof PostgresOrderStore
+    ? new PostgresReportAttentionStore(store.getPool())
+    : new InMemoryReportAttentionStore();
 
 // CR-006: mount create/confirm/refresh. Token posture matches write routes —
 // when SERVICE_TOKEN is set, Bearer is required; open_dev allows tokenless.
@@ -83,6 +92,14 @@ mountCollectionResolutionRoutes(app, {
 mountCollectionReportRoutes(app, {
   store,
   resolutionStore,
+  attentionStore,
+  serviceToken: writeRoutes === 'token' ? serviceToken : undefined,
+});
+
+// CR-305: idempotent mark-seen for report attention.
+mountReportAttentionRoutes(app, {
+  store,
+  attentionStore,
   serviceToken: writeRoutes === 'token' ? serviceToken : undefined,
 });
 

--- a/packages/services/ordering/migrations/006_report_attention_receipts.sql
+++ b/packages/services/ordering/migrations/006_report_attention_receipts.sql
@@ -1,0 +1,16 @@
+-- CR-305 — per-subject report-attention seen receipts.
+-- Keyed by (subject_ref, source_kind, source_id, transition_sequence).
+-- Mark-seen never mutates order lifecycle state.
+
+CREATE TABLE IF NOT EXISTS report_attention_receipts (
+  subject_ref TEXT NOT NULL,
+  source_kind TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  transition_sequence BIGINT NOT NULL,
+  community_ref TEXT NOT NULL,
+  seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (subject_ref, source_kind, source_id, transition_sequence)
+);
+
+CREATE INDEX IF NOT EXISTS report_attention_receipts_subject_community_idx
+  ON report_attention_receipts (subject_ref, community_ref);

--- a/packages/services/ordering/src/__tests__/report-attention-http.test.ts
+++ b/packages/services/ordering/src/__tests__/report-attention-http.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+import { Hono } from "hono";
+
+import { mountCollectionReportRoutes } from "../collection-report-http.js";
+import { mountReportAttentionRoutes } from "../report-attention-http.js";
+import { InMemoryOrderStore } from "../store.js";
+import { InMemoryReportAttentionStore } from "../report-attention-store.js";
+import { ORDER_LIFECYCLE_SUBJECTS } from "@freeside/ordering-protocol";
+
+const TOKEN = "test-service-token";
+
+function digest() {
+  return {
+    algorithm: "sha-256" as const,
+    domain: "collection-resolution.candidate-snapshot",
+    major_version: 1,
+    digest: "ab".repeat(32),
+  };
+}
+
+async function seed(
+  store: InMemoryOrderStore,
+  opts: {
+    order_id: string;
+    placed_by: string;
+    community_ref: string;
+    state?: "placed" | "producing" | "fulfilled" | "failed";
+  },
+) {
+  await store.placeOrder(
+    {
+      order_id: opts.order_id,
+      product: "collection-report",
+      placed_by: opts.placed_by,
+      inputs: {
+        schema_version: 1,
+        resolution_id: `res-${opts.order_id}`,
+        candidate_snapshot_digest: digest(),
+        community_ref: opts.community_ref,
+      },
+      placed_at_unix: 1_700_000_000,
+      inputs_digest: "digest",
+    },
+    { subject: ORDER_LIFECYCLE_SUBJECTS.placed, payload: { order_id: opts.order_id } },
+  );
+
+  if (opts.state === "producing" || opts.state === "fulfilled" || opts.state === "failed") {
+    await store.transition(opts.order_id, "placed", "routing");
+    await store.transition(opts.order_id, "routing", "producing");
+  }
+  if (opts.state === "fulfilled") {
+    await store.transition(opts.order_id, "producing", "fulfilled", {
+      patch: { result_ref: `artifact://${opts.order_id}` },
+    });
+  }
+  if (opts.state === "failed") {
+    await store.transition(opts.order_id, "producing", "failed", {
+      patch: { refusal: { code: "capacity_rejected", reason: "full" } },
+    });
+  }
+}
+
+function appWith(
+  store: InMemoryOrderStore,
+  attention: InMemoryReportAttentionStore,
+) {
+  const app = new Hono();
+  mountCollectionReportRoutes(app, {
+    store,
+    attentionStore: attention,
+    serviceToken: TOKEN,
+  });
+  mountReportAttentionRoutes(app, {
+    store,
+    attentionStore: attention,
+    serviceToken: TOKEN,
+  });
+  return app;
+}
+
+describe("CR-305 report attention", () => {
+  it("routine progress has null attention_kind and unseen false", async () => {
+    const store = new InMemoryOrderStore({ now: () => 1_700_000_100 });
+    const attention = new InMemoryReportAttentionStore({ now: () => 1_700_000_100 });
+    await seed(store, {
+      order_id: "ord-req",
+      placed_by: "user-a",
+      community_ref: "mibera",
+      state: "placed",
+    });
+    await seed(store, {
+      order_id: "ord-prep",
+      placed_by: "user-a",
+      community_ref: "mibera",
+      state: "producing",
+    });
+
+    const app = appWith(store, attention);
+    const res = await app.request(
+      "/v1/collection-reports?community_ref=mibera&subject_id=user-a",
+      { headers: { authorization: `Bearer ${TOKEN}` } },
+    );
+    const body = (await res.json()) as {
+      items: Array<{
+        order_id: string;
+        attention_kind: string | null;
+        attention_unseen: boolean;
+      }>;
+    };
+    for (const item of body.items) {
+      expect(item.attention_kind).toBeNull();
+      expect(item.attention_unseen).toBe(false);
+    }
+  });
+
+  it("ready/failed produce attention kinds and mark-seen clears unseen", async () => {
+    const store = new InMemoryOrderStore({ now: () => 1_700_000_200 });
+    const attention = new InMemoryReportAttentionStore({ now: () => 1_700_000_200 });
+    await seed(store, {
+      order_id: "ord-ready",
+      placed_by: "user-a",
+      community_ref: "mibera",
+      state: "fulfilled",
+    });
+    await seed(store, {
+      order_id: "ord-fail",
+      placed_by: "user-a",
+      community_ref: "mibera",
+      state: "failed",
+    });
+
+    const app = appWith(store, attention);
+    const list1 = await app.request(
+      "/v1/collection-reports?community_ref=mibera&subject_id=user-a",
+      { headers: { authorization: `Bearer ${TOKEN}` } },
+    );
+    const body1 = (await list1.json()) as {
+      items: Array<{
+        order_id: string;
+        attention_kind: string | null;
+        attention_unseen: boolean;
+        transition_sequence: number;
+      }>;
+    };
+    const ready = body1.items.find((i) => i.order_id === "ord-ready");
+    const failed = body1.items.find((i) => i.order_id === "ord-fail");
+    expect(ready?.attention_kind).toBe("report.ready");
+    expect(ready?.attention_unseen).toBe(true);
+    expect(failed?.attention_kind).toBe("report.needs_attention");
+    expect(failed?.attention_unseen).toBe(true);
+
+    const seen = await app.request(
+      `/v1/report-attention/collection_report_order/ord-ready/${ready!.transition_sequence}/seen`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ subject_id: "user-a", community_ref: "mibera" }),
+      },
+    );
+    expect(seen.status).toBe(200);
+
+    // Idempotent replay
+    const seen2 = await app.request(
+      `/v1/report-attention/collection_report_order/ord-ready/${ready!.transition_sequence}/seen`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ subject_id: "user-a", community_ref: "mibera" }),
+      },
+    );
+    expect(seen2.status).toBe(200);
+
+    const list2 = await app.request(
+      "/v1/collection-reports?community_ref=mibera&subject_id=user-a",
+      { headers: { authorization: `Bearer ${TOKEN}` } },
+    );
+    const body2 = (await list2.json()) as {
+      items: Array<{ order_id: string; attention_unseen: boolean }>;
+    };
+    expect(body2.items.find((i) => i.order_id === "ord-ready")?.attention_unseen).toBe(
+      false,
+    );
+    expect(body2.items.find((i) => i.order_id === "ord-fail")?.attention_unseen).toBe(
+      true,
+    );
+  });
+
+  it("denies cross-subject mark-seen", async () => {
+    const store = new InMemoryOrderStore({ now: () => 1_700_000_300 });
+    const attention = new InMemoryReportAttentionStore({ now: () => 1_700_000_300 });
+    await seed(store, {
+      order_id: "ord-a",
+      placed_by: "user-a",
+      community_ref: "mibera",
+      state: "fulfilled",
+    });
+    const record = await store.get("ord-a");
+    const seq = record!.updated_at_unix;
+    const app = appWith(store, attention);
+    const res = await app.request(
+      `/v1/report-attention/collection_report_order/ord-a/${seq}/seen`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ subject_id: "user-b", community_ref: "mibera" }),
+      },
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("requires bearer for mark-seen", async () => {
+    const store = new InMemoryOrderStore({ now: () => 1_700_000_400 });
+    const attention = new InMemoryReportAttentionStore();
+    const app = appWith(store, attention);
+    const res = await app.request(
+      "/v1/report-attention/collection_report_order/ord-x/1/seen",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ subject_id: "user-a", community_ref: "mibera" }),
+      },
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/services/ordering/src/collection-report-http.ts
+++ b/packages/services/ordering/src/collection-report-http.ts
@@ -1,5 +1,5 @@
 /**
- * CR-206 — authenticated collection-report list/detail HTTP edge.
+ * CR-206/CR-305 — authenticated collection-report list/detail HTTP edge.
  *
  *   GET /v1/collection-reports
  *   GET /v1/collection-reports/:order_id
@@ -7,27 +7,32 @@
  * Auth: Bearer SERVICE_TOKEN (Dashboard BFF). Authorization scope is supplied
  * in the query string and re-checked against community_ref (never trusted alone).
  *
- * Deferred vs full CR-206: identity-row paging, encrypted export, CR-015
- * disclosure fences, artifact byte retrieval + audit. This cut unblocks
- * Dashboard CR-304 table + detail status projections.
+ * CR-305 adds attention_kind / attention_unseen / transition_sequence on items.
  */
 
 import { Hono, type Context } from "hono";
 import { z } from "zod";
 
-import type { OrderStore } from "./store.js";
+import type { OrderRecord, OrderStore } from "./store.js";
 import type { ResolutionStore } from "./resolution-store.js";
 import {
   decodeCursor,
   encodeCursor,
+  mapAttentionKind,
   toCollectionReportListItem,
+  transitionSequenceOf,
   type CollectionReportListItem,
   type CollectionReportListResponse,
 } from "./collection-report-projection.js";
+import {
+  REPORT_ATTENTION_SOURCE_KIND,
+  type ReportAttentionStore,
+} from "./report-attention-store.js";
 
 export interface CollectionReportHttpDeps {
   readonly store: OrderStore;
   readonly resolutionStore?: ResolutionStore;
+  readonly attentionStore?: ReportAttentionStore;
   readonly serviceToken?: string;
 }
 
@@ -83,6 +88,22 @@ async function collectionSummary(
   }
 }
 
+async function attentionUnseenFor(
+  attentionStore: ReportAttentionStore | undefined,
+  subjectId: string,
+  record: OrderRecord,
+): Promise<boolean> {
+  if (mapAttentionKind(record) === null) return false;
+  if (!attentionStore) return true;
+  const seen = await attentionStore.hasSeen({
+    subject_ref: subjectId,
+    source_kind: REPORT_ATTENTION_SOURCE_KIND,
+    source_id: record.order_id,
+    transition_sequence: transitionSequenceOf(record),
+  });
+  return !seen;
+}
+
 export function mountCollectionReportRoutes(
   app: Hono,
   deps: CollectionReportHttpDeps,
@@ -123,7 +144,12 @@ export function mountCollectionReportRoutes(
         deps.resolutionStore,
         typeof inputs.resolution_id === "string" ? inputs.resolution_id : "",
       );
-      const item = toCollectionReportListItem(row, summary);
+      const unseen = await attentionUnseenFor(
+        deps.attentionStore,
+        parsed.data.subject_id,
+        row,
+      );
+      const item = toCollectionReportListItem(row, summary, { unseen });
       if (item) items.push(item);
     }
 
@@ -173,7 +199,8 @@ export function mountCollectionReportRoutes(
       deps.resolutionStore,
       typeof inputs.resolution_id === "string" ? inputs.resolution_id : "",
     );
-    const item = toCollectionReportListItem(record, summary);
+    const unseen = await attentionUnseenFor(deps.attentionStore, subject_id, record);
+    const item = toCollectionReportListItem(record, summary, { unseen });
     if (!item) return errorJson(c, 404, "not_found");
     return c.json(item, 200, { "Cache-Control": "no-store" });
   });

--- a/packages/services/ordering/src/collection-report-projection.ts
+++ b/packages/services/ordering/src/collection-report-projection.ts
@@ -1,8 +1,12 @@
 /**
- * CR-206 — safe collection-report list/detail projections for Dashboard BFF.
+ * CR-206/CR-305 — safe collection-report list/detail projections for Dashboard BFF.
  *
  * Redacts raw inputs, digests, refusal internals, and operator audit.
  * User-visible status maps from order lifecycle (sprint CR-202/CR-304 vocabulary).
+ *
+ * Attention fields (CR-305):
+ * - transition_sequence = updated_at_unix (documented V1 sequence for mark-seen)
+ * - attention_kind only for ready / needs_attention (no routine progress noise)
  */
 
 import type { OrderRecord } from "./store.js";
@@ -21,6 +25,8 @@ export type ArtifactAvailability =
   | "deleted"
   | "quarantined";
 
+export type ReportAttentionKind = "report.ready" | "report.needs_attention";
+
 export interface CollectionReportListItem {
   readonly schema_version: 1;
   readonly order_id: string;
@@ -37,6 +43,10 @@ export interface CollectionReportListItem {
   readonly placed_at_unix: number;
   readonly updated_at_unix: number;
   readonly created_at_unix: number;
+  /** V1: equals updated_at_unix — stable key for mark-seen receipts. */
+  readonly transition_sequence: number;
+  readonly attention_kind: ReportAttentionKind | null;
+  readonly attention_unseen: boolean;
 }
 
 export interface CollectionReportListResponse {
@@ -74,6 +84,18 @@ export function mapUserStatus(record: OrderRecord): CollectionReportUserStatus {
   }
 }
 
+export function mapAttentionKind(record: OrderRecord): ReportAttentionKind | null {
+  const status = mapUserStatus(record);
+  if (status === "ready") return "report.ready";
+  if (status === "needs_attention") return "report.needs_attention";
+  return null;
+}
+
+/** V1 attention sequence — updated_at_unix at the attention-bearing state. */
+export function transitionSequenceOf(record: OrderRecord): number {
+  return record.updated_at_unix;
+}
+
 export function mapArtifactAvailability(record: OrderRecord): ArtifactAvailability {
   if (record.state !== "fulfilled") return "none";
   if (typeof record.result_ref === "string" && record.result_ref.length > 0) {
@@ -100,6 +122,7 @@ export function toCollectionReportListItem(
     name: null,
     symbol: null,
   },
+  attention: { readonly unseen: boolean } = { unseen: false },
 ): CollectionReportListItem | null {
   if (record.product !== "collection-report") return null;
   const inputs = record.inputs as {
@@ -114,6 +137,7 @@ export function toCollectionReportListItem(
   }
 
   const artifact_availability = mapArtifactAvailability(record);
+  const attention_kind = mapAttentionKind(record);
   return {
     schema_version: 1,
     order_id: record.order_id,
@@ -130,6 +154,9 @@ export function toCollectionReportListItem(
     placed_at_unix: record.placed_at_unix,
     updated_at_unix: record.updated_at_unix,
     created_at_unix: record.created_at_unix,
+    transition_sequence: transitionSequenceOf(record),
+    attention_kind,
+    attention_unseen: attention_kind !== null ? attention.unseen : false,
   };
 }
 

--- a/packages/services/ordering/src/report-attention-http.ts
+++ b/packages/services/ordering/src/report-attention-http.ts
@@ -1,0 +1,134 @@
+/**
+ * CR-305 — authenticated mark-seen for report attention.
+ *
+ *   POST /v1/report-attention/:source_kind/:source_id/:transition_sequence/seen
+ *
+ * Body: { subject_id, community_ref }
+ * Never mutates order lifecycle state.
+ */
+
+import { Hono, type Context } from "hono";
+import { z } from "zod";
+
+import type { OrderStore } from "./store.js";
+import {
+  REPORT_ATTENTION_SOURCE_KIND,
+  type ReportAttentionStore,
+} from "./report-attention-store.js";
+import { mapAttentionKind, transitionSequenceOf } from "./collection-report-projection.js";
+
+export interface ReportAttentionHttpDeps {
+  readonly store: OrderStore;
+  readonly attentionStore: ReportAttentionStore;
+  readonly serviceToken?: string;
+}
+
+const SeenBodySchema = z
+  .object({
+    subject_id: z.string().min(1).max(256),
+    community_ref: z.string().min(1).max(128),
+  })
+  .strict();
+
+function requireBearer(c: Context, token: string | undefined): boolean {
+  if (!token) return true;
+  return c.req.header("authorization") === `Bearer ${token}`;
+}
+
+function errorJson(
+  c: Context,
+  status: 400 | 401 | 403 | 404,
+  code: string,
+): Response {
+  return c.json(
+    { schema_version: 1, code },
+    status,
+    { "Cache-Control": "no-store" },
+  );
+}
+
+export function mountReportAttentionRoutes(
+  app: Hono,
+  deps: ReportAttentionHttpDeps,
+): void {
+  app.post(
+    "/v1/report-attention/:source_kind/:source_id/:transition_sequence/seen",
+    async (c) => {
+      if (!requireBearer(c, deps.serviceToken)) {
+        return errorJson(c, 401, "unauthorized");
+      }
+
+      const source_kind = c.req.param("source_kind");
+      const source_id = c.req.param("source_id");
+      const transitionRaw = c.req.param("transition_sequence");
+      const transition_sequence = Number(transitionRaw);
+
+      if (source_kind !== REPORT_ATTENTION_SOURCE_KIND) {
+        return errorJson(c, 400, "invalid_request");
+      }
+      if (
+        typeof source_id !== "string" ||
+        source_id.length === 0 ||
+        !Number.isSafeInteger(transition_sequence) ||
+        transition_sequence < 0
+      ) {
+        return errorJson(c, 400, "invalid_request");
+      }
+
+      let raw: unknown;
+      try {
+        raw = await c.req.json();
+      } catch {
+        return errorJson(c, 400, "invalid_request");
+      }
+      const parsed = SeenBodySchema.safeParse(raw);
+      if (!parsed.success) {
+        return errorJson(c, 400, "invalid_request");
+      }
+
+      const record = await deps.store.get(source_id);
+      if (!record || record.product !== "collection-report") {
+        return errorJson(c, 404, "not_found");
+      }
+      if (record.placed_by !== parsed.data.subject_id) {
+        return errorJson(c, 403, "forbidden");
+      }
+      const inputs = record.inputs as { community_ref?: unknown };
+      if (inputs.community_ref !== parsed.data.community_ref) {
+        return errorJson(c, 403, "forbidden");
+      }
+
+      // Only attention-bearing states accept receipts (routine progress ignored).
+      if (mapAttentionKind(record) === null) {
+        return errorJson(c, 404, "not_found");
+      }
+
+      const expectedSeq = transitionSequenceOf(record);
+      if (expectedSeq !== transition_sequence) {
+        return errorJson(c, 404, "not_found");
+      }
+
+      const receipt = await deps.attentionStore.markSeen({
+        subject_ref: parsed.data.subject_id,
+        source_kind: REPORT_ATTENTION_SOURCE_KIND,
+        source_id,
+        transition_sequence,
+        community_ref: parsed.data.community_ref,
+      });
+
+      return c.json(
+        {
+          schema_version: 1,
+          source_kind: receipt.source_kind,
+          source_id: receipt.source_id,
+          transition_sequence: receipt.transition_sequence,
+          subject_id: receipt.subject_ref,
+          community_ref: receipt.community_ref,
+          seen_at_unix: receipt.seen_at_unix,
+        },
+        200,
+        { "Cache-Control": "no-store" },
+      );
+    },
+  );
+}

--- a/packages/services/ordering/src/report-attention-store-postgres.ts
+++ b/packages/services/ordering/src/report-attention-store-postgres.ts
@@ -1,0 +1,71 @@
+import type pg from "pg";
+
+import {
+  type AttentionReceipt,
+  type AttentionReceiptKey,
+  type ReportAttentionSourceKind,
+  type ReportAttentionStore,
+} from "./report-attention-store.js";
+
+export class PostgresReportAttentionStore implements ReportAttentionStore {
+  constructor(
+    private readonly pool: pg.Pool,
+    private readonly now: () => number = () => Math.floor(Date.now() / 1000),
+  ) {}
+
+  async hasSeen(key: AttentionReceiptKey): Promise<boolean> {
+    const res = await this.pool.query(
+      `SELECT 1 FROM report_attention_receipts
+       WHERE subject_ref = $1
+         AND source_kind = $2
+         AND source_id = $3
+         AND transition_sequence = $4
+       LIMIT 1`,
+      [key.subject_ref, key.source_kind, key.source_id, key.transition_sequence],
+    );
+    return res.rowCount !== null && res.rowCount > 0;
+  }
+
+  async markSeen(input: {
+    readonly subject_ref: string;
+    readonly source_kind: ReportAttentionSourceKind;
+    readonly source_id: string;
+    readonly transition_sequence: number;
+    readonly community_ref: string;
+  }): Promise<AttentionReceipt> {
+    const seenAt = new Date(this.now() * 1000).toISOString();
+    const res = await this.pool.query(
+      `INSERT INTO report_attention_receipts (
+         subject_ref, source_kind, source_id, transition_sequence, community_ref, seen_at
+       ) VALUES ($1, $2, $3, $4, $5, $6::timestamptz)
+       ON CONFLICT (subject_ref, source_kind, source_id, transition_sequence)
+       DO UPDATE SET seen_at = report_attention_receipts.seen_at
+       RETURNING subject_ref, source_kind, source_id, transition_sequence,
+                 community_ref, EXTRACT(EPOCH FROM seen_at)::bigint AS seen_at_unix`,
+      [
+        input.subject_ref,
+        input.source_kind,
+        input.source_id,
+        input.transition_sequence,
+        input.community_ref,
+        seenAt,
+      ],
+    );
+    const row = res.rows[0] as {
+      subject_ref: string;
+      source_kind: ReportAttentionSourceKind;
+      source_id: string;
+      transition_sequence: string | number;
+      community_ref: string;
+      seen_at_unix: string | number;
+    };
+    return {
+      subject_ref: row.subject_ref,
+      source_kind: row.source_kind,
+      source_id: row.source_id,
+      transition_sequence: Number(row.transition_sequence),
+      community_ref: row.community_ref,
+      seen_at_unix: Number(row.seen_at_unix),
+    };
+  }
+}

--- a/packages/services/ordering/src/report-attention-store.ts
+++ b/packages/services/ordering/src/report-attention-store.ts
@@ -1,0 +1,74 @@
+/**
+ * CR-305 — idempotent per-subject attention receipts.
+ *
+ * Logical uniqueness: (subject_ref, source_kind, source_id, transition_sequence).
+ * Mark-seen is an upsert of seen_at and never creates a receipt for a source
+ * the subject cannot currently read (callers enforce ACL before upsert).
+ */
+
+export const REPORT_ATTENTION_SOURCE_KIND = "collection_report_order" as const;
+export type ReportAttentionSourceKind = typeof REPORT_ATTENTION_SOURCE_KIND;
+
+export interface AttentionReceiptKey {
+  readonly subject_ref: string;
+  readonly source_kind: ReportAttentionSourceKind;
+  readonly source_id: string;
+  readonly transition_sequence: number;
+}
+
+export interface AttentionReceipt extends AttentionReceiptKey {
+  readonly community_ref: string;
+  readonly seen_at_unix: number;
+}
+
+export interface ReportAttentionStore {
+  hasSeen(key: AttentionReceiptKey): Promise<boolean>;
+  markSeen(input: {
+    readonly subject_ref: string;
+    readonly source_kind: ReportAttentionSourceKind;
+    readonly source_id: string;
+    readonly transition_sequence: number;
+    readonly community_ref: string;
+  }): Promise<AttentionReceipt>;
+}
+
+export class InMemoryReportAttentionStore implements ReportAttentionStore {
+  private readonly receipts = new Map<string, AttentionReceipt>();
+  private readonly now: () => number;
+
+  constructor(opts: { now?: () => number } = {}) {
+    this.now = opts.now ?? (() => Math.floor(Date.now() / 1000));
+  }
+
+  private keyOf(k: AttentionReceiptKey): string {
+    return `${k.subject_ref}\0${k.source_kind}\0${k.source_id}\0${k.transition_sequence}`;
+  }
+
+  async hasSeen(key: AttentionReceiptKey): Promise<boolean> {
+    return this.receipts.has(this.keyOf(key));
+  }
+
+  async markSeen(input: {
+    readonly subject_ref: string;
+    readonly source_kind: ReportAttentionSourceKind;
+    readonly source_id: string;
+    readonly transition_sequence: number;
+    readonly community_ref: string;
+  }): Promise<AttentionReceipt> {
+    const key: AttentionReceiptKey = {
+      subject_ref: input.subject_ref,
+      source_kind: input.source_kind,
+      source_id: input.source_id,
+      transition_sequence: input.transition_sequence,
+    };
+    const existing = this.receipts.get(this.keyOf(key));
+    if (existing) return existing;
+    const receipt: AttentionReceipt = {
+      ...key,
+      community_ref: input.community_ref,
+      seen_at_unix: this.now(),
+    };
+    this.receipts.set(this.keyOf(key), receipt);
+    return receipt;
+  }
+}

--- a/packages/services/ordering/src/store-postgres.ts
+++ b/packages/services/ordering/src/store-postgres.ts
@@ -73,6 +73,7 @@ export class PostgresOrderStore implements OrderStore {
       '002_probe_meta.sql',
       '004_collection_resolutions.sql',
       '005_collection_report_list.sql',
+      '006_report_attention_receipts.sql',
     ]) {
       const sql = readFileSync(join(__dirname, '../migrations', file), 'utf8');
       await this.pool.query(sql);


### PR DESCRIPTION
## Summary
- Add `report_attention_receipts` migration and mark-seen API `POST /v1/report-attention/:source_kind/:source_id/:transition_sequence/seen`
- Extend collection-report list/detail with `attention_kind`, `attention_unseen`, `transition_sequence` (V1 sequence = `updated_at_unix`)
- Routine Requested/Preparing/Building statuses emit `attention_kind: null` (no bell noise)
- healthz: `report_attention: true`

## Test plan
- [x] `vitest run` collection-report + report-attention unit tests
- [ ] Railway deploy + prove mark-seen on Art Blocks order / list unseen flip
- [ ] Dashboard CR-305 consumes fields via BFF


Made with [Cursor](https://cursor.com)