### PR TITLE
feat(protocol): CR-013 signing-key custody protocol

### DIFF
--- a/packages/protocol/signing-key-custody/README.md
+++ b/packages/protocol/signing-key-custody/README.md
@@ -1,0 +1,44 @@
+# `@freeside/signing-key-custody-protocol`
+
+CR-013 production KMS/HSM signing-key custody for collection-report Ordering
+signed dependency intake. Distinct from CR-009 wire semantics — this package
+defines registry distribution, key-class separation, rotation/revocation policy,
+remote signing backend interfaces, and database time-health gates.
+
+## Scope
+
+- **Pinned registry contract** — versioned `SigningKeyRegistryDocument` with
+  observable freshness; stale or unknown keys fail closed at intake.
+- **Fixture vs production separation** — fixture keys require `-fixture-` in
+  `signing_key_id` and `local-fixture` backend; production keys require KMS/HSM
+  backends. Fixture proof cannot satisfy production release gates.
+- **Rotation/revocation/compromise** — event schemas and in-memory coordinators
+  for overlap validation and emergency quarantine.
+- **Time-health** — Ordering database clock compared against ≥2 independent
+  sources; measured offset, uncertainty, regional divergence, and last-good time
+  are observable; skew >2s or unknown time blocks signed intake.
+- **No private keys in repo** — production custody is KMS/HSM-backed via
+  `RemoteSigningBackend`; local signing is fixture-only.
+
+## Adoption
+
+Ordering and producers should:
+
+1. Pin a distributed registry snapshot (object storage / config service), not
+   embed keys in application repos.
+2. Construct `PinnedKeyRegistry` at startup and refresh on a cadence shorter
+   than `max_staleness_ms`.
+3. Call `gateSignedIntake()` (or `assertSignedIntakeAllowed()`) before trust
+   envelope verification so time-health and registry freshness fail closed first.
+4. Map `CustodySigningKey` → `ServiceSigningKey` via `toTrustEnvelopeServiceKey()`
+   for `@freeside/trust-envelope-protocol` verification.
+
+## Game-day verification
+
+See `docs/runbook-game-day.md` for rotation, compromise, clock-jump, regional
+divergence, time-source loss, and recovery drills (EV-G1B4-key-custody-game-day).
+
+## Related
+
+- `@freeside/trust-envelope-protocol` — CR-009 envelope wire contract
+- `grimoires/loa/coordination/collection-report/owner-acceptance.md` — platform custody gaps

--- a/packages/protocol/signing-key-custody/docs/runbook-game-day.md
+++ b/packages/protocol/signing-key-custody/docs/runbook-game-day.md
@@ -1,0 +1,88 @@
+# CR-013 signing-key custody — game-day verification runbook
+
+**Evidence ID:** EV-G1B4-key-custody-game-day  
+**Owner:** platform-deployment-owner  
+**Renewal:** every 90 days  
+**Package:** `@freeside/signing-key-custody-protocol`
+
+This runbook exercises production signing-key custody without placing private
+keys in application repositories. Each drill produces observable evidence that
+registry propagation, fail-closed intake, and dependency quarantine behave as
+specified in sprint CR-013.
+
+## Preconditions
+
+- Production registry published to the pinned distribution channel (not git).
+- Ordering consumes `PinnedKeyRegistry` + `gateSignedIntake()` before CR-009 verify.
+- ≥2 independent NTP or cloud time sources configured for database skew probes.
+- On-call has KMS/HSM revoke/rotate permissions and registry publish access.
+
+## Observability checklist
+
+Before each drill, capture:
+
+| Signal | Source |
+|--------|--------|
+| `registry_id`, `registry_generation`, `age_ms`, `is_stale` | `registryObservability()` |
+| `measured_offset_ms`, `offset_uncertainty_ms`, `regional_divergence_ms` | `timeHealthObservability()` |
+| `intake_blocked`, `block_reason` | `TimeHealthSnapshot` |
+| Active signing keys per producer | pinned registry document |
+
+## Drill 1 — Overlap rotation
+
+1. Publish registry generation N+1 with overlapping `activated_at` / `revoked_at`
+   windows for previous and next production keys.
+2. Confirm producers sign with the new key while consumers accept both during overlap.
+3. After overlap ends, revoke previous key in generation N+2.
+4. **Pass:** envelopes verify through overlap; post-revocation envelopes from old key reject with `revoked_signing_key`.
+
+## Drill 2 — Emergency compromise
+
+1. Mark compromised key via `CompromiseEvent` and publish emergency registry generation.
+2. Execute `buildEmergencyRevocationPlan()` — quarantine signed intake enabled.
+3. **Pass:** intake rejects compromised key with `compromised_signing_key`; dependency ledger quarantines affected stream until clean generation pinned.
+
+## Drill 3 — Registry staleness
+
+1. Stop registry refresh beyond `max_staleness_ms`.
+2. Attempt signed envelope intake.
+3. **Pass:** `registry_stale` rejection before signature verification; observability shows `is_stale: true`.
+
+## Drill 4 — Database clock jump (>2s skew)
+
+1. Induce or simulate database clock offset >2000ms from authoritative sources.
+2. Attempt signed intake and authorization lease issuance.
+3. **Pass:** `database_clock_skew_exceeded` blocks intake; leases are not issued on skewed clock.
+
+## Drill 5 — Time-source loss
+
+1. Reduce authoritative sources below 2 (simulate NTP outage or network partition).
+2. **Pass:** `insufficient_time_sources` blocks intake fail-closed.
+
+## Drill 6 — Regional divergence
+
+1. Configure sources reporting >500ms inter-region median spread (test harness or controlled skew injection).
+2. **Pass:** `time_source_divergence` blocks intake until sources reconcile.
+
+## Drill 7 — Recovery
+
+1. Restore registry refresh, republish current generation, restore ≥2 time sources within skew threshold.
+2. Replay quarantined envelopes after baseline catch-up.
+3. **Pass:** `intake_blocked: false`, `last_good_at` updated, dependency intake resumes without accepting stale registry.
+
+## Fixture vs production gate
+
+T1 drills may use `key_class_scope: "fixture"` registries only. Production
+release gates (G1B-4) require `satisfiesProductionReleaseGate()` over a
+production-scoped registry — fixture proof must not satisfy this check.
+
+## Evidence retention
+
+Store for each drill:
+
+- Registry generation snapshots (public metadata only)
+- Time-health snapshots before/during/after
+- Rejection reason codes from intake gate
+- Operator timestamp and environment identifier
+
+Attach evidence to CR-013 / G1B-4 gate closure in the collection-report coordinator.

--- a/packages/protocol/signing-key-custody/fixtures/scenarios/registry-rotation.shared.json
+++ b/packages/protocol/signing-key-custody/fixtures/scenarios/registry-rotation.shared.json
@@ -1,0 +1,99 @@
+{
+  "schema_version": 1,
+  "accepted_at_ms": 1784322001000,
+  "registry": {
+    "schema_version": 1,
+    "registry_id": "collection-report.fixture-registry.v1",
+    "registry_generation": 1,
+    "published_at": "2026-07-17T21:00:00.000Z",
+    "max_staleness_ms": 300000,
+    "key_class_scope": "fixture",
+    "keys": [
+      {
+        "signing_key_id": "sonar-fixture-primary",
+        "public_key_hex": "3b6a27bcceb6a42d62a8a8d02670bf526ea390765392029577b579932c950db0",
+        "producer": "sonar-api",
+        "capabilities": ["collection-report.capability-evidence.v1"],
+        "tenant_scope_digests": ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
+        "activated_at": "2026-07-01T00:00:00.000Z",
+        "key_class": "fixture",
+        "custody_backend": "local-fixture",
+        "registry_generation": 1
+      },
+      {
+        "signing_key_id": "sonar-fixture-rotated",
+        "public_key_hex": "92de664a9627863859e1a8aaa2a6375f43adf7cbeac1d334c8a0e3693049b2c59",
+        "producer": "sonar-api",
+        "capabilities": ["collection-report.capability-evidence.v1"],
+        "tenant_scope_digests": ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
+        "activated_at": "2026-07-10T00:00:00.000Z",
+        "key_class": "fixture",
+        "custody_backend": "local-fixture",
+        "registry_generation": 1
+      },
+      {
+        "signing_key_id": "sonar-fixture-revoked",
+        "public_key_hex": "df0e812848eb2242846d0e28c0b1a4053e843b844b62121e6e5a1789d784a49d",
+        "producer": "sonar-api",
+        "capabilities": ["collection-report.capability-evidence.v1"],
+        "tenant_scope_digests": ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
+        "activated_at": "2026-07-01T00:00:00.000Z",
+        "revoked_at": "2026-07-15T00:00:00.000Z",
+        "key_class": "fixture",
+        "custody_backend": "local-fixture",
+        "registry_generation": 1
+      }
+    ],
+    "distribution_digest": "placeholder-regenerated-by-tests"
+  },
+  "scenarios": [
+    {
+      "id": "fresh-registry-primary",
+      "expect": "accept",
+      "signing_key_id": "sonar-fixture-primary"
+    },
+    {
+      "id": "rotation-overlap-rotated",
+      "expect": "accept",
+      "signing_key_id": "sonar-fixture-rotated"
+    },
+    {
+      "id": "revoked-key",
+      "expect": "reject",
+      "signing_key_id": "sonar-fixture-revoked",
+      "reject_reason": "revoked_signing_key"
+    },
+    {
+      "id": "unknown-key",
+      "expect": "reject",
+      "signing_key_id": "sonar-fixture-unknown",
+      "reject_reason": "unknown_signing_key"
+    },
+    {
+      "id": "stale-registry",
+      "expect": "reject",
+      "registry_published_at": "2026-07-17T20:00:00.000Z",
+      "accepted_at_ms": 1784325601000,
+      "signing_key_id": "sonar-fixture-primary",
+      "reject_reason": "registry_stale"
+    }
+  ],
+  "rotation": {
+    "event_id": "rotation-001",
+    "kind": "rotation",
+    "registry_id": "collection-report.fixture-registry.v1",
+    "previous_key_id": "sonar-fixture-primary",
+    "next_key_id": "sonar-fixture-rotated",
+    "overlap_starts_at": "2026-07-10T00:00:00.000Z",
+    "overlap_ends_at": "2026-07-20T00:00:00.000Z",
+    "issued_at": "2026-07-10T00:00:00.000Z"
+  },
+  "compromise": {
+    "event_id": "compromise-001",
+    "kind": "compromise",
+    "registry_id": "collection-report.fixture-registry.v1",
+    "signing_key_id": "sonar-fixture-primary",
+    "detected_at": "2026-07-17T21:30:00.000Z",
+    "issued_at": "2026-07-17T21:30:00.000Z"
+  }
+}

--- a/packages/protocol/signing-key-custody/fixtures/scenarios/time-health.shared.json
+++ b/packages/protocol/signing-key-custody/fixtures/scenarios/time-health.shared.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": 1,
+  "evaluated_at_ms": 1784322001000,
+  "database_unix_ms": 1784322000500,
+  "healthy_sources": [
+    {
+      "source_id": "ntp.pool.a",
+      "observed_at": "2026-07-17T21:00:01.000Z",
+      "unix_ms": 1784322001000,
+      "uncertainty_ms": 25,
+      "region": "us-west-2"
+    },
+    {
+      "source_id": "ntp.pool.b",
+      "observed_at": "2026-07-17T21:00:01.000Z",
+      "unix_ms": 1784322000990,
+      "uncertainty_ms": 30,
+      "region": "us-east-1"
+    }
+  ],
+  "scenarios": [
+    {
+      "id": "healthy-skew-within-threshold",
+      "expect": "accept",
+      "database_unix_ms": 1784322000500,
+      "max_skew_ms": 2000
+    },
+    {
+      "id": "skew-exceeds-2s-blocks-intake",
+      "expect": "reject",
+      "database_unix_ms": 1784322004000,
+      "reject_reason": "database_clock_skew_exceeded"
+    },
+    {
+      "id": "insufficient-time-sources",
+      "expect": "reject",
+      "sources": [
+        {
+          "source_id": "ntp.pool.a",
+          "observed_at": "2026-07-17T21:00:01.000Z",
+          "unix_ms": 1784322001000,
+          "uncertainty_ms": 25
+        }
+      ],
+      "reject_reason": "insufficient_time_sources"
+    },
+    {
+      "id": "regional-divergence",
+      "expect": "reject",
+      "sources": [
+        {
+          "source_id": "ntp.pool.a",
+          "observed_at": "2026-07-17T21:00:01.000Z",
+          "unix_ms": 1784322001000,
+          "uncertainty_ms": 25,
+          "region": "us-west-2"
+        },
+        {
+          "source_id": "ntp.pool.b",
+          "observed_at": "2026-07-17T21:00:01.000Z",
+          "unix_ms": 1784322002000,
+          "uncertainty_ms": 25,
+          "region": "eu-west-1"
+        }
+      ],
+      "reject_reason": "time_source_divergence"
+    },
+    {
+      "id": "clock-jump-unknown",
+      "expect": "reject",
+      "database_unix_ms": 1784322000500,
+      "last_good_at": "2026-07-17T19:00:00.000Z",
+      "reject_reason": "database_clock_unknown"
+    }
+  ]
+}

--- a/packages/protocol/signing-key-custody/package.json
+++ b/packages/protocol/signing-key-custody/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@freeside/signing-key-custody-protocol",
+  "version": "1.0.0",
+  "description": "CR-013 production KMS/HSM signing-key custody: pinned registry distribution, fixture vs production class separation, rotation/revocation, and Ordering database time-health for signed intake.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "fixtures",
+    "docs",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "rm -rf dist",
+    "prepack": "pnpm run build",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "license": "AGPL-3.0",
+  "dependencies": {
+    "@freeside/trust-envelope-protocol": "file:../trust-envelope"
+  },
+  "peerDependencies": {
+    "effect": "^3.21.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "effect": "^3.21.0",
+    "typescript": "^5.7.0",
+    "vitest": "^4.0.17"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/protocol/signing-key-custody/pnpm-lock.yaml
+++ b/packages/protocol/signing-key-custody/pnpm-lock.yaml
@@ -1,0 +1,832 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@freeside/trust-envelope-protocol':
+        specifier: file:../trust-envelope
+        version: file:../trust-envelope(effect@3.22.0)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.1
+      effect:
+        specifier: ^3.21.0
+        version: 3.22.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.17
+        version: 4.1.10(@types/node@22.20.1)(vite@8.1.5(@types/node@22.20.1))
+
+packages:
+
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@freeside/trust-envelope-protocol@file:../trust-envelope':
+    resolution: {directory: ../trust-envelope, type: directory}
+    peerDependencies:
+      effect: ^3.21.0
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  canonicalize@2.1.0:
+    resolution: {integrity: sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==}
+    hasBin: true
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  effect@3.22.0:
+    resolution: {integrity: sha512-jhYFe0zTlIRqYFrKTS+6luhmS/Tm0f+JLo0K9KUxvtFab1SUGEszQi2ehOP6QzAZvy831lDmTwwzvVDZSPNz3g==}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  vite@8.1.5:
+    resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+snapshots:
+
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@freeside/trust-envelope-protocol@file:../trust-envelope(effect@3.22.0)':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      canonicalize: 2.1.0
+      effect: 3.22.0
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.8.0': {}
+
+  '@oxc-project/types@0.139.0': {}
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@22.20.1))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.5(@types/node@22.20.1)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  assertion-error@2.0.1: {}
+
+  canonicalize@2.1.0: {}
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  detect-libc@2.1.2: {}
+
+  effect@3.22.0:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
+  es-module-lexer@2.3.1: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fsevents@2.3.3:
+    optional: true
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  nanoid@3.3.16: {}
+
+  obug@2.1.4: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.19:
+    dependencies:
+      nanoid: 3.3.16
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  pure-rand@6.1.0: {}
+
+  rolldown@1.1.5:
+    dependencies:
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
+
+  tslib@2.8.1:
+    optional: true
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  vite@8.1.5(@types/node@22.20.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.19
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.1
+      fsevents: 2.3.3
+
+  vitest@4.1.10(@types/node@22.20.1)(vite@8.1.5(@types/node@22.20.1)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@22.20.1))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.5(@types/node@22.20.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.20.1
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/packages/protocol/signing-key-custody/src/__tests__/intake-gate.test.ts
+++ b/packages/protocol/signing-key-custody/src/__tests__/intake-gate.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertSignedIntakeAllowed,
+  buildDefaultFixtureRegistryDocument,
+  buildTimeHealthSnapshot,
+  gateSignedIntake,
+  PinnedKeyRegistry,
+  type TimeSourceReading,
+} from "../index.js";
+
+const healthySources: TimeSourceReading[] = [
+  {
+    source_id: "ntp.a",
+    observed_at: "2026-07-17T21:00:01.000Z",
+    unix_ms: Date.parse("2026-07-17T21:00:01.000Z"),
+    uncertainty_ms: 20,
+  },
+  {
+    source_id: "ntp.b",
+    observed_at: "2026-07-17T21:00:01.000Z",
+    unix_ms: Date.parse("2026-07-17T21:00:01.000Z"),
+    uncertainty_ms: 25,
+  },
+];
+
+describe("signed intake gate (CR-013)", () => {
+  const acceptedAtMs = Date.parse("2026-07-17T21:00:01.000Z");
+  const registry = new PinnedKeyRegistry(buildDefaultFixtureRegistryDocument());
+
+  it("allows intake when registry and time-health are healthy", () => {
+    const timeHealth = buildTimeHealthSnapshot({
+      databaseUnixMs: acceptedAtMs - 100,
+      evaluatedAtMs: acceptedAtMs,
+      authoritativeSources: healthySources,
+    });
+
+    expect(
+      gateSignedIntake({
+        registry,
+        signingKeyId: "sonar-fixture-primary",
+        acceptedAtMs,
+        context: "fixture",
+        timeHealth,
+      }).allowed,
+    ).toBe(true);
+
+    expect(() =>
+      assertSignedIntakeAllowed({
+        registry,
+        signingKeyId: "sonar-fixture-primary",
+        acceptedAtMs,
+        context: "fixture",
+        timeHealth,
+      }),
+    ).not.toThrow();
+  });
+
+  it("blocks intake when time-health fails even with a valid key", () => {
+    const timeHealth = buildTimeHealthSnapshot({
+      databaseUnixMs: acceptedAtMs + 5_000,
+      evaluatedAtMs: acceptedAtMs,
+      authoritativeSources: healthySources,
+    });
+
+    const verdict = gateSignedIntake({
+      registry,
+      signingKeyId: "sonar-fixture-primary",
+      acceptedAtMs,
+      context: "fixture",
+      timeHealth,
+    });
+    expect(verdict.allowed).toBe(false);
+    expect(verdict.reason).toBe("database_clock_skew_exceeded");
+  });
+});

--- a/packages/protocol/signing-key-custody/src/__tests__/protocol.test.ts
+++ b/packages/protocol/signing-key-custody/src/__tests__/protocol.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDefaultFixtureRegistryDocument,
+  decodeSigningKeyRegistryDocument,
+  exampleProductionRegistryTemplate,
+  satisfiesProductionReleaseGate,
+  assertFixtureKeyOnly,
+  assertProductionAuthorizedKey,
+  isFixtureKeyId,
+  KeyCustodyRejectedError,
+} from "../index.js";
+
+describe("signing key custody contracts (CR-013)", () => {
+  it("decodes registry documents strictly", () => {
+    const document = buildDefaultFixtureRegistryDocument();
+    const decoded = decodeSigningKeyRegistryDocument(document);
+    expect(decoded.key_class_scope).toBe("fixture");
+    expect(() =>
+      decodeSigningKeyRegistryDocument({
+        ...document,
+        unexpected: true,
+      }),
+    ).toThrow();
+  });
+
+  it("mechanically separates fixture and production key classes", () => {
+    const fixtureDoc = buildDefaultFixtureRegistryDocument();
+    const productionDoc = exampleProductionRegistryTemplate();
+
+    expect(isFixtureKeyId("sonar-fixture-primary")).toBe(true);
+    expect(isFixtureKeyId("sonar-production-primary")).toBe(false);
+
+    for (const key of fixtureDoc.keys) {
+      expect(() => assertFixtureKeyOnly(key)).not.toThrow();
+      expect(() => assertProductionAuthorizedKey(key)).toThrow(KeyCustodyRejectedError);
+    }
+
+    for (const key of productionDoc.keys) {
+      expect(() => assertProductionAuthorizedKey(key)).not.toThrow();
+      expect(() => assertFixtureKeyOnly(key)).toThrow(KeyCustodyRejectedError);
+    }
+
+    expect(satisfiesProductionReleaseGate(fixtureDoc.keys)).toBe(false);
+    expect(satisfiesProductionReleaseGate(productionDoc.keys)).toBe(true);
+  });
+});

--- a/packages/protocol/signing-key-custody/src/__tests__/registry.test.ts
+++ b/packages/protocol/signing-key-custody/src/__tests__/registry.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  buildSigningKeyRegistryDocument,
+  decodeSigningKeyRegistryDocument,
+  defaultFixtureCustodyKeys,
+  KeyCustodyRejectedError,
+  PinnedKeyRegistry,
+  registryObservability,
+} from "../index.js";
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), "../../fixtures/scenarios");
+
+describe("pinned key registry (CR-013)", () => {
+  const bundle = JSON.parse(
+    readFileSync(join(fixturesDir, "registry-rotation.shared.json"), "utf8"),
+  ) as {
+    accepted_at_ms: number;
+    registry: ReturnType<typeof decodeSigningKeyRegistryDocument>;
+    scenarios: Array<{
+      id: string;
+      expect: "accept" | "reject";
+      signing_key_id: string;
+      reject_reason?: string;
+      registry_published_at?: string;
+      accepted_at_ms?: number;
+    }>;
+  };
+
+  const freshRegistry = (): PinnedKeyRegistry => {
+    const document = buildSigningKeyRegistryDocument({
+      registryId: bundle.registry.registry_id,
+      registryGeneration: bundle.registry.registry_generation,
+      publishedAt: bundle.registry.published_at,
+      keyClassScope: "fixture",
+      keys: defaultFixtureCustodyKeys(),
+      maxStalenessMs: bundle.registry.max_staleness_ms,
+    });
+    return new PinnedKeyRegistry(document);
+  };
+
+  it("exposes registry freshness observability", () => {
+    const registry = freshRegistry();
+    const observed = registryObservability(registry.document, bundle.accepted_at_ms);
+    expect(observed.is_stale).toBe(false);
+    expect(observed.key_class_scope).toBe("fixture");
+  });
+
+  it("resolves or rejects intake scenarios fail-closed", () => {
+    for (const scenario of bundle.scenarios) {
+      let registry = freshRegistry();
+      if (scenario.registry_published_at !== undefined) {
+        registry = new PinnedKeyRegistry(
+          buildSigningKeyRegistryDocument({
+            registryId: bundle.registry.registry_id,
+            registryGeneration: bundle.registry.registry_generation,
+            publishedAt: scenario.registry_published_at,
+            keyClassScope: "fixture",
+            keys: defaultFixtureCustodyKeys(),
+            maxStalenessMs: bundle.registry.max_staleness_ms,
+          }),
+        );
+      }
+
+      const acceptedAtMs = scenario.accepted_at_ms ?? bundle.accepted_at_ms;
+      const resolve = () =>
+        registry.resolveForIntake({
+          signingKeyId: scenario.signing_key_id,
+          acceptedAtMs,
+          context: "fixture",
+        });
+
+      if (scenario.expect === "accept") {
+        expect(resolve, scenario.id).not.toThrow();
+      } else {
+        try {
+          resolve();
+          expect.fail(`expected rejection for ${scenario.id}`);
+        } catch (error) {
+          expect(error).toBeInstanceOf(KeyCustodyRejectedError);
+          if (scenario.reject_reason !== undefined) {
+            expect((error as KeyCustodyRejectedError).reason).toBe(scenario.reject_reason);
+          }
+        }
+      }
+    }
+  });
+
+  it("rejects unknown registry at intake boundary", () => {
+    expect(() =>
+      PinnedKeyRegistry.assertFresh({
+        document: freshRegistry().document,
+        observedAtMs: Date.parse("2026-07-17T22:00:00.000Z"),
+      }),
+    ).toThrow(KeyCustodyRejectedError);
+  });
+});

--- a/packages/protocol/signing-key-custody/src/__tests__/rotation.test.ts
+++ b/packages/protocol/signing-key-custody/src/__tests__/rotation.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  applyCompromiseToKeys,
+  applyRevocationToKeys,
+  buildDefaultFixtureRegistryDocument,
+  createInMemoryRotationCoordinator,
+  decodeCompromiseEvent,
+  decodeRevocationEvent,
+  decodeRotationEvent,
+  defaultFixtureCustodyKeys,
+  PinnedKeyRegistry,
+  validateRotationOverlap,
+} from "../index.js";
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), "../../fixtures/scenarios");
+
+describe("rotation and revocation (CR-013)", () => {
+  const bundle = JSON.parse(
+    readFileSync(join(fixturesDir, "registry-rotation.shared.json"), "utf8"),
+  ) as {
+    accepted_at_ms: number;
+    rotation: unknown;
+    compromise: unknown;
+  };
+
+  const registry = new PinnedKeyRegistry(buildDefaultFixtureRegistryDocument());
+
+  it("validates overlap rotation windows", () => {
+    const rotation = decodeRotationEvent(bundle.rotation);
+    expect(() =>
+      validateRotationOverlap(rotation, registry, Date.parse("2026-07-15T00:00:00.000Z")),
+    ).not.toThrow();
+  });
+
+  it("applies revocation and compromise events", () => {
+    const coordinator = createInMemoryRotationCoordinator("collection-report.fixture-registry.v1");
+    const keys = defaultFixtureCustodyKeys();
+
+    const revocation = decodeRevocationEvent({
+      event_id: "revoke-test",
+      kind: "revocation",
+      registry_id: coordinator.registryId,
+      signing_key_id: "sonar-fixture-rotated",
+      revoked_at: "2026-07-17T21:00:00.000Z",
+      reason: "scheduled_rotation_complete",
+      issued_at: "2026-07-17T21:00:00.000Z",
+    });
+    const revokedKeys = coordinator.applyRevocation(revocation, keys);
+    const rotated = revokedKeys.find((key) => key.signing_key_id === "sonar-fixture-rotated");
+    expect(rotated?.revoked_at).toBe("2026-07-17T21:00:00.000Z");
+
+    const compromise = decodeCompromiseEvent(bundle.compromise);
+    const compromisedKeys = applyCompromiseToKeys(compromise, keys);
+    const compromised = compromisedKeys.find((key) => key.signing_key_id === compromise.signing_key_id);
+    expect(compromised?.compromise).toBe(true);
+    expect(compromised?.revoked_at).toBeDefined();
+
+    const manualRevoke = applyRevocationToKeys(revocation, keys);
+    expect(manualRevoke.find((key) => key.signing_key_id === revocation.signing_key_id)?.revoked_at).toBe(
+      revocation.revoked_at,
+    );
+  });
+});

--- a/packages/protocol/signing-key-custody/src/__tests__/time-health.test.ts
+++ b/packages/protocol/signing-key-custody/src/__tests__/time-health.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  assertSignedIntakeTimeHealthy,
+  buildTimeHealthSnapshot,
+  evaluateDatabaseClockSkew,
+  KeyCustodyRejectedError,
+  ORDERING_DATABASE_MAX_SKEW_MS,
+  timeHealthObservability,
+  type TimeSourceReading,
+} from "../index.js";
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), "../../fixtures/scenarios");
+
+describe("database time-health (CR-013)", () => {
+  const bundle = JSON.parse(
+    readFileSync(join(fixturesDir, "time-health.shared.json"), "utf8"),
+  ) as {
+    evaluated_at_ms: number;
+    database_unix_ms: number;
+    healthy_sources: TimeSourceReading[];
+    scenarios: Array<{
+      id: string;
+      expect: "accept" | "reject";
+      database_unix_ms?: number;
+      sources?: TimeSourceReading[];
+      max_skew_ms?: number;
+      last_good_at?: string;
+      reject_reason?: string;
+    }>;
+  };
+
+  it("blocks signed intake when skew exceeds 2 seconds", () => {
+    for (const scenario of bundle.scenarios) {
+      const verdict = evaluateDatabaseClockSkew({
+        databaseUnixMs: scenario.database_unix_ms ?? bundle.database_unix_ms,
+        evaluatedAtMs: bundle.evaluated_at_ms,
+        authoritativeSources: scenario.sources ?? bundle.healthy_sources,
+        maxSkewMs: scenario.max_skew_ms ?? ORDERING_DATABASE_MAX_SKEW_MS,
+        lastGoodAt: scenario.last_good_at,
+      });
+
+      if (scenario.expect === "accept") {
+        expect(verdict.intakeBlocked, scenario.id).toBe(false);
+      } else {
+        expect(verdict.intakeBlocked, scenario.id).toBe(true);
+        if (scenario.reject_reason !== undefined) {
+          expect(verdict.blockReason).toBe(scenario.reject_reason);
+        }
+      }
+    }
+  });
+
+  it("builds observable time-health snapshots", () => {
+    const snapshot = buildTimeHealthSnapshot({
+      databaseUnixMs: bundle.database_unix_ms,
+      evaluatedAtMs: bundle.evaluated_at_ms,
+      authoritativeSources: bundle.healthy_sources,
+    });
+    const obs = timeHealthObservability(snapshot);
+    expect(obs.intake_blocked).toBe(false);
+    expect(obs.source_count).toBeGreaterThanOrEqual(2);
+    expect(() => assertSignedIntakeTimeHealthy(snapshot)).not.toThrow();
+  });
+
+  it("fails closed on unhealthy snapshots", () => {
+    const snapshot = buildTimeHealthSnapshot({
+      databaseUnixMs: bundle.database_unix_ms + 10_000,
+      evaluatedAtMs: bundle.evaluated_at_ms,
+      authoritativeSources: bundle.healthy_sources,
+    });
+    expect(() => assertSignedIntakeTimeHealthy(snapshot)).toThrow(KeyCustodyRejectedError);
+  });
+});

--- a/packages/protocol/signing-key-custody/src/contracts.ts
+++ b/packages/protocol/signing-key-custody/src/contracts.ts
@@ -1,0 +1,155 @@
+import { Schema } from "effect";
+import type { ParseOptions } from "effect/SchemaAST";
+import { SIGNING_KEY_CUSTODY_SCHEMA_VERSION } from "./version.js";
+
+const Iso8601UtcSchema = Schema.String.pipe(
+  Schema.pattern(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/, {
+    message: () => "must be ISO-8601 UTC with trailing Z",
+  }),
+);
+
+const Hex64Schema = Schema.String.pipe(
+  Schema.pattern(/^[0-9a-f]{64}$/, {
+    message: () => "must be 64 lowercase hex chars (sha256)",
+  }),
+);
+
+const SigningKeyIdSchema = Schema.String.pipe(
+  Schema.pattern(/^[A-Za-z0-9_.:-]{1,128}$/),
+);
+
+const CellSlugSchema = Schema.String.pipe(
+  Schema.pattern(/^[a-z][a-z0-9-]*$/, {
+    message: () => "must be lowercase kebab-case producer slug",
+  }),
+);
+
+const CapabilitySchema = Schema.String.pipe(Schema.minLength(1), Schema.maxLength(256));
+
+export const strictDecodeOptions: ParseOptions = {
+  errors: "all",
+  onExcessProperty: "error",
+};
+
+export const KeyCustodyClass = Schema.Literal("fixture", "production");
+export type KeyCustodyClass = Schema.Schema.Type<typeof KeyCustodyClass>;
+
+export const CustodyBackendKind = Schema.Literal(
+  "local-fixture",
+  "aws-kms",
+  "gcp-kms",
+  "azure-keyvault",
+  "vault-transit",
+  "cloudhsm",
+);
+export type CustodyBackendKind = Schema.Schema.Type<typeof CustodyBackendKind>;
+
+export const CustodySigningKey = Schema.Struct({
+  signing_key_id: SigningKeyIdSchema,
+  public_key_hex: Schema.String.pipe(
+    Schema.pattern(/^[0-9a-f]{64}$/, { message: () => "must be 32-byte ed25519 pubkey hex" }),
+  ),
+  producer: CellSlugSchema,
+  capabilities: Schema.Array(CapabilitySchema).pipe(Schema.minItems(1)),
+  tenant_scope_digests: Schema.optionalWith(Schema.Array(Hex64Schema), { exact: true }),
+  activated_at: Iso8601UtcSchema,
+  revoked_at: Schema.optionalWith(Iso8601UtcSchema, { exact: true }),
+  compromise: Schema.optionalWith(Schema.Boolean, { exact: true }),
+  key_class: KeyCustodyClass,
+  custody_backend: CustodyBackendKind,
+  custody_key_ref: Schema.optionalWith(Schema.String.pipe(Schema.minLength(1)), { exact: true }),
+  registry_generation: Schema.optionalWith(Schema.Number.pipe(Schema.int(), Schema.greaterThanOrEqualTo(1)), {
+    exact: true,
+  }),
+}).annotations({ identifier: "CustodySigningKey" });
+export type CustodySigningKey = Schema.Schema.Type<typeof CustodySigningKey>;
+
+export const SigningKeyRegistryDocument = Schema.Struct({
+  schema_version: Schema.Literal(SIGNING_KEY_CUSTODY_SCHEMA_VERSION),
+  registry_id: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(128)),
+  registry_generation: Schema.Number.pipe(Schema.int(), Schema.greaterThanOrEqualTo(1)),
+  published_at: Iso8601UtcSchema,
+  max_staleness_ms: Schema.Number.pipe(Schema.int(), Schema.greaterThanOrEqualTo(1)),
+  key_class_scope: KeyCustodyClass,
+  keys: Schema.Array(CustodySigningKey).pipe(Schema.minItems(1)),
+  distribution_digest: Hex64Schema,
+}).annotations({ identifier: "SigningKeyRegistryDocument" });
+export type SigningKeyRegistryDocument = Schema.Schema.Type<typeof SigningKeyRegistryDocument>;
+
+export const RotationEvent = Schema.Struct({
+  event_id: Schema.String.pipe(Schema.minLength(1)),
+  kind: Schema.Literal("rotation"),
+  registry_id: Schema.String.pipe(Schema.minLength(1)),
+  previous_key_id: SigningKeyIdSchema,
+  next_key_id: SigningKeyIdSchema,
+  overlap_starts_at: Iso8601UtcSchema,
+  overlap_ends_at: Iso8601UtcSchema,
+  issued_at: Iso8601UtcSchema,
+}).annotations({ identifier: "RotationEvent" });
+export type RotationEvent = Schema.Schema.Type<typeof RotationEvent>;
+
+export const RevocationEvent = Schema.Struct({
+  event_id: Schema.String.pipe(Schema.minLength(1)),
+  kind: Schema.Literal("revocation"),
+  registry_id: Schema.String.pipe(Schema.minLength(1)),
+  signing_key_id: SigningKeyIdSchema,
+  revoked_at: Iso8601UtcSchema,
+  reason: Schema.String.pipe(Schema.minLength(1)),
+  issued_at: Iso8601UtcSchema,
+}).annotations({ identifier: "RevocationEvent" });
+export type RevocationEvent = Schema.Schema.Type<typeof RevocationEvent>;
+
+export const CompromiseEvent = Schema.Struct({
+  event_id: Schema.String.pipe(Schema.minLength(1)),
+  kind: Schema.Literal("compromise"),
+  registry_id: Schema.String.pipe(Schema.minLength(1)),
+  signing_key_id: SigningKeyIdSchema,
+  detected_at: Iso8601UtcSchema,
+  issued_at: Iso8601UtcSchema,
+}).annotations({ identifier: "CompromiseEvent" });
+export type CompromiseEvent = Schema.Schema.Type<typeof CompromiseEvent>;
+
+export const TimeSourceReading = Schema.Struct({
+  source_id: Schema.String.pipe(Schema.minLength(1)),
+  observed_at: Iso8601UtcSchema,
+  unix_ms: Schema.Number.pipe(Schema.int()),
+  uncertainty_ms: Schema.Number.pipe(Schema.int(), Schema.greaterThanOrEqualTo(0)),
+  region: Schema.optionalWith(Schema.String.pipe(Schema.minLength(1)), { exact: true }),
+}).annotations({ identifier: "TimeSourceReading" });
+export type TimeSourceReading = Schema.Schema.Type<typeof TimeSourceReading>;
+
+export const TimeHealthSnapshot = Schema.Struct({
+  schema_version: Schema.Literal(SIGNING_KEY_CUSTODY_SCHEMA_VERSION),
+  evaluated_at: Iso8601UtcSchema,
+  database_unix_ms: Schema.Number.pipe(Schema.int()),
+  authoritative_sources: Schema.Array(TimeSourceReading).pipe(Schema.minItems(1)),
+  measured_offset_ms: Schema.optionalWith(Schema.Number.pipe(Schema.int()), { exact: true }),
+  offset_uncertainty_ms: Schema.optionalWith(Schema.Number.pipe(Schema.int(), Schema.greaterThanOrEqualTo(0)), {
+    exact: true,
+  }),
+  regional_divergence_ms: Schema.optionalWith(Schema.Number.pipe(Schema.int(), Schema.greaterThanOrEqualTo(0)), {
+    exact: true,
+  }),
+  last_good_at: Schema.optionalWith(Iso8601UtcSchema, { exact: true }),
+  intake_blocked: Schema.Boolean,
+  block_reason: Schema.optionalWith(
+    Schema.Literal(
+      "database_clock_skew_exceeded",
+      "database_clock_unknown",
+      "insufficient_time_sources",
+      "time_source_divergence",
+    ),
+    { exact: true },
+  ),
+}).annotations({ identifier: "TimeHealthSnapshot" });
+export type TimeHealthSnapshot = Schema.Schema.Type<typeof TimeHealthSnapshot>;
+
+export const decodeCustodySigningKey = Schema.decodeUnknownSync(CustodySigningKey, strictDecodeOptions);
+export const decodeSigningKeyRegistryDocument = Schema.decodeUnknownSync(
+  SigningKeyRegistryDocument,
+  strictDecodeOptions,
+);
+export const decodeRotationEvent = Schema.decodeUnknownSync(RotationEvent, strictDecodeOptions);
+export const decodeRevocationEvent = Schema.decodeUnknownSync(RevocationEvent, strictDecodeOptions);
+export const decodeCompromiseEvent = Schema.decodeUnknownSync(CompromiseEvent, strictDecodeOptions);
+export const decodeTimeHealthSnapshot = Schema.decodeUnknownSync(TimeHealthSnapshot, strictDecodeOptions);

--- a/packages/protocol/signing-key-custody/src/errors.ts
+++ b/packages/protocol/signing-key-custody/src/errors.ts
@@ -1,0 +1,37 @@
+import { Data } from "effect";
+
+export class ContractIntegrityError extends Data.TaggedError("ContractIntegrityError")<{
+  readonly detail: string;
+}> {}
+
+export class KeyCustodyRejectedError extends Data.TaggedError("KeyCustodyRejectedError")<{
+  readonly reason:
+    | "unknown_signing_key"
+    | "revoked_signing_key"
+    | "compromised_signing_key"
+    | "registry_stale"
+    | "registry_unknown"
+    | "fixture_key_in_production_context"
+    | "production_key_in_fixture_context"
+    | "key_class_backend_mismatch"
+    | "invalid_key_id_pattern"
+    | "database_clock_skew_exceeded"
+    | "database_clock_unknown"
+    | "insufficient_time_sources"
+    | "time_source_divergence"
+    | "rotation_overlap_invalid"
+    | "signing_backend_unavailable";
+  readonly remediation?:
+    | "refresh_registry"
+    | "rotate_signing_key"
+    | "emergency_revoke"
+    | "quarantine_dependency_intake"
+    | "restore_time_sources"
+    | "fail_closed_until_recovery";
+}> {}
+
+export class SigningBackendError extends Data.TaggedError("SigningBackendError")<{
+  readonly backend: string;
+  readonly operation: "sign" | "get_public_key" | "health_check";
+  readonly detail: string;
+}> {}

--- a/packages/protocol/signing-key-custody/src/fixture-registry.ts
+++ b/packages/protocol/signing-key-custody/src/fixture-registry.ts
@@ -1,0 +1,112 @@
+import { createHash } from "node:crypto";
+import { jcsCanonicalize } from "@freeside/trust-envelope-protocol";
+import type { CustodySigningKey, KeyCustodyClass, SigningKeyRegistryDocument } from "./contracts.js";
+import {
+  FIXTURE_CAPABILITY,
+  FIXTURE_SIGNING_KEY_IDS,
+  FIXTURE_TENANT_SCOPE_DIGEST,
+  fixturePublicKeys,
+} from "@freeside/trust-envelope-protocol";
+import { DEFAULT_REGISTRY_MAX_STALENESS_MS, SIGNING_KEY_CUSTODY_SCHEMA_VERSION } from "./version.js";
+
+const digestRegistryMaterial = (material: unknown): string =>
+  createHash("sha256").update(jcsCanonicalize(material)).digest("hex");
+
+export const buildFixtureCustodyKey = (
+  signingKeyId: string,
+  options?: {
+    activatedAt?: string;
+    revokedAt?: string;
+    compromise?: boolean;
+    registryGeneration?: number;
+  },
+): CustodySigningKey => ({
+  signing_key_id: signingKeyId,
+  public_key_hex: fixturePublicKeys()[signingKeyId]!,
+  producer: "sonar-api",
+  capabilities: [FIXTURE_CAPABILITY],
+  tenant_scope_digests: [FIXTURE_TENANT_SCOPE_DIGEST],
+  activated_at: options?.activatedAt ?? "2026-07-01T00:00:00.000Z",
+  ...(options?.revokedAt !== undefined ? { revoked_at: options.revokedAt } : {}),
+  ...(options?.compromise !== undefined ? { compromise: options.compromise } : {}),
+  key_class: "fixture",
+  custody_backend: "local-fixture",
+  registry_generation: options?.registryGeneration ?? 1,
+});
+
+export const defaultFixtureCustodyKeys = (): CustodySigningKey[] => [
+  buildFixtureCustodyKey(FIXTURE_SIGNING_KEY_IDS.sonarPrimary),
+  buildFixtureCustodyKey(FIXTURE_SIGNING_KEY_IDS.sonarRotated, {
+    activatedAt: "2026-07-10T00:00:00.000Z",
+  }),
+  buildFixtureCustodyKey(FIXTURE_SIGNING_KEY_IDS.sonarRevoked, {
+    activatedAt: "2026-07-01T00:00:00.000Z",
+    revokedAt: "2026-07-15T00:00:00.000Z",
+  }),
+];
+
+export interface BuildRegistryDocumentInput {
+  readonly registryId: string;
+  readonly registryGeneration: number;
+  readonly publishedAt: string;
+  readonly keyClassScope: KeyCustodyClass;
+  readonly keys: readonly CustodySigningKey[];
+  readonly maxStalenessMs?: number;
+}
+
+export const buildSigningKeyRegistryDocument = ({
+  registryId,
+  registryGeneration,
+  publishedAt,
+  keyClassScope,
+  keys,
+  maxStalenessMs = DEFAULT_REGISTRY_MAX_STALENESS_MS,
+}: BuildRegistryDocumentInput): SigningKeyRegistryDocument => {
+  const body = {
+    schema_version: SIGNING_KEY_CUSTODY_SCHEMA_VERSION,
+    registry_id: registryId,
+    registry_generation: registryGeneration,
+    published_at: publishedAt,
+    max_staleness_ms: maxStalenessMs,
+    key_class_scope: keyClassScope,
+    keys,
+  } as const;
+
+  return {
+    ...body,
+    distribution_digest: digestRegistryMaterial(body),
+  };
+};
+
+export const buildDefaultFixtureRegistryDocument = (
+  publishedAt = "2026-07-17T21:00:00.000Z",
+): SigningKeyRegistryDocument =>
+  buildSigningKeyRegistryDocument({
+    registryId: "collection-report.fixture-registry.v1",
+    registryGeneration: 1,
+    publishedAt,
+    keyClassScope: "fixture",
+    keys: defaultFixtureCustodyKeys(),
+  });
+
+/** Example production registry shape — public metadata only; private keys live in KMS/HSM. */
+export const exampleProductionRegistryTemplate = (): SigningKeyRegistryDocument =>
+  buildSigningKeyRegistryDocument({
+    registryId: "collection-report.production-registry.v1",
+    registryGeneration: 1,
+    publishedAt: "2026-07-17T21:00:00.000Z",
+    keyClassScope: "production",
+    keys: [
+      {
+        signing_key_id: "sonar-production-primary",
+        public_key_hex: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        producer: "sonar-api",
+        capabilities: [FIXTURE_CAPABILITY],
+        activated_at: "2026-07-01T00:00:00.000Z",
+        key_class: "production",
+        custody_backend: "aws-kms",
+        custody_key_ref: "alias/collection-report/sonar-primary",
+        registry_generation: 1,
+      },
+    ],
+  });

--- a/packages/protocol/signing-key-custody/src/index.ts
+++ b/packages/protocol/signing-key-custody/src/index.ts
@@ -1,0 +1,104 @@
+/**
+ * @freeside/signing-key-custody-protocol
+ *
+ * CR-013 production KMS/HSM signing-key custody for collection-report Ordering.
+ * Distinct from CR-009 wire semantics — this package owns registry distribution,
+ * key-class separation, rotation/revocation policy, and database time-health gates.
+ */
+
+export {
+  SIGNING_KEY_CUSTODY_SCHEMA_VERSION,
+  ORDERING_DATABASE_MAX_SKEW_MS,
+  MIN_INDEPENDENT_TIME_SOURCES,
+  DEFAULT_REGISTRY_MAX_STALENESS_MS,
+  MIN_ROTATION_OVERLAP_MS,
+} from "./version.js";
+
+export {
+  ContractIntegrityError,
+  KeyCustodyRejectedError,
+  SigningBackendError,
+} from "./errors.js";
+
+export {
+  strictDecodeOptions,
+  KeyCustodyClass,
+  CustodyBackendKind,
+  CustodySigningKey,
+  SigningKeyRegistryDocument,
+  RotationEvent,
+  RevocationEvent,
+  CompromiseEvent,
+  TimeSourceReading,
+  TimeHealthSnapshot,
+  decodeCustodySigningKey,
+  decodeSigningKeyRegistryDocument,
+  decodeRotationEvent,
+  decodeRevocationEvent,
+  decodeCompromiseEvent,
+  decodeTimeHealthSnapshot,
+} from "./contracts.js";
+
+export {
+  FIXTURE_KEY_ID_MARKER,
+  isFixtureKeyId,
+  isProductionKeyId,
+  expectedBackendForClass,
+  backendMatchesClass,
+  validateKeyClassMechanics,
+  assertProductionAuthorizedKey,
+  assertFixtureKeyOnly,
+  satisfiesProductionReleaseGate,
+  toTrustEnvelopeServiceKey,
+} from "./key-class.js";
+
+export {
+  PinnedKeyRegistry,
+  registryObservability,
+  type RegistryFreshnessInput,
+  type ResolveKeyForIntakeInput,
+} from "./registry.js";
+
+export {
+  validateRotationOverlap,
+  applyRevocationToKeys,
+  applyCompromiseToKeys,
+  createInMemoryRotationCoordinator,
+  buildEmergencyRevocationPlan,
+  type RotationCoordinator,
+  type EmergencyRevocationPlan,
+} from "./rotation.js";
+
+export {
+  evaluateDatabaseClockSkew,
+  buildTimeHealthSnapshot,
+  assertSignedIntakeTimeHealthy,
+  timeHealthObservability,
+  type EvaluateDatabaseClockSkewInput,
+  type DatabaseClockSkewVerdict,
+} from "./time-health.js";
+
+export {
+  assertBackendAuthorizedForContext,
+  signWithBackend,
+  type RemoteSigningBackend,
+  type LocalFixtureSigningBackend,
+  type SigningBackend,
+  type KmsHsmKeyReference,
+} from "./signer.js";
+
+export {
+  gateSignedIntake,
+  assertSignedIntakeAllowed,
+  type GateSignedIntakeInput,
+  type SignedIntakeGateVerdict,
+} from "./intake-gate.js";
+
+export {
+  buildFixtureCustodyKey,
+  defaultFixtureCustodyKeys,
+  buildSigningKeyRegistryDocument,
+  buildDefaultFixtureRegistryDocument,
+  exampleProductionRegistryTemplate,
+  type BuildRegistryDocumentInput,
+} from "./fixture-registry.js";

--- a/packages/protocol/signing-key-custody/src/intake-gate.ts
+++ b/packages/protocol/signing-key-custody/src/intake-gate.ts
@@ -1,0 +1,51 @@
+import type { KeyCustodyClass, TimeHealthSnapshot } from "./contracts.js";
+import { KeyCustodyRejectedError } from "./errors.js";
+import type { PinnedKeyRegistry } from "./registry.js";
+import { assertSignedIntakeTimeHealthy } from "./time-health.js";
+
+export interface GateSignedIntakeInput {
+  readonly registry: PinnedKeyRegistry;
+  readonly signingKeyId: string;
+  readonly acceptedAtMs: number;
+  readonly context: KeyCustodyClass;
+  readonly timeHealth: TimeHealthSnapshot;
+}
+
+export interface SignedIntakeGateVerdict {
+  readonly allowed: boolean;
+  readonly reason?: KeyCustodyRejectedError["reason"];
+  readonly remediation?: KeyCustodyRejectedError["remediation"];
+}
+
+export const gateSignedIntake = ({
+  registry,
+  signingKeyId,
+  acceptedAtMs,
+  context,
+  timeHealth,
+}: GateSignedIntakeInput): SignedIntakeGateVerdict => {
+  try {
+    assertSignedIntakeTimeHealthy(timeHealth);
+    registry.resolveForIntake({ signingKeyId, acceptedAtMs, context });
+    return { allowed: true };
+  } catch (error) {
+    if (error instanceof KeyCustodyRejectedError) {
+      return {
+        allowed: false,
+        reason: error.reason,
+        remediation: error.remediation,
+      };
+    }
+    throw error;
+  }
+};
+
+export const assertSignedIntakeAllowed = (input: GateSignedIntakeInput): void => {
+  const verdict = gateSignedIntake(input);
+  if (!verdict.allowed) {
+    throw new KeyCustodyRejectedError({
+      reason: verdict.reason ?? "database_clock_unknown",
+      remediation: verdict.remediation,
+    });
+  }
+};

--- a/packages/protocol/signing-key-custody/src/key-class.ts
+++ b/packages/protocol/signing-key-custody/src/key-class.ts
@@ -1,0 +1,95 @@
+import type { CustodyBackendKind, CustodySigningKey, KeyCustodyClass } from "./contracts.js";
+import { KeyCustodyRejectedError } from "./errors.js";
+
+/** Mechanical marker embedded in every non-production signing_key_id. */
+export const FIXTURE_KEY_ID_MARKER = "-fixture-" as const;
+
+const FIXTURE_BACKEND: CustodyBackendKind = "local-fixture";
+
+const PRODUCTION_BACKENDS: ReadonlySet<CustodyBackendKind> = new Set([
+  "aws-kms",
+  "gcp-kms",
+  "azure-keyvault",
+  "vault-transit",
+  "cloudhsm",
+]);
+
+export const isFixtureKeyId = (signingKeyId: string): boolean =>
+  signingKeyId.includes(FIXTURE_KEY_ID_MARKER);
+
+export const isProductionKeyId = (signingKeyId: string): boolean =>
+  !isFixtureKeyId(signingKeyId);
+
+export const expectedBackendForClass = (keyClass: KeyCustodyClass): CustodyBackendKind =>
+  keyClass === "fixture" ? FIXTURE_BACKEND : "aws-kms";
+
+export const backendMatchesClass = (
+  keyClass: KeyCustodyClass,
+  custodyBackend: CustodyBackendKind,
+): boolean => {
+  if (keyClass === "fixture") return custodyBackend === FIXTURE_BACKEND;
+  return PRODUCTION_BACKENDS.has(custodyBackend);
+};
+
+export const validateKeyClassMechanics = (key: CustodySigningKey): void => {
+  const idMatchesClass =
+    key.key_class === "fixture" ? isFixtureKeyId(key.signing_key_id) : isProductionKeyId(key.signing_key_id);
+
+  if (!idMatchesClass) {
+    throw new KeyCustodyRejectedError({
+      reason: "invalid_key_id_pattern",
+      remediation: key.key_class === "fixture" ? undefined : "emergency_revoke",
+    });
+  }
+
+  if (!backendMatchesClass(key.key_class, key.custody_backend)) {
+    throw new KeyCustodyRejectedError({
+      reason: "key_class_backend_mismatch",
+      remediation: "emergency_revoke",
+    });
+  }
+};
+
+export const assertProductionAuthorizedKey = (key: CustodySigningKey): void => {
+  validateKeyClassMechanics(key);
+  if (key.key_class !== "production") {
+    throw new KeyCustodyRejectedError({
+      reason: "fixture_key_in_production_context",
+      remediation: "fail_closed_until_recovery",
+    });
+  }
+};
+
+export const assertFixtureKeyOnly = (key: CustodySigningKey): void => {
+  validateKeyClassMechanics(key);
+  if (key.key_class !== "fixture") {
+    throw new KeyCustodyRejectedError({
+      reason: "production_key_in_fixture_context",
+      remediation: "fail_closed_until_recovery",
+    });
+  }
+};
+
+/** Release gates must never treat fixture registry proof as production authorization. */
+export const satisfiesProductionReleaseGate = (keys: readonly CustodySigningKey[]): boolean =>
+  keys.length > 0 && keys.every((key) => {
+    try {
+      assertProductionAuthorizedKey(key);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+
+export const toTrustEnvelopeServiceKey = (
+  key: CustodySigningKey,
+): import("@freeside/trust-envelope-protocol").ServiceSigningKey => ({
+  signing_key_id: key.signing_key_id,
+  public_key_hex: key.public_key_hex,
+  producer: key.producer,
+  capabilities: key.capabilities,
+  tenant_scope_digests: key.tenant_scope_digests,
+  activated_at: key.activated_at,
+  revoked_at: key.revoked_at,
+  compromise: key.compromise,
+});

--- a/packages/protocol/signing-key-custody/src/registry.ts
+++ b/packages/protocol/signing-key-custody/src/registry.ts
@@ -1,0 +1,138 @@
+import { ServiceKeyRegistry } from "@freeside/trust-envelope-protocol";
+import type { CustodySigningKey, KeyCustodyClass, SigningKeyRegistryDocument } from "./contracts.js";
+import { ContractIntegrityError, KeyCustodyRejectedError } from "./errors.js";
+import {
+  assertFixtureKeyOnly,
+  assertProductionAuthorizedKey,
+  toTrustEnvelopeServiceKey,
+  validateKeyClassMechanics,
+} from "./key-class.js";
+
+export interface RegistryFreshnessInput {
+  readonly document: SigningKeyRegistryDocument;
+  readonly observedAtMs: number;
+}
+
+export interface ResolveKeyForIntakeInput {
+  readonly signingKeyId: string;
+  readonly acceptedAtMs: number;
+  readonly context: KeyCustodyClass;
+}
+
+export class PinnedKeyRegistry {
+  readonly #document: SigningKeyRegistryDocument;
+  readonly #trustRegistry: ServiceKeyRegistry;
+  readonly #keys: ReadonlyMap<string, CustodySigningKey>;
+
+  constructor(document: SigningKeyRegistryDocument) {
+    for (const key of document.keys) {
+      validateKeyClassMechanics(key);
+      if (key.key_class !== document.key_class_scope) {
+        throw new ContractIntegrityError({
+          detail: `key ${key.signing_key_id} class ${key.key_class} does not match registry scope ${document.key_class_scope}`,
+        });
+      }
+    }
+
+    this.#document = document;
+    this.#keys = new Map(document.keys.map((key) => [key.signing_key_id, key]));
+    this.#trustRegistry = new ServiceKeyRegistry(document.keys.map(toTrustEnvelopeServiceKey));
+  }
+
+  get document(): SigningKeyRegistryDocument {
+    return this.#document;
+  }
+
+  get trustRegistry(): ServiceKeyRegistry {
+    return this.#trustRegistry;
+  }
+
+  static assertFresh({ document, observedAtMs }: RegistryFreshnessInput): void {
+    const publishedAtMs = Date.parse(document.published_at);
+    const ageMs = observedAtMs - publishedAtMs;
+    if (ageMs > document.max_staleness_ms) {
+      throw new KeyCustodyRejectedError({
+        reason: "registry_stale",
+        remediation: "refresh_registry",
+      });
+    }
+  }
+
+  resolveForIntake({ signingKeyId, acceptedAtMs, context }: ResolveKeyForIntakeInput): CustodySigningKey {
+    PinnedKeyRegistry.assertFresh({
+      document: this.#document,
+      observedAtMs: acceptedAtMs,
+    });
+
+    const key = this.#keys.get(signingKeyId);
+    if (key === undefined) {
+      throw new KeyCustodyRejectedError({
+        reason: "unknown_signing_key",
+        remediation: "refresh_registry",
+      });
+    }
+
+    if (context === "production") {
+      assertProductionAuthorizedKey(key);
+    } else {
+      assertFixtureKeyOnly(key);
+    }
+
+    if (key.compromise === true) {
+      throw new KeyCustodyRejectedError({
+        reason: "compromised_signing_key",
+        remediation: "emergency_revoke",
+      });
+    }
+
+    if (!this.#trustRegistry.isActive(toTrustEnvelopeServiceKey(key), acceptedAtMs)) {
+      throw new KeyCustodyRejectedError({
+        reason: "revoked_signing_key",
+        remediation: "rotate_signing_key",
+      });
+    }
+
+    return key;
+  }
+
+  overlappingRotationWindow(
+    previousKeyId: string,
+    nextKeyId: string,
+    atMs: number,
+  ): boolean {
+    const previous = this.#keys.get(previousKeyId);
+    const next = this.#keys.get(nextKeyId);
+    if (previous === undefined || next === undefined) return false;
+    return this.#trustRegistry.overlappingRotationWindow(
+      toTrustEnvelopeServiceKey(previous),
+      toTrustEnvelopeServiceKey(next),
+      atMs,
+    );
+  }
+}
+
+export const registryObservability = (
+  document: SigningKeyRegistryDocument,
+  observedAtMs: number,
+): {
+  readonly registry_id: string;
+  readonly registry_generation: number;
+  readonly published_at: string;
+  readonly age_ms: number;
+  readonly max_staleness_ms: number;
+  readonly is_stale: boolean;
+  readonly key_class_scope: KeyCustodyClass;
+  readonly active_key_count: number;
+} => {
+  const ageMs = observedAtMs - Date.parse(document.published_at);
+  return {
+    registry_id: document.registry_id,
+    registry_generation: document.registry_generation,
+    published_at: document.published_at,
+    age_ms: ageMs,
+    max_staleness_ms: document.max_staleness_ms,
+    is_stale: ageMs > document.max_staleness_ms,
+    key_class_scope: document.key_class_scope,
+    active_key_count: document.keys.length,
+  };
+};

--- a/packages/protocol/signing-key-custody/src/rotation.ts
+++ b/packages/protocol/signing-key-custody/src/rotation.ts
@@ -1,0 +1,90 @@
+import type {
+  CompromiseEvent,
+  CustodySigningKey,
+  RevocationEvent,
+  RotationEvent,
+} from "./contracts.js";
+import { KeyCustodyRejectedError } from "./errors.js";
+import { PinnedKeyRegistry } from "./registry.js";
+
+export interface RotationCoordinator {
+  readonly registryId: string;
+  applyRotation(event: RotationEvent, keys: readonly CustodySigningKey[]): readonly CustodySigningKey[];
+  applyRevocation(event: RevocationEvent, keys: readonly CustodySigningKey[]): readonly CustodySigningKey[];
+  applyCompromise(event: CompromiseEvent, keys: readonly CustodySigningKey[]): readonly CustodySigningKey[];
+}
+
+export const validateRotationOverlap = (
+  event: RotationEvent,
+  registry: PinnedKeyRegistry,
+  atMs: number,
+): void => {
+  const overlapStart = Date.parse(event.overlap_starts_at);
+  const overlapEnd = Date.parse(event.overlap_ends_at);
+  if (overlapEnd <= overlapStart) {
+    throw new KeyCustodyRejectedError({
+      reason: "rotation_overlap_invalid",
+      remediation: "rotate_signing_key",
+    });
+  }
+
+  if (atMs < overlapStart || atMs > overlapEnd) {
+    return;
+  }
+
+  if (!registry.overlappingRotationWindow(event.previous_key_id, event.next_key_id, atMs)) {
+    throw new KeyCustodyRejectedError({
+      reason: "rotation_overlap_invalid",
+      remediation: "rotate_signing_key",
+    });
+  }
+};
+
+export const applyRevocationToKeys = (
+  event: RevocationEvent,
+  keys: readonly CustodySigningKey[],
+): readonly CustodySigningKey[] =>
+  keys.map((key) =>
+    key.signing_key_id === event.signing_key_id
+      ? { ...key, revoked_at: event.revoked_at, compromise: key.compromise ?? false }
+      : key,
+  );
+
+export const applyCompromiseToKeys = (
+  event: CompromiseEvent,
+  keys: readonly CustodySigningKey[],
+): readonly CustodySigningKey[] =>
+  keys.map((key) =>
+    key.signing_key_id === event.signing_key_id
+      ? {
+          ...key,
+          compromise: true,
+          revoked_at: key.revoked_at ?? event.detected_at,
+        }
+      : key,
+  );
+
+export const createInMemoryRotationCoordinator = (registryId: string): RotationCoordinator => ({
+  registryId,
+  applyRotation: (_event, keys) => keys,
+  applyRevocation: (event, keys) => applyRevocationToKeys(event, keys),
+  applyCompromise: (event, keys) => applyCompromiseToKeys(event, keys),
+});
+
+export interface EmergencyRevocationPlan {
+  readonly registry_id: string;
+  readonly compromised_key_ids: readonly string[];
+  readonly revoke_at: string;
+  readonly quarantine_signed_intake: true;
+}
+
+export const buildEmergencyRevocationPlan = (
+  registryId: string,
+  compromisedKeyIds: readonly string[],
+  revokeAtIso: string,
+): EmergencyRevocationPlan => ({
+  registry_id: registryId,
+  compromised_key_ids: compromisedKeyIds,
+  revoke_at: revokeAtIso,
+  quarantine_signed_intake: true,
+});

--- a/packages/protocol/signing-key-custody/src/signer.ts
+++ b/packages/protocol/signing-key-custody/src/signer.ts
@@ -1,0 +1,88 @@
+import type { KeyCustodyClass } from "./contracts.js";
+import { KeyCustodyRejectedError, SigningBackendError } from "./errors.js";
+import { assertFixtureKeyOnly, assertProductionAuthorizedKey } from "./key-class.js";
+
+export interface RemoteSigningBackend {
+  readonly backendKind: Exclude<
+    import("./contracts.js").CustodyBackendKind,
+    "local-fixture"
+  >;
+  readonly signingKeyId: string;
+  readonly keyClass: KeyCustodyClass;
+  sign(message: Uint8Array): Promise<Uint8Array>;
+  getPublicKeyHex(): Promise<string>;
+  healthCheck(): Promise<{ ok: true } | { ok: false; detail: string }>;
+}
+
+export interface LocalFixtureSigningBackend {
+  readonly backendKind: "local-fixture";
+  readonly signingKeyId: string;
+  readonly keyClass: "fixture";
+  sign(message: Uint8Array): Uint8Array;
+  getPublicKeyHex(): string;
+}
+
+export type SigningBackend = RemoteSigningBackend | LocalFixtureSigningBackend;
+
+export const assertBackendAuthorizedForContext = (
+  backend: SigningBackend,
+  context: KeyCustodyClass,
+): void => {
+  if (context === "production") {
+    if (backend.backendKind === "local-fixture" || backend.keyClass !== "production") {
+      throw new KeyCustodyRejectedError({
+        reason: "fixture_key_in_production_context",
+        remediation: "fail_closed_until_recovery",
+      });
+    }
+    assertProductionAuthorizedKey({
+      signing_key_id: backend.signingKeyId,
+      public_key_hex: "0".repeat(64),
+      producer: "placeholder",
+      capabilities: ["collection-report.capability-evidence.v1"],
+      activated_at: "2026-01-01T00:00:00.000Z",
+      key_class: backend.keyClass,
+      custody_backend: backend.backendKind,
+    });
+  } else if (backend.backendKind !== "local-fixture" || backend.keyClass !== "fixture") {
+    throw new KeyCustodyRejectedError({
+      reason: "production_key_in_fixture_context",
+      remediation: "fail_closed_until_recovery",
+    });
+  }
+};
+
+export const signWithBackend = async (
+  backend: SigningBackend,
+  message: Uint8Array,
+): Promise<Uint8Array> => {
+  if (backend.backendKind === "local-fixture") {
+    return backend.sign(message);
+  }
+
+  const health = await backend.healthCheck();
+  if (!health.ok) {
+    throw new SigningBackendError({
+      backend: backend.backendKind,
+      operation: "health_check",
+      detail: health.detail,
+    });
+  }
+
+  try {
+    return await backend.sign(message);
+  } catch (error) {
+    throw new SigningBackendError({
+      backend: backend.backendKind,
+      operation: "sign",
+      detail: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+
+export interface KmsHsmKeyReference {
+  readonly signing_key_id: string;
+  readonly custody_backend: RemoteSigningBackend["backendKind"];
+  readonly custody_key_ref: string;
+  readonly region?: string;
+}

--- a/packages/protocol/signing-key-custody/src/time-health.ts
+++ b/packages/protocol/signing-key-custody/src/time-health.ts
@@ -1,0 +1,161 @@
+import type { TimeHealthSnapshot, TimeSourceReading } from "./contracts.js";
+import { KeyCustodyRejectedError } from "./errors.js";
+import {
+  MIN_INDEPENDENT_TIME_SOURCES,
+  ORDERING_DATABASE_MAX_SKEW_MS,
+  SIGNING_KEY_CUSTODY_SCHEMA_VERSION,
+} from "./version.js";
+
+export interface EvaluateDatabaseClockSkewInput {
+  readonly databaseUnixMs: number;
+  readonly evaluatedAtMs: number;
+  readonly authoritativeSources: readonly TimeSourceReading[];
+  readonly maxSkewMs?: number;
+  readonly minSources?: number;
+  readonly maxRegionalDivergenceMs?: number;
+  readonly lastGoodAt?: string;
+}
+
+export interface DatabaseClockSkewVerdict {
+  readonly intakeBlocked: boolean;
+  readonly blockReason?: TimeHealthSnapshot["block_reason"];
+  readonly measuredOffsetMs?: number;
+  readonly offsetUncertaintyMs?: number;
+  readonly regionalDivergenceMs?: number;
+}
+
+const median = (values: readonly number[]): number => {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return Math.round((sorted[sorted.length - 1]! + sorted[mid]!) / 2);
+  }
+  return sorted[mid]!;
+};
+
+export const evaluateDatabaseClockSkew = ({
+  databaseUnixMs,
+  evaluatedAtMs,
+  authoritativeSources,
+  maxSkewMs = ORDERING_DATABASE_MAX_SKEW_MS,
+  minSources = MIN_INDEPENDENT_TIME_SOURCES,
+  maxRegionalDivergenceMs = 500,
+  lastGoodAt,
+}: EvaluateDatabaseClockSkewInput): DatabaseClockSkewVerdict => {
+  if (authoritativeSources.length < minSources) {
+    return {
+      intakeBlocked: true,
+      blockReason: "insufficient_time_sources",
+    };
+  }
+
+  const offsets = authoritativeSources.map((source) => databaseUnixMs - source.unix_ms);
+  const measuredOffsetMs = median(offsets);
+  const offsetUncertaintyMs = Math.max(
+    ...authoritativeSources.map((source) => source.uncertainty_ms),
+  );
+
+  const regions = new Map<string, number[]>();
+  for (const source of authoritativeSources) {
+    const region = source.region ?? "global";
+    const bucket = regions.get(region) ?? [];
+    bucket.push(source.unix_ms);
+    regions.set(region, bucket);
+  }
+
+  let regionalDivergenceMs = 0;
+  if (regions.size > 1) {
+    const regionMedians = [...regions.values()].map(median);
+    regionalDivergenceMs = Math.max(...regionMedians) - Math.min(...regionMedians);
+    if (regionalDivergenceMs > maxRegionalDivergenceMs) {
+      return {
+        intakeBlocked: true,
+        blockReason: "time_source_divergence",
+        measuredOffsetMs,
+        offsetUncertaintyMs,
+        regionalDivergenceMs,
+      };
+    }
+  }
+
+  const effectiveSkew = Math.abs(measuredOffsetMs) + offsetUncertaintyMs;
+
+  if (lastGoodAt !== undefined) {
+    const lastGoodAgeMs = evaluatedAtMs - Date.parse(lastGoodAt);
+    if (lastGoodAgeMs > maxSkewMs * 15) {
+      return {
+        intakeBlocked: true,
+        blockReason: "database_clock_unknown",
+        measuredOffsetMs,
+        offsetUncertaintyMs,
+        regionalDivergenceMs,
+      };
+    }
+  }
+
+  if (effectiveSkew > maxSkewMs) {
+    return {
+      intakeBlocked: true,
+      blockReason: "database_clock_skew_exceeded",
+      measuredOffsetMs,
+      offsetUncertaintyMs,
+      regionalDivergenceMs,
+    };
+  }
+
+  return {
+    intakeBlocked: false,
+    measuredOffsetMs,
+    offsetUncertaintyMs,
+    regionalDivergenceMs,
+  };
+};
+
+export const buildTimeHealthSnapshot = (
+  input: EvaluateDatabaseClockSkewInput,
+): TimeHealthSnapshot => {
+  const verdict = evaluateDatabaseClockSkew(input);
+  return {
+    schema_version: SIGNING_KEY_CUSTODY_SCHEMA_VERSION,
+    evaluated_at: new Date(input.evaluatedAtMs).toISOString(),
+    database_unix_ms: input.databaseUnixMs,
+    authoritative_sources: [...input.authoritativeSources],
+    measured_offset_ms: verdict.measuredOffsetMs,
+    offset_uncertainty_ms: verdict.offsetUncertaintyMs,
+    regional_divergence_ms: verdict.regionalDivergenceMs,
+    last_good_at: verdict.intakeBlocked ? input.lastGoodAt : new Date(input.evaluatedAtMs).toISOString(),
+    intake_blocked: verdict.intakeBlocked,
+    block_reason: verdict.blockReason,
+  };
+};
+
+export const assertSignedIntakeTimeHealthy = (snapshot: TimeHealthSnapshot): void => {
+  if (snapshot.intake_blocked) {
+    throw new KeyCustodyRejectedError({
+      reason: snapshot.block_reason ?? "database_clock_unknown",
+      remediation: snapshot.block_reason === "insufficient_time_sources"
+        ? "restore_time_sources"
+        : "quarantine_dependency_intake",
+    });
+  }
+};
+
+export const timeHealthObservability = (
+  snapshot: TimeHealthSnapshot,
+): {
+  readonly measured_offset_ms: number | undefined;
+  readonly offset_uncertainty_ms: number | undefined;
+  readonly regional_divergence_ms: number | undefined;
+  readonly last_good_at: string | undefined;
+  readonly intake_blocked: boolean;
+  readonly block_reason: TimeHealthSnapshot["block_reason"];
+  readonly source_count: number;
+} => ({
+  measured_offset_ms: snapshot.measured_offset_ms,
+  offset_uncertainty_ms: snapshot.offset_uncertainty_ms,
+  regional_divergence_ms: snapshot.regional_divergence_ms,
+  last_good_at: snapshot.last_good_at,
+  intake_blocked: snapshot.intake_blocked,
+  block_reason: snapshot.block_reason,
+  source_count: snapshot.authoritative_sources.length,
+});

--- a/packages/protocol/signing-key-custody/src/version.ts
+++ b/packages/protocol/signing-key-custody/src/version.ts
@@ -1,0 +1,14 @@
+/** Registry document schema version for CR-013 pinned service-key distribution. */
+export const SIGNING_KEY_CUSTODY_SCHEMA_VERSION = 1 as const;
+
+/** Sprint G1 authority threshold: database clock skew blocks signed intake above 2s. */
+export const ORDERING_DATABASE_MAX_SKEW_MS = 2_000 as const;
+
+/** Minimum independent authoritative time sources required before trusting skew measurement. */
+export const MIN_INDEPENDENT_TIME_SOURCES = 2 as const;
+
+/** Default maximum age of a distributed registry snapshot before intake fails closed. */
+export const DEFAULT_REGISTRY_MAX_STALENESS_MS = 300_000 as const;
+
+/** Overlap rotation window recommended minimum (both keys must remain verifiable). */
+export const MIN_ROTATION_OVERLAP_MS = 86_400_000 as const;

--- a/packages/protocol/signing-key-custody/tsconfig.json
+++ b/packages/protocol/signing-key-custody/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "resolveJsonModule": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": false,
+    "composite": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"],
+  "references": [
+    { "path": "../trust-envelope" }
+  ]
+}

--- a/packages/protocol/signing-key-custody/vitest.config.ts
+++ b/packages/protocol/signing-key-custody/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `@freeside/signing-key-custody-protocol` under `packages/protocol/signing-key-custody` for CR-013 production signing-key custody (expand-only; no private keys in repo).
- Defines pinned `SigningKeyRegistryDocument` contract with fail-closed stale/unknown key handling, mechanical fixture vs production key-class separation, rotation/revocation/compromise interfaces, database time-health policy (blocks signed intake when skew >2s or time sources insufficient), KMS/HSM remote signing backend interfaces, shared fixtures, and game-day runbook.

## Test plan

- [x] `pnpm --dir packages/protocol/signing-key-custody run build`
- [x] `pnpm --dir packages/protocol/signing-key-custody test` — 12/12 passing
- [ ] Ordering wires `PinnedKeyRegistry` + `gateSignedIntake()` before CR-009 verify (follow-up)
- [ ] Production registry distribution channel + live KMS/HSM backends (follow-up, not in repo)
- [ ] EV-G1B4-key-custody-game-day operational drills per `docs/runbook-game-day.md`

Master task: CR-013 (`collection-report-coordinator-f09.21`). Depends on merged CR-009.


Made with [Cursor](https://cursor.com)