### PR TITLE
fix(ordering): collection-report preparing path (no false invalid-inputs)

### DIFF
--- a/packages/services/ordering/src/__tests__/collection-report-orchestrator.test.ts
+++ b/packages/services/ordering/src/__tests__/collection-report-orchestrator.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { ORDER_LIFECYCLE_SUBJECTS } from "@freeside/ordering-protocol";
+
+import { CollectionReportOrchestrator } from "../collection-report-orchestrator.js";
+import { OrderOrchestrator } from "../orchestrator.js";
+import { InMemoryOrderStore } from "../store.js";
+import { ConfigCapabilityResolver } from "../resolver.js";
+import type { AuditPort } from "../audit-acl.js";
+import type { Cta } from "@freeside/shadow-audit-protocol";
+
+const CTA: Cta = {
+  product: "https://example.test/audit",
+  conversation: "https://example.test/talk",
+};
+
+function digest() {
+  return {
+    algorithm: "sha-256" as const,
+    domain: "collection-resolution.candidate-snapshot",
+    major_version: 1,
+    digest: "ab".repeat(32),
+  };
+}
+
+class NoopAudit implements AuditPort {
+  async invoke() {
+    return {
+      ok: true as const,
+      output: {} as never,
+      uncertain: false,
+      unmatchedRoleHolders: 0,
+    };
+  }
+}
+
+describe("CollectionReportOrchestrator", () => {
+  it("drives placed → producing and holds (no fake fulfill / no invalid-inputs)", async () => {
+    const store = new InMemoryOrderStore({ now: () => 1_700_000_500 });
+    await store.placeOrder(
+      {
+        order_id: "cr-ord-1",
+        product: "collection-report",
+        placed_by: "user-a",
+        inputs: {
+          schema_version: 1,
+          resolution_id: "res-1",
+          candidate_snapshot_digest: digest(),
+          community_ref: "mibera",
+        },
+        placed_at_unix: 1_700_000_500,
+        inputs_digest: "digest",
+      },
+      {
+        subject: ORDER_LIFECYCLE_SUBJECTS.placed,
+        payload: { order_id: "cr-ord-1" },
+      },
+    );
+
+    const orch = new CollectionReportOrchestrator({
+      store,
+      resolver: new ConfigCapabilityResolver({
+        "collection-index": {
+          building: "sonar-api",
+          endpoint: "http://sonar.internal",
+        },
+      }),
+      now: () => 1_700_000_500_000,
+    });
+
+    const result = await orch.process("cr-ord-1", (await store.get("cr-ord-1"))!);
+    expect(result.success).toBe(true);
+    const record = await store.get("cr-ord-1");
+    expect(record?.state).toBe("producing");
+    expect(record?.refusal).toBeUndefined();
+  });
+
+  it("OrderOrchestrator dispatches collection-report away from access-risk path", async () => {
+    const store = new InMemoryOrderStore({ now: () => 1_700_000_600 });
+    await store.placeOrder(
+      {
+        order_id: "cr-ord-2",
+        product: "collection-report",
+        placed_by: "user-a",
+        inputs: {
+          schema_version: 1,
+          resolution_id: "res-2",
+          candidate_snapshot_digest: digest(),
+          community_ref: "mibera",
+        },
+        placed_at_unix: 1_700_000_600,
+        inputs_digest: "digest",
+      },
+      {
+        subject: ORDER_LIFECYCLE_SUBJECTS.placed,
+        payload: { order_id: "cr-ord-2" },
+      },
+    );
+
+    const orchestrator = new OrderOrchestrator({
+      store,
+      resolver: new ConfigCapabilityResolver({
+        "collection-index": {
+          building: "sonar-api",
+          endpoint: "http://sonar.internal",
+        },
+      }),
+      audit: new NoopAudit(),
+      communities: () => undefined,
+      cta: CTA,
+      now: () => 1_700_000_600_000,
+    });
+
+    const result = await orchestrator.process("cr-ord-2");
+    expect(result.success).toBe(true);
+    const record = await store.get("cr-ord-2");
+    expect(record?.state).toBe("producing");
+    expect(record?.refusal?.code).toBeUndefined();
+  });
+});

--- a/packages/services/ordering/src/collection-report-orchestrator.ts
+++ b/packages/services/ordering/src/collection-report-orchestrator.ts
@@ -1,0 +1,145 @@
+/**
+ * Collection-report lifecycle driver (CR-303 honesty).
+ *
+ * Intake already admits a confirmed resolution binding. This orchestrator must
+ * NOT route through AccessRiskAuditInputs (that caused immediate invalid-inputs
+ * failures). V1 advances placed → routing → producing and holds in preparing
+ * until a real Gate Leak producer exists — no fake fulfill, no ETA theater.
+ */
+
+import {
+  ORDER_LIFECYCLE_SUBJECTS,
+  resolvePreset,
+  type OrderRouting,
+  type OrderProducing,
+  type OrderFailed,
+  type OrderRefusal,
+  type ResolvedBuilding,
+} from "@freeside/ordering-protocol";
+import { isTerminal, type OrderState } from "./order-state.js";
+import type { OrderStore, OrderRecord } from "./store.js";
+import {
+  type CapabilityResolver,
+  type ResolvedEndpoint,
+  CapabilityUnresolvedError,
+} from "./resolver.js";
+import type { PrivateOpsPublisher } from "./private-ops.js";
+import type { ProcessResult } from "./orchestrator.js";
+
+export interface CollectionReportOrchestratorDeps {
+  store: OrderStore;
+  resolver: CapabilityResolver;
+  now: () => number;
+  opsChannel?: PrivateOpsPublisher;
+}
+
+export class CollectionReportOrchestrator {
+  constructor(private readonly deps: CollectionReportOrchestratorDeps) {}
+
+  async process(orderId: string, record: OrderRecord): Promise<ProcessResult> {
+    if (isTerminal(record.state)) return { success: true };
+    if (record.product !== "collection-report") {
+      return {
+        success: false,
+        retryable: false,
+        error: new Error(`not a collection-report order: ${record.product}`),
+      };
+    }
+
+    const preset = resolvePreset("collection-report");
+    const parsedInputs = preset.inputSchema.safeParse(record.inputs);
+    if (!parsedInputs.success) {
+      return this.settleFailed(orderId, record.state, {
+        code: "invalid-inputs",
+        reason: "order inputs failed collection-report preset validation",
+      });
+    }
+
+    if (record.state === "placed") {
+      let resolved: ResolvedEndpoint[];
+      try {
+        resolved = [];
+        for (const cap of preset.capabilityNeeds) {
+          resolved.push(await this.deps.resolver.resolve(cap));
+        }
+      } catch (e) {
+        const cap = e instanceof CapabilityUnresolvedError ? e.capability : "unknown";
+        return this.settleFailed(orderId, "placed", {
+          code: "capability-unresolved",
+          reason: `a required capability could not be resolved: ${cap}`,
+        });
+      }
+
+      const resolved_buildings: ResolvedBuilding[] = resolved.map((r) => ({
+        capability: r.capability,
+        building: r.building,
+        endpoint: r.endpoint,
+        source: r.source,
+      }));
+      const routing: OrderRouting = {
+        order_id: orderId,
+        recipe_id: preset.id,
+        resolved_buildings,
+      };
+      const claim = await this.deps.store.transition(orderId, "placed", "routing", {
+        patch: { recipe_id: preset.id, resolved_buildings },
+        event: { subject: ORDER_LIFECYCLE_SUBJECTS.routing, payload: routing },
+      });
+      record = await this.reread(orderId, claim.ok ? claim.record : undefined);
+      if (isTerminal(record.state)) return { success: true };
+    }
+
+    if (record.state === "routing") {
+      const producing: OrderProducing = {
+        order_id: orderId,
+        step: 0,
+        step_label: preset.recipe[0]?.label ?? "prepare collection report",
+      };
+      // No fulfillment patch: CommunityOnboardingOutput shape is onboarding-only.
+      // Bare `producing` maps to user_status preparing_collection_data (CR-206).
+      const claim = await this.deps.store.transition(orderId, "routing", "producing", {
+        event: { subject: ORDER_LIFECYCLE_SUBJECTS.producing, payload: producing },
+      });
+      record = await this.reread(orderId, claim.ok ? claim.record : undefined);
+      if (isTerminal(record.state)) return { success: true };
+    }
+
+    // Hold in producing — Gate Leak artifact producer is not mounted yet.
+    // Honest UI maps this to "Preparing collection data" (not Needs attention).
+    if (record.state === "producing") {
+      return { success: true };
+    }
+
+    return { success: true };
+  }
+
+  private async settleFailed(
+    orderId: string,
+    expectedFrom: OrderState,
+    refusal: OrderRefusal,
+  ): Promise<ProcessResult> {
+    if (this.deps.opsChannel) {
+      await this.deps.opsChannel.emit({
+        order_id: orderId,
+        correlation_id: orderId,
+        cause: { code: refusal.code, reason: refusal.reason },
+      });
+    }
+    const failed: OrderFailed = { order_id: orderId, refusal };
+    await this.deps.store.transition(orderId, expectedFrom, "failed", {
+      patch: { refusal },
+      event: { subject: ORDER_LIFECYCLE_SUBJECTS.failed, payload: failed },
+    });
+    return { success: true };
+  }
+
+  private async reread(
+    orderId: string,
+    won: OrderRecord | undefined,
+  ): Promise<OrderRecord> {
+    if (won) return won;
+    const current = await this.deps.store.get(orderId);
+    if (!current) throw new Error(`order vanished mid-flight: ${orderId}`);
+    return current;
+  }
+}

--- a/packages/services/ordering/src/orchestrator.ts
+++ b/packages/services/ordering/src/orchestrator.ts
@@ -6,6 +6,7 @@ import { type AuditPort, type OperatedCommunityRegistry } from './audit-acl.js';
 import type { PrivateOpsPublisher } from './private-ops.js';
 import { AccessRiskAuditOrchestrator } from './access-risk-audit-orchestrator.js';
 import { CommunityOnboardingOrchestrator, type CommunityOnboardingOrchestratorDeps } from './community-onboarding-orchestrator.js';
+import { CollectionReportOrchestrator } from './collection-report-orchestrator.js';
 import type { TriagePorts } from './triage-ports.js';
 import { StubTriagePorts } from './triage-ports.js';
 import type { IngredientEnqueueService } from './ingredient-enqueue.js';
@@ -46,6 +47,7 @@ export interface OrchestratorDeps {
 export class OrderOrchestrator {
   private readonly accessRiskAudit: AccessRiskAuditOrchestrator;
   readonly communityOnboarding: CommunityOnboardingOrchestrator;
+  private readonly collectionReport: CollectionReportOrchestrator;
 
   constructor(private readonly deps: OrchestratorDeps) {
     const shared = {
@@ -66,6 +68,7 @@ export class OrderOrchestrator {
       enqueue: deps.enqueue,
       discordHealth: deps.discordHealth,
     });
+    this.collectionReport = new CollectionReportOrchestrator(shared);
   }
 
   async process(orderId: string): Promise<ProcessResult> {
@@ -77,6 +80,9 @@ export class OrderOrchestrator {
 
     if (record.product === 'community-onboarding') {
       return this.communityOnboarding.process(orderId, record);
+    }
+    if (record.product === 'collection-report') {
+      return this.collectionReport.process(orderId, record);
     }
     return this.accessRiskAudit.process(orderId, record);
   }


### PR DESCRIPTION
## Summary
- collection-report orders were dispatched to AccessRiskAuditOrchestrator and immediately failed with `invalid-inputs`
- Add CollectionReportOrchestrator: placed → routing → producing, then hold
- Reports UI maps producing → Preparing collection data (CR-206)

## Test plan
- [x] Unit tests for orchestrator + OrderOrchestrator dispatch
- [ ] Railway deploy + place new Art Blocks order → state producing, not failed


Made with [Cursor](https://cursor.com)