### PR TITLE
feat(ordering): CR-007A public resolution/order/demand authorization

### DIFF
--- a/packages/protocol/collection-resolution/README.md
+++ b/packages/protocol/collection-resolution/README.md
@@ -51,9 +51,10 @@ Canonical rules:
   scope — raw client candidate metadata is refused.
 
 The fixtures are protocol publication artifacts. `Dashboard` and `Sonar`
-consumer-shaped tests intentionally decode the same committed files; HTTP
-authorization endpoints and production Postgres adapters remain downstream work
-(CR-007A / persistence adapter).
+consumer-shaped tests intentionally decode the same committed files. CR-007A
+public authorization is ratified in `@freeside/public-authorization-protocol`
+and wired at the Ordering HTTP edge; production Postgres adapters and Identity
+grant-stream ingestion remain downstream.
 
 ## Pre-existing Ordering failures (out of CR-006 scope)
 

--- a/packages/protocol/public-authorization/README.md
+++ b/packages/protocol/public-authorization/README.md
@@ -1,0 +1,18 @@
+# `@freeside/public-authorization-protocol`
+
+CR-007A public subject-resource-action contract for T0/T1 boundaries.
+
+Ordering is the grant authority for `report:create`, `report:read`, and
+capability-demand permissions on the public path. Identity API membership
+streams and restricted grants (`report:identity-read`, artifact access) are
+CR-007B.
+
+This package defines:
+
+- public permission literals and the protected resource/action matrix;
+- BFF wire scopes with strict decoders;
+- membership/grant projection watermarks and 30-second authorization leases;
+- fixture-backed ACL vectors for cross-user, cross-community, revoked
+  membership, and client scope tampering.
+
+HTTP wiring and durable projection ingestion remain in `@freeside/ordering-service`.

--- a/packages/protocol/public-authorization/fixtures/acl/projection-baseline.valid.json
+++ b/packages/protocol/public-authorization/fixtures/acl/projection-baseline.valid.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "description": "Baseline T0/T1 fixture community with report:create and report:read grants",
+  "watermarks": {
+    "schema_version": 1,
+    "membership_stream_epoch": 1,
+    "membership_sequence": 10,
+    "grant_stream_epoch": 1,
+    "grant_sequence": 20,
+    "projected_at_unix_ms": 0
+  },
+  "memberships": [
+    { "subject_id": "subject-alice", "community_ref": "community-alpha", "active": true },
+    { "subject_id": "subject-bob", "community_ref": "community-alpha", "active": true },
+    { "subject_id": "subject-carol", "community_ref": "community-beta", "active": true }
+  ],
+  "grants": [
+    {
+      "subject_id": "subject-alice",
+      "community_ref": "community-alpha",
+      "permission": "report:create",
+      "active": true
+    },
+    {
+      "subject_id": "subject-alice",
+      "community_ref": "community-alpha",
+      "permission": "report:read",
+      "active": true
+    },
+    {
+      "subject_id": "subject-alice",
+      "community_ref": "community-alpha",
+      "permission": "demand:create",
+      "active": true
+    },
+    {
+      "subject_id": "subject-alice",
+      "community_ref": "community-alpha",
+      "permission": "demand:read",
+      "active": true
+    },
+    {
+      "subject_id": "subject-alice",
+      "community_ref": "community-alpha",
+      "permission": "demand:withdraw",
+      "active": true
+    },
+    {
+      "subject_id": "subject-bob",
+      "community_ref": "community-alpha",
+      "permission": "report:read",
+      "active": true
+    },
+    {
+      "subject_id": "subject-carol",
+      "community_ref": "community-beta",
+      "permission": "report:create",
+      "active": true
+    }
+  ]
+}

--- a/packages/protocol/public-authorization/fixtures/acl/scope-demand-create.valid.json
+++ b/packages/protocol/public-authorization/fixtures/acl/scope-demand-create.valid.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": 1,
+  "subject_id": "subject-alice",
+  "community_ref": "community-alpha",
+  "permission": "demand:create",
+  "idempotency_key": "demand-create-1"
+}

--- a/packages/protocol/public-authorization/fixtures/acl/scope-report-create.valid.json
+++ b/packages/protocol/public-authorization/fixtures/acl/scope-report-create.valid.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": 1,
+  "subject_id": "subject-alice",
+  "community_ref": "community-alpha",
+  "permission": "report:create",
+  "idempotency_key": "resolve-create-1"
+}

--- a/packages/protocol/public-authorization/fixtures/acl/scope-report-read.valid.json
+++ b/packages/protocol/public-authorization/fixtures/acl/scope-report-read.valid.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "subject_id": "subject-alice",
+  "community_ref": "community-alpha",
+  "permission": "report:read"
+}

--- a/packages/protocol/public-authorization/package.json
+++ b/packages/protocol/public-authorization/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@freeside/public-authorization-protocol",
+  "version": "1.0.0",
+  "description": "CR-007A public subject-resource-action authorization, grant projection watermarks, and short-lived leases for T0/T1 resolution, order, and capability-demand boundaries.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "fixtures",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "rm -rf dist",
+    "prepack": "pnpm run build",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "license": "AGPL-3.0",
+  "peerDependencies": {
+    "effect": "^3.21.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "effect": "^3.21.0",
+    "typescript": "^5.7.0",
+    "vitest": "^4.0.17"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/protocol/public-authorization/pnpm-lock.yaml
+++ b/packages/protocol/public-authorization/pnpm-lock.yaml
@@ -1,0 +1,796 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.1
+      effect:
+        specifier: ^3.21.0
+        version: 3.22.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.17
+        version: 4.1.10(@types/node@22.20.1)(vite@8.1.5(@types/node@22.20.1))
+
+packages:
+
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  effect@3.22.0:
+    resolution: {integrity: sha512-jhYFe0zTlIRqYFrKTS+6luhmS/Tm0f+JLo0K9KUxvtFab1SUGEszQi2ehOP6QzAZvy831lDmTwwzvVDZSPNz3g==}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  vite@8.1.5:
+    resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+snapshots:
+
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@oxc-project/types@0.139.0': {}
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@22.20.1))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.5(@types/node@22.20.1)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  assertion-error@2.0.1: {}
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  detect-libc@2.1.2: {}
+
+  effect@3.22.0:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
+  es-module-lexer@2.3.1: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fsevents@2.3.3:
+    optional: true
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  nanoid@3.3.16: {}
+
+  obug@2.1.4: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.19:
+    dependencies:
+      nanoid: 3.3.16
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  pure-rand@6.1.0: {}
+
+  rolldown@1.1.5:
+    dependencies:
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
+
+  tslib@2.8.1:
+    optional: true
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  vite@8.1.5(@types/node@22.20.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.19
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.1
+      fsevents: 2.3.3
+
+  vitest@4.1.10(@types/node@22.20.1)(vite@8.1.5(@types/node@22.20.1)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@22.20.1))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.5(@types/node@22.20.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.20.1
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/packages/protocol/public-authorization/src/__tests__/protocol.test.ts
+++ b/packages/protocol/public-authorization/src/__tests__/protocol.test.ts
@@ -1,0 +1,145 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { Effect } from "effect";
+import {
+  acquirePublicAuthorizationLease,
+  authorizePublicOperation,
+  AuthorizationDeniedError,
+  decodeFixtureProjectionBundle,
+  decodePublicAuthorizationScope,
+  fixtureProjectionFromBundle,
+  PUBLIC_AUTHORIZATION_LEASE_MAX_MS,
+  resolutionScopeToPublic,
+} from "../index.js";
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), "../../fixtures/acl");
+
+function readJson(name: string): unknown {
+  return JSON.parse(readFileSync(join(fixturesDir, name), "utf8"));
+}
+
+const NOW = 1_752_768_000_000;
+
+function baselineProjections() {
+  const bundle = Effect.runSync(decodeFixtureProjectionBundle(readJson("projection-baseline.valid.json")));
+  return fixtureProjectionFromBundle(bundle, NOW);
+}
+
+describe("public authorization protocol (CR-007A)", () => {
+  it("decodes public authorization scopes strictly", () => {
+    const scope = Effect.runSync(decodePublicAuthorizationScope(readJson("scope-report-create.valid.json")));
+    expect(scope.permission).toBe("report:create");
+  });
+
+  it("acquires a resolution create lease for an authorized subject", () => {
+    const { membership, grants } = baselineProjections();
+    const scope = Effect.runSync(decodePublicAuthorizationScope(readJson("scope-report-create.valid.json")));
+    const lease = acquirePublicAuthorizationLease({
+      operation: { resource: "resolution", action: "create" },
+      scope,
+      membership,
+      grants,
+      nowMs: NOW,
+    });
+    expect(lease.resource).toBe("resolution");
+    expect(lease.expires_at_unix_ms - lease.issued_at_unix_ms).toBe(
+      PUBLIC_AUTHORIZATION_LEASE_MAX_MS,
+    );
+  });
+
+  it("denies cross-community scope tampering", () => {
+    const { membership, grants } = baselineProjections();
+    const scope = Effect.runSync(decodePublicAuthorizationScope(readJson("scope-report-create.valid.json")));
+    expect(() =>
+      authorizePublicOperation({
+        operation: { resource: "resolution", action: "create" },
+        scope,
+        membership,
+        grants,
+        nowMs: NOW,
+        authoritativeCommunityRef: "community-beta",
+      }),
+    ).toThrow(AuthorizationDeniedError);
+  });
+
+  it("denies cross-user replay (subject mismatch)", () => {
+    const { membership, grants } = baselineProjections();
+    const scope = Effect.runSync(decodePublicAuthorizationScope(readJson("scope-report-create.valid.json")));
+    expect(() =>
+      authorizePublicOperation({
+        operation: { resource: "report_order", action: "detail" },
+        scope,
+        membership,
+        grants,
+        nowMs: NOW,
+        authoritativeSubjectId: "subject-bob",
+      }),
+    ).toThrow(AuthorizationDeniedError);
+  });
+
+  it("denies revoked membership", () => {
+    const bundle = Effect.runSync(decodeFixtureProjectionBundle(readJson("projection-baseline.valid.json")));
+    const revoked = {
+      ...bundle,
+      memberships: bundle.memberships.map((m) =>
+        m.subject_id === "subject-alice" ? { ...m, active: false } : m,
+      ),
+    };
+    const { membership, grants } = fixtureProjectionFromBundle(revoked, NOW);
+    const scope = Effect.runSync(decodePublicAuthorizationScope(readJson("scope-report-create.valid.json")));
+    expect(() =>
+      authorizePublicOperation({
+        operation: { resource: "resolution", action: "create" },
+        scope,
+        membership,
+        grants,
+        nowMs: NOW,
+      }),
+    ).toThrow(AuthorizationDeniedError);
+  });
+
+  it("denies permission revoked while membership remains", () => {
+    const bundle = Effect.runSync(decodeFixtureProjectionBundle(readJson("projection-baseline.valid.json")));
+    const revokedGrant = {
+      ...bundle,
+      grants: bundle.grants.map((g) =>
+        g.subject_id === "subject-alice" && g.permission === "report:create"
+          ? { ...g, active: false }
+          : g,
+      ),
+    };
+    const { membership, grants } = fixtureProjectionFromBundle(revokedGrant, NOW);
+    const scope = Effect.runSync(decodePublicAuthorizationScope(readJson("scope-report-create.valid.json")));
+    expect(() =>
+      authorizePublicOperation({
+        operation: { resource: "resolution", action: "create" },
+        scope,
+        membership,
+        grants,
+        nowMs: NOW,
+      }),
+    ).toThrow(AuthorizationDeniedError);
+  });
+
+  it("bridges CR-006 resolution scopes into public authorization", () => {
+    const publicScope = resolutionScopeToPublic({
+      schema_version: 1,
+      subject_id: "subject-alice",
+      community_ref: "community-alpha",
+      permission: "report:create",
+    });
+    expect(publicScope.community_ref).toBe("community-alpha");
+  });
+
+  it("rejects resolution scopes missing community_ref", () => {
+    expect(() =>
+      resolutionScopeToPublic({
+        schema_version: 1,
+        subject_id: "subject-alice",
+        permission: "report:create",
+      }),
+    ).toThrow(AuthorizationDeniedError);
+  });
+});

--- a/packages/protocol/public-authorization/src/authorize.ts
+++ b/packages/protocol/public-authorization/src/authorize.ts
@@ -1,0 +1,201 @@
+import { randomUUID } from "node:crypto";
+import { AuthorizationDeniedError } from "./errors.js";
+import {
+  type AuthorityWatermarks,
+  type AuthorizationDenial,
+  type AuthorizationLease,
+  type ProtectedOperation,
+  type PublicAuthorizationScope,
+  requiredPermissionFor,
+  scopesPermissionMatch,
+} from "./contracts.js";
+import {
+  PUBLIC_AUTHORIZATION_LEASE_MAX_MS,
+  PUBLIC_AUTHORIZATION_PROJECTION_MAX_LAG_MS,
+} from "./version.js";
+
+export interface MembershipProjectionView {
+  readonly isActiveMember: (subjectId: string, communityRef: string) => boolean;
+  readonly watermarks: AuthorityWatermarks;
+}
+
+export interface GrantProjectionView {
+  readonly hasGrant: (
+    subjectId: string,
+    communityRef: string,
+    permission: PublicAuthorizationScope["permission"],
+  ) => boolean;
+  readonly watermarks: Pick<AuthorityWatermarks, "grant_stream_epoch" | "grant_sequence">;
+}
+
+export interface AuthorizePublicOperationInput {
+  readonly operation: ProtectedOperation;
+  readonly scope: PublicAuthorizationScope;
+  readonly membership: MembershipProjectionView;
+  readonly grants: GrantProjectionView;
+  readonly nowMs: number;
+  readonly authoritativeCommunityRef?: string;
+  readonly authoritativeSubjectId?: string;
+}
+
+export interface AcquireLeaseInput extends AuthorizePublicOperationInput {
+  readonly leaseId?: string;
+}
+
+function mergeWatermarks(
+  membership: MembershipProjectionView,
+  grants: GrantProjectionView,
+): AuthorityWatermarks {
+  return {
+    schema_version: 1,
+    membership_stream_epoch: membership.watermarks.membership_stream_epoch,
+    membership_sequence: membership.watermarks.membership_sequence,
+    grant_stream_epoch: grants.watermarks.grant_stream_epoch,
+    grant_sequence: grants.watermarks.grant_sequence,
+    projected_at_unix_ms: membership.watermarks.projected_at_unix_ms,
+  };
+}
+
+function assertProjectionFresh(watermarks: AuthorityWatermarks, nowMs: number): void {
+  if (nowMs - watermarks.projected_at_unix_ms > PUBLIC_AUTHORIZATION_PROJECTION_MAX_LAG_MS) {
+    throw new AuthorizationDeniedError({
+      reason: "projection_stale",
+      safe_code: "forbidden",
+    });
+  }
+}
+
+function assertMembership(
+  scope: PublicAuthorizationScope,
+  membership: MembershipProjectionView,
+): void {
+  if (!membership.isActiveMember(scope.subject_id, scope.community_ref)) {
+    throw new AuthorizationDeniedError({
+      reason: "membership_revoked",
+      safe_code: "forbidden",
+    });
+  }
+}
+
+function assertGrant(
+  scope: PublicAuthorizationScope,
+  grants: GrantProjectionView,
+): void {
+  if (!grants.hasGrant(scope.subject_id, scope.community_ref, scope.permission)) {
+    throw new AuthorizationDeniedError({
+      reason: "permission_revoked",
+      safe_code: "forbidden",
+    });
+  }
+}
+
+function assertAuthoritativeScope(
+  scope: PublicAuthorizationScope,
+  authoritativeCommunityRef?: string,
+  authoritativeSubjectId?: string,
+): void {
+  if (
+    authoritativeCommunityRef !== undefined &&
+    scope.community_ref !== authoritativeCommunityRef
+  ) {
+    throw new AuthorizationDeniedError({
+      reason: "scope_tamper",
+      safe_code: "authorization_scope_mismatch",
+    });
+  }
+  if (
+    authoritativeSubjectId !== undefined &&
+    scope.subject_id !== authoritativeSubjectId
+  ) {
+    throw new AuthorizationDeniedError({
+      reason: "cross_subject",
+      safe_code: "authorization_scope_mismatch",
+    });
+  }
+}
+
+/** Fail-closed membership + grant recheck for a protected public operation. */
+export function authorizePublicOperation(input: AuthorizePublicOperationInput): void {
+  const required = requiredPermissionFor(input.operation);
+  if (required === undefined) {
+    throw new AuthorizationDeniedError({
+      reason: "unsupported_permission",
+      safe_code: "forbidden",
+    });
+  }
+  if (!scopesPermissionMatch(input.scope, input.operation)) {
+    throw new AuthorizationDeniedError({
+      reason: "scope_tamper",
+      safe_code: "authorization_scope_mismatch",
+    });
+  }
+
+  const watermarks = mergeWatermarks(input.membership, input.grants);
+  assertProjectionFresh(watermarks, input.nowMs);
+  assertAuthoritativeScope(
+    input.scope,
+    input.authoritativeCommunityRef,
+    input.authoritativeSubjectId,
+  );
+  assertMembership(input.scope, input.membership);
+  assertGrant(input.scope, input.grants);
+}
+
+/** Acquire a short database-stamped lease after authorizePublicOperation succeeds. */
+export function acquirePublicAuthorizationLease(
+  input: AcquireLeaseInput,
+): AuthorizationLease {
+  authorizePublicOperation(input);
+  const watermarks = mergeWatermarks(input.membership, input.grants);
+  const issuedAt = input.nowMs;
+  return {
+    schema_version: 1,
+    lease_id: input.leaseId ?? randomUUID(),
+    subject_id: input.scope.subject_id,
+    community_ref: input.scope.community_ref,
+    resource: input.operation.resource,
+    action: input.operation.action,
+    permission: input.scope.permission,
+    watermarks,
+    issued_at_unix_ms: issuedAt,
+    expires_at_unix_ms: issuedAt + PUBLIC_AUTHORIZATION_LEASE_MAX_MS,
+  };
+}
+
+export function assertLeaseValid(lease: AuthorizationLease, nowMs: number): void {
+  if (nowMs >= lease.expires_at_unix_ms) {
+    throw new AuthorizationDeniedError({
+      reason: "lease_expired",
+      safe_code: "forbidden",
+    });
+  }
+}
+
+export function toAuthorizationDenial(err: AuthorizationDeniedError): AuthorizationDenial {
+  return {
+    schema_version: 1,
+    code: err.safe_code,
+    reason: err.reason,
+  };
+}
+
+/** Bridge CR-006 resolution scopes (report:create only) into public authorization. */
+export function resolutionScopeToPublic(scope: {
+  schema_version: 1;
+  subject_id: string;
+  community_ref?: string;
+  permission: "report:create";
+}): PublicAuthorizationScope {
+  if (scope.community_ref === undefined) {
+    throw new AuthorizationDeniedError({
+      reason: "scope_tamper",
+      safe_code: "authorization_scope_mismatch",
+    });
+  }
+  return {
+    schema_version: 1,
+    subject_id: scope.subject_id,
+    community_ref: scope.community_ref,
+    permission: scope.permission,
+  };
+}

--- a/packages/protocol/public-authorization/src/contracts.ts
+++ b/packages/protocol/public-authorization/src/contracts.ts
@@ -1,0 +1,170 @@
+import { Schema } from "effect";
+import type { ParseOptions } from "effect/SchemaAST";
+import { PUBLIC_AUTHORIZATION_SCHEMA_VERSION } from "./version.js";
+
+const SchemaVersion = Schema.Literal(PUBLIC_AUTHORIZATION_SCHEMA_VERSION);
+const NonEmptyString = Schema.String.pipe(Schema.minLength(1));
+const SubjectId = NonEmptyString.pipe(Schema.maxLength(256)).annotations({
+  identifier: "SubjectId",
+});
+const CommunityRef = NonEmptyString.pipe(Schema.maxLength(256)).annotations({
+  identifier: "CommunityRef",
+});
+const IdempotencyKey = NonEmptyString.pipe(Schema.maxLength(256)).annotations({
+  identifier: "IdempotencyKey",
+});
+const LeaseId = NonEmptyString.pipe(Schema.maxLength(128)).annotations({
+  identifier: "LeaseId",
+});
+
+const strictOptions: ParseOptions = {
+  errors: "all",
+  onExcessProperty: "error",
+};
+
+/** Public-path permissions ratified by CR-007A. Restricted grants are CR-007B. */
+export const PublicPermission = Schema.Literal(
+  "report:create",
+  "report:read",
+  "demand:create",
+  "demand:read",
+  "demand:withdraw",
+).annotations({ identifier: "PublicPermission" });
+export type PublicPermission = Schema.Schema.Type<typeof PublicPermission>;
+
+export const ProtectedResource = Schema.Literal(
+  "resolution",
+  "report_order",
+  "capability_demand",
+).annotations({ identifier: "ProtectedResource" });
+export type ProtectedResource = Schema.Schema.Type<typeof ProtectedResource>;
+
+export const ProtectedAction = Schema.Literal(
+  "create",
+  "confirm",
+  "refresh",
+  "list",
+  "detail",
+  "withdraw",
+).annotations({ identifier: "ProtectedAction" });
+export type ProtectedAction = Schema.Schema.Type<typeof ProtectedAction>;
+
+/**
+ * BFF-supplied scope for a protected operation. Client community and subject
+ * claims are never authoritative — Ordering revalidates against projections.
+ */
+export const PublicAuthorizationScope = Schema.Struct({
+  schema_version: SchemaVersion,
+  subject_id: SubjectId,
+  community_ref: CommunityRef,
+  permission: PublicPermission,
+  idempotency_key: Schema.optionalWith(IdempotencyKey, { exact: true }),
+}).annotations({ identifier: "PublicAuthorizationScope" });
+export type PublicAuthorizationScope = Schema.Schema.Type<typeof PublicAuthorizationScope>;
+
+/** Local projection watermarks bound into every lease (SDD §11.1). */
+export const AuthorityWatermarks = Schema.Struct({
+  schema_version: SchemaVersion,
+  membership_stream_epoch: Schema.Number,
+  membership_sequence: Schema.Number,
+  grant_stream_epoch: Schema.Number,
+  grant_sequence: Schema.Number,
+  projected_at_unix_ms: Schema.Number,
+}).annotations({ identifier: "AuthorityWatermarks" });
+export type AuthorityWatermarks = Schema.Schema.Type<typeof AuthorityWatermarks>;
+
+/** Database-stamped short lease acquired at a protected boundary. */
+export const AuthorizationLease = Schema.Struct({
+  schema_version: SchemaVersion,
+  lease_id: LeaseId,
+  subject_id: SubjectId,
+  community_ref: CommunityRef,
+  resource: ProtectedResource,
+  action: ProtectedAction,
+  permission: PublicPermission,
+  watermarks: AuthorityWatermarks,
+  issued_at_unix_ms: Schema.Number,
+  expires_at_unix_ms: Schema.Number,
+}).annotations({ identifier: "AuthorizationLease" });
+export type AuthorizationLease = Schema.Schema.Type<typeof AuthorizationLease>;
+
+/** Safe denial envelope returned to BFF callers — no cross-tenant hints. */
+export const AuthorizationDenial = Schema.Struct({
+  schema_version: SchemaVersion,
+  code: Schema.Literal(
+    "unauthorized",
+    "forbidden",
+    "authorization_scope_mismatch",
+    "idempotency_conflict",
+    "rate_limited",
+  ),
+  reason: Schema.Literal(
+    "unauthenticated",
+    "membership_revoked",
+    "permission_revoked",
+    "community_mismatch",
+    "cross_subject",
+    "scope_tamper",
+    "projection_stale",
+    "projection_gap",
+    "lease_expired",
+    "unsupported_permission",
+    "idempotency_replay_mismatch",
+  ),
+}).annotations({ identifier: "AuthorizationDenial" });
+export type AuthorizationDenial = Schema.Schema.Type<typeof AuthorizationDenial>;
+
+export const ProtectedOperation = Schema.Struct({
+  resource: ProtectedResource,
+  action: ProtectedAction,
+}).annotations({ identifier: "ProtectedOperation" });
+export type ProtectedOperation = Schema.Schema.Type<typeof ProtectedOperation>;
+
+const decodePublicAuthorizationScopeStruct = Schema.decodeUnknown(
+  PublicAuthorizationScope,
+  strictOptions,
+);
+const decodeAuthorityWatermarksStruct = Schema.decodeUnknown(AuthorityWatermarks, strictOptions);
+const decodeAuthorizationLeaseStruct = Schema.decodeUnknown(AuthorizationLease, strictOptions);
+const decodeProtectedOperationStruct = Schema.decodeUnknown(ProtectedOperation, strictOptions);
+
+export const decodePublicAuthorizationScope = decodePublicAuthorizationScopeStruct;
+export const decodeAuthorityWatermarks = decodeAuthorityWatermarksStruct;
+export const decodeAuthorizationLease = decodeAuthorizationLeaseStruct;
+export const decodeProtectedOperation = decodeProtectedOperationStruct;
+
+/** Maps resource+action to the permission Ordering must recheck at the boundary. */
+export const REQUIRED_PERMISSION: Readonly<
+  Record<ProtectedResource, Partial<Record<ProtectedAction, PublicPermission>>>
+> = {
+  resolution: {
+    create: "report:create",
+    confirm: "report:create",
+    refresh: "report:create",
+  },
+  report_order: {
+    create: "report:create",
+    list: "report:read",
+    detail: "report:read",
+  },
+  capability_demand: {
+    create: "demand:create",
+    list: "demand:read",
+    detail: "demand:read",
+    withdraw: "demand:withdraw",
+  },
+};
+
+export function requiredPermissionFor(
+  operation: ProtectedOperation,
+): PublicPermission | undefined {
+  return REQUIRED_PERMISSION[operation.resource]?.[operation.action];
+}
+
+export function scopesPermissionMatch(
+  scope: PublicAuthorizationScope,
+  operation: ProtectedOperation,
+): boolean {
+  const required = requiredPermissionFor(operation);
+  return required !== undefined && scope.permission === required;
+}

--- a/packages/protocol/public-authorization/src/errors.ts
+++ b/packages/protocol/public-authorization/src/errors.ts
@@ -1,0 +1,25 @@
+import { Data } from "effect";
+
+export class AuthorizationDeniedError extends Data.TaggedError("AuthorizationDeniedError")<{
+  readonly reason:
+    | "unauthenticated"
+    | "membership_revoked"
+    | "permission_revoked"
+    | "community_mismatch"
+    | "cross_subject"
+    | "scope_tamper"
+    | "projection_stale"
+    | "projection_gap"
+    | "lease_expired"
+    | "unsupported_permission"
+    | "idempotency_replay_mismatch";
+  readonly safe_code:
+    | "unauthorized"
+    | "forbidden"
+    | "authorization_scope_mismatch"
+    | "idempotency_conflict";
+}> {}
+
+export class ContractIntegrityError extends Data.TaggedError("ContractIntegrityError")<{
+  readonly detail: string;
+}> {}

--- a/packages/protocol/public-authorization/src/fixture-projections.ts
+++ b/packages/protocol/public-authorization/src/fixture-projections.ts
@@ -1,0 +1,74 @@
+import { Schema } from "effect";
+import type { ParseOptions } from "effect/SchemaAST";
+import { PUBLIC_AUTHORIZATION_SCHEMA_VERSION } from "./version.js";
+import { AuthorityWatermarks, PublicPermission } from "./contracts.js";
+import type { GrantProjectionView, MembershipProjectionView } from "./authorize.js";
+import type { FixtureProjectionBundle } from "./fixture-types.js";
+
+export type { FixtureGrantRecord, FixtureMembershipRecord, FixtureProjectionBundle } from "./fixture-types.js";
+
+const strictOptions: ParseOptions = {
+  errors: "all",
+  onExcessProperty: "error",
+};
+
+const FixtureGrantRecordSchema = Schema.Struct({
+  subject_id: Schema.String,
+  community_ref: Schema.String,
+  permission: PublicPermission,
+  active: Schema.Boolean,
+});
+
+const FixtureMembershipRecordSchema = Schema.Struct({
+  subject_id: Schema.String,
+  community_ref: Schema.String,
+  active: Schema.Boolean,
+});
+
+export const FixtureProjectionBundleSchema = Schema.Struct({
+  schema_version: Schema.Literal(PUBLIC_AUTHORIZATION_SCHEMA_VERSION),
+  description: Schema.optional(Schema.String),
+  watermarks: AuthorityWatermarks,
+  memberships: Schema.Array(FixtureMembershipRecordSchema),
+  grants: Schema.Array(FixtureGrantRecordSchema),
+}).annotations({ identifier: "FixtureProjectionBundle" });
+
+export const decodeFixtureProjectionBundle = Schema.decodeUnknown(
+  FixtureProjectionBundleSchema,
+  strictOptions,
+);
+
+export function fixtureProjectionFromBundle(
+  bundle: FixtureProjectionBundle,
+  nowMs: number,
+): { membership: MembershipProjectionView; grants: GrantProjectionView } {
+  const membershipActive = new Set<string>();
+  for (const row of bundle.memberships) {
+    if (row.active) membershipActive.add(`${row.subject_id}\0${row.community_ref}`);
+  }
+  const grantActive = new Set<string>();
+  for (const row of bundle.grants) {
+    if (row.active) grantActive.add(`${row.subject_id}\0${row.community_ref}\0${row.permission}`);
+  }
+
+  const watermarks: AuthorityWatermarks = {
+    ...bundle.watermarks,
+    projected_at_unix_ms: nowMs,
+  };
+
+  return {
+    membership: {
+      watermarks,
+      isActiveMember: (subjectId, communityRef) =>
+        membershipActive.has(`${subjectId}\0${communityRef}`),
+    },
+    grants: {
+      watermarks: {
+        grant_stream_epoch: watermarks.grant_stream_epoch,
+        grant_sequence: watermarks.grant_sequence,
+      },
+      hasGrant: (subjectId, communityRef, permission) =>
+        grantActive.has(`${subjectId}\0${communityRef}\0${permission}`),
+    },
+  };
+}

--- a/packages/protocol/public-authorization/src/fixture-types.ts
+++ b/packages/protocol/public-authorization/src/fixture-types.ts
@@ -1,0 +1,28 @@
+import { Schema } from "effect";
+import { PublicPermission } from "./contracts.js";
+import { AuthorityWatermarks } from "./contracts.js";
+import { PUBLIC_AUTHORIZATION_SCHEMA_VERSION } from "./version.js";
+
+export const FixtureGrantRecord = Schema.Struct({
+  subject_id: Schema.String,
+  community_ref: Schema.String,
+  permission: PublicPermission,
+  active: Schema.Boolean,
+});
+export type FixtureGrantRecord = Schema.Schema.Type<typeof FixtureGrantRecord>;
+
+export const FixtureMembershipRecord = Schema.Struct({
+  subject_id: Schema.String,
+  community_ref: Schema.String,
+  active: Schema.Boolean,
+});
+export type FixtureMembershipRecord = Schema.Schema.Type<typeof FixtureMembershipRecord>;
+
+export const FixtureProjectionBundle = Schema.Struct({
+  schema_version: Schema.Literal(PUBLIC_AUTHORIZATION_SCHEMA_VERSION),
+  description: Schema.optional(Schema.String),
+  watermarks: AuthorityWatermarks,
+  memberships: Schema.Array(FixtureMembershipRecord),
+  grants: Schema.Array(FixtureGrantRecord),
+});
+export type FixtureProjectionBundle = Schema.Schema.Type<typeof FixtureProjectionBundle>;

--- a/packages/protocol/public-authorization/src/index.ts
+++ b/packages/protocol/public-authorization/src/index.ts
@@ -1,0 +1,53 @@
+/**
+ * @freeside/public-authorization-protocol
+ *
+ * CR-007A public subject-resource-action contract, grant/membership projection
+ * watermarks, and short-lived authorization leases for resolution, report-order,
+ * and capability-demand boundaries. Restricted artifact grants are CR-007B.
+ */
+
+export {
+  PUBLIC_AUTHORIZATION_SCHEMA_VERSION,
+  PUBLIC_AUTHORIZATION_LEASE_MAX_MS,
+  PUBLIC_AUTHORIZATION_PROJECTION_MAX_LAG_MS,
+} from "./version.js";
+
+export { AuthorizationDeniedError, ContractIntegrityError } from "./errors.js";
+
+export {
+  PublicPermission,
+  ProtectedResource,
+  ProtectedAction,
+  PublicAuthorizationScope,
+  AuthorityWatermarks,
+  AuthorizationLease,
+  AuthorizationDenial,
+  ProtectedOperation,
+  REQUIRED_PERMISSION,
+  decodePublicAuthorizationScope,
+  decodeAuthorityWatermarks,
+  decodeAuthorizationLease,
+  decodeProtectedOperation,
+  requiredPermissionFor,
+  scopesPermissionMatch,
+} from "./contracts.js";
+
+export {
+  type MembershipProjectionView,
+  type GrantProjectionView,
+  type AuthorizePublicOperationInput,
+  type AcquireLeaseInput,
+  authorizePublicOperation,
+  acquirePublicAuthorizationLease,
+  assertLeaseValid,
+  toAuthorizationDenial,
+  resolutionScopeToPublic,
+} from "./authorize.js";
+
+export {
+  type FixtureGrantRecord,
+  type FixtureMembershipRecord,
+  type FixtureProjectionBundle,
+  decodeFixtureProjectionBundle,
+  fixtureProjectionFromBundle,
+} from "./fixture-projections.js";

--- a/packages/protocol/public-authorization/src/version.ts
+++ b/packages/protocol/public-authorization/src/version.ts
@@ -1,0 +1,8 @@
+/** Wire contract version for CR-007A public authorization scopes and leases. */
+export const PUBLIC_AUTHORIZATION_SCHEMA_VERSION = 1 as const;
+
+/** Maximum interactive lease lifetime for public-path protected reads and mutations (SDD §11.1). */
+export const PUBLIC_AUTHORIZATION_LEASE_MAX_MS = 30_000;
+
+/** Authority projection freshness ceiling before fail-closed denial (SDD §11.1). */
+export const PUBLIC_AUTHORIZATION_PROJECTION_MAX_LAG_MS = 60_000;

--- a/packages/protocol/public-authorization/tsconfig.json
+++ b/packages/protocol/public-authorization/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "resolveJsonModule": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": false,
+    "composite": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/protocol/public-authorization/vitest.config.ts
+++ b/packages/protocol/public-authorization/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/services/ordering/bin/http.ts
+++ b/packages/services/ordering/bin/http.ts
@@ -27,11 +27,16 @@ import {
 import { DEFAULT_BASELINE_FIXTURE } from '../src/public-authorization-projections.js';
 import { InMemoryCapabilityDemandStore } from '../src/capability-demand-store.js';
 import { mountCapabilityDemandRoutes } from '../src/capability-demand-http.js';
+import {
+  publicAuthPostureFromEnv,
+  serviceTokenForPublicAuthMounts,
+} from '../src/public-auth-posture.js';
 
 const { store, orchestrator, enqueue } = await createOrderingComposition();
 
 const serviceToken = serviceTokenFromEnv();
 const writeRoutes = writeRoutePostureFromEnv();
+const publicAuthPosture = publicAuthPostureFromEnv();
 
 // FR-10a fail-closed: in a deployed environment with no SERVICE_TOKEN, the write routes
 // (advance-ingredient, reprobe) are never mounted. Reads + /healthz stay available.
@@ -40,6 +45,26 @@ if (!mountWrites) {
   // eslint-disable-next-line no-console
   console.error(
     '[ordering-service] SERVICE_TOKEN is unset in a deployed environment — write routes are DISABLED (fail-closed, FR-10a). Set SERVICE_TOKEN to enable advance-ingredient/reprobe.',
+  );
+}
+
+// CR-007A: never silently wire fixture ACL in deployed envs (BB review #496).
+const publicAuth = publicAuthPosture.allowFixture
+  ? createFixturePublicAuthorizationService(DEFAULT_BASELINE_FIXTURE)
+  : undefined;
+if (!publicAuth) {
+  // eslint-disable-next-line no-console
+  console.error(
+    `[ordering-service] public authorization DISABLED (${publicAuthPosture.mode}` +
+      `${publicAuthPosture.reason ? `: ${publicAuthPosture.reason}` : ''}). ` +
+      'Set PUBLIC_AUTH_MODE=fixture and PUBLIC_AUTH_FIXTURE_WAIVER=t0_t1 for lab-only, or wait for CR-007B identity projections.',
+  );
+}
+const publicAuthToken = serviceTokenForPublicAuthMounts(writeRoutes, serviceToken);
+if (publicAuthToken.kind === 'refuse') {
+  // eslint-disable-next-line no-console
+  console.error(
+    '[ordering-service] public-auth mounts REFUSED — deployed without SERVICE_TOKEN (FR-10a parity).',
   );
 }
 
@@ -59,8 +84,11 @@ const resolutionService = new CollectionResolutionService({
   sonar: sonarProbe,
 });
 
-const publicAuth = createFixturePublicAuthorizationService(DEFAULT_BASELINE_FIXTURE);
 const capabilityDemandStore = new InMemoryCapabilityDemandStore();
+const mountPublicAuthRoutes =
+  publicAuth !== undefined && publicAuthToken.kind !== 'refuse';
+const publicAuthServiceToken =
+  publicAuthToken.kind === 'token' ? publicAuthToken.token : undefined;
 
 const app = createIntakeApp({
   store,
@@ -73,16 +101,23 @@ const app = createIntakeApp({
   serviceTokenLabel: serviceTokenLabelFromEnv(),
   resolutionService,
   resolutionStore,
-  publicAuth,
+  publicAuth: mountPublicAuthRoutes ? publicAuth : undefined,
   healthz: {
     store: process.env.DATABASE_URL ? 'postgres' : 'memory',
     kitchen_enqueue: Boolean(enqueue),
     write_routes: writeRoutes,
     collection_resolutions: true,
-    collection_reports: true,
+    collection_reports: mountPublicAuthRoutes,
     report_attention: true,
-    capability_demands: true,
-    public_authorization: true,
+    capability_demands: {
+      enabled: mountPublicAuthRoutes,
+      store: 'memory',
+    },
+    public_authorization: {
+      mode: publicAuthPosture.mode,
+      wired: mountPublicAuthRoutes,
+      reason: publicAuthPosture.reason,
+    },
     resolve_probe: resolutionProbeMode,
   },
 });
@@ -92,32 +127,35 @@ const attentionStore =
     ? new PostgresReportAttentionStore(store.getPool())
     : new InMemoryReportAttentionStore();
 
-// CR-006: mount create/confirm/refresh. Token posture matches write routes —
-// when SERVICE_TOKEN is set, Bearer is required; open_dev allows tokenless.
+// CR-006: mount create/confirm/refresh. When public-auth is refused/disabled,
+// mount without auth so probe/read paths stay available; mutable ACL paths
+// inside the mount fail closed if auth is required by the handler.
 mountCollectionResolutionRoutes(app, {
   store: resolutionStore,
   sonar: sonarProbe,
   service: resolutionService,
-  serviceToken: writeRoutes === 'token' ? serviceToken : undefined,
-  auth: publicAuth,
+  serviceToken: publicAuthServiceToken,
+  auth: mountPublicAuthRoutes ? publicAuth : undefined,
 });
 
-// CR-206: authenticated collection-report list/detail projections.
-mountCollectionReportRoutes(app, {
-  store,
-  resolutionStore,
-  attentionStore,
-  serviceToken: writeRoutes === 'token' ? serviceToken : undefined,
-  auth: publicAuth,
-});
+// CR-206: authenticated collection-report list/detail — require wired public auth.
+if (mountPublicAuthRoutes && publicAuth) {
+  mountCollectionReportRoutes(app, {
+    store,
+    resolutionStore,
+    attentionStore,
+    serviceToken: publicAuthServiceToken,
+    auth: publicAuth,
+  });
 
-// CR-007A: capability-demand authorization contract (CR-208 extends lifecycle).
-mountCapabilityDemandRoutes(app, {
-  store: capabilityDemandStore,
-  auth: publicAuth,
-  serviceToken: writeRoutes === 'token' ? serviceToken : undefined,
-  now: () => Date.now(),
-});
+  // CR-007A: capability-demand authorization contract (CR-208 extends lifecycle).
+  mountCapabilityDemandRoutes(app, {
+    store: capabilityDemandStore,
+    auth: publicAuth,
+    serviceToken: publicAuthServiceToken,
+    now: () => Date.now(),
+  });
+}
 
 // CR-305: idempotent mark-seen for report attention.
 mountReportAttentionRoutes(app, {
@@ -135,5 +173,5 @@ const port = Number(process.env.PORT ?? 8090);
 serve({ fetch: app.fetch, port });
 // eslint-disable-next-line no-console
 console.log(
-  `ordering-service listening on :${port} (write_routes=${writeRoutes}, resolve_probe=${resolutionProbeMode})`,
+  `ordering-service listening on :${port} (write_routes=${writeRoutes}, resolve_probe=${resolutionProbeMode}, public_auth=${publicAuthPosture.mode}/wired=${mountPublicAuthRoutes})`,
 );

--- a/packages/services/ordering/bin/http.ts
+++ b/packages/services/ordering/bin/http.ts
@@ -21,6 +21,12 @@ import { sonarResolveProbeFromEnv } from '../src/sonar-resolve-probe-client.js';
 import { PostgresOrderStore } from '../src/store-postgres.js';
 import { InMemoryReportAttentionStore } from '../src/report-attention-store.js';
 import { PostgresReportAttentionStore } from '../src/report-attention-store-postgres.js';
+import {
+  createFixturePublicAuthorizationService,
+} from '../src/public-authorization-service.js';
+import { DEFAULT_BASELINE_FIXTURE } from '../src/public-authorization-projections.js';
+import { InMemoryCapabilityDemandStore } from '../src/capability-demand-store.js';
+import { mountCapabilityDemandRoutes } from '../src/capability-demand-http.js';
 
 const { store, orchestrator, enqueue } = await createOrderingComposition();
 
@@ -47,10 +53,14 @@ const probeModeOverride = process.env.COLLECTION_RESOLVE_PROBE_MODE?.trim().toLo
 const httpSonarProbe =
   probeModeOverride === 'catalog' ? undefined : sonarResolveProbeFromEnv();
 const sonarProbe = httpSonarProbe ?? createCatalogResolveProbePort();
-const resolutionProbeMode = httpSonarProbe ? 'http' : 'catalog';const resolutionService = new CollectionResolutionService({
+const resolutionProbeMode = httpSonarProbe ? 'http' : 'catalog';
+const resolutionService = new CollectionResolutionService({
   store: resolutionStore,
   sonar: sonarProbe,
 });
+
+const publicAuth = createFixturePublicAuthorizationService(DEFAULT_BASELINE_FIXTURE);
+const capabilityDemandStore = new InMemoryCapabilityDemandStore();
 
 const app = createIntakeApp({
   store,
@@ -63,6 +73,7 @@ const app = createIntakeApp({
   serviceTokenLabel: serviceTokenLabelFromEnv(),
   resolutionService,
   resolutionStore,
+  publicAuth,
   healthz: {
     store: process.env.DATABASE_URL ? 'postgres' : 'memory',
     kitchen_enqueue: Boolean(enqueue),
@@ -70,6 +81,8 @@ const app = createIntakeApp({
     collection_resolutions: true,
     collection_reports: true,
     report_attention: true,
+    capability_demands: true,
+    public_authorization: true,
     resolve_probe: resolutionProbeMode,
   },
 });
@@ -86,6 +99,7 @@ mountCollectionResolutionRoutes(app, {
   sonar: sonarProbe,
   service: resolutionService,
   serviceToken: writeRoutes === 'token' ? serviceToken : undefined,
+  auth: publicAuth,
 });
 
 // CR-206: authenticated collection-report list/detail projections.
@@ -94,6 +108,15 @@ mountCollectionReportRoutes(app, {
   resolutionStore,
   attentionStore,
   serviceToken: writeRoutes === 'token' ? serviceToken : undefined,
+  auth: publicAuth,
+});
+
+// CR-007A: capability-demand authorization contract (CR-208 extends lifecycle).
+mountCapabilityDemandRoutes(app, {
+  store: capabilityDemandStore,
+  auth: publicAuth,
+  serviceToken: writeRoutes === 'token' ? serviceToken : undefined,
+  now: () => Date.now(),
 });
 
 // CR-305: idempotent mark-seen for report attention.

--- a/packages/services/ordering/package.json
+++ b/packages/services/ordering/package.json
@@ -29,6 +29,7 @@
     "zod": "^3.23.8",
     "@freeside/collection-protocol": "file:../../protocol/collection",
     "@freeside/collection-resolution-protocol": "file:../../protocol/collection-resolution",
+    "@freeside/public-authorization-protocol": "file:../../protocol/public-authorization",
     "effect": "^3.21.0"
   },
   "devDependencies": {

--- a/packages/services/ordering/pnpm-lock.yaml
+++ b/packages/services/ordering/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@freeside/ordering-protocol':
         specifier: file:../../protocol/ordering
         version: file:../../protocol/ordering(zod@3.25.76)
+      '@freeside/public-authorization-protocol':
+        specifier: file:../../protocol/public-authorization
+        version: file:../../protocol/public-authorization(effect@3.22.0)
       '@freeside/shadow-audit-protocol':
         specifier: file:../../protocol/shadow-audit
         version: file:../../protocol/shadow-audit(zod@3.25.76)
@@ -338,6 +341,11 @@ packages:
     resolution: {directory: ../../protocol/ordering, type: directory}
     peerDependencies:
       zod: ^3.23.0
+
+  '@freeside/public-authorization-protocol@file:../../protocol/public-authorization':
+    resolution: {directory: ../../protocol/public-authorization, type: directory}
+    peerDependencies:
+      effect: ^3.21.0
 
   '@freeside/shadow-audit-protocol@file:../../protocol/shadow-audit':
     resolution: {directory: ../../protocol/shadow-audit, type: directory}
@@ -1526,6 +1534,10 @@ snapshots:
   '@freeside/ordering-protocol@file:../../protocol/ordering(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
+
+  '@freeside/public-authorization-protocol@file:../../protocol/public-authorization(effect@3.22.0)':
+    dependencies:
+      effect: 3.22.0
 
   '@freeside/shadow-audit-protocol@file:../../protocol/shadow-audit(zod@3.25.76)':
     dependencies:

--- a/packages/services/ordering/src/__tests__/collection-report-http.test.ts
+++ b/packages/services/ordering/src/__tests__/collection-report-http.test.ts
@@ -79,7 +79,7 @@ async function seed(
   }
 }
 
-function appWith(store: InMemoryOrderStore, withAuth = false) {
+function appWith(store: InMemoryOrderStore, withAuth = true) {
   const app = new Hono();
   mountCollectionReportRoutes(app, {
     store,
@@ -94,45 +94,57 @@ describe("CR-206 collection-report HTTP", () => {
     const store = new InMemoryOrderStore({ now: () => 1_700_000_000 });
     const app = appWith(store);
     const res = await app.request(
-      "/v1/collection-reports?community_ref=mibera&subject_id=user-a",
+      "/v1/collection-reports?community_ref=community-alpha&subject_id=subject-alice",
     );
     expect(res.status).toBe(401);
+  });
+
+  it("fails closed when auth is omitted from the mount", async () => {
+    const store = new InMemoryOrderStore({ now: () => 1_700_000_000 });
+    const app = appWith(store, false);
+    const res = await app.request(
+      "/v1/collection-reports?community_ref=community-alpha&subject_id=subject-alice",
+      { headers: { authorization: `Bearer ${TOKEN}` } },
+    );
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("public_authorization_unconfigured");
   });
 
   it("lists only the subject+community rows with safe projection", async () => {
     const store = new InMemoryOrderStore({ now: () => 1_700_000_000 });
     await seed(store, {
       order_id: "ord-a",
-      placed_by: "user-a",
-      community_ref: "mibera",
+      placed_by: "subject-alice",
+      community_ref: "community-alpha",
       state: "fulfilled",
       created_at_unix: 100,
     });
     await seed(store, {
       order_id: "ord-b",
-      placed_by: "user-a",
-      community_ref: "mibera",
+      placed_by: "subject-alice",
+      community_ref: "community-alpha",
       state: "placed",
       created_at_unix: 90,
     });
     await seed(store, {
       order_id: "ord-other-user",
-      placed_by: "user-b",
-      community_ref: "mibera",
+      placed_by: "subject-bob",
+      community_ref: "community-alpha",
       state: "placed",
       created_at_unix: 110,
     });
     await seed(store, {
       order_id: "ord-other-community",
-      placed_by: "user-a",
-      community_ref: "other",
+      placed_by: "subject-alice",
+      community_ref: "community-beta",
       state: "placed",
       created_at_unix: 120,
     });
 
     const app = appWith(store);
     const res = await app.request(
-      "/v1/collection-reports?community_ref=mibera&subject_id=user-a&limit=10",
+      "/v1/collection-reports?community_ref=community-alpha&subject_id=subject-alice&limit=10",
       { headers: { authorization: `Bearer ${TOKEN}` } },
     );
     expect(res.status).toBe(200);
@@ -202,26 +214,26 @@ describe("CR-206 collection-report HTTP", () => {
     const store = new InMemoryOrderStore({ now: () => 1_700_000_000 });
     await seed(store, {
       order_id: "ord-3",
-      placed_by: "user-a",
-      community_ref: "mibera",
+      placed_by: "subject-alice",
+      community_ref: "community-alpha",
       created_at_unix: 30,
     });
     await seed(store, {
       order_id: "ord-2",
-      placed_by: "user-a",
-      community_ref: "mibera",
+      placed_by: "subject-alice",
+      community_ref: "community-alpha",
       created_at_unix: 20,
     });
     await seed(store, {
       order_id: "ord-1",
-      placed_by: "user-a",
-      community_ref: "mibera",
+      placed_by: "subject-alice",
+      community_ref: "community-alpha",
       created_at_unix: 10,
     });
 
     const app = appWith(store);
     const page1 = await app.request(
-      "/v1/collection-reports?community_ref=mibera&subject_id=user-a&limit=2",
+      "/v1/collection-reports?community_ref=community-alpha&subject_id=subject-alice&limit=2",
       { headers: { authorization: `Bearer ${TOKEN}` } },
     );
     const body1 = (await page1.json()) as {
@@ -232,7 +244,7 @@ describe("CR-206 collection-report HTTP", () => {
     expect(body1.next_cursor).toBeTruthy();
 
     const page2 = await app.request(
-      `/v1/collection-reports?community_ref=mibera&subject_id=user-a&limit=2&cursor=${encodeURIComponent(body1.next_cursor)}`,
+      `/v1/collection-reports?community_ref=community-alpha&subject_id=subject-alice&limit=2&cursor=${encodeURIComponent(body1.next_cursor)}`,
       { headers: { authorization: `Bearer ${TOKEN}` } },
     );
     const body2 = (await page2.json()) as {

--- a/packages/services/ordering/src/__tests__/collection-report-http.test.ts
+++ b/packages/services/ordering/src/__tests__/collection-report-http.test.ts
@@ -1,11 +1,22 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { Hono } from "hono";
 
 import { mountCollectionReportRoutes } from "../collection-report-http.js";
 import { InMemoryOrderStore } from "../store.js";
 import { ORDER_LIFECYCLE_SUBJECTS } from "@freeside/ordering-protocol";
+import { createFixturePublicAuthorizationService } from "../public-authorization-service.js";
 
 const TOKEN = "test-service-token";
+const fixtureDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../protocol/public-authorization/fixtures/acl",
+);
+const baselineFixture = JSON.parse(
+  readFileSync(join(fixtureDir, "projection-baseline.valid.json"), "utf8"),
+);
 
 function digest() {
   return {
@@ -68,9 +79,13 @@ async function seed(
   }
 }
 
-function appWith(store: InMemoryOrderStore) {
+function appWith(store: InMemoryOrderStore, withAuth = false) {
   const app = new Hono();
-  mountCollectionReportRoutes(app, { store, serviceToken: TOKEN });
+  mountCollectionReportRoutes(app, {
+    store,
+    serviceToken: TOKEN,
+    auth: withAuth ? createFixturePublicAuthorizationService(baselineFixture) : undefined,
+  });
   return app;
 }
 
@@ -139,20 +154,48 @@ describe("CR-206 collection-report HTTP", () => {
     expect(body.items[0]).not.toHaveProperty("inputs");
   });
 
-  it("denies cross-subject detail", async () => {
+  it("denies detail when membership is revoked under CR-007A auth", async () => {
     const store = new InMemoryOrderStore({ now: () => 1_700_000_000 });
     await seed(store, {
       order_id: "ord-a",
-      placed_by: "user-a",
-      community_ref: "mibera",
+      placed_by: "subject-alice",
+      community_ref: "community-alpha",
       state: "placed",
     });
-    const app = appWith(store);
+    const revokedFixture = {
+      ...baselineFixture,
+      memberships: baselineFixture.memberships.map(
+        (m: { subject_id: string; community_ref: string; active: boolean }) =>
+          m.subject_id === "subject-bob" ? { ...m, active: false } : m,
+      ),
+    };
+    const app = new Hono();
+    mountCollectionReportRoutes(app, {
+      store,
+      serviceToken: TOKEN,
+      auth: createFixturePublicAuthorizationService(revokedFixture),
+    });
     const res = await app.request(
-      "/v1/collection-reports/ord-a?community_ref=mibera&subject_id=user-b",
+      "/v1/collection-reports/ord-a?community_ref=community-alpha&subject_id=subject-bob",
       { headers: { authorization: `Bearer ${TOKEN}` } },
     );
     expect(res.status).toBe(403);
+  });
+
+  it("allows report:read holder to open another member's order in the same community", async () => {
+    const store = new InMemoryOrderStore({ now: () => 1_700_000_000 });
+    await seed(store, {
+      order_id: "ord-a",
+      placed_by: "subject-alice",
+      community_ref: "community-alpha",
+      state: "placed",
+    });
+    const app = appWith(store, true);
+    const res = await app.request(
+      "/v1/collection-reports/ord-a?community_ref=community-alpha&subject_id=subject-bob",
+      { headers: { authorization: `Bearer ${TOKEN}` } },
+    );
+    expect(res.status).toBe(200);
   });
 
   it("pages with immutable created_at+order_id cursor", async () => {

--- a/packages/services/ordering/src/__tests__/public-auth-posture.test.ts
+++ b/packages/services/ordering/src/__tests__/public-auth-posture.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolvePublicAuthPosture,
+  serviceTokenForPublicAuthMounts,
+} from "../public-auth-posture.js";
+import { createFixturePublicAuthorizationService } from "../public-authorization-service.js";
+import { DEFAULT_BASELINE_FIXTURE } from "../public-authorization-projections.js";
+import { AuthorizationDeniedError } from "@freeside/public-authorization-protocol";
+
+describe("resolvePublicAuthPosture", () => {
+  it("defaults to fixture in local/dev", () => {
+    const p = resolvePublicAuthPosture({ nodeEnv: "development" });
+    expect(p.mode).toBe("fixture");
+    expect(p.allowFixture).toBe(true);
+  });
+
+  it("defaults to disabled when deployed and mode unset", () => {
+    const p = resolvePublicAuthPosture({ nodeEnv: "production" });
+    expect(p.mode).toBe("disabled");
+    expect(p.allowFixture).toBe(false);
+  });
+
+  it("allows deployed fixture only with t0_t1 waiver", () => {
+    expect(
+      resolvePublicAuthPosture({
+        mode: "fixture",
+        nodeEnv: "production",
+      }).allowFixture,
+    ).toBe(false);
+    expect(
+      resolvePublicAuthPosture({
+        mode: "fixture",
+        fixtureWaiver: "t0_t1",
+        railwayEnvironment: "production",
+      }).allowFixture,
+    ).toBe(true);
+  });
+
+  it("refuses identity until CR-007B port exists", () => {
+    const p = resolvePublicAuthPosture({ mode: "identity" });
+    expect(p.mode).toBe("identity");
+    expect(p.allowFixture).toBe(false);
+  });
+});
+
+describe("serviceTokenForPublicAuthMounts — FR-10a", () => {
+  it("refuses when write routes are disabled_no_token", () => {
+    expect(serviceTokenForPublicAuthMounts("disabled_no_token", undefined)).toEqual({
+      kind: "refuse",
+    });
+  });
+
+  it("requires token when write posture is token", () => {
+    expect(serviceTokenForPublicAuthMounts("token", "secret")).toEqual({
+      kind: "token",
+      token: "secret",
+    });
+    expect(serviceTokenForPublicAuthMounts("token", undefined).kind).toBe("refuse");
+  });
+
+  it("allows open_dev without token", () => {
+    expect(serviceTokenForPublicAuthMounts("open_dev", undefined)).toEqual({
+      kind: "open_dev",
+    });
+  });
+});
+
+describe("fixture ACL blast radius", () => {
+  it("denies live-shaped CM subject_id under DEFAULT_BASELINE_FIXTURE", () => {
+    const auth = createFixturePublicAuthorizationService(
+      DEFAULT_BASELINE_FIXTURE,
+      () => 1_752_768_000_000,
+    );
+    expect(() =>
+      auth.acquireLease({
+        operation: { resource: "report_order", action: "list" },
+        scope: {
+          schema_version: 1,
+          subject_id: "11111111-1111-1111-1111-111111111111",
+          community_ref: "mibera",
+          permission: "report:read",
+        },
+        authoritativeCommunityRef: "mibera",
+        authoritativeSubjectId: "11111111-1111-1111-1111-111111111111",
+      }),
+    ).toThrow(AuthorizationDeniedError);
+  });
+});

--- a/packages/services/ordering/src/__tests__/public-authorization-http.test.ts
+++ b/packages/services/ordering/src/__tests__/public-authorization-http.test.ts
@@ -1,0 +1,164 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { mountCapabilityDemandRoutes } from "../capability-demand-http.js";
+import { InMemoryCapabilityDemandStore } from "../capability-demand-store.js";
+import { createFixturePublicAuthorizationService } from "../public-authorization-service.js";
+import { mountCollectionResolutionRoutes } from "../resolution-http.js";
+import { InMemoryResolutionStore } from "../resolution-store.js";
+import { CollectionResolutionService } from "../resolution-service.js";
+
+const fixtureDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../protocol/public-authorization/fixtures/acl",
+);
+
+function readJson(name: string): unknown {
+  return JSON.parse(readFileSync(join(fixtureDir, name), "utf8"));
+}
+
+const NOW = 1_752_768_000_000;
+const TOKEN = "service-secret";
+
+function authApp() {
+  const auth = createFixturePublicAuthorizationService(readJson("projection-baseline.valid.json"), () => NOW);
+  const app = new Hono();
+  mountCapabilityDemandRoutes(app, {
+    store: new InMemoryCapabilityDemandStore(),
+    auth,
+    serviceToken: TOKEN,
+    now: () => NOW,
+  });
+  return app;
+}
+
+describe("CR-007A public authorization HTTP", () => {
+  it("denies capability-demand create without service bearer", async () => {
+    const res = await authApp().request("/v1/capability-demands", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        command: {
+          schema_version: 1,
+          deployment_set_digest: "dep-set-1",
+          required_capability: "ownership_index.v1",
+          policy_version: "policy-1",
+          resolution_id: "res-1",
+        },
+        authorization_scope: readJson("scope-demand-create.valid.json"),
+      }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("creates capability demand for authorized subject", async () => {
+    const res = await authApp().request("/v1/capability-demands", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        command: {
+          schema_version: 1,
+          deployment_set_digest: "dep-set-1",
+          required_capability: "ownership_index.v1",
+          policy_version: "policy-1",
+          resolution_id: "res-1",
+        },
+        authorization_scope: readJson("scope-demand-create.valid.json"),
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { demand_id: string; state: string };
+    expect(body.demand_id.length).toBeGreaterThan(0);
+    expect(body.state).toBe("open");
+  });
+
+  it("denies cross-community scope tampering on resolution create", async () => {
+    const auth = createFixturePublicAuthorizationService(readJson("projection-baseline.valid.json"), () => NOW);
+    const store = new InMemoryResolutionStore();
+    const sonar = {
+      resolveProbe: async () => ({
+        capability_snapshot_version: {
+          schema_version: 1 as const,
+          registry_epoch: 1,
+          registry_sequence: 1,
+        },
+        candidates: [],
+        diagnostics: {
+          schema_version: 1 as const,
+          searched: [],
+          timed_out: [],
+          unavailable: [],
+        },
+      }),
+    };
+    const service = new CollectionResolutionService({ store, sonar });
+    const app = new Hono();
+    mountCollectionResolutionRoutes(app, {
+      store,
+      sonar,
+      service,
+      serviceToken: TOKEN,
+      auth,
+    });
+
+    const scope = readJson("scope-report-create.valid.json") as Record<string, unknown>;
+    const res = await app.request("/v1/collection-resolutions", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        command: {
+          schema_version: 1,
+          identifier: "0xabc",
+          environment: "mainnet",
+          report_type: "gate_leak",
+          report_version: "1",
+          community_ref: "community-beta",
+          idempotency_key: "k1",
+        },
+        authorization_scope: scope,
+      }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("replays equivalent capability demand idempotency keys", async () => {
+    const app = authApp();
+    const body = {
+      command: {
+        schema_version: 1,
+        deployment_set_digest: "dep-set-1",
+        required_capability: "ownership_index.v1",
+        policy_version: "policy-1",
+        resolution_id: "res-1",
+      },
+      authorization_scope: readJson("scope-demand-create.valid.json"),
+    };
+    const headers = {
+      authorization: `Bearer ${TOKEN}`,
+      "content-type": "application/json",
+    };
+    const first = await app.request("/v1/capability-demands", {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+    const second = await app.request("/v1/capability-demands", {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    const firstBody = (await first.json()) as { demand_id: string };
+    const secondBody = (await second.json()) as { demand_id: string };
+    expect(firstBody.demand_id).toBe(secondBody.demand_id);
+  });
+});

--- a/packages/services/ordering/src/capability-demand-http.ts
+++ b/packages/services/ordering/src/capability-demand-http.ts
@@ -1,0 +1,245 @@
+/**
+ * CR-007A capability-demand HTTP edge (authorization contract; CR-208 owns full lifecycle).
+ *
+ *   POST   /v1/capability-demands
+ *   GET    /v1/capability-demands
+ *   GET    /v1/capability-demands/:demand_id
+ *   DELETE /v1/capability-demands/:demand_id
+ *
+ * Auth: Bearer SERVICE_TOKEN (Dashboard BFF) + authorization_scope recheck.
+ * Public projections expose no subscriber counts or cross-tenant demand.
+ */
+
+import { Hono, type Context } from "hono";
+import { z } from "zod";
+import type { PublicAuthorizationService } from "./public-authorization-service.js";
+import {
+  noStoreHeaders,
+  readAuthorizedBody,
+  requireServiceBearer,
+} from "./public-authorization-http.js";
+import {
+  type CapabilityDemandStore,
+  toPublicCapabilityDemandProjection,
+} from "./capability-demand-store.js";
+
+export interface CapabilityDemandHttpDeps {
+  readonly store: CapabilityDemandStore;
+  readonly auth: PublicAuthorizationService;
+  readonly serviceToken?: string;
+  readonly now: () => number;
+}
+
+const CreateCommandSchema = z
+  .object({
+    schema_version: z.literal(1),
+    deployment_set_digest: z.string().min(1).max(256),
+    required_capability: z.string().min(1).max(128),
+    policy_version: z.string().min(1).max(64),
+    resolution_id: z.string().min(1).max(128),
+  })
+  .strict();
+
+const ScopeQuerySchema = z
+  .object({
+    community_ref: z.string().min(1).max(256),
+    subject_id: z.string().min(1).max(256),
+    limit: z.coerce.number().int().min(1).max(100).optional(),
+  })
+  .strict();
+
+function errorJson(c: Context, status: 400 | 401 | 403 | 404 | 409, code: string) {
+  return c.json({ schema_version: 1, code }, status, noStoreHeaders());
+}
+
+export function mountCapabilityDemandRoutes(app: Hono, deps: CapabilityDemandHttpDeps): void {
+  app.post("/v1/capability-demands", async (c) => {
+    if (!requireServiceBearer(c, deps.serviceToken)) {
+      return errorJson(c, 401, "unauthorized");
+    }
+    const parsedBody = await readAuthorizedBody(c);
+    if (!parsedBody.ok) return parsedBody.response;
+
+    let scope;
+    try {
+      scope = deps.auth.decodeScope(parsedBody.body.authorization_scope);
+    } catch {
+      return errorJson(c, 400, "invalid_request");
+    }
+
+    const command = CreateCommandSchema.safeParse(parsedBody.body.command);
+    if (!command.success) {
+      return errorJson(c, 400, "invalid_request");
+    }
+    if (scope.idempotency_key === undefined) {
+      return errorJson(c, 400, "invalid_request");
+    }
+
+    try {
+      deps.auth.acquireLease({
+        operation: { resource: "capability_demand", action: "create" },
+        scope,
+      });
+    } catch (err) {
+      const mapped = deps.auth.mapDenial(err);
+      return c.json(mapped.body, mapped.status, noStoreHeaders());
+    }
+
+    const result = await deps.store.create({
+      requester_subject: scope.subject_id,
+      community_ref: scope.community_ref,
+      deployment_set_digest: command.data.deployment_set_digest,
+      required_capability: command.data.required_capability,
+      policy_version: command.data.policy_version,
+      resolution_id: command.data.resolution_id,
+      idempotency_key: scope.idempotency_key,
+      now_ms: deps.now(),
+    });
+
+    if (result.kind === "conflict") {
+      return errorJson(c, 409, "idempotency_conflict");
+    }
+
+    return c.json(toPublicCapabilityDemandProjection(result.record), 200, noStoreHeaders());
+  });
+
+  app.get("/v1/capability-demands", async (c) => {
+    if (!requireServiceBearer(c, deps.serviceToken)) {
+      return errorJson(c, 401, "unauthorized");
+    }
+
+    const scopeRaw = {
+      schema_version: 1,
+      subject_id: c.req.query("subject_id"),
+      community_ref: c.req.query("community_ref"),
+      permission: "demand:read" as const,
+    };
+    const query = ScopeQuerySchema.safeParse({
+      community_ref: c.req.query("community_ref"),
+      subject_id: c.req.query("subject_id"),
+      limit: c.req.query("limit") ?? undefined,
+    });
+    if (!query.success) {
+      return errorJson(c, 400, "invalid_request");
+    }
+
+    let scope;
+    try {
+      scope = deps.auth.decodeScope(scopeRaw);
+    } catch {
+      return errorJson(c, 400, "invalid_request");
+    }
+
+    try {
+      deps.auth.acquireLease({
+        operation: { resource: "capability_demand", action: "list" },
+        scope,
+        authoritativeCommunityRef: query.data.community_ref,
+        authoritativeSubjectId: query.data.subject_id,
+      });
+    } catch (err) {
+      const mapped = deps.auth.mapDenial(err);
+      return c.json(mapped.body, mapped.status, noStoreHeaders());
+    }
+
+    const items = await deps.store.list({
+      community_ref: query.data.community_ref,
+      requester_subject: query.data.subject_id,
+      limit: query.data.limit ?? 25,
+    });
+
+    return c.json(
+      {
+        schema_version: 1,
+        items: items.map(toPublicCapabilityDemandProjection),
+      },
+      200,
+      noStoreHeaders(),
+    );
+  });
+
+  app.get("/v1/capability-demands/:demand_id", async (c) => {
+    if (!requireServiceBearer(c, deps.serviceToken)) {
+      return errorJson(c, 401, "unauthorized");
+    }
+
+    const community_ref = c.req.query("community_ref");
+    const subject_id = c.req.query("subject_id");
+    if (typeof community_ref !== "string" || typeof subject_id !== "string") {
+      return errorJson(c, 400, "invalid_request");
+    }
+
+    let scope;
+    try {
+      scope = deps.auth.decodeScope({
+        schema_version: 1,
+        subject_id,
+        community_ref,
+        permission: "demand:read",
+      });
+    } catch {
+      return errorJson(c, 400, "invalid_request");
+    }
+
+    try {
+      deps.auth.acquireLease({
+        operation: { resource: "capability_demand", action: "detail" },
+        scope,
+        authoritativeCommunityRef: community_ref,
+        authoritativeSubjectId: subject_id,
+      });
+    } catch (err) {
+      const mapped = deps.auth.mapDenial(err);
+      return c.json(mapped.body, mapped.status, noStoreHeaders());
+    }
+
+    const record = await deps.store.get(c.req.param("demand_id"));
+    if (
+      record === undefined ||
+      record.community_ref !== community_ref ||
+      record.requester_subject !== subject_id
+    ) {
+      return errorJson(c, 404, "not_found");
+    }
+
+    return c.json(toPublicCapabilityDemandProjection(record), 200, noStoreHeaders());
+  });
+
+  app.delete("/v1/capability-demands/:demand_id", async (c) => {
+    if (!requireServiceBearer(c, deps.serviceToken)) {
+      return errorJson(c, 401, "unauthorized");
+    }
+
+    const parsedBody = await readAuthorizedBody(c);
+    if (!parsedBody.ok) return parsedBody.response;
+
+    let scope;
+    try {
+      scope = deps.auth.decodeScope(parsedBody.body.authorization_scope);
+    } catch {
+      return errorJson(c, 400, "invalid_request");
+    }
+
+    try {
+      deps.auth.acquireLease({
+        operation: { resource: "capability_demand", action: "withdraw" },
+        scope,
+      });
+    } catch (err) {
+      const mapped = deps.auth.mapDenial(err);
+      return c.json(mapped.body, mapped.status, noStoreHeaders());
+    }
+
+    const record = await deps.store.withdraw({
+      demand_id: c.req.param("demand_id"),
+      requester_subject: scope.subject_id,
+      community_ref: scope.community_ref,
+      now_ms: deps.now(),
+    });
+    if (record === undefined) {
+      return errorJson(c, 404, "not_found");
+    }
+
+    return c.json(toPublicCapabilityDemandProjection(record), 200, noStoreHeaders());
+  });
+}

--- a/packages/services/ordering/src/capability-demand-store.ts
+++ b/packages/services/ordering/src/capability-demand-store.ts
@@ -1,0 +1,182 @@
+import { randomUUID } from "node:crypto";
+
+export type CapabilityDemandState = "open" | "supported" | "notified" | "closed" | "declined" | "expired";
+
+export interface CapabilityDemandRecord {
+  readonly demand_id: string;
+  readonly requester_subject: string;
+  readonly community_ref: string;
+  readonly deployment_set_digest: string;
+  readonly required_capability: string;
+  readonly policy_version: string;
+  readonly resolution_id: string;
+  readonly state: CapabilityDemandState;
+  readonly created_at_unix_ms: number;
+  readonly updated_at_unix_ms: number;
+  readonly idempotency_key: string;
+}
+
+export interface CapabilityDemandStore {
+  create(input: {
+    requester_subject: string;
+    community_ref: string;
+    deployment_set_digest: string;
+    required_capability: string;
+    policy_version: string;
+    resolution_id: string;
+    idempotency_key: string;
+    now_ms: number;
+  }): Promise<
+    | { kind: "created"; record: CapabilityDemandRecord }
+    | { kind: "replay"; record: CapabilityDemandRecord }
+    | { kind: "conflict" }
+  >;
+  get(demandId: string): Promise<CapabilityDemandRecord | undefined>;
+  list(input: {
+    community_ref: string;
+    requester_subject: string;
+    limit: number;
+  }): Promise<ReadonlyArray<CapabilityDemandRecord>>;
+  withdraw(input: {
+    demand_id: string;
+    requester_subject: string;
+    community_ref: string;
+    now_ms: number;
+  }): Promise<CapabilityDemandRecord | undefined>;
+}
+
+function canonicalKey(input: {
+  requester_subject: string;
+  community_ref: string;
+  deployment_set_digest: string;
+  required_capability: string;
+  policy_version: string;
+}): string {
+  return [
+    input.requester_subject,
+    input.community_ref,
+    input.deployment_set_digest,
+    input.required_capability,
+    input.policy_version,
+  ].join("\0");
+}
+
+export class InMemoryCapabilityDemandStore implements CapabilityDemandStore {
+  private readonly byId = new Map<string, CapabilityDemandRecord>();
+  private readonly openByCanonical = new Map<string, string>();
+  private readonly idempotency = new Map<string, CapabilityDemandRecord>();
+
+  async create(input: {
+    requester_subject: string;
+    community_ref: string;
+    deployment_set_digest: string;
+    required_capability: string;
+    policy_version: string;
+    resolution_id: string;
+    idempotency_key: string;
+    now_ms: number;
+  }): Promise<
+    | { kind: "created"; record: CapabilityDemandRecord }
+    | { kind: "replay"; record: CapabilityDemandRecord }
+    | { kind: "conflict" }
+  > {
+    const idemKey = `${input.requester_subject}\0${input.idempotency_key}`;
+    const prior = this.idempotency.get(idemKey);
+    if (prior !== undefined) {
+      if (
+        prior.deployment_set_digest !== input.deployment_set_digest ||
+        prior.required_capability !== input.required_capability ||
+        prior.policy_version !== input.policy_version ||
+        prior.community_ref !== input.community_ref
+      ) {
+        return { kind: "conflict" };
+      }
+      return { kind: "replay", record: prior };
+    }
+
+    const canonical = canonicalKey(input);
+    const existingOpenId = this.openByCanonical.get(canonical);
+    if (existingOpenId !== undefined) {
+      const existing = this.byId.get(existingOpenId);
+      if (existing !== undefined && existing.state === "open") {
+        this.idempotency.set(idemKey, existing);
+        return { kind: "replay", record: existing };
+      }
+    }
+
+    const record: CapabilityDemandRecord = {
+      demand_id: randomUUID(),
+      requester_subject: input.requester_subject,
+      community_ref: input.community_ref,
+      deployment_set_digest: input.deployment_set_digest,
+      required_capability: input.required_capability,
+      policy_version: input.policy_version,
+      resolution_id: input.resolution_id,
+      state: "open",
+      created_at_unix_ms: input.now_ms,
+      updated_at_unix_ms: input.now_ms,
+      idempotency_key: input.idempotency_key,
+    };
+    this.byId.set(record.demand_id, record);
+    this.openByCanonical.set(canonical, record.demand_id);
+    this.idempotency.set(idemKey, record);
+    return { kind: "created", record };
+  }
+
+  async get(demandId: string): Promise<CapabilityDemandRecord | undefined> {
+    return this.byId.get(demandId);
+  }
+
+  async list(input: {
+    community_ref: string;
+    requester_subject: string;
+    limit: number;
+  }): Promise<ReadonlyArray<CapabilityDemandRecord>> {
+    const rows = [...this.byId.values()].filter(
+      (row) =>
+        row.community_ref === input.community_ref &&
+        row.requester_subject === input.requester_subject,
+    );
+    rows.sort((a, b) => b.created_at_unix_ms - a.created_at_unix_ms);
+    return rows.slice(0, input.limit);
+  }
+
+  async withdraw(input: {
+    demand_id: string;
+    requester_subject: string;
+    community_ref: string;
+    now_ms: number;
+  }): Promise<CapabilityDemandRecord | undefined> {
+    const record = this.byId.get(input.demand_id);
+    if (record === undefined) return undefined;
+    if (
+      record.requester_subject !== input.requester_subject ||
+      record.community_ref !== input.community_ref
+    ) {
+      return undefined;
+    }
+    if (record.state !== "open") return record;
+    const updated: CapabilityDemandRecord = {
+      ...record,
+      state: "closed",
+      updated_at_unix_ms: input.now_ms,
+    };
+    this.byId.set(updated.demand_id, updated);
+    return updated;
+  }
+}
+
+export function toPublicCapabilityDemandProjection(record: CapabilityDemandRecord) {
+  return {
+    schema_version: 1 as const,
+    demand_id: record.demand_id,
+    community_ref: record.community_ref,
+    requester_subject: record.requester_subject,
+    required_capability: record.required_capability,
+    policy_version: record.policy_version,
+    resolution_id: record.resolution_id,
+    state: record.state,
+    created_at_unix_ms: record.created_at_unix_ms,
+    updated_at_unix_ms: record.updated_at_unix_ms,
+  };
+}

--- a/packages/services/ordering/src/collection-report-http.ts
+++ b/packages/services/ordering/src/collection-report-http.ts
@@ -28,12 +28,15 @@ import {
   REPORT_ATTENTION_SOURCE_KIND,
   type ReportAttentionStore,
 } from "./report-attention-store.js";
+import type { PublicAuthorizationService } from "./public-authorization-service.js";
+import { noStoreHeaders, requireServiceBearer } from "./public-authorization-http.js";
 
 export interface CollectionReportHttpDeps {
   readonly store: OrderStore;
   readonly resolutionStore?: ResolutionStore;
   readonly attentionStore?: ReportAttentionStore;
   readonly serviceToken?: string;
+  readonly auth?: PublicAuthorizationService;
 }
 
 const ScopeQuerySchema = z
@@ -45,21 +48,41 @@ const ScopeQuerySchema = z
   })
   .strict();
 
-function requireBearer(c: Context, token: string | undefined): boolean {
-  if (!token) return true;
-  return c.req.header("authorization") === `Bearer ${token}`;
-}
+const requireBearer = requireServiceBearer;
 
 function errorJson(
   c: Context,
   status: 400 | 401 | 403 | 404,
   code: string,
 ): Response {
-  return c.json(
-    { schema_version: 1, code },
-    status,
-    { "Cache-Control": "no-store" },
-  );
+  return c.json({ schema_version: 1, code }, status, noStoreHeaders());
+}
+
+function authorizeReportRead(
+  deps: CollectionReportHttpDeps,
+  c: Context,
+  communityRef: string,
+  subjectId: string,
+  action: "list" | "detail",
+): Response | undefined {
+  if (!deps.auth) return undefined;
+  try {
+    deps.auth.acquireLease({
+      operation: { resource: "report_order", action },
+      scope: {
+        schema_version: 1,
+        subject_id: subjectId,
+        community_ref: communityRef,
+        permission: "report:read",
+      },
+      authoritativeCommunityRef: communityRef,
+      authoritativeSubjectId: subjectId,
+    });
+    return undefined;
+  } catch (err) {
+    const mapped = deps.auth.mapDenial(err);
+    return c.json(mapped.body, mapped.status, noStoreHeaders());
+  }
 }
 
 async function collectionSummary(
@@ -123,6 +146,15 @@ export function mountCollectionReportRoutes(
       return errorJson(c, 400, "invalid_request");
     }
 
+    const denied = authorizeReportRead(
+      deps,
+      c,
+      parsed.data.community_ref,
+      parsed.data.subject_id,
+      "list",
+    );
+    if (denied) return denied;
+
     const cursor = decodeCursor(parsed.data.cursor);
     if (parsed.data.cursor !== undefined && cursor === undefined) {
       return errorJson(c, 400, "invalid_request");
@@ -183,12 +215,12 @@ export function mountCollectionReportRoutes(
       return errorJson(c, 400, "invalid_request");
     }
 
+    const denied = authorizeReportRead(deps, c, community_ref, subject_id, "detail");
+    if (denied) return denied;
+
     const record = await deps.store.get(c.req.param("order_id"));
     if (!record || record.product !== "collection-report") {
       return errorJson(c, 404, "not_found");
-    }
-    if (record.placed_by !== subject_id) {
-      return errorJson(c, 403, "forbidden");
     }
     const inputs = record.inputs as { community_ref?: unknown; resolution_id?: unknown };
     if (inputs.community_ref !== community_ref) {

--- a/packages/services/ordering/src/collection-report-http.ts
+++ b/packages/services/ordering/src/collection-report-http.ts
@@ -65,7 +65,10 @@ function authorizeReportRead(
   subjectId: string,
   action: "list" | "detail",
 ): Response | undefined {
-  if (!deps.auth) return undefined;
+  // Fail closed: production mount must always pass auth (BB #496 LOW).
+  if (!deps.auth) {
+    return errorJson(c, 503, "public_authorization_unconfigured");
+  }
   try {
     deps.auth.acquireLease({
       operation: { resource: "report_order", action },

--- a/packages/services/ordering/src/index.ts
+++ b/packages/services/ordering/src/index.ts
@@ -116,6 +116,13 @@ export {
 export { normalizeContractAddress, normalizeChainId } from './contract-address.js';
 export { ReProbeWorker, reprobeIntervalMs } from './reprobe-worker.js';
 export { createOrderingComposition, serviceTokenFromEnv, ctaFromEnv } from './composition.js';
+export {
+  resolvePublicAuthPosture,
+  publicAuthPostureFromEnv,
+  serviceTokenForPublicAuthMounts,
+  isDeployedEnv,
+} from './public-auth-posture.js';
+export type { PublicAuthMode, PublicAuthPosture } from './public-auth-posture.js';
 
 export { createFrontendApp } from './frontend.js';
 

--- a/packages/services/ordering/src/index.ts
+++ b/packages/services/ordering/src/index.ts
@@ -169,6 +169,24 @@ export { PostgresResolutionStore } from './resolution-store-postgres.js';
 export { createResolutionStore } from './resolution-store-factory.js';
 export { mountCollectionResolutionRoutes } from './resolution-http.js';
 export {
+  PublicAuthorizationService,
+  createFixturePublicAuthorizationService,
+  type PublicAuthorizationProjections,
+  type PublicAuthorizationProjectionPort,
+} from './public-authorization-service.js';
+export {
+  FixturePublicAuthorizationProjectionPort,
+  publicAuthFixtureFromEnv,
+  DEFAULT_BASELINE_FIXTURE,
+} from './public-authorization-projections.js';
+export { mountCapabilityDemandRoutes } from './capability-demand-http.js';
+export {
+  InMemoryCapabilityDemandStore,
+  toPublicCapabilityDemandProjection,
+  type CapabilityDemandStore,
+  type CapabilityDemandRecord,
+} from './capability-demand-store.js';
+export {
   createHttpSonarResolveProbePort,
   sonarResolveProbeFromEnv,
 } from './sonar-resolve-probe-client.js';

--- a/packages/services/ordering/src/intake.ts
+++ b/packages/services/ordering/src/intake.ts
@@ -21,6 +21,8 @@ import {
 import type { CollectionResolutionService } from './resolution-service.js';
 import type { ResolutionStore } from './resolution-store.js';
 import { buildLocalCapabilityFromRecord } from './admission-local-capability.js';
+import type { PublicAuthorizationService } from './public-authorization-service.js';
+import { noStoreHeaders, requireServiceBearer } from './public-authorization-http.js';
 
 /**
  * order-intake (SDD §5) — the internal HTTP edge.
@@ -55,6 +57,8 @@ export interface IntakeDeps {
   /** CR-006 resolution admission for collection-report orders. */
   resolutionService?: CollectionResolutionService;
   resolutionStore?: ResolutionStore;
+  /** CR-007A public authorization recheck for collection-report placement. */
+  publicAuth?: PublicAuthorizationService;
 }
 
 const PlaceOrderBodySchema = z
@@ -62,6 +66,7 @@ const PlaceOrderBodySchema = z
     product: ProductId,
     placed_by: z.string().min(1),
     inputs: z.record(z.string(), z.unknown()),
+    authorization_scope: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 
@@ -125,20 +130,58 @@ export function createIntakeApp(deps: IntakeDeps): Hono {
       if (!deps.resolutionService || !deps.resolutionStore) {
         return c.json({ error: 'collection-report admission unavailable' }, 503);
       }
+      if (!deps.publicAuth) {
+        return c.json({ error: 'collection-report authorization unavailable' }, 503);
+      }
+      if (body.data.authorization_scope === undefined) {
+        return c.json({ error: 'authorization_scope required for collection-report' }, 400);
+      }
+      let scope;
+      try {
+        scope = deps.publicAuth.decodeScope(body.data.authorization_scope);
+      } catch {
+        return c.json({ error: 'invalid authorization_scope' }, 400);
+      }
+      if (scope.permission !== 'report:create') {
+        return c.json({ error: 'order placement requires report:create' }, 403);
+      }
+      if (scope.subject_id !== body.data.placed_by) {
+        return c.json({ error: 'placed_by must match authorization subject' }, 403);
+      }
       const binding = inputsParsed.data as {
         schema_version: 1;
         resolution_id: string;
         candidate_snapshot_digest: unknown;
         community_ref: string;
       };
+      if (binding.community_ref !== scope.community_ref) {
+        return c.json({ error: 'community_ref must match authorization scope' }, 403);
+      }
       const record = await deps.resolutionStore.get(binding.resolution_id);
       if (record === undefined) {
         return c.json({ error: 'order binding rejected', reason: 'resolution_not_found' }, 409);
       }
       try {
+        deps.publicAuth.acquireLease({
+          operation: { resource: 'report_order', action: 'create' },
+          scope,
+          authoritativeCommunityRef: binding.community_ref,
+          authoritativeSubjectId: body.data.placed_by,
+        });
+      } catch (err) {
+        const mapped = deps.publicAuth.mapDenial(err);
+        return c.json(mapped.body, mapped.status, noStoreHeaders());
+      }
+      const resolutionScope = {
+        schema_version: 1 as const,
+        subject_id: scope.subject_id,
+        community_ref: scope.community_ref,
+        permission: 'report:create' as const,
+      };
+      try {
         const admitted = await deps.resolutionService.admit(
           binding,
-          record.authorization_scope,
+          resolutionScope,
           buildLocalCapabilityFromRecord(record),
         );
         if (admitted.decision !== 'admit') {

--- a/packages/services/ordering/src/intake.ts
+++ b/packages/services/ordering/src/intake.ts
@@ -127,26 +127,42 @@ export function createIntakeApp(deps: IntakeDeps): Hono {
     }
 
     if (body.data.product === 'collection-report') {
+      // CR-007A denial envelope — schema_version/code/reason (BB #496).
+      const deny = (
+        status: 400 | 403 | 409 | 503,
+        code: string,
+        reason?: string,
+      ) =>
+        c.json(
+          {
+            schema_version: 1,
+            code,
+            ...(reason !== undefined ? { reason } : {}),
+          },
+          status,
+          noStoreHeaders(),
+        );
+
       if (!deps.resolutionService || !deps.resolutionStore) {
-        return c.json({ error: 'collection-report admission unavailable' }, 503);
+        return deny(503, 'collection_report_admission_unavailable');
       }
       if (!deps.publicAuth) {
-        return c.json({ error: 'collection-report authorization unavailable' }, 503);
+        return deny(503, 'public_authorization_unconfigured');
       }
       if (body.data.authorization_scope === undefined) {
-        return c.json({ error: 'authorization_scope required for collection-report' }, 400);
+        return deny(400, 'authorization_scope_required');
       }
       let scope;
       try {
         scope = deps.publicAuth.decodeScope(body.data.authorization_scope);
       } catch {
-        return c.json({ error: 'invalid authorization_scope' }, 400);
+        return deny(400, 'invalid_authorization_scope');
       }
       if (scope.permission !== 'report:create') {
-        return c.json({ error: 'order placement requires report:create' }, 403);
+        return deny(403, 'permission_mismatch', 'order placement requires report:create');
       }
       if (scope.subject_id !== body.data.placed_by) {
-        return c.json({ error: 'placed_by must match authorization subject' }, 403);
+        return deny(403, 'cross_subject', 'placed_by must match authorization subject');
       }
       const binding = inputsParsed.data as {
         schema_version: 1;
@@ -155,11 +171,11 @@ export function createIntakeApp(deps: IntakeDeps): Hono {
         community_ref: string;
       };
       if (binding.community_ref !== scope.community_ref) {
-        return c.json({ error: 'community_ref must match authorization scope' }, 403);
+        return deny(403, 'scope_tamper', 'community_ref must match authorization scope');
       }
       const record = await deps.resolutionStore.get(binding.resolution_id);
       if (record === undefined) {
-        return c.json({ error: 'order binding rejected', reason: 'resolution_not_found' }, 409);
+        return deny(409, 'resolution_not_found');
       }
       try {
         deps.publicAuth.acquireLease({
@@ -185,13 +201,10 @@ export function createIntakeApp(deps: IntakeDeps): Hono {
           buildLocalCapabilityFromRecord(record),
         );
         if (admitted.decision !== 'admit') {
-          return c.json(
-            { error: 'order binding rejected', decision: admitted.decision },
-            409,
-          );
+          return deny(409, 'order_binding_rejected', admitted.decision);
         }
       } catch {
-        return c.json({ error: 'order binding rejected' }, 409);
+        return deny(409, 'order_binding_rejected');
       }
     }
 

--- a/packages/services/ordering/src/public-auth-posture.ts
+++ b/packages/services/ordering/src/public-auth-posture.ts
@@ -1,0 +1,128 @@
+/**
+ * CR-007A deploy posture for public authorization.
+ *
+ * Fixture ACL (`subject-alice|bob|carol`) must NEVER silently ship as the
+ * production Identity projection. Deployed envs default to `disabled` unless
+ * an explicit mode + (for fixture) T0/T1 waiver is set.
+ *
+ *   PUBLIC_AUTH_MODE=fixture|identity|disabled
+ *   PUBLIC_AUTH_FIXTURE_WAIVER=t0_t1   # required with mode=fixture when deployed
+ */
+
+import type { WriteRoutePosture } from "./composition.js";
+
+export type PublicAuthMode = "fixture" | "identity" | "disabled";
+
+export interface PublicAuthPostureEnv {
+  readonly mode?: string;
+  readonly fixtureWaiver?: string;
+  readonly railwayEnvironment?: string;
+  readonly nodeEnv?: string;
+}
+
+export interface PublicAuthPosture {
+  readonly mode: PublicAuthMode;
+  /** True when fixture ACL may be wired into the composition root. */
+  readonly allowFixture: boolean;
+  /** Why fixture/identity was refused (for logs + healthz). */
+  readonly reason: string | null;
+}
+
+export function isDeployedEnv(env: {
+  railwayEnvironment?: string;
+  nodeEnv?: string;
+}): boolean {
+  return Boolean(env.railwayEnvironment?.trim()) || env.nodeEnv === "production";
+}
+
+/**
+ * Resolve public-auth mode.
+ *
+ * | env      | PUBLIC_AUTH_MODE | waiver     | result                         |
+ * |----------|------------------|------------|--------------------------------|
+ * | local    | unset            | —          | fixture (lab default)          |
+ * | deployed | unset            | —          | disabled (fail-closed)         |
+ * | deployed | fixture          | t0_t1      | fixture (explicit T0/T1 only)  |
+ * | deployed | fixture          | unset/other| disabled                       |
+ * | any      | identity         | —          | disabled until CR-007B port    |
+ * | any      | disabled         | —          | disabled                       |
+ */
+export function resolvePublicAuthPosture(env: PublicAuthPostureEnv): PublicAuthPosture {
+  const deployed = isDeployedEnv(env);
+  const raw = env.mode?.trim().toLowerCase();
+  const waiver = env.fixtureWaiver?.trim().toLowerCase();
+
+  if (raw === "disabled") {
+    return { mode: "disabled", allowFixture: false, reason: "PUBLIC_AUTH_MODE=disabled" };
+  }
+
+  if (raw === "identity") {
+    return {
+      mode: "identity",
+      allowFixture: false,
+      reason: "identity projections require CR-007B / live Identity port (not wired)",
+    };
+  }
+
+  if (raw === "fixture") {
+    if (deployed && waiver !== "t0_t1") {
+      return {
+        mode: "fixture",
+        allowFixture: false,
+        reason:
+          "deployed fixture ACL refused without PUBLIC_AUTH_FIXTURE_WAIVER=t0_t1",
+      };
+    }
+    return {
+      mode: "fixture",
+      allowFixture: true,
+      reason: deployed ? "fixture+t0_t1_waiver" : null,
+    };
+  }
+
+  if (raw !== undefined && raw.length > 0) {
+    return {
+      mode: "disabled",
+      allowFixture: false,
+      reason: `unknown PUBLIC_AUTH_MODE=${raw}`,
+    };
+  }
+
+  // Unset: lab fixture locally; fail-closed when deployed.
+  if (deployed) {
+    return {
+      mode: "disabled",
+      allowFixture: false,
+      reason: "deployed default: PUBLIC_AUTH_MODE unset → disabled (set fixture+waiver or identity)",
+    };
+  }
+
+  return { mode: "fixture", allowFixture: true, reason: null };
+}
+
+export function publicAuthPostureFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): PublicAuthPosture {
+  return resolvePublicAuthPosture({
+    mode: env.PUBLIC_AUTH_MODE,
+    fixtureWaiver: env.PUBLIC_AUTH_FIXTURE_WAIVER,
+    railwayEnvironment: env.RAILWAY_ENVIRONMENT,
+    nodeEnv: env.NODE_ENV,
+  });
+}
+
+/**
+ * Bearer posture for CR-007A mounts — FR-10a parity with write routes.
+ * When deployed with no SERVICE_TOKEN, never treat unset token as open_dev.
+ */
+export function serviceTokenForPublicAuthMounts(
+  writeRoutes: WriteRoutePosture,
+  serviceToken: string | undefined,
+): { kind: "open_dev" } | { kind: "token"; token: string } | { kind: "refuse" } {
+  if (writeRoutes === "disabled_no_token") return { kind: "refuse" };
+  if (writeRoutes === "token") {
+    if (!serviceToken) return { kind: "refuse" };
+    return { kind: "token", token: serviceToken };
+  }
+  return { kind: "open_dev" };
+}

--- a/packages/services/ordering/src/public-authorization-http.ts
+++ b/packages/services/ordering/src/public-authorization-http.ts
@@ -1,0 +1,72 @@
+import type { Context } from "hono";
+import type { PublicAuthorizationService } from "./public-authorization-service.js";
+
+export function requireServiceBearer(c: Context, token: string | undefined): boolean {
+  if (!token) return true;
+  return c.req.header("authorization") === `Bearer ${token}`;
+}
+
+export function noStoreHeaders(): Record<string, string> {
+  return { "Cache-Control": "no-store" };
+}
+
+export interface AuthorizedBody {
+  authorization_scope: unknown;
+  [key: string]: unknown;
+}
+
+export async function readAuthorizedBody(
+  c: Context,
+): Promise<{ ok: true; body: AuthorizedBody } | { ok: false; response: Response }> {
+  let raw: unknown;
+  try {
+    raw = await c.req.json();
+  } catch {
+    return {
+      ok: false,
+      response: c.json(
+        { schema_version: 1, code: "invalid_request" },
+        400,
+        noStoreHeaders(),
+      ),
+    };
+  }
+  if (!raw || typeof raw !== "object") {
+    return {
+      ok: false,
+      response: c.json(
+        { schema_version: 1, code: "invalid_request" },
+        400,
+        noStoreHeaders(),
+      ),
+    };
+  }
+  const body = raw as AuthorizedBody;
+  if (body.authorization_scope === undefined) {
+    return {
+      ok: false,
+      response: c.json(
+        { schema_version: 1, code: "invalid_request" },
+        400,
+        noStoreHeaders(),
+      ),
+    };
+  }
+  return { ok: true, body };
+}
+
+export function authorizeOrRespond(
+  auth: PublicAuthorizationService,
+  run: () => void,
+): Response | undefined {
+  try {
+    run();
+    return undefined;
+  } catch (err) {
+    const mapped = auth.mapDenial(err);
+    return new Response(JSON.stringify(mapped.body), {
+      status: mapped.status,
+      headers: { "Content-Type": "application/json", ...noStoreHeaders() },
+    });
+  }
+}

--- a/packages/services/ordering/src/public-authorization-projections.ts
+++ b/packages/services/ordering/src/public-authorization-projections.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from "node:fs";
+import { Effect } from "effect";
+import {
+  decodeFixtureProjectionBundle,
+  fixtureProjectionFromBundle,
+  type GrantProjectionView,
+  type MembershipProjectionView,
+} from "@freeside/public-authorization-protocol";
+
+export interface PublicAuthorizationProjections {
+  readonly membership: MembershipProjectionView;
+  readonly grants: GrantProjectionView;
+}
+
+export interface PublicAuthorizationProjectionPort {
+  /** Current membership + grant projections for fail-closed recheck. */
+  load(nowMs: number): PublicAuthorizationProjections;
+}
+
+/** Fixture-backed projections for T0/T1 until Identity grant streams land (CR-007B). */
+export class FixturePublicAuthorizationProjectionPort implements PublicAuthorizationProjectionPort {
+  constructor(private readonly fixtureJson: unknown) {}
+
+  load(nowMs: number): PublicAuthorizationProjections {
+    const bundle = Effect.runSync(decodeFixtureProjectionBundle(this.fixtureJson));
+    return fixtureProjectionFromBundle(bundle, nowMs);
+  }
+}
+
+export function publicAuthFixtureFromEnv(nowMs: number): PublicAuthorizationProjections {
+  const path = process.env.PUBLIC_AUTH_FIXTURE_PATH?.trim();
+  const raw =
+    path !== undefined && path.length > 0
+      ? JSON.parse(readFileSync(path, "utf8"))
+      : DEFAULT_BASELINE_FIXTURE;
+  return new FixturePublicAuthorizationProjectionPort(raw).load(nowMs);
+}
+
+/** Embedded baseline — mirrors packages/protocol/public-authorization/fixtures/acl/projection-baseline.valid.json */
+export const DEFAULT_BASELINE_FIXTURE = {
+  schema_version: 1,
+  watermarks: {
+    schema_version: 1,
+    membership_stream_epoch: 1,
+    membership_sequence: 10,
+    grant_stream_epoch: 1,
+    grant_sequence: 20,
+    projected_at_unix_ms: 0,
+  },
+  memberships: [
+    { subject_id: "subject-alice", community_ref: "community-alpha", active: true },
+    { subject_id: "subject-bob", community_ref: "community-alpha", active: true },
+    { subject_id: "subject-carol", community_ref: "community-beta", active: true },
+  ],
+  grants: [
+    {
+      subject_id: "subject-alice",
+      community_ref: "community-alpha",
+      permission: "report:create",
+      active: true,
+    },
+    {
+      subject_id: "subject-alice",
+      community_ref: "community-alpha",
+      permission: "report:read",
+      active: true,
+    },
+    {
+      subject_id: "subject-alice",
+      community_ref: "community-alpha",
+      permission: "demand:create",
+      active: true,
+    },
+    {
+      subject_id: "subject-alice",
+      community_ref: "community-alpha",
+      permission: "demand:read",
+      active: true,
+    },
+    {
+      subject_id: "subject-alice",
+      community_ref: "community-alpha",
+      permission: "demand:withdraw",
+      active: true,
+    },
+    {
+      subject_id: "subject-bob",
+      community_ref: "community-alpha",
+      permission: "report:read",
+      active: true,
+    },
+    {
+      subject_id: "subject-carol",
+      community_ref: "community-beta",
+      permission: "report:create",
+      active: true,
+    },
+  ],
+} as const;

--- a/packages/services/ordering/src/public-authorization-service.ts
+++ b/packages/services/ordering/src/public-authorization-service.ts
@@ -1,0 +1,91 @@
+import { Effect } from "effect";
+import {
+  acquirePublicAuthorizationLease,
+  AuthorizationDeniedError,
+  decodePublicAuthorizationScope,
+  resolutionScopeToPublic,
+  toAuthorizationDenial,
+  type AuthorizationLease,
+  type ProtectedOperation,
+  type PublicAuthorizationScope,
+} from "@freeside/public-authorization-protocol";
+import type { AuthorizationScope } from "@freeside/collection-resolution-protocol";
+import {
+  type PublicAuthorizationProjections,
+  type PublicAuthorizationProjectionPort,
+  FixturePublicAuthorizationProjectionPort,
+} from "./public-authorization-projections.js";
+
+export interface PublicAuthorizationServiceOptions {
+  readonly projections: PublicAuthorizationProjectionPort;
+  readonly now: () => number;
+}
+
+export class PublicAuthorizationService {
+  private readonly projections: PublicAuthorizationProjectionPort;
+  private readonly now: () => number;
+
+  constructor(options: PublicAuthorizationServiceOptions) {
+    this.projections = options.projections;
+    this.now = options.now;
+  }
+
+  acquireLease(input: {
+    operation: ProtectedOperation;
+    scope: PublicAuthorizationScope;
+    authoritativeCommunityRef?: string;
+    authoritativeSubjectId?: string;
+  }): AuthorizationLease {
+    const { membership, grants } = this.projections.load(this.now());
+    return acquirePublicAuthorizationLease({
+      operation: input.operation,
+      scope: input.scope,
+      membership,
+      grants,
+      nowMs: this.now(),
+      authoritativeCommunityRef: input.authoritativeCommunityRef,
+      authoritativeSubjectId: input.authoritativeSubjectId,
+    });
+  }
+
+  acquireLeaseFromResolutionScope(input: {
+    operation: ProtectedOperation;
+    scope: AuthorizationScope;
+    authoritativeCommunityRef?: string;
+  }): AuthorizationLease {
+    return this.acquireLease({
+      operation: input.operation,
+      scope: resolutionScopeToPublic(input.scope),
+      authoritativeCommunityRef: input.authoritativeCommunityRef,
+    });
+  }
+
+  decodeScope(raw: unknown): PublicAuthorizationScope {
+    return Effect.runSync(decodePublicAuthorizationScope(raw));
+  }
+
+  mapDenial(err: unknown): { status: 401 | 403 | 409; body: ReturnType<typeof toAuthorizationDenial> } {
+    if (err instanceof AuthorizationDeniedError) {
+      const status =
+        err.safe_code === "unauthorized"
+          ? 401
+          : err.safe_code === "idempotency_conflict"
+            ? 409
+            : 403;
+      return { status, body: toAuthorizationDenial(err) };
+    }
+    throw err;
+  }
+}
+
+export function createFixturePublicAuthorizationService(
+  fixtureJson: unknown,
+  now: () => number = () => Date.now(),
+): PublicAuthorizationService {
+  return new PublicAuthorizationService({
+    projections: new FixturePublicAuthorizationProjectionPort(fixtureJson),
+    now,
+  });
+}
+
+export type { PublicAuthorizationProjections, PublicAuthorizationProjectionPort };

--- a/packages/services/ordering/src/resolution-http.ts
+++ b/packages/services/ordering/src/resolution-http.ts
@@ -29,12 +29,16 @@ import {
 } from "./resolution-service.js";
 import type { ResolutionStore } from "./resolution-store.js";
 import { SonarResolveProbeUnavailableError } from "./sonar-resolve-probe-client.js";
+import type { PublicAuthorizationService } from "./public-authorization-service.js";
+import { noStoreHeaders, requireServiceBearer } from "./public-authorization-http.js";
+import type { AuthorizationScope } from "@freeside/collection-resolution-protocol";
 
 export interface ResolutionHttpDeps {
   readonly store: ResolutionStore;
   readonly sonar: SonarResolveProbePort;
   readonly serviceToken?: string;
   readonly service?: CollectionResolutionService;
+  readonly auth?: PublicAuthorizationService;
 }
 
 type OrderingErrorCode =
@@ -147,10 +151,7 @@ function mapError(err: unknown): { status: number; body: ReturnType<typeof error
   return { status: 503, body: errorBody("unavailable") };
 }
 
-function requireBearer(c: Context, token: string | undefined): boolean {
-  if (!token) return true;
-  return c.req.header("authorization") === `Bearer ${token}`;
-}
+const requireBearer = requireServiceBearer;
 
 async function readCommandBody(
   c: Context,
@@ -195,25 +196,65 @@ export function mountCollectionResolutionRoutes(
     deps.service ??
     new CollectionResolutionService({ store: deps.store, sonar: deps.sonar });
 
+  const authorizeResolution = (
+    c: Context,
+    action: "create" | "confirm" | "refresh",
+    scope: AuthorizationScope,
+    commandCommunityRef?: string,
+  ): Response | undefined => {
+    if (!deps.auth) return undefined;
+    try {
+      deps.auth.acquireLeaseFromResolutionScope({
+        operation: { resource: "resolution", action },
+        scope,
+        authoritativeCommunityRef: commandCommunityRef,
+      });
+      return undefined;
+    } catch (err) {
+      const mapped = deps.auth.mapDenial(err);
+      return c.json(
+        {
+          schema_version: COLLECTION_RESOLUTION_SCHEMA_VERSION,
+          code:
+            mapped.body.code === "authorization_scope_mismatch"
+              ? "authorization_scope_mismatch"
+              : mapped.body.code === "unauthorized"
+                ? "unauthorized"
+                : "forbidden",
+        },
+        mapped.status as 401,
+        noStoreHeaders(),
+      );
+    }
+  };
+
   const respond = async (
     c: Context,
     run: () => Promise<ResolutionPublicProjection>,
   ) => {
     try {
       const projection = await run();
-      return c.json(projection, 200, { "Cache-Control": "no-store" });
+      return c.json(projection, 200, noStoreHeaders());
     } catch (err) {
       const mapped = mapError(err);
-      return c.json(mapped.body, mapped.status as 400);
+      return c.json(mapped.body, mapped.status as 400, noStoreHeaders());
     }
   };
 
   app.post("/v1/collection-resolutions", async (c) => {
     if (!requireBearer(c, deps.serviceToken)) {
-      return c.json(errorBody("unauthorized"), 401);
+      return c.json(errorBody("unauthorized"), 401, noStoreHeaders());
     }
     const parsed = await readCommandBody(c);
     if (!parsed.ok) return parsed.response;
+    const command = parsed.command as { community_ref?: string };
+    const denied = authorizeResolution(
+      c,
+      "create",
+      parsed.authorization_scope as AuthorizationScope,
+      command.community_ref,
+    );
+    if (denied) return denied;
     return respond(c, () =>
       service.create(parsed.command as never, parsed.authorization_scope as never),
     );
@@ -221,10 +262,16 @@ export function mountCollectionResolutionRoutes(
 
   app.post("/v1/collection-resolutions/:id/confirm", async (c) => {
     if (!requireBearer(c, deps.serviceToken)) {
-      return c.json(errorBody("unauthorized"), 401);
+      return c.json(errorBody("unauthorized"), 401, noStoreHeaders());
     }
     const parsed = await readCommandBody(c);
     if (!parsed.ok) return parsed.response;
+    const denied = authorizeResolution(
+      c,
+      "confirm",
+      parsed.authorization_scope as AuthorizationScope,
+    );
+    if (denied) return denied;
     return respond(c, () =>
       service.confirm(
         c.req.param("id"),
@@ -236,10 +283,16 @@ export function mountCollectionResolutionRoutes(
 
   app.post("/v1/collection-resolutions/:id/refresh", async (c) => {
     if (!requireBearer(c, deps.serviceToken)) {
-      return c.json(errorBody("unauthorized"), 401);
+      return c.json(errorBody("unauthorized"), 401, noStoreHeaders());
     }
     const parsed = await readCommandBody(c);
     if (!parsed.ok) return parsed.response;
+    const denied = authorizeResolution(
+      c,
+      "refresh",
+      parsed.authorization_scope as AuthorizationScope,
+    );
+    if (denied) return denied;
     return respond(c, () =>
       service.refresh(
         c.req.param("id"),

--- a/packages/services/ordering/src/resolution-service.ts
+++ b/packages/services/ordering/src/resolution-service.ts
@@ -7,7 +7,7 @@
  * cloned/frozen at every ingress/egress boundary.
  *
  * EXTERNAL IMPLEMENTATION BLOCKER: no production Postgres adapter.
- * EXTERNAL AUTH/HTTP BLOCKER: no production authorization endpoint wiring.
+ * CR-007A wires public authorization at the HTTP edge; Identity stream ingestion is downstream.
  */
 
 import { createHash, randomUUID } from "node:crypto";

--- a/packages/services/ordering/src/resolution-store.ts
+++ b/packages/services/ordering/src/resolution-store.ts
@@ -11,7 +11,8 @@
  * create/confirm/refresh + idempotency retention guarantees.
  *
  * EXTERNAL AUTH/HTTP BLOCKER: no production authorization endpoint wiring is
- * shipped by CR-006; Dashboard/Sonar HTTP auth remains downstream (CR-007A).
+ * CR-007A wires membership/grant projections and short-lived leases at the HTTP
+ * edge; Dashboard BFF holds service credentials.
  */
 
 import type {


### PR DESCRIPTION
## Summary
- Adds `@freeside/public-authorization-protocol` (lease acquire, denial mapping, fixture ACL projections) for CR-007A.
- Wires Ordering HTTP edges so resolution, collection-report list/detail, intake placement, and capability-demand recheck authorization against community/subject scope — never trust query scope alone.
- Unblocks the collection-report critical path: CR-009 → CR-011A → CR-012A → CR-204A (idle Preparing / Gap 1).

## Test plan
- [x] `pnpm test` in `packages/protocol/public-authorization` (8/8)
- [x] `vitest run src/__tests__/public-authorization-http.test.ts` in ordering (4/4)
- [ ] CI green on this PR
- [ ] Confirm Dashboard BFF still passes `SERVICE_TOKEN` + scope query for report list/detail
- [ ] Smoke: unauthenticated `/v1/collection-reports` → 401; revoked membership fixture → deny


Made with [Cursor](https://cursor.com)