### PR TITLE
feat(protocol): CR-009 signed trust-envelope protocol

### DIFF
--- a/packages/protocol/trust-envelope/README.md
+++ b/packages/protocol/trust-envelope/README.md
@@ -1,0 +1,28 @@
+# `@freeside/trust-envelope-protocol`
+
+CR-009 signed trust-envelope wire contract for collection-report Ordering
+dependency intake. Distinct from the events-pillar `acvp-l1-v2` NATS envelope.
+
+The package owns:
+
+- strict header/body envelope schemas and decoders;
+- Ed25519 signing bytes (JCS + SHA-256 digest, empty-string signature placeholder);
+- fixture service-key registry binding (producer, capability, tenant scope);
+- producer signing helpers and consumer inbox/stream verification;
+- shared rotation, revocation, replay, expiry, gap-repair, retention, and
+  disaster-recovery fixtures consumed by planned producers and Ordering replay.
+
+Canonical rules:
+
+- header fields bind producer, signing key, contract, event ID, stream ID,
+  epoch/sequence, issued/expiry, tenant/privacy scope digest, capability, and
+  body digest;
+- `event_id` is the idempotency key; contiguous sequence is enforced only when
+  `trust_stream` is true;
+- epoch reset requires a signed complete baseline before a new epoch is accepted;
+- unknown contract major or required-field violation fails closed; mixed-minor
+  acceptance is explicit in `versioning.ts`;
+- Ordering database `accepted_at` evaluates issued/expiry (30s future skew).
+
+Production signing-key custody remains CR-013. This package publishes wire
+semantics and non-production fixture keys only.

--- a/packages/protocol/trust-envelope/fixtures/scenarios/producer-consumer.shared.json
+++ b/packages/protocol/trust-envelope/fixtures/scenarios/producer-consumer.shared.json
@@ -1,0 +1,315 @@
+{
+  "schema_version": 1,
+  "accepted_at_ms": 1784322001000,
+  "registry": {
+    "schema_version": 1,
+    "keys": [
+      {
+        "signing_key_id": "sonar-fixture-primary",
+        "public_key_hex": "3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29",
+        "producer": "sonar-api",
+        "capabilities": [
+          "collection-report.capability-evidence.v1"
+        ],
+        "tenant_scope_digests": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "activated_at": "2026-07-01T00:00:00.000Z"
+      },
+      {
+        "signing_key_id": "sonar-fixture-rotated",
+        "public_key_hex": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+        "producer": "sonar-api",
+        "capabilities": [
+          "collection-report.capability-evidence.v1"
+        ],
+        "tenant_scope_digests": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "activated_at": "2026-07-10T00:00:00.000Z"
+      },
+      {
+        "signing_key_id": "sonar-fixture-revoked",
+        "public_key_hex": "a09aa5f47a6759802ff955f8dc2d2a14a5c99d23be97f864127ff9383455a4f0",
+        "producer": "sonar-api",
+        "capabilities": [
+          "collection-report.capability-evidence.v1"
+        ],
+        "tenant_scope_digests": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "activated_at": "2026-07-01T00:00:00.000Z",
+        "revoked_at": "2026-07-16T00:00:00.000Z"
+      }
+    ]
+  },
+  "envelopes": [
+    {
+      "id": "valid-primary",
+      "envelope": {
+        "header": {
+          "schema_version": 1,
+          "schema_minor": 0,
+          "algorithm": "Ed25519",
+          "signing_key_id": "sonar-fixture-primary",
+          "producer": "sonar-api",
+          "contract": {
+            "name": "collection-report.trust-envelope",
+            "major_version": 1,
+            "minor_version": 0
+          },
+          "event_id": "11111111-1111-4111-8111-111111111111",
+          "stream_id": "sonar.public-capability.v1",
+          "stream_epoch": 1,
+          "sequence": 1,
+          "trust_stream": true,
+          "issued_at": "2026-07-17T21:00:00.000Z",
+          "expires_at": "2026-07-17T21:05:00.000Z",
+          "tenant_scope_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "capability": "collection-report.capability-evidence.v1",
+          "body_digest": "f9353be76f4f70fc1d95a58d2b86930b8bc3864c11c08c5e07be8e26de317cc9"
+        },
+        "body": {
+          "schema_version": 1,
+          "deployment_id": "deploy-alpha-mainnet",
+          "capability_state": "ready"
+        },
+        "signature": "N19RYOoixxffLK5z1khRrJ-Tq7LeXV4NXoZ5wBHsawSljoeL5x7BmZjJlHjuDQph4vWHUhQ414_DIee3sYz4BA"
+      },
+      "expect": "accept"
+    },
+    {
+      "id": "rotation-overlap-new-key",
+      "envelope": {
+        "header": {
+          "schema_version": 1,
+          "schema_minor": 0,
+          "algorithm": "Ed25519",
+          "signing_key_id": "sonar-fixture-rotated",
+          "producer": "sonar-api",
+          "contract": {
+            "name": "collection-report.trust-envelope",
+            "major_version": 1,
+            "minor_version": 0
+          },
+          "event_id": "22222222-2222-4222-8222-222222222222",
+          "stream_id": "sonar.public-capability.v1",
+          "stream_epoch": 1,
+          "sequence": 2,
+          "trust_stream": true,
+          "issued_at": "2026-07-17T21:00:00.000Z",
+          "expires_at": "2026-07-17T21:05:00.000Z",
+          "tenant_scope_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "capability": "collection-report.capability-evidence.v1",
+          "body_digest": "f9353be76f4f70fc1d95a58d2b86930b8bc3864c11c08c5e07be8e26de317cc9"
+        },
+        "body": {
+          "schema_version": 1,
+          "deployment_id": "deploy-alpha-mainnet",
+          "capability_state": "ready"
+        },
+        "signature": "do1Kx8Kh7k1cxlUM9nfYrhF8pij9R3x-lJqWczTEW6vaJ45lNK-1bjW4VuOfU96-wUbCVSRbKdD0CCKrEBUFCQ"
+      },
+      "expect": "accept"
+    },
+    {
+      "id": "revoked-key",
+      "envelope": {
+        "header": {
+          "schema_version": 1,
+          "schema_minor": 0,
+          "algorithm": "Ed25519",
+          "signing_key_id": "sonar-fixture-revoked",
+          "producer": "sonar-api",
+          "contract": {
+            "name": "collection-report.trust-envelope",
+            "major_version": 1,
+            "minor_version": 0
+          },
+          "event_id": "33333333-3333-4333-8333-333333333333",
+          "stream_id": "sonar.public-capability.v1",
+          "stream_epoch": 1,
+          "sequence": 3,
+          "trust_stream": true,
+          "issued_at": "2026-07-17T21:00:00.000Z",
+          "expires_at": "2026-07-17T21:05:00.000Z",
+          "tenant_scope_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "capability": "collection-report.capability-evidence.v1",
+          "body_digest": "f9353be76f4f70fc1d95a58d2b86930b8bc3864c11c08c5e07be8e26de317cc9"
+        },
+        "body": {
+          "schema_version": 1,
+          "deployment_id": "deploy-alpha-mainnet",
+          "capability_state": "ready"
+        },
+        "signature": "_XC3U7D9msfdTX8TQgLhDyCbSkb_Ld7yPJ2bELtM27KhdEXVTWbJZnpO7TwEHpkyH73MDB1uWZbzu75cNNJQBA"
+      },
+      "expect": "reject",
+      "reject_reason": "revoked_signing_key",
+      "reject_stage": "verify"
+    },
+    {
+      "id": "expired",
+      "envelope": {
+        "header": {
+          "schema_version": 1,
+          "schema_minor": 0,
+          "algorithm": "Ed25519",
+          "signing_key_id": "sonar-fixture-primary",
+          "producer": "sonar-api",
+          "contract": {
+            "name": "collection-report.trust-envelope",
+            "major_version": 1,
+            "minor_version": 0
+          },
+          "event_id": "44444444-4444-4444-8444-444444444444",
+          "stream_id": "sonar.public-capability.v1",
+          "stream_epoch": 1,
+          "sequence": 4,
+          "trust_stream": true,
+          "issued_at": "2026-07-17T20:50:00.000Z",
+          "expires_at": "2026-07-17T20:51:00.000Z",
+          "tenant_scope_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "capability": "collection-report.capability-evidence.v1",
+          "body_digest": "f9353be76f4f70fc1d95a58d2b86930b8bc3864c11c08c5e07be8e26de317cc9"
+        },
+        "body": {
+          "schema_version": 1,
+          "deployment_id": "deploy-alpha-mainnet",
+          "capability_state": "ready"
+        },
+        "signature": "v9k27T98zu6MjMEYn9a4YKXI55QdmcuDfYQYNhkGxzLcdOef-V49ZW4q_WCUgVGRvsiAfbUEc9EDl_6q4bNDAg"
+      },
+      "expect": "reject",
+      "reject_reason": "expired",
+      "reject_stage": "verify"
+    },
+    {
+      "id": "sequence-gap",
+      "envelope": {
+        "header": {
+          "schema_version": 1,
+          "schema_minor": 0,
+          "algorithm": "Ed25519",
+          "signing_key_id": "sonar-fixture-primary",
+          "producer": "sonar-api",
+          "contract": {
+            "name": "collection-report.trust-envelope",
+            "major_version": 1,
+            "minor_version": 0
+          },
+          "event_id": "55555555-5555-4555-8555-555555555555",
+          "stream_id": "sonar.public-capability.v1",
+          "stream_epoch": 1,
+          "sequence": 6,
+          "trust_stream": true,
+          "issued_at": "2026-07-17T21:00:00.000Z",
+          "expires_at": "2026-07-17T21:05:00.000Z",
+          "tenant_scope_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "capability": "collection-report.capability-evidence.v1",
+          "body_digest": "f9353be76f4f70fc1d95a58d2b86930b8bc3864c11c08c5e07be8e26de317cc9"
+        },
+        "body": {
+          "schema_version": 1,
+          "deployment_id": "deploy-alpha-mainnet",
+          "capability_state": "ready"
+        },
+        "signature": "Lbs5MpoFR7ToubR6_0iS6RH5bon07ISaLqV5CaeFzigshQtsEJsiILMCSEYUzIJGjdPfrYHv44lNg6BI_pqhDQ"
+      },
+      "expect": "reject",
+      "reject_reason": "sequence_gap",
+      "reject_stage": "ingest"
+    },
+    {
+      "id": "epoch-without-baseline",
+      "envelope": {
+        "header": {
+          "schema_version": 1,
+          "schema_minor": 0,
+          "algorithm": "Ed25519",
+          "signing_key_id": "sonar-fixture-primary",
+          "producer": "sonar-api",
+          "contract": {
+            "name": "collection-report.trust-envelope",
+            "major_version": 1,
+            "minor_version": 0
+          },
+          "event_id": "66666666-6666-4666-8666-666666666666",
+          "stream_id": "sonar.public-capability.v1",
+          "stream_epoch": 2,
+          "sequence": 1,
+          "trust_stream": true,
+          "issued_at": "2026-07-17T21:00:00.000Z",
+          "expires_at": "2026-07-17T21:05:00.000Z",
+          "tenant_scope_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "capability": "collection-report.capability-evidence.v1",
+          "body_digest": "f9353be76f4f70fc1d95a58d2b86930b8bc3864c11c08c5e07be8e26de317cc9"
+        },
+        "body": {
+          "schema_version": 1,
+          "deployment_id": "deploy-alpha-mainnet",
+          "capability_state": "ready"
+        },
+        "signature": "oH7pxJlLCsT85y6p5QHR-_IkIDcUBJPu4fkG_Xh9BflI3lbMNGb_4dC-gic7NPOpUPQyn3vCJqh0ba0rqcD1Aw"
+      },
+      "expect": "reject",
+      "reject_reason": "epoch_baseline_required",
+      "reject_stage": "ingest"
+    },
+    {
+      "id": "tampered-body",
+      "envelope": {
+        "header": {
+          "schema_version": 1,
+          "schema_minor": 0,
+          "algorithm": "Ed25519",
+          "signing_key_id": "sonar-fixture-primary",
+          "producer": "sonar-api",
+          "contract": {
+            "name": "collection-report.trust-envelope",
+            "major_version": 1,
+            "minor_version": 0
+          },
+          "event_id": "77777777-7777-4777-8777-777777777777",
+          "stream_id": "sonar.public-capability.v1",
+          "stream_epoch": 1,
+          "sequence": 5,
+          "trust_stream": false,
+          "issued_at": "2026-07-17T21:00:00.000Z",
+          "expires_at": "2026-07-17T21:05:00.000Z",
+          "tenant_scope_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "capability": "collection-report.capability-evidence.v1",
+          "body_digest": "f9353be76f4f70fc1d95a58d2b86930b8bc3864c11c08c5e07be8e26de317cc9"
+        },
+        "body": {
+          "schema_version": 1,
+          "deployment_id": "deploy-alpha-mainnet",
+          "capability_state": "tampered"
+        },
+        "signature": "ZlrJXId9D5FaK29eQ92DAkY3a92zfB8JMdpGv5uqvFax4pdrmJeX7uMAZF5zZgFXyT6NC7eJyRU0SVkVHFE_BQ"
+      },
+      "expect": "reject",
+      "reject_reason": "body_digest_mismatch",
+      "reject_stage": "verify"
+    }
+  ],
+  "baselines": [
+    {
+      "id": "epoch-2-complete",
+      "baseline": {
+        "schema_version": 1,
+        "schema_minor": 0,
+        "algorithm": "Ed25519",
+        "producer": "sonar-api",
+        "stream_id": "sonar.public-capability.v1",
+        "stream_epoch": 2,
+        "highest_sequence": 2,
+        "envelope_count": 2,
+        "baseline_digest": "d32e712512f816bf0305aae3b29d8e34f3a4fab4bc93be8778da65f7adc8de4c",
+        "issued_at": "2026-07-17T21:00:00.000Z",
+        "signing_key_id": "sonar-fixture-primary",
+        "signature": "3q-jZvDczB3AamRUfsy2E79yWmSE4JvzWzVxO4z8__2cJgyB-96mgN-N27MpnlT1gcTBxVnPxFiyCEdTP5FCAg"
+      }
+    }
+  ]
+}

--- a/packages/protocol/trust-envelope/package.json
+++ b/packages/protocol/trust-envelope/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@freeside/trust-envelope-protocol",
+  "version": "1.0.0",
+  "description": "CR-009 signed trust-envelope wire contract, Ed25519 verification, stream sequencing, and shared producer/consumer fixtures for Ordering dependency intake.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "fixtures",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "generate-fixtures": "pnpm run build && node --experimental-strip-types scripts/generate-fixtures.ts",
+    "clean": "rm -rf dist",
+    "prepack": "pnpm run build",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "license": "AGPL-3.0",
+  "dependencies": {
+    "@noble/curves": "^1.9.1",
+    "@noble/hashes": "^1.8.0",
+    "canonicalize": "^2.1.0"
+  },
+  "peerDependencies": {
+    "effect": "^3.21.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "effect": "^3.21.0",
+    "typescript": "^5.7.0",
+    "vitest": "^4.0.17"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/protocol/trust-envelope/pnpm-lock.yaml
+++ b/packages/protocol/trust-envelope/pnpm-lock.yaml
@@ -1,0 +1,826 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@noble/curves':
+        specifier: ^1.9.1
+        version: 1.9.7
+      '@noble/hashes':
+        specifier: ^1.8.0
+        version: 1.8.0
+      canonicalize:
+        specifier: ^2.1.0
+        version: 2.1.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.1
+      effect:
+        specifier: ^3.21.0
+        version: 3.22.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.17
+        version: 4.1.10(@types/node@22.20.1)(vite@8.1.5(@types/node@22.20.1))
+
+packages:
+
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  canonicalize@2.1.0:
+    resolution: {integrity: sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==}
+    hasBin: true
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  effect@3.22.0:
+    resolution: {integrity: sha512-jhYFe0zTlIRqYFrKTS+6luhmS/Tm0f+JLo0K9KUxvtFab1SUGEszQi2ehOP6QzAZvy831lDmTwwzvVDZSPNz3g==}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  vite@8.1.5:
+    resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+snapshots:
+
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.8.0': {}
+
+  '@oxc-project/types@0.139.0': {}
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@22.20.1))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.5(@types/node@22.20.1)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  assertion-error@2.0.1: {}
+
+  canonicalize@2.1.0: {}
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  detect-libc@2.1.2: {}
+
+  effect@3.22.0:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
+  es-module-lexer@2.3.1: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fsevents@2.3.3:
+    optional: true
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  nanoid@3.3.16: {}
+
+  obug@2.1.4: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.19:
+    dependencies:
+      nanoid: 3.3.16
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  pure-rand@6.1.0: {}
+
+  rolldown@1.1.5:
+    dependencies:
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
+
+  tslib@2.8.1:
+    optional: true
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  vite@8.1.5(@types/node@22.20.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.19
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.1
+      fsevents: 2.3.3
+
+  vitest@4.1.10(@types/node@22.20.1)(vite@8.1.5(@types/node@22.20.1)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@22.20.1))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.5(@types/node@22.20.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.20.1
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/packages/protocol/trust-envelope/scripts/generate-fixtures.ts
+++ b/packages/protocol/trust-envelope/scripts/generate-fixtures.ts
@@ -1,0 +1,227 @@
+import { writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  FIXTURE_CAPABILITY,
+  FIXTURE_SIGNING_KEY_IDS,
+  FIXTURE_STREAM_ID,
+  FIXTURE_TENANT_SCOPE_DIGEST,
+  fixturePublicKeys,
+  fixtureSigners,
+} from "../dist/fixture-keys.js";
+import { digestEpochBaselineMaterial, signStreamEpochBaseline } from "../dist/signing.js";
+import { emitTrustEnvelope } from "../dist/producer.js";
+
+const NOW = Date.parse("2026-07-17T21:00:00.000Z");
+const ACCEPTED_AT = NOW + 1_000;
+
+const signers = fixtureSigners();
+const publicKeys = fixturePublicKeys();
+
+const body = {
+  schema_version: 1,
+  deployment_id: "deploy-alpha-mainnet",
+  capability_state: "ready",
+};
+
+const acceptedEnvelope = emitTrustEnvelope({
+  signer: signers.sonarPrimary,
+  producer: "sonar-api",
+  eventId: "11111111-1111-4111-8111-111111111111",
+  streamId: FIXTURE_STREAM_ID,
+  streamEpoch: 1,
+  sequence: 1,
+  trustStream: true,
+  issuedAtMs: NOW,
+  tenantScopeDigest: FIXTURE_TENANT_SCOPE_DIGEST,
+  capability: FIXTURE_CAPABILITY,
+  body,
+});
+
+const rotatedEnvelope = emitTrustEnvelope({
+  signer: signers.sonarRotated,
+  producer: "sonar-api",
+  eventId: "22222222-2222-4222-8222-222222222222",
+  streamId: FIXTURE_STREAM_ID,
+  streamEpoch: 1,
+  sequence: 2,
+  trustStream: true,
+  issuedAtMs: NOW,
+  tenantScopeDigest: FIXTURE_TENANT_SCOPE_DIGEST,
+  capability: FIXTURE_CAPABILITY,
+  body,
+});
+
+const revokedKeyEnvelope = emitTrustEnvelope({
+  signer: signers.sonarRevoked,
+  producer: "sonar-api",
+  eventId: "33333333-3333-4333-8333-333333333333",
+  streamId: FIXTURE_STREAM_ID,
+  streamEpoch: 1,
+  sequence: 3,
+  trustStream: true,
+  issuedAtMs: NOW,
+  tenantScopeDigest: FIXTURE_TENANT_SCOPE_DIGEST,
+  capability: FIXTURE_CAPABILITY,
+  body,
+});
+
+const expiredEnvelope = emitTrustEnvelope({
+  signer: signers.sonarPrimary,
+  producer: "sonar-api",
+  eventId: "44444444-4444-4444-8444-444444444444",
+  streamId: FIXTURE_STREAM_ID,
+  streamEpoch: 1,
+  sequence: 4,
+  trustStream: true,
+  issuedAtMs: NOW - 600_000,
+  ttlMs: 60_000,
+  tenantScopeDigest: FIXTURE_TENANT_SCOPE_DIGEST,
+  capability: FIXTURE_CAPABILITY,
+  body,
+});
+
+const gapEnvelope = emitTrustEnvelope({
+  signer: signers.sonarPrimary,
+  producer: "sonar-api",
+  eventId: "55555555-5555-4555-8555-555555555555",
+  streamId: FIXTURE_STREAM_ID,
+  streamEpoch: 1,
+  sequence: 6,
+  trustStream: true,
+  issuedAtMs: NOW,
+  tenantScopeDigest: FIXTURE_TENANT_SCOPE_DIGEST,
+  capability: FIXTURE_CAPABILITY,
+  body,
+});
+
+const epochTwoEnvelope = emitTrustEnvelope({
+  signer: signers.sonarPrimary,
+  producer: "sonar-api",
+  eventId: "66666666-6666-4666-8666-666666666666",
+  streamId: FIXTURE_STREAM_ID,
+  streamEpoch: 2,
+  sequence: 1,
+  trustStream: true,
+  issuedAtMs: NOW,
+  tenantScopeDigest: FIXTURE_TENANT_SCOPE_DIGEST,
+  capability: FIXTURE_CAPABILITY,
+  body,
+});
+
+const tamperedBodyEnvelope = emitTrustEnvelope({
+  signer: signers.sonarPrimary,
+  producer: "sonar-api",
+  eventId: "77777777-7777-4777-8777-777777777777",
+  streamId: FIXTURE_STREAM_ID,
+  streamEpoch: 1,
+  sequence: 5,
+  trustStream: false,
+  issuedAtMs: NOW,
+  tenantScopeDigest: FIXTURE_TENANT_SCOPE_DIGEST,
+  capability: FIXTURE_CAPABILITY,
+  body,
+});
+const tampered = structuredClone(tamperedBodyEnvelope);
+(tampered.body as { capability_state: string }).capability_state = "tampered";
+
+const baselineDigest = digestEpochBaselineMaterial({
+  stream_id: FIXTURE_STREAM_ID,
+  stream_epoch: 1,
+  highest_sequence: 2,
+  envelope_count: 2,
+  envelopes: [acceptedEnvelope, rotatedEnvelope],
+});
+
+const epochBaseline = signStreamEpochBaseline(signers.sonarPrimary, {
+  schema_version: 1,
+  schema_minor: 0,
+  algorithm: "Ed25519",
+  producer: "sonar-api",
+  stream_id: FIXTURE_STREAM_ID,
+  stream_epoch: 2,
+  highest_sequence: 2,
+  envelope_count: 2,
+  baseline_digest: baselineDigest,
+  issued_at: new Date(NOW).toISOString(),
+});
+
+const bundle = {
+  schema_version: 1 as const,
+  accepted_at_ms: ACCEPTED_AT,
+  registry: {
+    schema_version: 1 as const,
+    keys: [
+      {
+        signing_key_id: FIXTURE_SIGNING_KEY_IDS.sonarPrimary,
+        public_key_hex: publicKeys[FIXTURE_SIGNING_KEY_IDS.sonarPrimary],
+        producer: "sonar-api",
+        capabilities: [FIXTURE_CAPABILITY],
+        tenant_scope_digests: [FIXTURE_TENANT_SCOPE_DIGEST],
+        activated_at: "2026-07-01T00:00:00.000Z",
+      },
+      {
+        signing_key_id: FIXTURE_SIGNING_KEY_IDS.sonarRotated,
+        public_key_hex: publicKeys[FIXTURE_SIGNING_KEY_IDS.sonarRotated],
+        producer: "sonar-api",
+        capabilities: [FIXTURE_CAPABILITY],
+        tenant_scope_digests: [FIXTURE_TENANT_SCOPE_DIGEST],
+        activated_at: "2026-07-10T00:00:00.000Z",
+      },
+      {
+        signing_key_id: FIXTURE_SIGNING_KEY_IDS.sonarRevoked,
+        public_key_hex: publicKeys[FIXTURE_SIGNING_KEY_IDS.sonarRevoked],
+        producer: "sonar-api",
+        capabilities: [FIXTURE_CAPABILITY],
+        tenant_scope_digests: [FIXTURE_TENANT_SCOPE_DIGEST],
+        activated_at: "2026-07-01T00:00:00.000Z",
+        revoked_at: "2026-07-16T00:00:00.000Z",
+      },
+    ],
+  },
+  envelopes: [
+    { id: "valid-primary", envelope: acceptedEnvelope, expect: "accept" as const },
+    { id: "rotation-overlap-new-key", envelope: rotatedEnvelope, expect: "accept" as const },
+    {
+      id: "revoked-key",
+      envelope: revokedKeyEnvelope,
+      expect: "reject" as const,
+      reject_reason: "revoked_signing_key",
+      reject_stage: "verify",
+    },
+    {
+      id: "expired",
+      envelope: expiredEnvelope,
+      expect: "reject" as const,
+      reject_reason: "expired",
+      reject_stage: "verify",
+    },
+    {
+      id: "sequence-gap",
+      envelope: gapEnvelope,
+      expect: "reject" as const,
+      reject_reason: "sequence_gap",
+      reject_stage: "ingest",
+    },
+    {
+      id: "epoch-without-baseline",
+      envelope: epochTwoEnvelope,
+      expect: "reject" as const,
+      reject_reason: "epoch_baseline_required",
+      reject_stage: "ingest",
+    },
+    {
+      id: "tampered-body",
+      envelope: tampered,
+      expect: "reject" as const,
+      reject_reason: "body_digest_mismatch",
+      reject_stage: "verify",
+    },
+  ],
+  baselines: [{ id: "epoch-2-complete", baseline: epochBaseline }],
+};
+
+const outDir = join(dirname(fileURLToPath(import.meta.url)), "../fixtures/scenarios");
+writeFileSync(join(outDir, "producer-consumer.shared.json"), `${JSON.stringify(bundle, null, 2)}\n`);
+
+console.log(`Wrote ${join(outDir, "producer-consumer.shared.json")}`);

--- a/packages/protocol/trust-envelope/src/__tests__/ordering-consumer.test.ts
+++ b/packages/protocol/trust-envelope/src/__tests__/ordering-consumer.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  createStreamConsumerState,
+  decodeFixtureScenarioBundle,
+  fixtureRegistryFromBundle,
+  ingestTrustEnvelope,
+  FIXTURE_STREAM_ID,
+} from "../index.js";
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), "../../fixtures/scenarios");
+
+describe("Ordering replay consumer fixture contract", () => {
+  it("Ordering-shaped inbox consumer ingests the same committed envelope vectors", () => {
+    const bundle = decodeFixtureScenarioBundle(
+      JSON.parse(readFileSync(join(fixturesDir, "producer-consumer.shared.json"), "utf8")),
+    );
+    const registry = fixtureRegistryFromBundle(bundle);
+    const acceptedAtMs = Date.parse("2026-07-17T21:00:01.000Z");
+    let state = createStreamConsumerState(FIXTURE_STREAM_ID, 1);
+
+    for (const scenario of bundle.envelopes) {
+      if (scenario.expect !== "accept") continue;
+      const result = ingestTrustEnvelope({
+        envelope: scenario.envelope,
+        registry,
+        acceptedAtMs,
+        state,
+      });
+      expect(result.kind, scenario.id).toBe("accepted");
+      if (result.kind === "accepted") {
+        state = result.state;
+      }
+    }
+
+    expect(state.highestContiguousSequence).toBeGreaterThan(0);
+    expect(state.seenEventIds.size).toBeGreaterThan(0);
+  });
+});

--- a/packages/protocol/trust-envelope/src/__tests__/producer-consumer.test.ts
+++ b/packages/protocol/trust-envelope/src/__tests__/producer-consumer.test.ts
@@ -145,6 +145,24 @@ describe("shared producer/consumer fixtures (CR-009)", () => {
     if (gapResult.kind === "rejected") {
       expect(gapResult.error.reason).toBe("sequence_gap");
       expect(requestGapRepairRange(gapResult.state)).toEqual({ fromSequence: 3, toSequence: 5 });
+      // BB #497: gap reject must not poison event_id or skip missing sequences.
+      expect(gapResult.state.seenEventIds.has(gap!.envelope.header.event_id)).toBe(false);
+      expect(gapResult.state.highestContiguousSequence).toBe(
+        second.state.highestContiguousSequence,
+      );
+    }
+
+    // Redelivery of the same jumped-ahead envelope still reports sequence_gap
+    // (not event_id_replay) until the missing range is repaired in order.
+    const gapRedelivery = ingestTrustEnvelope({
+      envelope: gap!.envelope,
+      registry,
+      acceptedAtMs,
+      state: gapResult.state,
+    });
+    expect(gapRedelivery.kind).toBe("rejected");
+    if (gapRedelivery.kind === "rejected") {
+      expect(gapRedelivery.error.reason).toBe("sequence_gap");
     }
 
     const epochReject = ingestTrustEnvelope({

--- a/packages/protocol/trust-envelope/src/__tests__/producer-consumer.test.ts
+++ b/packages/protocol/trust-envelope/src/__tests__/producer-consumer.test.ts
@@ -1,0 +1,179 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  TrustEnvelopeRejectedError,
+  createStreamConsumerState,
+  decodeFixtureScenarioBundle,
+  fixtureRegistryFromBundle,
+  ingestTrustEnvelope,
+  installEpochBaseline,
+  requestGapRepairRange,
+  verifyTrustEnvelope,
+  FIXTURE_STREAM_ID,
+} from "../index.js";
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), "../../fixtures/scenarios");
+
+describe("shared producer/consumer fixtures (CR-009)", () => {
+  const bundle = decodeFixtureScenarioBundle(
+    JSON.parse(readFileSync(join(fixturesDir, "producer-consumer.shared.json"), "utf8")),
+  );
+  const registry = fixtureRegistryFromBundle(bundle);
+  const acceptedAtMs = (bundle as { accepted_at_ms?: number }).accepted_at_ms ?? Date.parse(
+    "2026-07-17T21:00:01.000Z",
+  );
+
+  it("passes verification for every accept fixture", () => {
+    for (const scenario of bundle.envelopes.filter((entry) => entry.expect === "accept")) {
+      expect(() =>
+        verifyTrustEnvelope({
+          envelope: scenario.envelope,
+          registry,
+          acceptedAtMs,
+        }),
+      ).not.toThrow();
+    }
+  });
+
+  it("rejects verify-stage fixtures before persistence", () => {
+    for (const scenario of bundle.envelopes.filter(
+      (entry) => entry.expect === "reject" && entry.reject_stage === "verify",
+    )) {
+      try {
+        verifyTrustEnvelope({
+          envelope: scenario.envelope,
+          registry,
+          acceptedAtMs,
+        });
+        expect.fail(`expected rejection for ${scenario.id}`);
+      } catch (error) {
+        expect(error).toBeInstanceOf(TrustEnvelopeRejectedError);
+        if (scenario.reject_reason !== undefined) {
+          expect((error as TrustEnvelopeRejectedError).reason).toBe(scenario.reject_reason);
+        }
+      }
+    }
+  });
+
+  it("rejects ingest-stage fixtures at the inbox boundary", () => {
+    let state = createStreamConsumerState(FIXTURE_STREAM_ID, 1);
+    const accepted = bundle.envelopes.find((entry) => entry.id === "valid-primary");
+    const rotated = bundle.envelopes.find((entry) => entry.id === "rotation-overlap-new-key");
+    expect(accepted).toBeDefined();
+    expect(rotated).toBeDefined();
+
+    for (const envelope of [accepted!, rotated!]) {
+      const result = ingestTrustEnvelope({
+        envelope: envelope.envelope,
+        registry,
+        acceptedAtMs,
+        state,
+      });
+      expect(result.kind).toBe("accepted");
+      if (result.kind === "accepted") state = result.state;
+    }
+
+    for (const scenario of bundle.envelopes.filter(
+      (entry) => entry.expect === "reject" && entry.reject_stage === "ingest",
+    )) {
+      const result = ingestTrustEnvelope({
+        envelope: scenario.envelope,
+        registry,
+        acceptedAtMs,
+        state,
+      });
+      expect(result.kind, scenario.id).toBe("rejected");
+      if (result.kind === "rejected" && scenario.reject_reason !== undefined) {
+        expect(result.error.reason).toBe(scenario.reject_reason);
+      }
+    }
+  });
+
+  it("covers rotation, gap repair, epoch baseline, replay, and disaster recovery", () => {
+    let state = createStreamConsumerState(FIXTURE_STREAM_ID, 1);
+
+    const accepted = bundle.envelopes.find((entry) => entry.id === "valid-primary");
+    const rotated = bundle.envelopes.find((entry) => entry.id === "rotation-overlap-new-key");
+    const gap = bundle.envelopes.find((entry) => entry.id === "sequence-gap");
+    const epochWithoutBaseline = bundle.envelopes.find(
+      (entry) => entry.id === "epoch-without-baseline",
+    );
+    const baselineScenario = bundle.baselines?.find((entry) => entry.id === "epoch-2-complete");
+
+    expect(accepted).toBeDefined();
+    expect(rotated).toBeDefined();
+    expect(gap).toBeDefined();
+    expect(epochWithoutBaseline).toBeDefined();
+    expect(baselineScenario).toBeDefined();
+
+    const first = ingestTrustEnvelope({
+      envelope: accepted!.envelope,
+      registry,
+      acceptedAtMs,
+      state,
+    });
+    expect(first.kind).toBe("accepted");
+
+    const second = ingestTrustEnvelope({
+      envelope: rotated!.envelope,
+      registry,
+      acceptedAtMs,
+      state: first.state,
+    });
+    expect(second.kind).toBe("accepted");
+
+    const replay = ingestTrustEnvelope({
+      envelope: accepted!.envelope,
+      registry,
+      acceptedAtMs,
+      state: second.state,
+    });
+    expect(replay.kind).toBe("rejected");
+    if (replay.kind === "rejected") {
+      expect(replay.error.reason).toBe("event_id_replay");
+    }
+
+    const gapResult = ingestTrustEnvelope({
+      envelope: gap!.envelope,
+      registry,
+      acceptedAtMs,
+      state: second.state,
+    });
+    expect(gapResult.kind).toBe("rejected");
+    if (gapResult.kind === "rejected") {
+      expect(gapResult.error.reason).toBe("sequence_gap");
+      expect(requestGapRepairRange(gapResult.state)).toEqual({ fromSequence: 3, toSequence: 5 });
+    }
+
+    const epochReject = ingestTrustEnvelope({
+      envelope: epochWithoutBaseline!.envelope,
+      registry,
+      acceptedAtMs,
+      state: second.state,
+    });
+    expect(epochReject.kind).toBe("rejected");
+
+    state = installEpochBaseline({
+      baseline: baselineScenario!.baseline,
+      registry,
+      acceptedAtMs,
+      state: second.state,
+      expectedBaselineDigest: baselineScenario!.baseline.baseline_digest,
+    });
+    expect(state.streamEpoch).toBe(2);
+    expect(state.baselineInstalled).toBe(true);
+
+    const resumedOldEpoch = ingestTrustEnvelope({
+      envelope: accepted!.envelope,
+      registry,
+      acceptedAtMs,
+      state,
+    });
+    expect(resumedOldEpoch.kind).toBe("rejected");
+    if (resumedOldEpoch.kind === "rejected") {
+      expect(resumedOldEpoch.error.reason).toBe("epoch_resume_forbidden");
+    }
+  });
+});

--- a/packages/protocol/trust-envelope/src/__tests__/protocol.test.ts
+++ b/packages/protocol/trust-envelope/src/__tests__/protocol.test.ts
@@ -1,0 +1,106 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  acceptsEnvelopeSchemaMinor,
+  computeBodyDigest,
+  decodeTrustEnvelope,
+  emitTrustEnvelope,
+  envelopeSigningBytes,
+  fixtureSigners,
+  mixedMinorRules,
+  verifyEd25519Signature,
+  verifyTrustEnvelope,
+  ServiceKeyRegistry,
+  FIXTURE_CAPABILITY,
+  FIXTURE_STREAM_ID,
+  FIXTURE_TENANT_SCOPE_DIGEST,
+  TRUST_ENVELOPE_SCHEMA_MAJOR,
+} from "../index.js";
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), "../../fixtures/scenarios");
+const NOW = Date.parse("2026-07-17T21:00:00.000Z");
+
+describe("trust envelope protocol (CR-009)", () => {
+  it("decodes envelopes strictly and rejects excess properties", () => {
+    const signers = fixtureSigners();
+    const envelope = emitTrustEnvelope({
+      signer: signers.sonarPrimary,
+      producer: "sonar-api",
+      eventId: "88888888-8888-4888-8888-888888888888",
+      streamId: FIXTURE_STREAM_ID,
+      streamEpoch: 1,
+      sequence: 1,
+      trustStream: true,
+      issuedAtMs: NOW,
+      tenantScopeDigest: FIXTURE_TENANT_SCOPE_DIGEST,
+      capability: FIXTURE_CAPABILITY,
+      body: { schema_version: 1, ok: true },
+    });
+    const decoded = decodeTrustEnvelope(envelope);
+    expect(decoded.header.contract.major_version).toBe(TRUST_ENVELOPE_SCHEMA_MAJOR);
+    expect(() =>
+      decodeTrustEnvelope({
+        ...envelope,
+        unexpected: true,
+      }),
+    ).toThrow();
+  });
+
+  it("binds body digest and verifies Ed25519 signature bytes", () => {
+    const signers = fixtureSigners();
+    const body = { schema_version: 1, value: 42 };
+    const envelope = emitTrustEnvelope({
+      signer: signers.sonarPrimary,
+      producer: "sonar-api",
+      eventId: "99999999-9999-4999-8999-999999999999",
+      streamId: FIXTURE_STREAM_ID,
+      streamEpoch: 1,
+      sequence: 1,
+      trustStream: false,
+      issuedAtMs: NOW,
+      tenantScopeDigest: FIXTURE_TENANT_SCOPE_DIGEST,
+      capability: FIXTURE_CAPABILITY,
+      body,
+    });
+    expect(envelope.header.body_digest).toBe(computeBodyDigest(body));
+    expect(
+      verifyEd25519Signature(
+        signers.sonarPrimary.publicKeyHex(),
+        envelopeSigningBytes({ header: envelope.header, body: envelope.body }),
+        envelope.signature,
+      ),
+    ).toBe(true);
+  });
+
+  it("documents explicit mixed-minor rules", () => {
+    expect(mixedMinorRules.unknownMajor).toBe("fail_closed");
+    expect(acceptsEnvelopeSchemaMinor(0, 0)).toBe(true);
+    expect(acceptsEnvelopeSchemaMinor(1, 0)).toBe(false);
+  });
+
+  it("rejects unknown schema major before signature verification", () => {
+    const bundle = JSON.parse(
+      readFileSync(join(fixturesDir, "producer-consumer.shared.json"), "utf8"),
+    ) as {
+      registry: { keys: import("../contracts.js").ServiceSigningKey[] };
+      envelopes: Array<{ envelope: ReturnType<typeof decodeTrustEnvelope> }>;
+    };
+    const registry = new ServiceKeyRegistry(bundle.registry.keys);
+    const envelope = {
+      ...structuredClone(bundle.envelopes[0]!.envelope),
+      header: {
+        ...bundle.envelopes[0]!.envelope.header,
+        schema_version: 99 as unknown as 1,
+      },
+    };
+    expect(() =>
+      verifyTrustEnvelope({
+        envelope,
+        registry,
+        acceptedAtMs: NOW + 1_000,
+      }),
+    ).toThrow(/unsupported trust-envelope schema major/);
+  });
+});

--- a/packages/protocol/trust-envelope/src/__tests__/sonar-producer.test.ts
+++ b/packages/protocol/trust-envelope/src/__tests__/sonar-producer.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  advanceTrustStreamProducer,
+  createTrustStreamProducerState,
+  decodeFixtureScenarioBundle,
+  emitTrustEnvelope,
+  fixtureSigners,
+  verifyTrustEnvelope,
+  fixtureRegistryFromBundle,
+  FIXTURE_CAPABILITY,
+  FIXTURE_STREAM_ID,
+  FIXTURE_TENANT_SCOPE_DIGEST,
+} from "../index.js";
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), "../../fixtures/scenarios");
+
+describe("Sonar producer fixture contract", () => {
+  it("Sonar-shaped producers emit envelopes that pass shared verification", () => {
+    const bundle = decodeFixtureScenarioBundle(
+      JSON.parse(readFileSync(join(fixturesDir, "producer-consumer.shared.json"), "utf8")),
+    );
+    const registry = fixtureRegistryFromBundle(bundle);
+    const signers = fixtureSigners();
+    let producer = createTrustStreamProducerState(FIXTURE_STREAM_ID, 1);
+    const issuedAtMs = Date.parse("2026-07-17T21:00:00.000Z");
+    const acceptedAtMs = Date.parse("2026-07-17T21:00:01.000Z");
+
+    const emitted = emitTrustEnvelope({
+      signer: signers.sonarPrimary,
+      producer: "sonar-api",
+      eventId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      streamId: producer.streamId,
+      streamEpoch: producer.streamEpoch,
+      sequence: producer.nextSequence,
+      trustStream: true,
+      issuedAtMs,
+      tenantScopeDigest: FIXTURE_TENANT_SCOPE_DIGEST,
+      capability: FIXTURE_CAPABILITY,
+      body: { schema_version: 1, probe: "sonar-fixture" },
+    });
+    producer = advanceTrustStreamProducer(producer);
+
+    expect(() =>
+      verifyTrustEnvelope({
+        envelope: emitted,
+        registry,
+        acceptedAtMs,
+      }),
+    ).not.toThrow();
+
+    const fixturePrimary = bundle.envelopes.find((entry) => entry.id === "valid-primary");
+    expect(fixturePrimary?.envelope.header.producer).toBe("sonar-api");
+  });
+});

--- a/packages/protocol/trust-envelope/src/consumer.ts
+++ b/packages/protocol/trust-envelope/src/consumer.ts
@@ -50,10 +50,18 @@ const cloneState = (state: StreamConsumerState): StreamConsumerState => ({
   retainedAcceptedAtMs: [...state.retainedAcceptedAtMs],
 });
 
+const commitAccepted = (
+  state: StreamConsumerState,
+  envelope: TrustEnvelope,
+  acceptedAtMs: number,
+): void => {
+  state.seenEventIds.add(envelope.header.event_id);
+  state.retainedAcceptedAtMs.push(acceptedAtMs);
+};
+
 export const ingestTrustEnvelope = (
   input: IngestTrustEnvelopeInput,
 ): IngestTrustEnvelopeResult => {
-  const state = cloneState(input.state);
   const retentionMs = input.retentionMs ?? TRUST_STREAM_MIN_RETENTION_MS;
 
   try {
@@ -69,7 +77,7 @@ export const ingestTrustEnvelope = (
     throw error;
   }
 
-  if (input.envelope.header.stream_id !== state.streamId) {
+  if (input.envelope.header.stream_id !== input.state.streamId) {
     return {
       kind: "rejected",
       error: new TrustEnvelopeRejectedError({ reason: "epoch_mismatch" }),
@@ -77,7 +85,7 @@ export const ingestTrustEnvelope = (
     };
   }
 
-  if (input.envelope.header.stream_epoch < state.streamEpoch) {
+  if (input.envelope.header.stream_epoch < input.state.streamEpoch) {
     return {
       kind: "rejected",
       error: new TrustEnvelopeRejectedError({
@@ -88,7 +96,7 @@ export const ingestTrustEnvelope = (
     };
   }
 
-  if (input.envelope.header.stream_epoch > state.streamEpoch) {
+  if (input.envelope.header.stream_epoch > input.state.streamEpoch) {
     return {
       kind: "rejected",
       error: new TrustEnvelopeRejectedError({
@@ -99,7 +107,7 @@ export const ingestTrustEnvelope = (
     };
   }
 
-  if (state.seenEventIds.has(input.envelope.header.event_id)) {
+  if (input.state.seenEventIds.has(input.envelope.header.event_id)) {
     return {
       kind: "rejected",
       error: new TrustEnvelopeRejectedError({ reason: "event_id_replay" }),
@@ -107,7 +115,7 @@ export const ingestTrustEnvelope = (
     };
   }
 
-  const oldestRetained = state.retainedAcceptedAtMs[0];
+  const oldestRetained = input.state.retainedAcceptedAtMs[0];
   if (
     oldestRetained !== undefined &&
     input.acceptedAtMs - oldestRetained > retentionMs
@@ -122,15 +130,15 @@ export const ingestTrustEnvelope = (
     };
   }
 
-  state.seenEventIds.add(input.envelope.header.event_id);
-  state.retainedAcceptedAtMs.push(input.acceptedAtMs);
-
+  // Non-trust streams: event_id idempotency only — no contiguous sequence.
   if (!input.envelope.header.trust_stream) {
+    const state = cloneState(input.state);
+    commitAccepted(state, input.envelope, input.acceptedAtMs);
     return { kind: "accepted", state, replay: false };
   }
 
   const sequence = input.envelope.header.sequence;
-  if (sequence <= state.highestContiguousSequence) {
+  if (sequence <= input.state.highestContiguousSequence) {
     return {
       kind: "rejected",
       error: new TrustEnvelopeRejectedError({ reason: "sequence_reuse" }),
@@ -138,8 +146,11 @@ export const ingestTrustEnvelope = (
     };
   }
 
-  const expected = state.highestContiguousSequence + 1;
+  const expected = input.state.highestContiguousSequence + 1;
   if (sequence > expected) {
+    // Record missing sequences for repair, but do NOT accept this envelope and
+    // do NOT commit event_id (redelivery after gap fill must succeed).
+    const state = cloneState(input.state);
     for (let gap = expected; gap < sequence; gap += 1) {
       state.gaps.add(gap);
     }
@@ -153,12 +164,11 @@ export const ingestTrustEnvelope = (
     };
   }
 
+  // sequence === expected: accept in order only. Never advance across gaps.
+  const state = cloneState(input.state);
+  commitAccepted(state, input.envelope, input.acceptedAtMs);
   state.highestContiguousSequence = sequence;
   state.gaps.delete(sequence);
-  while (state.gaps.has(state.highestContiguousSequence + 1)) {
-    state.highestContiguousSequence += 1;
-    state.gaps.delete(state.highestContiguousSequence);
-  }
 
   return { kind: "accepted", state, replay: false };
 };
@@ -211,6 +221,10 @@ export const replayEnvelopeIdempotently = (
       error: new TrustEnvelopeRejectedError({ reason: "event_id_replay" }),
       state: input.state,
     };
+  }
+  // True idempotent replay of an already-accepted event_id.
+  if (input.state.seenEventIds.has(input.envelope.header.event_id)) {
+    return { kind: "accepted", state: input.state, replay: true };
   }
   return ingestTrustEnvelope(input);
 };

--- a/packages/protocol/trust-envelope/src/consumer.ts
+++ b/packages/protocol/trust-envelope/src/consumer.ts
@@ -1,0 +1,216 @@
+import type { StreamEpochBaseline, TrustEnvelope } from "./contracts.js";
+import { TrustEnvelopeRejectedError } from "./errors.js";
+import { ServiceKeyRegistry } from "./registry.js";
+import { TRUST_STREAM_MIN_RETENTION_MS } from "./version.js";
+import { verifyStreamEpochBaseline, verifyTrustEnvelope } from "./verify.js";
+
+export interface StreamConsumerState {
+  readonly streamId: string;
+  streamEpoch: number;
+  highestContiguousSequence: number;
+  readonly gaps: Set<number>;
+  readonly seenEventIds: Set<string>;
+  baselineInstalled: boolean;
+  readonly retainedAcceptedAtMs: number[];
+}
+
+export interface IngestTrustEnvelopeInput {
+  readonly envelope: TrustEnvelope;
+  readonly registry: ServiceKeyRegistry;
+  readonly acceptedAtMs: number;
+  readonly state: StreamConsumerState;
+  readonly retentionMs?: number;
+}
+
+export type IngestTrustEnvelopeResult =
+  | { readonly kind: "accepted"; readonly state: StreamConsumerState; readonly replay: boolean }
+  | {
+      readonly kind: "rejected";
+      readonly error: TrustEnvelopeRejectedError;
+      readonly state: StreamConsumerState;
+    };
+
+export const createStreamConsumerState = (
+  streamId: string,
+  streamEpoch = 1,
+): StreamConsumerState => ({
+  streamId,
+  streamEpoch,
+  highestContiguousSequence: 0,
+  gaps: new Set<number>(),
+  seenEventIds: new Set<string>(),
+  baselineInstalled: streamEpoch === 1,
+  retainedAcceptedAtMs: [],
+});
+
+const cloneState = (state: StreamConsumerState): StreamConsumerState => ({
+  ...state,
+  gaps: new Set(state.gaps),
+  seenEventIds: new Set(state.seenEventIds),
+  retainedAcceptedAtMs: [...state.retainedAcceptedAtMs],
+});
+
+export const ingestTrustEnvelope = (
+  input: IngestTrustEnvelopeInput,
+): IngestTrustEnvelopeResult => {
+  const state = cloneState(input.state);
+  const retentionMs = input.retentionMs ?? TRUST_STREAM_MIN_RETENTION_MS;
+
+  try {
+    verifyTrustEnvelope({
+      envelope: input.envelope,
+      registry: input.registry,
+      acceptedAtMs: input.acceptedAtMs,
+    });
+  } catch (error) {
+    if (error instanceof TrustEnvelopeRejectedError) {
+      return { kind: "rejected", error, state: input.state };
+    }
+    throw error;
+  }
+
+  if (input.envelope.header.stream_id !== state.streamId) {
+    return {
+      kind: "rejected",
+      error: new TrustEnvelopeRejectedError({ reason: "epoch_mismatch" }),
+      state: input.state,
+    };
+  }
+
+  if (input.envelope.header.stream_epoch < state.streamEpoch) {
+    return {
+      kind: "rejected",
+      error: new TrustEnvelopeRejectedError({
+        reason: "epoch_resume_forbidden",
+        remediation: "install_epoch_baseline",
+      }),
+      state: input.state,
+    };
+  }
+
+  if (input.envelope.header.stream_epoch > state.streamEpoch) {
+    return {
+      kind: "rejected",
+      error: new TrustEnvelopeRejectedError({
+        reason: "epoch_baseline_required",
+        remediation: "install_epoch_baseline",
+      }),
+      state: input.state,
+    };
+  }
+
+  if (state.seenEventIds.has(input.envelope.header.event_id)) {
+    return {
+      kind: "rejected",
+      error: new TrustEnvelopeRejectedError({ reason: "event_id_replay" }),
+      state: input.state,
+    };
+  }
+
+  const oldestRetained = state.retainedAcceptedAtMs[0];
+  if (
+    oldestRetained !== undefined &&
+    input.acceptedAtMs - oldestRetained > retentionMs
+  ) {
+    return {
+      kind: "rejected",
+      error: new TrustEnvelopeRejectedError({
+        reason: "retention_violation",
+        remediation: "request_replay_range",
+      }),
+      state: input.state,
+    };
+  }
+
+  state.seenEventIds.add(input.envelope.header.event_id);
+  state.retainedAcceptedAtMs.push(input.acceptedAtMs);
+
+  if (!input.envelope.header.trust_stream) {
+    return { kind: "accepted", state, replay: false };
+  }
+
+  const sequence = input.envelope.header.sequence;
+  if (sequence <= state.highestContiguousSequence) {
+    return {
+      kind: "rejected",
+      error: new TrustEnvelopeRejectedError({ reason: "sequence_reuse" }),
+      state: input.state,
+    };
+  }
+
+  const expected = state.highestContiguousSequence + 1;
+  if (sequence > expected) {
+    for (let gap = expected; gap < sequence; gap += 1) {
+      state.gaps.add(gap);
+    }
+    return {
+      kind: "rejected",
+      error: new TrustEnvelopeRejectedError({
+        reason: "sequence_gap",
+        remediation: "request_replay_range",
+      }),
+      state,
+    };
+  }
+
+  state.highestContiguousSequence = sequence;
+  state.gaps.delete(sequence);
+  while (state.gaps.has(state.highestContiguousSequence + 1)) {
+    state.highestContiguousSequence += 1;
+    state.gaps.delete(state.highestContiguousSequence);
+  }
+
+  return { kind: "accepted", state, replay: false };
+};
+
+export interface InstallEpochBaselineInput {
+  readonly baseline: StreamEpochBaseline;
+  readonly registry: ServiceKeyRegistry;
+  readonly acceptedAtMs: number;
+  readonly state: StreamConsumerState;
+  readonly expectedBaselineDigest: string;
+}
+
+export const installEpochBaseline = (
+  input: InstallEpochBaselineInput,
+): StreamConsumerState => {
+  verifyStreamEpochBaseline({
+    baseline: input.baseline,
+    registry: input.registry,
+    acceptedAtMs: input.acceptedAtMs,
+    previousEpoch: input.state.streamEpoch,
+    expectedBaselineDigest: input.expectedBaselineDigest,
+  });
+
+  return {
+    ...input.state,
+    streamEpoch: input.baseline.stream_epoch,
+    highestContiguousSequence: input.baseline.highest_sequence,
+    gaps: new Set<number>(),
+    baselineInstalled: true,
+  };
+};
+
+export const requestGapRepairRange = (
+  state: StreamConsumerState,
+): { fromSequence: number; toSequence: number } | undefined => {
+  if (state.gaps.size === 0) return undefined;
+  const sorted = [...state.gaps].sort((left, right) => left - right);
+  const fromSequence = sorted[0];
+  const toSequence = sorted[sorted.length - 1];
+  if (fromSequence === undefined || toSequence === undefined) return undefined;
+  return { fromSequence, toSequence };
+};
+
+export const replayEnvelopeIdempotently = (
+  input: IngestTrustEnvelopeInput & { readonly prior: TrustEnvelope },
+): IngestTrustEnvelopeResult => {
+  if (input.prior.header.event_id !== input.envelope.header.event_id) {
+    return {
+      kind: "rejected",
+      error: new TrustEnvelopeRejectedError({ reason: "event_id_replay" }),
+      state: input.state,
+    };
+  }
+  return ingestTrustEnvelope(input);
+};

--- a/packages/protocol/trust-envelope/src/contracts.ts
+++ b/packages/protocol/trust-envelope/src/contracts.ts
@@ -1,0 +1,132 @@
+import { Schema } from "effect";
+import type { ParseOptions } from "effect/SchemaAST";
+import {
+  TRUST_ENVELOPE_SCHEMA_MAJOR,
+  TRUST_ENVELOPE_SCHEMA_MINOR,
+} from "./version.js";
+
+const SchemaMajor = Schema.Literal(TRUST_ENVELOPE_SCHEMA_MAJOR);
+const SchemaMinor = Schema.Number.pipe(Schema.int(), Schema.greaterThanOrEqualTo(0));
+
+const Hex64Schema = Schema.String.pipe(
+  Schema.pattern(/^[0-9a-f]{64}$/, {
+    message: () => "must be 64 lowercase hex chars (sha256)",
+  }),
+);
+
+const Base64UrlSchema = Schema.String.pipe(
+  Schema.pattern(/^[A-Za-z0-9_-]+$/, {
+    message: () => "must be base64url-encoded (no padding)",
+  }),
+);
+
+const Iso8601UtcSchema = Schema.String.pipe(
+  Schema.pattern(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/, {
+    message: () => "must be ISO-8601 UTC with trailing Z",
+  }),
+);
+
+const CellSlugSchema = Schema.String.pipe(
+  Schema.pattern(/^[a-z][a-z0-9-]*$/, {
+    message: () => "must be lowercase kebab-case producer slug",
+  }),
+);
+
+const SigningKeyIdSchema = Schema.String.pipe(
+  Schema.pattern(/^[A-Za-z0-9_.:-]{1,128}$/),
+);
+
+const EventIdSchema = Schema.String.pipe(
+  Schema.pattern(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/),
+);
+
+const StreamIdSchema = Schema.String.pipe(Schema.minLength(1), Schema.maxLength(256));
+const CapabilitySchema = Schema.String.pipe(Schema.minLength(1), Schema.maxLength(256));
+const ContractNameSchema = Schema.String.pipe(Schema.minLength(1), Schema.maxLength(128));
+
+export const strictDecodeOptions: ParseOptions = {
+  errors: "all",
+  onExcessProperty: "error",
+};
+
+export const TrustContractRef = Schema.Struct({
+  name: ContractNameSchema,
+  major_version: Schema.Number.pipe(Schema.int(), Schema.greaterThanOrEqualTo(1)),
+  minor_version: Schema.Number.pipe(Schema.int(), Schema.greaterThanOrEqualTo(0)),
+}).annotations({ identifier: "TrustContractRef" });
+export type TrustContractRef = Schema.Schema.Type<typeof TrustContractRef>;
+
+export const TrustEnvelopeHeader = Schema.Struct({
+  schema_version: SchemaMajor,
+  schema_minor: SchemaMinor,
+  algorithm: Schema.Literal("Ed25519"),
+  signing_key_id: SigningKeyIdSchema,
+  producer: CellSlugSchema,
+  contract: TrustContractRef,
+  event_id: EventIdSchema,
+  stream_id: StreamIdSchema,
+  stream_epoch: Schema.Number.pipe(Schema.int(), Schema.greaterThanOrEqualTo(1)),
+  sequence: Schema.Number.pipe(Schema.int(), Schema.greaterThanOrEqualTo(1)),
+  trust_stream: Schema.Boolean,
+  issued_at: Iso8601UtcSchema,
+  expires_at: Iso8601UtcSchema,
+  tenant_scope_digest: Hex64Schema,
+  capability: CapabilitySchema,
+  body_digest: Hex64Schema,
+}).annotations({ identifier: "TrustEnvelopeHeader" });
+export type TrustEnvelopeHeader = Schema.Schema.Type<typeof TrustEnvelopeHeader>;
+
+export const TrustEnvelope = Schema.Struct({
+  header: TrustEnvelopeHeader,
+  body: Schema.Unknown,
+  signature: Base64UrlSchema,
+}).annotations({ identifier: "TrustEnvelope" });
+export type TrustEnvelope = Schema.Schema.Type<typeof TrustEnvelope>;
+
+export const StreamEpochBaseline = Schema.Struct({
+  schema_version: SchemaMajor,
+  schema_minor: SchemaMinor,
+  algorithm: Schema.Literal("Ed25519"),
+  signing_key_id: SigningKeyIdSchema,
+  producer: CellSlugSchema,
+  stream_id: StreamIdSchema,
+  stream_epoch: Schema.Number.pipe(Schema.int(), Schema.greaterThanOrEqualTo(1)),
+  highest_sequence: Schema.Number.pipe(Schema.int(), Schema.greaterThanOrEqualTo(0)),
+  envelope_count: Schema.Number.pipe(Schema.int(), Schema.greaterThanOrEqualTo(0)),
+  baseline_digest: Hex64Schema,
+  issued_at: Iso8601UtcSchema,
+  signature: Base64UrlSchema,
+}).annotations({ identifier: "StreamEpochBaseline" });
+export type StreamEpochBaseline = Schema.Schema.Type<typeof StreamEpochBaseline>;
+
+export const ServiceSigningKey = Schema.Struct({
+  signing_key_id: SigningKeyIdSchema,
+  public_key_hex: Schema.String.pipe(
+    Schema.pattern(/^[0-9a-f]{64}$/, { message: () => "must be 32-byte ed25519 pubkey hex" }),
+  ),
+  producer: CellSlugSchema,
+  capabilities: Schema.Array(CapabilitySchema).pipe(Schema.minItems(1)),
+  tenant_scope_digests: Schema.optionalWith(Schema.Array(Hex64Schema), { exact: true }),
+  activated_at: Iso8601UtcSchema,
+  revoked_at: Schema.optionalWith(Iso8601UtcSchema, { exact: true }),
+  compromise: Schema.optionalWith(Schema.Boolean, { exact: true }),
+}).annotations({ identifier: "ServiceSigningKey" });
+export type ServiceSigningKey = Schema.Schema.Type<typeof ServiceSigningKey>;
+
+export const FixtureKeyRegistry = Schema.Struct({
+  schema_version: SchemaMajor,
+  keys: Schema.Array(ServiceSigningKey).pipe(Schema.minItems(1)),
+}).annotations({ identifier: "FixtureKeyRegistry" });
+export type FixtureKeyRegistry = Schema.Schema.Type<typeof FixtureKeyRegistry>;
+
+export const decodeTrustEnvelope = Schema.decodeUnknownSync(TrustEnvelope, strictDecodeOptions);
+export const decodeStreamEpochBaseline = Schema.decodeUnknownSync(
+  StreamEpochBaseline,
+  strictDecodeOptions,
+);
+export const decodeFixtureKeyRegistry = Schema.decodeUnknownSync(
+  FixtureKeyRegistry,
+  strictDecodeOptions,
+);
+
+export const supportedSchemaMinor = (): number => TRUST_ENVELOPE_SCHEMA_MINOR;

--- a/packages/protocol/trust-envelope/src/errors.ts
+++ b/packages/protocol/trust-envelope/src/errors.ts
@@ -1,0 +1,43 @@
+import { Data } from "effect";
+
+export class ContractIntegrityError extends Data.TaggedError("ContractIntegrityError")<{
+  readonly detail: string;
+}> {}
+
+export class TrustEnvelopeRejectedError extends Data.TaggedError("TrustEnvelopeRejectedError")<{
+  readonly reason:
+    | "unknown_schema_major"
+    | "schema_minor_unsupported"
+    | "excess_property"
+    | "signature_invalid"
+    | "body_digest_mismatch"
+    | "unknown_signing_key"
+    | "revoked_signing_key"
+    | "capability_not_bound"
+    | "tenant_scope_not_bound"
+    | "issued_in_future"
+    | "expired"
+    | "event_id_replay"
+    | "sequence_gap"
+    | "sequence_reuse"
+    | "epoch_mismatch"
+    | "epoch_baseline_required"
+    | "epoch_resume_forbidden"
+    | "retention_violation";
+  readonly remediation?:
+    | "request_replay_range"
+    | "install_epoch_baseline"
+    | "rotate_signing_key"
+    | "retry_after_authority_catchup";
+}> {}
+
+export class StreamEpochBaselineRejectedError extends Data.TaggedError(
+  "StreamEpochBaselineRejectedError",
+)<{
+  readonly reason:
+    | "signature_invalid"
+    | "unknown_signing_key"
+    | "revoked_signing_key"
+    | "epoch_not_advanced"
+    | "baseline_incomplete";
+}> {}

--- a/packages/protocol/trust-envelope/src/fixture-keys.ts
+++ b/packages/protocol/trust-envelope/src/fixture-keys.ts
@@ -1,0 +1,50 @@
+import { LocalEd25519TrustSigner } from "./signing.js";
+
+/** Deterministic non-production fixture seeds — CR-013 owns production custody. */
+export const FIXTURE_SIGNING_SEEDS = Object.freeze({
+  sonarPrimary: "0000000000000000000000000000000000000000000000000000000000000000",
+  sonarRotated: "1111111111111111111111111111111111111111111111111111111111111111",
+  sonarRevoked: "2222222222222222222222222222222222222222222222222222222222222222",
+  orderingReplay: "3333333333333333333333333333333333333333333333333333333333333333",
+});
+
+export const FIXTURE_SIGNING_KEY_IDS = Object.freeze({
+  sonarPrimary: "sonar-fixture-primary",
+  sonarRotated: "sonar-fixture-rotated",
+  sonarRevoked: "sonar-fixture-revoked",
+  orderingReplay: "ordering-fixture-replay",
+});
+
+export const FIXTURE_STREAM_ID = "sonar.public-capability.v1";
+export const FIXTURE_TENANT_SCOPE_DIGEST =
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+export const FIXTURE_CAPABILITY = "collection-report.capability-evidence.v1";
+
+export const fixtureSigners = () => ({
+  sonarPrimary: LocalEd25519TrustSigner.fromSeedHex(
+    FIXTURE_SIGNING_SEEDS.sonarPrimary,
+    FIXTURE_SIGNING_KEY_IDS.sonarPrimary,
+  ),
+  sonarRotated: LocalEd25519TrustSigner.fromSeedHex(
+    FIXTURE_SIGNING_SEEDS.sonarRotated,
+    FIXTURE_SIGNING_KEY_IDS.sonarRotated,
+  ),
+  sonarRevoked: LocalEd25519TrustSigner.fromSeedHex(
+    FIXTURE_SIGNING_SEEDS.sonarRevoked,
+    FIXTURE_SIGNING_KEY_IDS.sonarRevoked,
+  ),
+  orderingReplay: LocalEd25519TrustSigner.fromSeedHex(
+    FIXTURE_SIGNING_SEEDS.orderingReplay,
+    FIXTURE_SIGNING_KEY_IDS.orderingReplay,
+  ),
+});
+
+export const fixturePublicKeys = (): Record<string, string> => {
+  const signers = fixtureSigners();
+  return {
+    [FIXTURE_SIGNING_KEY_IDS.sonarPrimary]: signers.sonarPrimary.publicKeyHex(),
+    [FIXTURE_SIGNING_KEY_IDS.sonarRotated]: signers.sonarRotated.publicKeyHex(),
+    [FIXTURE_SIGNING_KEY_IDS.sonarRevoked]: signers.sonarRevoked.publicKeyHex(),
+    [FIXTURE_SIGNING_KEY_IDS.orderingReplay]: signers.orderingReplay.publicKeyHex(),
+  };
+};

--- a/packages/protocol/trust-envelope/src/fixture-scenarios.ts
+++ b/packages/protocol/trust-envelope/src/fixture-scenarios.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Schema } from "effect";
+import {
+  FixtureKeyRegistry,
+  StreamEpochBaseline,
+  TrustEnvelope,
+  decodeFixtureKeyRegistry,
+} from "./contracts.js";
+import { ServiceKeyRegistry } from "./registry.js";
+
+const ScenarioEnvelope = Schema.Struct({
+  id: Schema.String,
+  envelope: TrustEnvelope,
+  expect: Schema.Literal("accept", "reject"),
+  reject_reason: Schema.optional(Schema.String),
+  reject_stage: Schema.optional(Schema.Literal("verify", "ingest")),
+});
+
+const ScenarioBaseline = Schema.Struct({
+  id: Schema.String,
+  baseline: StreamEpochBaseline,
+});
+
+export const FixtureScenarioBundle = Schema.Struct({
+  schema_version: Schema.Literal(1),
+  registry: FixtureKeyRegistry,
+  envelopes: Schema.Array(ScenarioEnvelope),
+  baselines: Schema.optionalWith(Schema.Array(ScenarioBaseline), { exact: true }),
+}).annotations({ identifier: "FixtureScenarioBundle" });
+export type FixtureScenarioBundle = Schema.Schema.Type<typeof FixtureScenarioBundle>;
+
+export const decodeFixtureScenarioBundle = Schema.decodeUnknownSync(FixtureScenarioBundle);
+
+export const fixtureRegistryFromBundle = (bundle: FixtureScenarioBundle): ServiceKeyRegistry =>
+  new ServiceKeyRegistry(bundle.registry.keys);
+
+export const readFixtureScenarioBundle = (): FixtureScenarioBundle => {
+  const fixturesDirectory = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "../fixtures/scenarios",
+  );
+  const parsed: unknown = JSON.parse(
+    readFileSync(join(fixturesDirectory, "producer-consumer.shared.json"), "utf8"),
+  );
+  return decodeFixtureScenarioBundle(parsed);
+};
+
+export const decodeFixtureKeyRegistryFromFile = (relativePath: string): ServiceKeyRegistry => {
+  const fixturesDirectory = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "../fixtures",
+  );
+  const parsed: unknown = JSON.parse(readFileSync(join(fixturesDirectory, relativePath), "utf8"));
+  return new ServiceKeyRegistry(decodeFixtureKeyRegistry(parsed).keys);
+};

--- a/packages/protocol/trust-envelope/src/index.ts
+++ b/packages/protocol/trust-envelope/src/index.ts
@@ -1,0 +1,110 @@
+/**
+ * @freeside/trust-envelope-protocol
+ *
+ * CR-009 signed trust-envelope wire contract for Ordering dependency intake.
+ * Distinct from events-pillar acvp-l1-v2 NATS envelopes.
+ */
+
+export {
+  TRUST_ENVELOPE_SCHEMA_MAJOR,
+  TRUST_ENVELOPE_SCHEMA_MINOR,
+  TRUST_ENVELOPE_PROTOCOL_VERSION,
+  TRUST_ENVELOPE_CONTRACT,
+  TRUST_ENVELOPE_MAX_FUTURE_SKEW_MS,
+  TRUST_STREAM_MIN_RETENTION_MS,
+  TRUST_ENVELOPE_DEFAULT_TTL_MS,
+} from "./version.js";
+
+export {
+  ContractIntegrityError,
+  TrustEnvelopeRejectedError,
+  StreamEpochBaselineRejectedError,
+} from "./errors.js";
+
+export {
+  TrustContractRef,
+  TrustEnvelopeHeader,
+  TrustEnvelope,
+  StreamEpochBaseline,
+  ServiceSigningKey,
+  FixtureKeyRegistry,
+  decodeTrustEnvelope,
+  decodeStreamEpochBaseline,
+  decodeFixtureKeyRegistry,
+  supportedSchemaMinor,
+  strictDecodeOptions,
+} from "./contracts.js";
+
+export {
+  acceptsEnvelopeSchemaMinor,
+  assertSupportedSchemaMajor,
+  assertSupportedSchemaMinor,
+  mixedMinorRules,
+} from "./versioning.js";
+
+export {
+  jcsCanonicalize,
+  sha256Hex,
+  digestJcs,
+} from "./jcs.js";
+
+export {
+  computeBodyDigest,
+  envelopeSigningBytes,
+  baselineSigningBytes,
+  verifyEd25519Signature,
+  signTrustEnvelope,
+  signStreamEpochBaseline,
+  digestEpochBaselineMaterial,
+  LocalEd25519TrustSigner,
+  type TrustEnvelopeSigner,
+} from "./signing.js";
+
+export { ServiceKeyRegistry } from "./registry.js";
+
+export {
+  verifyTrustEnvelope,
+  verifyStreamEpochBaseline,
+  resolveActiveKey,
+  type VerifyTrustEnvelopeInput,
+  type VerifyStreamEpochBaselineInput,
+} from "./verify.js";
+
+export {
+  buildTrustEnvelopeHeader,
+  emitTrustEnvelope,
+  createTrustStreamProducerState,
+  advanceTrustStreamProducer,
+  resetTrustStreamEpoch,
+  type BuildTrustEnvelopeHeaderInput,
+  type EmitTrustEnvelopeInput,
+  type TrustStreamProducerState,
+} from "./producer.js";
+
+export {
+  createStreamConsumerState,
+  ingestTrustEnvelope,
+  installEpochBaseline,
+  requestGapRepairRange,
+  replayEnvelopeIdempotently,
+  type StreamConsumerState,
+  type IngestTrustEnvelopeInput,
+  type IngestTrustEnvelopeResult,
+  type InstallEpochBaselineInput,
+} from "./consumer.js";
+
+export {
+  FIXTURE_SIGNING_SEEDS,
+  FIXTURE_SIGNING_KEY_IDS,
+  FIXTURE_STREAM_ID,
+  FIXTURE_TENANT_SCOPE_DIGEST,
+  FIXTURE_CAPABILITY,
+  fixtureSigners,
+  fixturePublicKeys,
+} from "./fixture-keys.js";
+
+export {
+  decodeFixtureScenarioBundle,
+  fixtureRegistryFromBundle,
+  type FixtureScenarioBundle,
+} from "./fixture-scenarios.js";

--- a/packages/protocol/trust-envelope/src/jcs.ts
+++ b/packages/protocol/trust-envelope/src/jcs.ts
@@ -1,0 +1,24 @@
+import canonicalizeMod from "canonicalize";
+import { sha256 } from "@noble/hashes/sha2";
+import { bytesToHex } from "@noble/hashes/utils";
+
+const canonicalize = canonicalizeMod as unknown as (value: unknown) => string | undefined;
+
+export function jcsCanonicalize(value: unknown): string {
+  const out = canonicalize(value);
+  if (typeof out !== "string") {
+    throw new Error(
+      "jcsCanonicalize: input is not JSON-representable (functions, symbols, Infinity, NaN, BigInt without toJSON, or undefined at root)",
+    );
+  }
+  return out;
+}
+
+export function sha256Hex(input: string | Uint8Array): string {
+  const bytes = typeof input === "string" ? new TextEncoder().encode(input) : input;
+  return bytesToHex(sha256(bytes));
+}
+
+export function digestJcs(value: unknown): string {
+  return sha256Hex(jcsCanonicalize(value));
+}

--- a/packages/protocol/trust-envelope/src/producer.ts
+++ b/packages/protocol/trust-envelope/src/producer.ts
@@ -1,0 +1,90 @@
+import type { TrustContractRef, TrustEnvelope, TrustEnvelopeHeader } from "./contracts.js";
+import {
+  TRUST_ENVELOPE_CONTRACT,
+  TRUST_ENVELOPE_DEFAULT_TTL_MS,
+  TRUST_ENVELOPE_SCHEMA_MINOR,
+} from "./version.js";
+import { computeBodyDigest, signTrustEnvelope, type TrustEnvelopeSigner } from "./signing.js";
+
+export interface BuildTrustEnvelopeHeaderInput {
+  readonly producer: string;
+  readonly contract?: TrustContractRef;
+  readonly eventId: string;
+  readonly streamId: string;
+  readonly streamEpoch: number;
+  readonly sequence: number;
+  readonly trustStream: boolean;
+  readonly issuedAtMs: number;
+  readonly ttlMs?: number;
+  readonly tenantScopeDigest: string;
+  readonly capability: string;
+  readonly body: unknown;
+  readonly schemaMinor?: number;
+}
+
+export const buildTrustEnvelopeHeader = (
+  input: BuildTrustEnvelopeHeaderInput,
+): TrustEnvelopeHeader => {
+  const issuedAt = new Date(input.issuedAtMs).toISOString();
+  const expiresAt = new Date(
+    input.issuedAtMs + (input.ttlMs ?? TRUST_ENVELOPE_DEFAULT_TTL_MS),
+  ).toISOString();
+  return {
+    schema_version: TRUST_ENVELOPE_CONTRACT.major_version,
+    schema_minor: input.schemaMinor ?? TRUST_ENVELOPE_SCHEMA_MINOR,
+    algorithm: "Ed25519",
+    signing_key_id: "pending",
+    producer: input.producer,
+    contract: input.contract ?? TRUST_ENVELOPE_CONTRACT,
+    event_id: input.eventId,
+    stream_id: input.streamId,
+    stream_epoch: input.streamEpoch,
+    sequence: input.sequence,
+    trust_stream: input.trustStream,
+    issued_at: issuedAt,
+    expires_at: expiresAt,
+    tenant_scope_digest: input.tenantScopeDigest,
+    capability: input.capability,
+    body_digest: computeBodyDigest(input.body),
+  };
+};
+
+export interface EmitTrustEnvelopeInput extends BuildTrustEnvelopeHeaderInput {
+  readonly signer: TrustEnvelopeSigner;
+}
+
+export const emitTrustEnvelope = (input: EmitTrustEnvelopeInput): TrustEnvelope =>
+  signTrustEnvelope(input.signer, {
+    header: buildTrustEnvelopeHeader(input),
+    body: input.body,
+  });
+
+export interface TrustStreamProducerState {
+  readonly streamId: string;
+  streamEpoch: number;
+  nextSequence: number;
+}
+
+export const createTrustStreamProducerState = (
+  streamId: string,
+  streamEpoch = 1,
+): TrustStreamProducerState => ({
+  streamId,
+  streamEpoch,
+  nextSequence: 1,
+});
+
+export const advanceTrustStreamProducer = (
+  state: TrustStreamProducerState,
+): TrustStreamProducerState => ({
+  ...state,
+  nextSequence: state.nextSequence + 1,
+});
+
+export const resetTrustStreamEpoch = (
+  state: TrustStreamProducerState,
+): TrustStreamProducerState => ({
+  streamId: state.streamId,
+  streamEpoch: state.streamEpoch + 1,
+  nextSequence: 1,
+});

--- a/packages/protocol/trust-envelope/src/registry.ts
+++ b/packages/protocol/trust-envelope/src/registry.ts
@@ -1,0 +1,53 @@
+import type { ServiceSigningKey } from "./contracts.js";
+
+const parseIso = (value: string): number => Date.parse(value);
+
+export class ServiceKeyRegistry {
+  readonly #keys: ReadonlyMap<string, ServiceSigningKey>;
+
+  constructor(keys: readonly ServiceSigningKey[]) {
+    this.#keys = new Map(keys.map((key) => [key.signing_key_id, key]));
+  }
+
+  resolve(signingKeyId: string): ServiceSigningKey | undefined {
+    return this.#keys.get(signingKeyId);
+  }
+
+  isActive(key: ServiceSigningKey, acceptedAtMs: number): boolean {
+    if (key.compromise === true) return false;
+    if (Date.parse(key.activated_at) > acceptedAtMs) return false;
+    if (key.revoked_at !== undefined && Date.parse(key.revoked_at) <= acceptedAtMs) {
+      return false;
+    }
+    return true;
+  }
+
+  bindsProducer(key: ServiceSigningKey, producer: string): boolean {
+    return key.producer === producer;
+  }
+
+  bindsCapability(key: ServiceSigningKey, capability: string): boolean {
+    return key.capabilities.includes(capability);
+  }
+
+  bindsTenantScope(key: ServiceSigningKey, tenantScopeDigest: string): boolean {
+    if (key.tenant_scope_digests === undefined) return true;
+    return key.tenant_scope_digests.includes(tenantScopeDigest);
+  }
+
+  overlappingRotationWindow(
+    previous: ServiceSigningKey,
+    next: ServiceSigningKey,
+    atMs: number,
+  ): boolean {
+    return (
+      previous.producer === next.producer &&
+      this.isActive(previous, atMs) &&
+      this.isActive(next, atMs) &&
+      previous.signing_key_id !== next.signing_key_id
+    );
+  }
+}
+
+export const issuedAtMs = parseIso;
+export const expiresAtMs = parseIso;

--- a/packages/protocol/trust-envelope/src/signing.ts
+++ b/packages/protocol/trust-envelope/src/signing.ts
@@ -1,0 +1,139 @@
+import { ed25519 } from "@noble/curves/ed25519.js";
+import { bytesToHex, hexToBytes } from "@noble/hashes/utils";
+import type { StreamEpochBaseline, TrustEnvelope } from "./contracts.js";
+import { digestJcs, jcsCanonicalize, sha256Hex } from "./jcs.js";
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64url");
+}
+
+function base64UrlToBytes(b64u: string): Uint8Array {
+  const buf = Buffer.from(b64u, "base64url");
+  return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+}
+
+export type SigningKeyId = string;
+
+export interface TrustEnvelopeSigner {
+  readonly keyId: SigningKeyId;
+  sign(message: Uint8Array): string;
+  publicKeyHex(): string;
+}
+
+export class LocalEd25519TrustSigner implements TrustEnvelopeSigner {
+  readonly keyId: SigningKeyId;
+  readonly #secretKey: Uint8Array;
+
+  private constructor(keyId: SigningKeyId, secretKey: Uint8Array) {
+    this.keyId = keyId;
+    this.#secretKey = secretKey;
+  }
+
+  static fromSeedHex(seedHex: string, keyId: SigningKeyId): LocalEd25519TrustSigner {
+    if (!/^[0-9a-fA-F]{64}$/.test(seedHex)) {
+      throw new Error("LocalEd25519TrustSigner.fromSeedHex: expected 64 hex chars");
+    }
+    return new LocalEd25519TrustSigner(keyId, hexToBytes(seedHex.toLowerCase()));
+  }
+
+  sign(message: Uint8Array): string {
+    return bytesToBase64Url(ed25519.sign(message, this.#secretKey));
+  }
+
+  publicKeyHex(): string {
+    return bytesToHex(ed25519.getPublicKey(this.#secretKey));
+  }
+}
+
+export const computeBodyDigest = (body: unknown): string => digestJcs(body);
+
+export const envelopeSigningBytes = (
+  envelopeWithoutSignature: Omit<TrustEnvelope, "signature">,
+): Uint8Array => {
+  const tbs: TrustEnvelope = {
+    ...envelopeWithoutSignature,
+    signature: "",
+  };
+  const digestHex = sha256Hex(jcsCanonicalize(tbs));
+  return new TextEncoder().encode(digestHex);
+};
+
+export const baselineSigningBytes = (
+  baselineWithoutSignature: Omit<StreamEpochBaseline, "signature">,
+): Uint8Array => {
+  const tbs: StreamEpochBaseline = {
+    ...baselineWithoutSignature,
+    signature: "",
+  };
+  const digestHex = sha256Hex(jcsCanonicalize(tbs));
+  return new TextEncoder().encode(digestHex);
+};
+
+export const verifyEd25519Signature = (
+  publicKeyHex: string,
+  message: Uint8Array,
+  signatureBase64Url: string,
+): boolean => {
+  try {
+    return ed25519.verify(
+      base64UrlToBytes(signatureBase64Url),
+      message,
+      hexToBytes(publicKeyHex),
+    );
+  } catch {
+    return false;
+  }
+};
+
+export const signTrustEnvelope = (
+  signer: TrustEnvelopeSigner,
+  envelope: Omit<TrustEnvelope, "signature">,
+): TrustEnvelope => ({
+  ...envelope,
+  header: {
+    ...envelope.header,
+    signing_key_id: signer.keyId,
+    body_digest: computeBodyDigest(envelope.body),
+  },
+  signature: signer.sign(envelopeSigningBytes({
+    ...envelope,
+    header: {
+      ...envelope.header,
+      signing_key_id: signer.keyId,
+      body_digest: computeBodyDigest(envelope.body),
+    },
+  })),
+});
+
+export const signStreamEpochBaseline = (
+  signer: TrustEnvelopeSigner,
+  baseline: Omit<StreamEpochBaseline, "signature" | "signing_key_id">,
+): StreamEpochBaseline => {
+  const material = {
+    ...baseline,
+    signing_key_id: signer.keyId,
+  };
+  return {
+    ...material,
+    signature: signer.sign(baselineSigningBytes(material)),
+  };
+};
+
+export const digestEpochBaselineMaterial = (input: {
+  stream_id: string;
+  stream_epoch: number;
+  highest_sequence: number;
+  envelope_count: number;
+  envelopes: ReadonlyArray<Pick<TrustEnvelope, "header">>;
+}): string =>
+  digestJcs({
+    stream_id: input.stream_id,
+    stream_epoch: input.stream_epoch,
+    highest_sequence: input.highest_sequence,
+    envelope_count: input.envelope_count,
+    envelopes: input.envelopes.map((envelope) => ({
+      event_id: envelope.header.event_id,
+      sequence: envelope.header.sequence,
+      body_digest: envelope.header.body_digest,
+    })),
+  });

--- a/packages/protocol/trust-envelope/src/verify.ts
+++ b/packages/protocol/trust-envelope/src/verify.ts
@@ -1,0 +1,138 @@
+import type { ServiceSigningKey, StreamEpochBaseline, TrustEnvelope } from "./contracts.js";
+import { TrustEnvelopeRejectedError, StreamEpochBaselineRejectedError } from "./errors.js";
+import {
+  baselineSigningBytes,
+  computeBodyDigest,
+  envelopeSigningBytes,
+  verifyEd25519Signature,
+} from "./signing.js";
+import { ServiceKeyRegistry } from "./registry.js";
+import { TRUST_ENVELOPE_MAX_FUTURE_SKEW_MS } from "./version.js";
+import { assertSupportedSchemaMajor, assertSupportedSchemaMinor } from "./versioning.js";
+
+export interface VerifyTrustEnvelopeInput {
+  readonly envelope: TrustEnvelope;
+  readonly registry: ServiceKeyRegistry;
+  readonly acceptedAtMs: number;
+  readonly consumerSupportedMinor?: number;
+}
+
+export const verifyTrustEnvelope = ({
+  envelope,
+  registry,
+  acceptedAtMs,
+  consumerSupportedMinor,
+}: VerifyTrustEnvelopeInput): void => {
+  assertSupportedSchemaMajor(envelope.header.schema_version);
+  assertSupportedSchemaMinor(envelope.header.schema_minor, consumerSupportedMinor);
+
+  if (computeBodyDigest(envelope.body) !== envelope.header.body_digest) {
+    throw new TrustEnvelopeRejectedError({
+      reason: "body_digest_mismatch",
+    });
+  }
+
+  const key = registry.resolve(envelope.header.signing_key_id);
+  if (key === undefined) {
+    throw new TrustEnvelopeRejectedError({ reason: "unknown_signing_key" });
+  }
+  if (!registry.isActive(key, acceptedAtMs)) {
+    throw new TrustEnvelopeRejectedError({ reason: "revoked_signing_key" });
+  }
+  if (!registry.bindsProducer(key, envelope.header.producer)) {
+    throw new TrustEnvelopeRejectedError({ reason: "capability_not_bound" });
+  }
+  if (!registry.bindsCapability(key, envelope.header.capability)) {
+    throw new TrustEnvelopeRejectedError({ reason: "capability_not_bound" });
+  }
+  if (!registry.bindsTenantScope(key, envelope.header.tenant_scope_digest)) {
+    throw new TrustEnvelopeRejectedError({ reason: "tenant_scope_not_bound" });
+  }
+
+  const issuedAt = Date.parse(envelope.header.issued_at);
+  const expiresAt = Date.parse(envelope.header.expires_at);
+  if (issuedAt > acceptedAtMs + TRUST_ENVELOPE_MAX_FUTURE_SKEW_MS) {
+    throw new TrustEnvelopeRejectedError({ reason: "issued_in_future" });
+  }
+  if (expiresAt <= acceptedAtMs) {
+    throw new TrustEnvelopeRejectedError({ reason: "expired" });
+  }
+
+  const validSignature = verifyEd25519Signature(
+    key.public_key_hex,
+    envelopeSigningBytes({
+      header: envelope.header,
+      body: envelope.body,
+    }),
+    envelope.signature,
+  );
+  if (!validSignature) {
+    throw new TrustEnvelopeRejectedError({ reason: "signature_invalid" });
+  }
+};
+
+export interface VerifyStreamEpochBaselineInput {
+  readonly baseline: StreamEpochBaseline;
+  readonly registry: ServiceKeyRegistry;
+  readonly acceptedAtMs: number;
+  readonly previousEpoch: number;
+  readonly expectedBaselineDigest: string;
+}
+
+export const verifyStreamEpochBaseline = ({
+  baseline,
+  registry,
+  acceptedAtMs,
+  previousEpoch,
+  expectedBaselineDigest,
+}: VerifyStreamEpochBaselineInput): void => {
+  assertSupportedSchemaMajor(baseline.schema_version);
+
+  if (baseline.stream_epoch <= previousEpoch) {
+    throw new StreamEpochBaselineRejectedError({ reason: "epoch_not_advanced" });
+  }
+  if (baseline.baseline_digest !== expectedBaselineDigest) {
+    throw new StreamEpochBaselineRejectedError({ reason: "baseline_incomplete" });
+  }
+
+  const key = registry.resolve(baseline.signing_key_id);
+  if (key === undefined) {
+    throw new StreamEpochBaselineRejectedError({ reason: "unknown_signing_key" });
+  }
+  if (!registry.isActive(key, acceptedAtMs)) {
+    throw new StreamEpochBaselineRejectedError({ reason: "revoked_signing_key" });
+  }
+
+  const validSignature = verifyEd25519Signature(
+    key.public_key_hex,
+    baselineSigningBytes({
+      schema_version: baseline.schema_version,
+      schema_minor: baseline.schema_minor,
+      algorithm: baseline.algorithm,
+      signing_key_id: baseline.signing_key_id,
+      producer: baseline.producer,
+      stream_id: baseline.stream_id,
+      stream_epoch: baseline.stream_epoch,
+      highest_sequence: baseline.highest_sequence,
+      envelope_count: baseline.envelope_count,
+      baseline_digest: baseline.baseline_digest,
+      issued_at: baseline.issued_at,
+    }),
+    baseline.signature,
+  );
+  if (!validSignature) {
+    throw new StreamEpochBaselineRejectedError({ reason: "signature_invalid" });
+  }
+};
+
+export const resolveActiveKey = (
+  registry: ServiceKeyRegistry,
+  signingKeyId: string,
+  acceptedAtMs: number,
+): ServiceSigningKey => {
+  const key = registry.resolve(signingKeyId);
+  if (key === undefined || !registry.isActive(key, acceptedAtMs)) {
+    throw new TrustEnvelopeRejectedError({ reason: "revoked_signing_key" });
+  }
+  return key;
+};

--- a/packages/protocol/trust-envelope/src/version.ts
+++ b/packages/protocol/trust-envelope/src/version.ts
@@ -1,0 +1,22 @@
+/** Wire contract major version for CR-009 trust envelopes and epoch baselines. */
+export const TRUST_ENVELOPE_SCHEMA_MAJOR = 1 as const;
+
+/** Highest schema minor this package emits and fully understands. */
+export const TRUST_ENVELOPE_SCHEMA_MINOR = 0 as const;
+
+export const TRUST_ENVELOPE_PROTOCOL_VERSION = "collection-report.trust-envelope.v1" as const;
+
+export const TRUST_ENVELOPE_CONTRACT = {
+  name: "collection-report.trust-envelope",
+  major_version: TRUST_ENVELOPE_SCHEMA_MAJOR,
+  minor_version: TRUST_ENVELOPE_SCHEMA_MINOR,
+} as const;
+
+/** Producer clock may lead consumer authority by at most 30 seconds (SDD §11.1). */
+export const TRUST_ENVELOPE_MAX_FUTURE_SKEW_MS = 30_000;
+
+/** Minimum stream retention covering live resolution/order reconciliation (SDD §11.1). */
+export const TRUST_STREAM_MIN_RETENTION_MS = 86_400_000;
+
+/** Default interactive envelope lifetime when producer does not override. */
+export const TRUST_ENVELOPE_DEFAULT_TTL_MS = 300_000;

--- a/packages/protocol/trust-envelope/src/versioning.ts
+++ b/packages/protocol/trust-envelope/src/versioning.ts
@@ -1,0 +1,43 @@
+import {
+  TRUST_ENVELOPE_SCHEMA_MAJOR,
+  TRUST_ENVELOPE_SCHEMA_MINOR,
+} from "./version.js";
+
+/**
+ * Mixed-minor acceptance rules for CR-009.
+ *
+ * - Unknown major always fails closed.
+ * - Within the same major, a consumer accepts envelope minors <= its supported minor.
+ * - Envelope minors greater than supported fail closed until the consumer upgrades.
+ * - Strict decoders reject unknown fields regardless of minor (onExcessProperty: error).
+ * - Optional future minors may add only optional fields; required-field additions require major bump.
+ */
+export const acceptsEnvelopeSchemaMinor = (
+  envelopeMinor: number,
+  consumerSupportedMinor: number = TRUST_ENVELOPE_SCHEMA_MINOR,
+): boolean => envelopeMinor <= consumerSupportedMinor;
+
+export const assertSupportedSchemaMajor = (major: number): void => {
+  if (major !== TRUST_ENVELOPE_SCHEMA_MAJOR) {
+    throw new Error(`unsupported trust-envelope schema major ${major}`);
+  }
+};
+
+export const assertSupportedSchemaMinor = (
+  minor: number,
+  consumerSupportedMinor: number = TRUST_ENVELOPE_SCHEMA_MINOR,
+): void => {
+  if (!acceptsEnvelopeSchemaMinor(minor, consumerSupportedMinor)) {
+    throw new Error(
+      `unsupported trust-envelope schema minor ${minor} (consumer supports <= ${consumerSupportedMinor})`,
+    );
+  }
+};
+
+export const mixedMinorRules = Object.freeze({
+  unknownMajor: "fail_closed",
+  unknownRequiredField: "fail_closed",
+  excessProperty: "fail_closed",
+  higherMinorThanConsumer: "fail_closed",
+  lowerOrEqualMinorWithinMajor: "accept_if_decoder_succeeds",
+});

--- a/packages/protocol/trust-envelope/tsconfig.json
+++ b/packages/protocol/trust-envelope/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "resolveJsonModule": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": false,
+    "composite": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/protocol/trust-envelope/vitest.config.ts
+++ b/packages/protocol/trust-envelope/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- Adds `@freeside/trust-envelope-protocol` (`packages/protocol/trust-envelope`) ratifying CR-009 Ordering trust envelopes distinct from events-pillar `acvp-l1-v2`.
- Headers bind producer, signing key, contract, event ID, stream ID, epoch/sequence, issued/expiry, tenant scope digest, capability, and body digest; strict decoders fail closed on unknown major/required-field violations with explicit mixed-minor rules.
- Shared producer/consumer fixtures cover rotation, revocation, replay, expiry, gap repair, epoch baseline reset, and disaster-recovery refusal paths; Sonar producer and Ordering consumer tests consume the same committed vectors.

## Test plan
- [x] `cd packages/protocol/trust-envelope && pnpm test` (10/10)
- [x] `cd packages/protocol/trust-envelope && pnpm typecheck`
- [ ] CR-011A Sonar producer adoption (downstream)
- [ ] CR-012A Ordering dependency ledger wiring (downstream)
- [ ] CR-013 production signing-key custody (downstream)


Made with [Cursor](https://cursor.com)