### PR TITLE
feat(ordering): CR-208 recognition-only capability demand lifecycle

### DIFF
--- a/packages/protocol/public-authorization/fixtures/acl/scope-demand-withdraw.valid.json
+++ b/packages/protocol/public-authorization/fixtures/acl/scope-demand-withdraw.valid.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": 1,
+  "subject_id": "subject-alice",
+  "community_ref": "community-alpha",
+  "permission": "demand:withdraw",
+  "idempotency_key": "demand-withdraw-1"
+}

--- a/packages/services/ordering/bin/http.ts
+++ b/packages/services/ordering/bin/http.ts
@@ -112,6 +112,7 @@ const app = createIntakeApp({
     capability_demands: {
       enabled: mountPublicAuthRoutes,
       store: 'memory',
+      lifecycle: 'cr-208',
     },
     public_authorization: {
       mode: publicAuthPosture.mode,
@@ -148,7 +149,7 @@ if (mountPublicAuthRoutes && publicAuth) {
     auth: publicAuth,
   });
 
-  // CR-007A: capability-demand authorization contract (CR-208 extends lifecycle).
+  // CR-208: recognition-only capability-demand lifecycle (no report orders).
   mountCapabilityDemandRoutes(app, {
     store: capabilityDemandStore,
     auth: publicAuth,

--- a/packages/services/ordering/src/__tests__/capability-demand-lifecycle.test.ts
+++ b/packages/services/ordering/src/__tests__/capability-demand-lifecycle.test.ts
@@ -1,0 +1,329 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { Hono } from "hono";
+
+import { mountCapabilityDemandRoutes } from "../capability-demand-http.js";
+import {
+  InMemoryCapabilityDemandStore,
+  type CapabilityDemandRecord,
+} from "../capability-demand-store.js";
+import {
+  OPEN_DEMAND_LIMIT_PER_SUBJECT,
+  OPEN_DEMAND_TTL_MS,
+} from "../capability-demand-constants.js";
+import { createFixturePublicAuthorizationService } from "../public-authorization-service.js";
+
+const fixtureDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../protocol/public-authorization/fixtures/acl",
+);
+
+function readJson(name: string): unknown {
+  return JSON.parse(readFileSync(join(fixtureDir, name), "utf8"));
+}
+
+const BASE_NOW = 1_752_768_000_000;
+const TOKEN = "service-secret";
+
+function demandCreateBody(overrides: Record<string, unknown> = {}) {
+  return {
+    command: {
+      schema_version: 1,
+      deployment_set_digest: "dep-set-1",
+      network_ref: "ethereum-mainnet",
+      token_standard: "erc721",
+      required_capability: "ownership_index.v1",
+      policy_version: "policy-1",
+      resolution_id: "res-1",
+      ...overrides,
+    },
+    authorization_scope: readJson("scope-demand-create.valid.json"),
+  };
+}
+
+function appHarness(now: () => number = () => BASE_NOW) {
+  const auth = createFixturePublicAuthorizationService(
+    readJson("projection-baseline.valid.json"),
+    now,
+  );
+  const store = new InMemoryCapabilityDemandStore();
+  const app = new Hono();
+  mountCapabilityDemandRoutes(app, {
+    store,
+    auth,
+    serviceToken: TOKEN,
+    now,
+  });
+  return { app, store, auth };
+}
+
+async function createDemand(
+  app: Hono,
+  overrides: Record<string, unknown> = {},
+  scopeOverride?: unknown,
+) {
+  const res = await app.request("/v1/capability-demands", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${TOKEN}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      ...demandCreateBody(overrides),
+      authorization_scope: scopeOverride ?? readJson("scope-demand-create.valid.json"),
+    }),
+  });
+  return res;
+}
+
+describe("CR-208 capability demand lifecycle", () => {
+  it("creates a typed support_request row in open state without creating orders", async () => {
+    const { app } = appHarness();
+    const res = await createDemand(app);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      row_kind: string;
+      user_status: string;
+      lifecycle_state: string;
+      demand_id: string;
+    };
+    expect(body.row_kind).toBe("support_request");
+    expect(body.user_status).toBe("open");
+    expect(body.lifecycle_state).toBe("open");
+    expect(body.demand_id.length).toBeGreaterThan(0);
+  });
+
+  it("replays equivalent canonical keys with different transport idempotency keys", async () => {
+    const { app } = appHarness();
+    const scopeA = {
+      ...(readJson("scope-demand-create.valid.json") as Record<string, unknown>),
+      idempotency_key: "transport-a",
+    };
+    const scopeB = {
+      ...(readJson("scope-demand-create.valid.json") as Record<string, unknown>),
+      idempotency_key: "transport-b",
+    };
+    const first = await createDemand(app, {}, scopeA);
+    const second = await createDemand(app, {}, scopeB);
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    const firstBody = (await first.json()) as { demand_id: string };
+    const secondBody = (await second.json()) as { demand_id: string };
+    expect(firstBody.demand_id).toBe(secondBody.demand_id);
+  });
+
+  it("enforces subject open-demand quota", async () => {
+    const { app } = appHarness();
+    for (let i = 0; i < OPEN_DEMAND_LIMIT_PER_SUBJECT; i += 1) {
+      const scope = {
+        ...(readJson("scope-demand-create.valid.json") as Record<string, unknown>),
+        idempotency_key: `k-${i}`,
+      };
+      const res = await createDemand(
+        app,
+        {
+          deployment_set_digest: `dep-${i}`,
+          resolution_id: `res-${i}`,
+        },
+        scope,
+      );
+      expect(res.status).toBe(200);
+    }
+    const overflow = await createDemand(
+      app,
+      { deployment_set_digest: "dep-overflow", resolution_id: "res-overflow" },
+      {
+        ...(readJson("scope-demand-create.valid.json") as Record<string, unknown>),
+        idempotency_key: "overflow",
+      },
+    );
+    expect(overflow.status).toBe(429);
+    const overflowBody = (await overflow.json()) as { code: string };
+    expect(overflowBody.code).toBe("demand_quota_subject");
+  });
+
+  it("expires open demand after 90 days and blocks support transition CAS", async () => {
+    let now = BASE_NOW;
+    const { app, store } = appHarness(() => now);
+    const created = await createDemand(app);
+    const createdBody = (await created.json()) as { demand_id: string };
+
+    now = BASE_NOW + OPEN_DEMAND_TTL_MS + 1;
+    const listRes = await app.request(
+      "/v1/capability-demands?community_ref=community-alpha&subject_id=subject-alice",
+      { headers: { authorization: `Bearer ${TOKEN}` } },
+    );
+    const listBody = (await listRes.json()) as {
+      items: Array<{ demand_id: string; lifecycle_state: string }>;
+    };
+    const expired = listBody.items.find((row) => row.demand_id === createdBody.demand_id);
+    expect(expired?.lifecycle_state).toBe("expired");
+
+    const support = await app.request("/v1/capability-demands/support-events", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        schema_version: 1,
+        event_id: "evt-expired",
+        required_capability: "ownership_index.v1",
+        deployment_set_digest: "dep-set-1",
+        network_ref: "ethereum-mainnet",
+        token_standard: "erc721",
+      }),
+    });
+    const supportBody = (await support.json()) as { transitioned: unknown[]; intents: unknown[] };
+    expect(supportBody.transitioned).toHaveLength(0);
+    expect(supportBody.intents).toHaveLength(0);
+    expect(await store.listIntents()).toHaveLength(0);
+  });
+
+  it("runs recognized unsupported -> support demand -> capability enabled -> continuation", async () => {
+    const { app, store } = appHarness();
+    const created = await createDemand(app);
+    const createdBody = (await created.json()) as { demand_id: string; user_status: string };
+    expect(createdBody.user_status).toBe("open");
+
+    const support = await app.request("/v1/capability-demands/support-events", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        schema_version: 1,
+        event_id: "evt-1",
+        required_capability: "ownership_index.v1",
+        deployment_set_digest: "dep-set-1",
+        network_ref: "ethereum-mainnet",
+        token_standard: "erc721",
+      }),
+    });
+    expect(support.status).toBe(200);
+    const supportBody = (await support.json()) as {
+      replay: boolean;
+      transitioned: Array<{ demand_id: string; user_status: string; lifecycle_state: string }>;
+      intents: Array<{ kind: string; intent_id: string }>;
+    };
+    expect(supportBody.replay).toBe(false);
+    expect(supportBody.transitioned).toHaveLength(1);
+    expect(supportBody.transitioned[0]?.demand_id).toBe(createdBody.demand_id);
+    expect(supportBody.transitioned[0]?.user_status).toBe("support_ready");
+    expect(supportBody.transitioned[0]?.lifecycle_state).toBe("notified");
+    expect(supportBody.intents).toHaveLength(1);
+    expect(supportBody.intents[0]?.kind).toBe("capability_demand.supported");
+
+    const duplicate = await app.request("/v1/capability-demands/support-events", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        schema_version: 1,
+        event_id: "evt-1",
+        required_capability: "ownership_index.v1",
+        deployment_set_digest: "dep-set-1",
+        network_ref: "ethereum-mainnet",
+        token_standard: "erc721",
+      }),
+    });
+    const dupBody = (await duplicate.json()) as { replay: boolean; intents: unknown[] };
+    expect(dupBody.replay).toBe(true);
+    expect(await store.listIntents()).toHaveLength(1);
+  });
+
+  it("withdraws open demand and prevents later support intent emission", async () => {
+    const { app, store } = appHarness();
+    const created = await createDemand(app);
+    const createdBody = (await created.json()) as { demand_id: string };
+
+    const withdrawn = await app.request(`/v1/capability-demands/${createdBody.demand_id}`, {
+      method: "DELETE",
+      headers: {
+        authorization: `Bearer ${TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        authorization_scope: readJson("scope-demand-withdraw.valid.json"),
+      }),
+    });
+    expect(withdrawn.status).toBe(200);
+    expect(((await withdrawn.json()) as { user_status: string }).user_status).toBe("withdrawn");
+
+    const support = await app.request("/v1/capability-demands/support-events", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        schema_version: 1,
+        event_id: "evt-withdrawn",
+        required_capability: "ownership_index.v1",
+        deployment_set_digest: "dep-set-1",
+        network_ref: "ethereum-mainnet",
+        token_standard: "erc721",
+      }),
+    });
+    const supportBody = (await support.json()) as { intents: unknown[] };
+    expect(supportBody.intents).toHaveLength(0);
+    expect(await store.listIntents()).toHaveLength(0);
+  });
+
+  it("returns aggregate triage projection grouped by network, standard, and deployment", async () => {
+    const { app } = appHarness();
+    await createDemand(app);
+    await createDemand(app, {
+      deployment_set_digest: "dep-set-2",
+      resolution_id: "res-2",
+    }, {
+      ...(readJson("scope-demand-create.valid.json") as Record<string, unknown>),
+      idempotency_key: "other-demand",
+    });
+
+    const triage = await app.request("/v1/capability-demands/triage-aggregate", {
+      headers: { authorization: `Bearer ${TOKEN}` },
+    });
+    expect(triage.status).toBe(200);
+    const body = (await triage.json()) as {
+      schema_version: number;
+      buckets: Array<{ unique_open_demand_count: number; network_ref: string }>;
+    };
+    expect(body.schema_version).toBe(1);
+    expect(body.buckets.length).toBeGreaterThanOrEqual(2);
+    expect(body.buckets.every((b) => b.network_ref === "ethereum-mainnet")).toBe(true);
+  });
+
+  it("never exposes Preparing semantics on support projections", async () => {
+    const record: CapabilityDemandRecord = {
+      demand_id: "d-1",
+      requester_subject: "subject-alice",
+      community_ref: "community-alpha",
+      deployment_set_digest: "dep-set-1",
+      network_ref: "ethereum-mainnet",
+      token_standard: "erc721",
+      required_capability: "ownership_index.v1",
+      policy_version: "policy-1",
+      resolution_id: "res-1",
+      state: "notified",
+      transition_sequence: 2,
+      created_at_unix_ms: BASE_NOW,
+      updated_at_unix_ms: BASE_NOW,
+      expires_at_unix_ms: BASE_NOW + OPEN_DEMAND_TTL_MS,
+      idempotency_key: "k1",
+      support_intent_id: "intent-1",
+    };
+    const { toSupportRequestListItem } = await import("../capability-demand-projection.js");
+    const projection = toSupportRequestListItem(record);
+    expect(projection.row_kind).toBe("support_request");
+    expect(projection.user_status).toBe("support_ready");
+    expect(JSON.stringify(projection).toLowerCase()).not.toContain("preparing");
+    expect(projection).not.toHaveProperty("eta");
+    expect(projection).not.toHaveProperty("queue_position");
+  });
+});

--- a/packages/services/ordering/src/__tests__/public-authorization-http.test.ts
+++ b/packages/services/ordering/src/__tests__/public-authorization-http.test.ts
@@ -43,6 +43,8 @@ describe("CR-007A public authorization HTTP", () => {
         command: {
           schema_version: 1,
           deployment_set_digest: "dep-set-1",
+          network_ref: "ethereum-mainnet",
+          token_standard: "erc721",
           required_capability: "ownership_index.v1",
           policy_version: "policy-1",
           resolution_id: "res-1",
@@ -64,6 +66,8 @@ describe("CR-007A public authorization HTTP", () => {
         command: {
           schema_version: 1,
           deployment_set_digest: "dep-set-1",
+          network_ref: "ethereum-mainnet",
+          token_standard: "erc721",
           required_capability: "ownership_index.v1",
           policy_version: "policy-1",
           resolution_id: "res-1",
@@ -72,9 +76,9 @@ describe("CR-007A public authorization HTTP", () => {
       }),
     });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { demand_id: string; state: string };
+    const body = (await res.json()) as { demand_id: string; lifecycle_state: string };
     expect(body.demand_id.length).toBeGreaterThan(0);
-    expect(body.state).toBe("open");
+    expect(body.lifecycle_state).toBe("open");
   });
 
   it("denies cross-community scope tampering on resolution create", async () => {
@@ -135,6 +139,8 @@ describe("CR-007A public authorization HTTP", () => {
       command: {
         schema_version: 1,
         deployment_set_digest: "dep-set-1",
+        network_ref: "ethereum-mainnet",
+        token_standard: "erc721",
         required_capability: "ownership_index.v1",
         policy_version: "policy-1",
         resolution_id: "res-1",

--- a/packages/services/ordering/src/capability-demand-constants.ts
+++ b/packages/services/ordering/src/capability-demand-constants.ts
@@ -1,0 +1,8 @@
+/** CR-208 demand/disposal thresholds (sprint §4, SDD §6.7). */
+export const OPEN_DEMAND_LIMIT_PER_SUBJECT = 20;
+export const OPEN_DEMAND_LIMIT_PER_COMMUNITY = 500;
+export const OPEN_DEMAND_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+
+export const CAPABILITY_DEMAND_ATTENTION_KIND = "capability_demand.supported" as const;
+export const CAPABILITY_DEMAND_SOURCE_KIND = "capability_demand" as const;
+export const CAPABILITY_DEMAND_INTENT_SCHEMA_VERSION = 1 as const;

--- a/packages/services/ordering/src/capability-demand-http.ts
+++ b/packages/services/ordering/src/capability-demand-http.ts
@@ -1,13 +1,18 @@
 /**
- * CR-007A capability-demand HTTP edge (authorization contract; CR-208 owns full lifecycle).
+ * CR-208 capability-demand HTTP edge (recognition-only support demand).
  *
  *   POST   /v1/capability-demands
  *   GET    /v1/capability-demands
  *   GET    /v1/capability-demands/:demand_id
  *   DELETE /v1/capability-demands/:demand_id
+ *   POST   /v1/capability-demands/support-events
+ *   POST   /v1/capability-demands/:demand_id/decline
+ *   GET    /v1/capability-demands/triage-aggregate
  *
- * Auth: Bearer SERVICE_TOKEN (Dashboard BFF) + authorization_scope recheck.
+ * Auth: Bearer SERVICE_TOKEN (Dashboard BFF / Sonar) + authorization_scope recheck
+ * on subject-scoped routes. Internal transition routes are service-bearer only.
  * Public projections expose no subscriber counts or cross-tenant demand.
+ * Never creates report orders or shared preparation work.
  */
 
 import { Hono, type Context } from "hono";
@@ -19,9 +24,10 @@ import {
   requireServiceBearer,
 } from "./public-authorization-http.js";
 import {
-  type CapabilityDemandStore,
+  buildTriageAggregate,
   toPublicCapabilityDemandProjection,
-} from "./capability-demand-store.js";
+} from "./capability-demand-projection.js";
+import { type CapabilityDemandStore } from "./capability-demand-store.js";
 
 export interface CapabilityDemandHttpDeps {
   readonly store: CapabilityDemandStore;
@@ -34,9 +40,22 @@ const CreateCommandSchema = z
   .object({
     schema_version: z.literal(1),
     deployment_set_digest: z.string().min(1).max(256),
+    network_ref: z.string().min(1).max(128),
+    token_standard: z.string().min(1).max(64),
     required_capability: z.string().min(1).max(128),
     policy_version: z.string().min(1).max(64),
     resolution_id: z.string().min(1).max(128),
+  })
+  .strict();
+
+const SupportEventCommandSchema = z
+  .object({
+    schema_version: z.literal(1),
+    event_id: z.string().min(1).max(256),
+    required_capability: z.string().min(1).max(128),
+    deployment_set_digest: z.string().min(1).max(256),
+    network_ref: z.string().min(1).max(128),
+    token_standard: z.string().min(1).max(64),
   })
   .strict();
 
@@ -48,7 +67,11 @@ const ScopeQuerySchema = z
   })
   .strict();
 
-function errorJson(c: Context, status: 400 | 401 | 403 | 404 | 409, code: string) {
+function errorJson(
+  c: Context,
+  status: 400 | 401 | 403 | 404 | 409 | 429,
+  code: string,
+) {
   return c.json({ schema_version: 1, code }, status, noStoreHeaders());
 }
 
@@ -89,6 +112,8 @@ export function mountCapabilityDemandRoutes(app: Hono, deps: CapabilityDemandHtt
       requester_subject: scope.subject_id,
       community_ref: scope.community_ref,
       deployment_set_digest: command.data.deployment_set_digest,
+      network_ref: command.data.network_ref,
+      token_standard: command.data.token_standard,
       required_capability: command.data.required_capability,
       policy_version: command.data.policy_version,
       resolution_id: command.data.resolution_id,
@@ -99,8 +124,52 @@ export function mountCapabilityDemandRoutes(app: Hono, deps: CapabilityDemandHtt
     if (result.kind === "conflict") {
       return errorJson(c, 409, "idempotency_conflict");
     }
+    if (result.kind === "quota_exceeded") {
+      return errorJson(c, 429, `demand_quota_${result.limit}`);
+    }
 
     return c.json(toPublicCapabilityDemandProjection(result.record), 200, noStoreHeaders());
+  });
+
+  app.get("/v1/capability-demands/triage-aggregate", async (c) => {
+    if (!requireServiceBearer(c, deps.serviceToken)) {
+      return errorJson(c, 401, "unauthorized");
+    }
+    const now_ms = deps.now();
+    const openRows = await deps.store.listOpenForTriage(now_ms);
+    return c.json(buildTriageAggregate(openRows, now_ms), 200, noStoreHeaders());
+  });
+
+  app.post("/v1/capability-demands/support-events", async (c) => {
+    if (!requireServiceBearer(c, deps.serviceToken)) {
+      return errorJson(c, 401, "unauthorized");
+    }
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return errorJson(c, 400, "invalid_request");
+    }
+    const command = SupportEventCommandSchema.safeParse(body);
+    if (!command.success) {
+      return errorJson(c, 400, "invalid_request");
+    }
+
+    const result = await deps.store.applyCapabilitySupport({
+      ...command.data,
+      now_ms: deps.now(),
+    });
+
+    return c.json(
+      {
+        schema_version: 1,
+        replay: result.replay,
+        transitioned: result.transitioned.map(toPublicCapabilityDemandProjection),
+        intents: result.intents,
+      },
+      200,
+      noStoreHeaders(),
+    );
   });
 
   app.get("/v1/capability-demands", async (c) => {
@@ -108,12 +177,6 @@ export function mountCapabilityDemandRoutes(app: Hono, deps: CapabilityDemandHtt
       return errorJson(c, 401, "unauthorized");
     }
 
-    const scopeRaw = {
-      schema_version: 1,
-      subject_id: c.req.query("subject_id"),
-      community_ref: c.req.query("community_ref"),
-      permission: "demand:read" as const,
-    };
     const query = ScopeQuerySchema.safeParse({
       community_ref: c.req.query("community_ref"),
       subject_id: c.req.query("subject_id"),
@@ -125,7 +188,12 @@ export function mountCapabilityDemandRoutes(app: Hono, deps: CapabilityDemandHtt
 
     let scope;
     try {
-      scope = deps.auth.decodeScope(scopeRaw);
+      scope = deps.auth.decodeScope({
+        schema_version: 1,
+        subject_id: query.data.subject_id,
+        community_ref: query.data.community_ref,
+        permission: "demand:read",
+      });
     } catch {
       return errorJson(c, 400, "invalid_request");
     }
@@ -142,10 +210,12 @@ export function mountCapabilityDemandRoutes(app: Hono, deps: CapabilityDemandHtt
       return c.json(mapped.body, mapped.status, noStoreHeaders());
     }
 
+    const now_ms = deps.now();
     const items = await deps.store.list({
       community_ref: query.data.community_ref,
       requester_subject: query.data.subject_id,
       limit: query.data.limit ?? 25,
+      now_ms,
     });
 
     return c.json(
@@ -240,6 +310,20 @@ export function mountCapabilityDemandRoutes(app: Hono, deps: CapabilityDemandHtt
       return errorJson(c, 404, "not_found");
     }
 
+    return c.json(toPublicCapabilityDemandProjection(record), 200, noStoreHeaders());
+  });
+
+  app.post("/v1/capability-demands/:demand_id/decline", async (c) => {
+    if (!requireServiceBearer(c, deps.serviceToken)) {
+      return errorJson(c, 401, "unauthorized");
+    }
+    const record = await deps.store.decline({
+      demand_id: c.req.param("demand_id"),
+      now_ms: deps.now(),
+    });
+    if (record === undefined) {
+      return errorJson(c, 404, "not_found");
+    }
     return c.json(toPublicCapabilityDemandProjection(record), 200, noStoreHeaders());
   });
 }

--- a/packages/services/ordering/src/capability-demand-intent.ts
+++ b/packages/services/ordering/src/capability-demand-intent.ts
@@ -1,0 +1,61 @@
+import { digestOf } from "./digest.js";
+import {
+  CAPABILITY_DEMAND_ATTENTION_KIND,
+  CAPABILITY_DEMAND_INTENT_SCHEMA_VERSION,
+  CAPABILITY_DEMAND_SOURCE_KIND,
+} from "./capability-demand-constants.js";
+
+export interface CapabilityDemandAttentionIntent {
+  readonly schema_version: typeof CAPABILITY_DEMAND_INTENT_SCHEMA_VERSION;
+  readonly intent_id: string;
+  readonly kind: typeof CAPABILITY_DEMAND_ATTENTION_KIND;
+  readonly subject_ref: string;
+  readonly source_kind: typeof CAPABILITY_DEMAND_SOURCE_KIND;
+  readonly source_id: string;
+  readonly community_ref: string;
+  readonly transition_sequence: number;
+  readonly deep_link_path: string;
+  readonly occurred_at_unix_ms: number;
+}
+
+export function stableCapabilityDemandIntentId(input: {
+  demand_id: string;
+  transition_sequence: number;
+  subject_ref: string;
+}): string {
+  return digestOf({
+    schema_version: CAPABILITY_DEMAND_INTENT_SCHEMA_VERSION,
+    kind: CAPABILITY_DEMAND_ATTENTION_KIND,
+    source_kind: CAPABILITY_DEMAND_SOURCE_KIND,
+    source_id: input.demand_id,
+    transition_sequence: input.transition_sequence,
+    subject_ref: input.subject_ref,
+  });
+}
+
+export function buildCapabilityDemandSupportedIntent(input: {
+  demand_id: string;
+  subject_ref: string;
+  community_ref: string;
+  transition_sequence: number;
+  resolution_id: string;
+  occurred_at_unix_ms: number;
+}): CapabilityDemandAttentionIntent {
+  const intent_id = stableCapabilityDemandIntentId({
+    demand_id: input.demand_id,
+    transition_sequence: input.transition_sequence,
+    subject_ref: input.subject_ref,
+  });
+  return {
+    schema_version: CAPABILITY_DEMAND_INTENT_SCHEMA_VERSION,
+    intent_id,
+    kind: CAPABILITY_DEMAND_ATTENTION_KIND,
+    subject_ref: input.subject_ref,
+    source_kind: CAPABILITY_DEMAND_SOURCE_KIND,
+    source_id: input.demand_id,
+    community_ref: input.community_ref,
+    transition_sequence: input.transition_sequence,
+    deep_link_path: `/reports/resolutions/${encodeURIComponent(input.resolution_id)}`,
+    occurred_at_unix_ms: input.occurred_at_unix_ms,
+  };
+}

--- a/packages/services/ordering/src/capability-demand-projection.ts
+++ b/packages/services/ordering/src/capability-demand-projection.ts
@@ -1,0 +1,136 @@
+import type { CapabilityDemandRecord, CapabilityDemandState } from "./capability-demand-store.js";
+
+/** Reports-facing support row — never a report order or Preparing state. */
+export type SupportRequestUserStatus =
+  | "open"
+  | "support_ready"
+  | "withdrawn"
+  | "declined"
+  | "expired";
+
+export interface SupportRequestListItem {
+  readonly schema_version: 1;
+  readonly row_kind: "support_request";
+  readonly demand_id: string;
+  readonly community_ref: string;
+  readonly requester_subject: string;
+  readonly required_capability: string;
+  readonly policy_version: string;
+  readonly resolution_id: string;
+  readonly network_ref: string;
+  readonly token_standard: string;
+  readonly deployment_set_digest: string;
+  readonly lifecycle_state: CapabilityDemandState;
+  readonly user_status: SupportRequestUserStatus;
+  readonly transition_sequence: number;
+  readonly created_at_unix_ms: number;
+  readonly updated_at_unix_ms: number;
+  readonly expires_at_unix_ms: number;
+}
+
+export interface CapabilityDemandTriageBucket {
+  readonly network_ref: string;
+  readonly token_standard: string;
+  readonly deployment_set_digest: string;
+  readonly required_capability: string;
+  readonly unique_open_demand_count: number;
+}
+
+export interface CapabilityDemandTriageAggregate {
+  readonly schema_version: 1;
+  readonly generated_at_unix_ms: number;
+  readonly buckets: readonly CapabilityDemandTriageBucket[];
+}
+
+export function mapSupportRequestUserStatus(
+  state: CapabilityDemandState,
+): SupportRequestUserStatus {
+  switch (state) {
+    case "open":
+      return "open";
+    case "supported":
+    case "notified":
+      return "support_ready";
+    case "closed":
+      return "withdrawn";
+    case "declined":
+      return "declined";
+    case "expired":
+      return "expired";
+    default: {
+      const _exhaustive: never = state;
+      return _exhaustive;
+    }
+  }
+}
+
+export function toSupportRequestListItem(
+  record: CapabilityDemandRecord,
+): SupportRequestListItem {
+  return {
+    schema_version: 1,
+    row_kind: "support_request",
+    demand_id: record.demand_id,
+    community_ref: record.community_ref,
+    requester_subject: record.requester_subject,
+    required_capability: record.required_capability,
+    policy_version: record.policy_version,
+    resolution_id: record.resolution_id,
+    network_ref: record.network_ref,
+    token_standard: record.token_standard,
+    deployment_set_digest: record.deployment_set_digest,
+    lifecycle_state: record.state,
+    user_status: mapSupportRequestUserStatus(record.state),
+    transition_sequence: record.transition_sequence,
+    created_at_unix_ms: record.created_at_unix_ms,
+    updated_at_unix_ms: record.updated_at_unix_ms,
+    expires_at_unix_ms: record.expires_at_unix_ms,
+  };
+}
+
+export function buildTriageAggregate(
+  records: readonly CapabilityDemandRecord[],
+  now_ms: number,
+): CapabilityDemandTriageAggregate {
+  const open = records.filter((row) => row.state === "open");
+  const bucketMap = new Map<string, CapabilityDemandTriageBucket>();
+  for (const row of open) {
+    const key = [
+      row.network_ref,
+      row.token_standard,
+      row.deployment_set_digest,
+      row.required_capability,
+    ].join("\0");
+    const existing = bucketMap.get(key);
+    if (existing !== undefined) {
+      bucketMap.set(key, {
+        ...existing,
+        unique_open_demand_count: existing.unique_open_demand_count + 1,
+      });
+    } else {
+      bucketMap.set(key, {
+        network_ref: row.network_ref,
+        token_standard: row.token_standard,
+        deployment_set_digest: row.deployment_set_digest,
+        required_capability: row.required_capability,
+        unique_open_demand_count: 1,
+      });
+    }
+  }
+  const buckets = [...bucketMap.values()].sort((a, b) => {
+    const byNetwork = a.network_ref.localeCompare(b.network_ref);
+    if (byNetwork !== 0) return byNetwork;
+    const byStandard = a.token_standard.localeCompare(b.token_standard);
+    if (byStandard !== 0) return byStandard;
+    return a.deployment_set_digest.localeCompare(b.deployment_set_digest);
+  });
+  return {
+    schema_version: 1,
+    generated_at_unix_ms: now_ms,
+    buckets,
+  };
+}
+
+export function toPublicCapabilityDemandProjection(record: CapabilityDemandRecord) {
+  return toSupportRequestListItem(record);
+}

--- a/packages/services/ordering/src/capability-demand-store.ts
+++ b/packages/services/ordering/src/capability-demand-store.ts
@@ -1,19 +1,40 @@
 import { randomUUID } from "node:crypto";
 
-export type CapabilityDemandState = "open" | "supported" | "notified" | "closed" | "declined" | "expired";
+import {
+  OPEN_DEMAND_LIMIT_PER_COMMUNITY,
+  OPEN_DEMAND_LIMIT_PER_SUBJECT,
+  OPEN_DEMAND_TTL_MS,
+} from "./capability-demand-constants.js";
+import {
+  buildCapabilityDemandSupportedIntent,
+  type CapabilityDemandAttentionIntent,
+} from "./capability-demand-intent.js";
+
+export type CapabilityDemandState =
+  | "open"
+  | "supported"
+  | "notified"
+  | "closed"
+  | "declined"
+  | "expired";
 
 export interface CapabilityDemandRecord {
   readonly demand_id: string;
   readonly requester_subject: string;
   readonly community_ref: string;
   readonly deployment_set_digest: string;
+  readonly network_ref: string;
+  readonly token_standard: string;
   readonly required_capability: string;
   readonly policy_version: string;
   readonly resolution_id: string;
   readonly state: CapabilityDemandState;
+  readonly transition_sequence: number;
   readonly created_at_unix_ms: number;
   readonly updated_at_unix_ms: number;
+  readonly expires_at_unix_ms: number;
   readonly idempotency_key: string;
+  readonly support_intent_id: string | null;
 }
 
 export interface CapabilityDemandStore {
@@ -21,6 +42,8 @@ export interface CapabilityDemandStore {
     requester_subject: string;
     community_ref: string;
     deployment_set_digest: string;
+    network_ref: string;
+    token_standard: string;
     required_capability: string;
     policy_version: string;
     resolution_id: string;
@@ -30,19 +53,39 @@ export interface CapabilityDemandStore {
     | { kind: "created"; record: CapabilityDemandRecord }
     | { kind: "replay"; record: CapabilityDemandRecord }
     | { kind: "conflict" }
+    | { kind: "quota_exceeded"; limit: "subject" | "community" }
   >;
   get(demandId: string): Promise<CapabilityDemandRecord | undefined>;
   list(input: {
     community_ref: string;
     requester_subject: string;
     limit: number;
+    now_ms: number;
   }): Promise<ReadonlyArray<CapabilityDemandRecord>>;
+  listOpenForTriage(now_ms: number): Promise<ReadonlyArray<CapabilityDemandRecord>>;
   withdraw(input: {
     demand_id: string;
     requester_subject: string;
     community_ref: string;
     now_ms: number;
   }): Promise<CapabilityDemandRecord | undefined>;
+  applyCapabilitySupport(input: {
+    required_capability: string;
+    deployment_set_digest: string;
+    network_ref: string;
+    token_standard: string;
+    event_id: string;
+    now_ms: number;
+  }): Promise<{
+    transitioned: ReadonlyArray<CapabilityDemandRecord>;
+    intents: ReadonlyArray<CapabilityDemandAttentionIntent>;
+    replay: boolean;
+  }>;
+  decline(input: {
+    demand_id: string;
+    now_ms: number;
+  }): Promise<CapabilityDemandRecord | undefined>;
+  listIntents(): Promise<ReadonlyArray<CapabilityDemandAttentionIntent>>;
 }
 
 function canonicalKey(input: {
@@ -61,15 +104,64 @@ function canonicalKey(input: {
   ].join("\0");
 }
 
+function isOpenForQuota(state: CapabilityDemandState): boolean {
+  return state === "open";
+}
+
 export class InMemoryCapabilityDemandStore implements CapabilityDemandStore {
   private readonly byId = new Map<string, CapabilityDemandRecord>();
   private readonly openByCanonical = new Map<string, string>();
   private readonly idempotency = new Map<string, CapabilityDemandRecord>();
+  private readonly supportEvents = new Map<string, CapabilityDemandAttentionIntent[]>();
+  private readonly intents = new Map<string, CapabilityDemandAttentionIntent>();
+
+  private expireOpenDemands(now_ms: number): void {
+    for (const record of this.byId.values()) {
+      if (record.state !== "open") continue;
+      if (now_ms < record.expires_at_unix_ms) continue;
+      const updated: CapabilityDemandRecord = {
+        ...record,
+        state: "expired",
+        transition_sequence: record.transition_sequence + 1,
+        updated_at_unix_ms: now_ms,
+      };
+      this.byId.set(updated.demand_id, updated);
+      this.openByCanonical.delete(
+        canonicalKey({
+          requester_subject: record.requester_subject,
+          community_ref: record.community_ref,
+          deployment_set_digest: record.deployment_set_digest,
+          required_capability: record.required_capability,
+          policy_version: record.policy_version,
+        }),
+      );
+    }
+  }
+
+  private countOpenForSubject(subject: string, now_ms: number): number {
+    this.expireOpenDemands(now_ms);
+    let count = 0;
+    for (const row of this.byId.values()) {
+      if (row.requester_subject === subject && isOpenForQuota(row.state)) count += 1;
+    }
+    return count;
+  }
+
+  private countOpenForCommunity(community: string, now_ms: number): number {
+    this.expireOpenDemands(now_ms);
+    let count = 0;
+    for (const row of this.byId.values()) {
+      if (row.community_ref === community && isOpenForQuota(row.state)) count += 1;
+    }
+    return count;
+  }
 
   async create(input: {
     requester_subject: string;
     community_ref: string;
     deployment_set_digest: string;
+    network_ref: string;
+    token_standard: string;
     required_capability: string;
     policy_version: string;
     resolution_id: string;
@@ -79,7 +171,10 @@ export class InMemoryCapabilityDemandStore implements CapabilityDemandStore {
     | { kind: "created"; record: CapabilityDemandRecord }
     | { kind: "replay"; record: CapabilityDemandRecord }
     | { kind: "conflict" }
+    | { kind: "quota_exceeded"; limit: "subject" | "community" }
   > {
+    this.expireOpenDemands(input.now_ms);
+
     const idemKey = `${input.requester_subject}\0${input.idempotency_key}`;
     const prior = this.idempotency.get(idemKey);
     if (prior !== undefined) {
@@ -87,7 +182,9 @@ export class InMemoryCapabilityDemandStore implements CapabilityDemandStore {
         prior.deployment_set_digest !== input.deployment_set_digest ||
         prior.required_capability !== input.required_capability ||
         prior.policy_version !== input.policy_version ||
-        prior.community_ref !== input.community_ref
+        prior.community_ref !== input.community_ref ||
+        prior.network_ref !== input.network_ref ||
+        prior.token_standard !== input.token_standard
       ) {
         return { kind: "conflict" };
       }
@@ -104,18 +201,30 @@ export class InMemoryCapabilityDemandStore implements CapabilityDemandStore {
       }
     }
 
+    if (this.countOpenForSubject(input.requester_subject, input.now_ms) >= OPEN_DEMAND_LIMIT_PER_SUBJECT) {
+      return { kind: "quota_exceeded", limit: "subject" };
+    }
+    if (this.countOpenForCommunity(input.community_ref, input.now_ms) >= OPEN_DEMAND_LIMIT_PER_COMMUNITY) {
+      return { kind: "quota_exceeded", limit: "community" };
+    }
+
     const record: CapabilityDemandRecord = {
       demand_id: randomUUID(),
       requester_subject: input.requester_subject,
       community_ref: input.community_ref,
       deployment_set_digest: input.deployment_set_digest,
+      network_ref: input.network_ref,
+      token_standard: input.token_standard,
       required_capability: input.required_capability,
       policy_version: input.policy_version,
       resolution_id: input.resolution_id,
       state: "open",
+      transition_sequence: 1,
       created_at_unix_ms: input.now_ms,
       updated_at_unix_ms: input.now_ms,
+      expires_at_unix_ms: input.now_ms + OPEN_DEMAND_TTL_MS,
       idempotency_key: input.idempotency_key,
+      support_intent_id: null,
     };
     this.byId.set(record.demand_id, record);
     this.openByCanonical.set(canonical, record.demand_id);
@@ -131,7 +240,9 @@ export class InMemoryCapabilityDemandStore implements CapabilityDemandStore {
     community_ref: string;
     requester_subject: string;
     limit: number;
+    now_ms: number;
   }): Promise<ReadonlyArray<CapabilityDemandRecord>> {
+    this.expireOpenDemands(input.now_ms);
     const rows = [...this.byId.values()].filter(
       (row) =>
         row.community_ref === input.community_ref &&
@@ -141,12 +252,18 @@ export class InMemoryCapabilityDemandStore implements CapabilityDemandStore {
     return rows.slice(0, input.limit);
   }
 
+  async listOpenForTriage(now_ms: number): Promise<ReadonlyArray<CapabilityDemandRecord>> {
+    this.expireOpenDemands(now_ms);
+    return [...this.byId.values()].filter((row) => row.state === "open");
+  }
+
   async withdraw(input: {
     demand_id: string;
     requester_subject: string;
     community_ref: string;
     now_ms: number;
   }): Promise<CapabilityDemandRecord | undefined> {
+    this.expireOpenDemands(input.now_ms);
     const record = this.byId.get(input.demand_id);
     if (record === undefined) return undefined;
     if (
@@ -159,24 +276,132 @@ export class InMemoryCapabilityDemandStore implements CapabilityDemandStore {
     const updated: CapabilityDemandRecord = {
       ...record,
       state: "closed",
+      transition_sequence: record.transition_sequence + 1,
       updated_at_unix_ms: input.now_ms,
     };
     this.byId.set(updated.demand_id, updated);
+    this.openByCanonical.delete(
+      canonicalKey({
+        requester_subject: record.requester_subject,
+        community_ref: record.community_ref,
+        deployment_set_digest: record.deployment_set_digest,
+        required_capability: record.required_capability,
+        policy_version: record.policy_version,
+      }),
+    );
     return updated;
+  }
+
+  async applyCapabilitySupport(input: {
+    required_capability: string;
+    deployment_set_digest: string;
+    network_ref: string;
+    token_standard: string;
+    event_id: string;
+    now_ms: number;
+  }): Promise<{
+    transitioned: ReadonlyArray<CapabilityDemandRecord>;
+    intents: ReadonlyArray<CapabilityDemandAttentionIntent>;
+    replay: boolean;
+  }> {
+    this.expireOpenDemands(input.now_ms);
+
+    const priorIntents = this.supportEvents.get(input.event_id);
+    if (priorIntents !== undefined) {
+      const transitioned = priorIntents
+        .map((intent) => this.byId.get(intent.source_id))
+        .filter((row): row is CapabilityDemandRecord => row !== undefined);
+      return { transitioned, intents: priorIntents, replay: true };
+    }
+
+    const matches = [...this.byId.values()].filter(
+      (row) =>
+        row.state === "open" &&
+        row.required_capability === input.required_capability &&
+        row.deployment_set_digest === input.deployment_set_digest &&
+        row.network_ref === input.network_ref &&
+        row.token_standard === input.token_standard,
+    );
+
+    const transitioned: CapabilityDemandRecord[] = [];
+    const intents: CapabilityDemandAttentionIntent[] = [];
+
+    for (const record of matches) {
+      if (record.support_intent_id !== null) {
+        const existingIntent = this.intents.get(record.support_intent_id);
+        if (existingIntent !== undefined) {
+          transitioned.push(record);
+          intents.push(existingIntent);
+        }
+        continue;
+      }
+
+      const nextSequence = record.transition_sequence + 1;
+      const intent = buildCapabilityDemandSupportedIntent({
+        demand_id: record.demand_id,
+        subject_ref: record.requester_subject,
+        community_ref: record.community_ref,
+        transition_sequence: nextSequence,
+        resolution_id: record.resolution_id,
+        occurred_at_unix_ms: input.now_ms,
+      });
+
+      const updated: CapabilityDemandRecord = {
+        ...record,
+        state: "notified",
+        transition_sequence: nextSequence,
+        updated_at_unix_ms: input.now_ms,
+        support_intent_id: intent.intent_id,
+      };
+      this.byId.set(updated.demand_id, updated);
+      this.openByCanonical.delete(
+        canonicalKey({
+          requester_subject: record.requester_subject,
+          community_ref: record.community_ref,
+          deployment_set_digest: record.deployment_set_digest,
+          required_capability: record.required_capability,
+          policy_version: record.policy_version,
+        }),
+      );
+      this.intents.set(intent.intent_id, intent);
+      transitioned.push(updated);
+      intents.push(intent);
+    }
+
+    this.supportEvents.set(input.event_id, intents);
+    return { transitioned, intents, replay: false };
+  }
+
+  async decline(input: {
+    demand_id: string;
+    now_ms: number;
+  }): Promise<CapabilityDemandRecord | undefined> {
+    this.expireOpenDemands(input.now_ms);
+    const record = this.byId.get(input.demand_id);
+    if (record === undefined) return undefined;
+    if (record.state !== "open") return record;
+    const updated: CapabilityDemandRecord = {
+      ...record,
+      state: "declined",
+      transition_sequence: record.transition_sequence + 1,
+      updated_at_unix_ms: input.now_ms,
+    };
+    this.byId.set(updated.demand_id, updated);
+    this.openByCanonical.delete(
+      canonicalKey({
+        requester_subject: record.requester_subject,
+        community_ref: record.community_ref,
+        deployment_set_digest: record.deployment_set_digest,
+        required_capability: record.required_capability,
+        policy_version: record.policy_version,
+      }),
+    );
+    return updated;
+  }
+
+  async listIntents(): Promise<ReadonlyArray<CapabilityDemandAttentionIntent>> {
+    return [...this.intents.values()];
   }
 }
 
-export function toPublicCapabilityDemandProjection(record: CapabilityDemandRecord) {
-  return {
-    schema_version: 1 as const,
-    demand_id: record.demand_id,
-    community_ref: record.community_ref,
-    requester_subject: record.requester_subject,
-    required_capability: record.required_capability,
-    policy_version: record.policy_version,
-    resolution_id: record.resolution_id,
-    state: record.state,
-    created_at_unix_ms: record.created_at_unix_ms,
-    updated_at_unix_ms: record.updated_at_unix_ms,
-  };
-}
+export { toPublicCapabilityDemandProjection } from "./capability-demand-projection.js";

--- a/packages/services/ordering/src/index.ts
+++ b/packages/services/ordering/src/index.ts
@@ -188,10 +188,32 @@ export {
 } from './public-authorization-projections.js';
 export { mountCapabilityDemandRoutes } from './capability-demand-http.js';
 export {
+  OPEN_DEMAND_LIMIT_PER_SUBJECT,
+  OPEN_DEMAND_LIMIT_PER_COMMUNITY,
+  OPEN_DEMAND_TTL_MS,
+  CAPABILITY_DEMAND_ATTENTION_KIND,
+  CAPABILITY_DEMAND_SOURCE_KIND,
+} from './capability-demand-constants.js';
+export {
+  buildCapabilityDemandSupportedIntent,
+  stableCapabilityDemandIntentId,
+  type CapabilityDemandAttentionIntent,
+} from './capability-demand-intent.js';
+export {
+  buildTriageAggregate,
+  mapSupportRequestUserStatus,
+  toSupportRequestListItem,
+  type CapabilityDemandTriageAggregate,
+  type CapabilityDemandTriageBucket,
+  type SupportRequestListItem,
+  type SupportRequestUserStatus,
+} from './capability-demand-projection.js';
+export {
   InMemoryCapabilityDemandStore,
   toPublicCapabilityDemandProjection,
   type CapabilityDemandStore,
   type CapabilityDemandRecord,
+  type CapabilityDemandState,
 } from './capability-demand-store.js';
 export {
   createHttpSonarResolveProbePort,


### PR DESCRIPTION
## Summary
- Implements CR-208 Ordering contract on top of CR-007A: idempotent `capability_demand` resource with open → notified lifecycle (plus closed/declined/expired terminals), quota/expiry enforcement, and `capability_demand.supported` intent emission.
- Adds typed `support_request` projections (never Preparing / report-order semantics), authorized withdraw/list/detail, Sonar-facing triage aggregate endpoint, and service-only support transition ingress.
- Does not create report orders or shared preparation work from demand paths.

## Test plan
- [x] `pnpm vitest run src/__tests__/capability-demand-lifecycle.test.ts src/__tests__/public-authorization-http.test.ts` (12/12)
- [ ] CI Unit Tests / Lint on PR

## Gaps (honest — not Ready)
- In-memory store only; Postgres persistence + transactional outbox deferred
- Dashboard BFF + “Request support” UI not in this slice
- Sonar triage consumer wiring stub-only (aggregate shape exposed)
- Identity-change reconfirmation E2E journey deferred to Dashboard + CR-301/302 integration
- `supported` intermediate state collapsed into atomic open→notified transition in-memory


Made with [Cursor](https://cursor.com)