### PR TITLE
feat(ordering): CR-012A public dependency ledger inbox (f09.19)

### DIFF
--- a/packages/protocol/dependency-ledger/README.md
+++ b/packages/protocol/dependency-ledger/README.md
@@ -1,0 +1,41 @@
+# `@freeside/dependency-ledger-protocol`
+
+CR-012A public Ordering reverse-dependency ledger and inbox closure for
+collection-report. Distinct from producer-local outboxes — Ordering is the
+authoritative reverse index without claiming a cross-service transaction.
+
+## Scope
+
+- **Dependency edge body contract** — evidence and invalidation edges carried
+  inside CR-009 trust envelopes (`collection-report.dependency-edge.v1`).
+- **Inbox intake** — chains CR-013 `gateSignedIntake()` with CR-009
+  `ingestTrustEnvelope()` before persisting edges idempotently by `event_id`.
+- **Closure + quarantine** — derivatives stay unfulfillable until required edge
+  sets and producer watermarks close; equivalence revocation and key compromise
+  enumerate reachable derivatives and deny fulfillment.
+- **Reconciliation** — bidirectional lost/delayed edge detection with quarantine
+  metrics for repair deadlines.
+- **Shared fixtures** — lost, duplicated, delayed, compromise, backfill, and
+  mixed-minor enforcement vectors for G1B-2 (`EV-G1B2-closure-backfill`).
+
+## CR-011A dependency (honest)
+
+This package implements the **Ordering consumer/inbox** side only. Sonar
+public trust-stream producer adoption (**CR-011A**, bead `f09.43`) is still
+open — G1B-1 end-to-end replay (`EV-G1B1-sonar-ordering-replay`) cannot pass
+until that producer lands. Ordering intake is ready against CR-009/CR-013
+contracts using shared fixture envelopes.
+
+## Adoption
+
+1. Pin a CR-013 registry snapshot and healthy `TimeHealthSnapshot`.
+2. Construct `DependencyLedgerInboxState` per Ordering instance.
+3. Call `ingestDependencyEdgeEnvelope()` for each signed producer outbox edge.
+4. Gate fulfillment on `DerivativeClosureRecord.fulfillable === true`.
+5. Run `reconcileLedger()` on a schedule against producer outbox expectations.
+
+## Related
+
+- `@freeside/trust-envelope-protocol` — CR-009 envelope wire contract
+- `@freeside/signing-key-custody-protocol` — CR-013 intake gate + registry
+- `grimoires/loa/coordination/collection-report/owner-acceptance.md` — ledger ownership

--- a/packages/protocol/dependency-ledger/fixtures/scenarios/ledger-closure.shared.json
+++ b/packages/protocol/dependency-ledger/fixtures/scenarios/ledger-closure.shared.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "accepted_at_ms": 1784322001000,
+  "note": "CR-012A shared fixture index — programmatic vectors live in ledger-inbox.test.ts until CR-011A Sonar producer ships EV-G1B1-sonar-ordering-replay.",
+  "scenarios": [
+    "lost_edge",
+    "duplicated_edge",
+    "delayed_edge",
+    "signing_key_compromised",
+    "backfill_complete",
+    "unsupported_schema_minor"
+  ]
+}

--- a/packages/protocol/dependency-ledger/package.json
+++ b/packages/protocol/dependency-ledger/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@freeside/dependency-ledger-protocol",
+  "version": "1.0.0",
+  "description": "CR-012A public Ordering reverse-dependency ledger, inbox closure, quarantine, and reconciliation contracts consumed with CR-009 trust envelopes and CR-013 intake gates.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "fixtures",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "rm -rf dist",
+    "prepack": "pnpm run build",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "license": "AGPL-3.0",
+  "dependencies": {
+    "@freeside/signing-key-custody-protocol": "file:../signing-key-custody",
+    "@freeside/trust-envelope-protocol": "file:../trust-envelope"
+  },
+  "peerDependencies": {
+    "effect": "^3.21.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "effect": "^3.21.0",
+    "typescript": "^5.7.0",
+    "vitest": "^4.0.17"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/protocol/dependency-ledger/pnpm-lock.yaml
+++ b/packages/protocol/dependency-ledger/pnpm-lock.yaml
@@ -1,0 +1,845 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@freeside/signing-key-custody-protocol':
+        specifier: file:../signing-key-custody
+        version: file:../signing-key-custody(effect@3.22.0)
+      '@freeside/trust-envelope-protocol':
+        specifier: file:../trust-envelope
+        version: file:../trust-envelope(effect@3.22.0)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.1
+      effect:
+        specifier: ^3.21.0
+        version: 3.22.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.17
+        version: 4.1.10(@types/node@22.20.1)(vite@8.1.5(@types/node@22.20.1))
+
+packages:
+
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@freeside/signing-key-custody-protocol@file:../signing-key-custody':
+    resolution: {directory: ../signing-key-custody, type: directory}
+    peerDependencies:
+      effect: ^3.21.0
+
+  '@freeside/trust-envelope-protocol@file:../trust-envelope':
+    resolution: {directory: ../trust-envelope, type: directory}
+    peerDependencies:
+      effect: ^3.21.0
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  canonicalize@2.1.0:
+    resolution: {integrity: sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==}
+    hasBin: true
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  effect@3.22.0:
+    resolution: {integrity: sha512-jhYFe0zTlIRqYFrKTS+6luhmS/Tm0f+JLo0K9KUxvtFab1SUGEszQi2ehOP6QzAZvy831lDmTwwzvVDZSPNz3g==}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  vite@8.1.5:
+    resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+snapshots:
+
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@freeside/signing-key-custody-protocol@file:../signing-key-custody(effect@3.22.0)':
+    dependencies:
+      '@freeside/trust-envelope-protocol': file:../trust-envelope(effect@3.22.0)
+      effect: 3.22.0
+
+  '@freeside/trust-envelope-protocol@file:../trust-envelope(effect@3.22.0)':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      canonicalize: 2.1.0
+      effect: 3.22.0
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.8.0': {}
+
+  '@oxc-project/types@0.139.0': {}
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@22.20.1))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.5(@types/node@22.20.1)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  assertion-error@2.0.1: {}
+
+  canonicalize@2.1.0: {}
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  detect-libc@2.1.2: {}
+
+  effect@3.22.0:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
+  es-module-lexer@2.3.1: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fsevents@2.3.3:
+    optional: true
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  nanoid@3.3.16: {}
+
+  obug@2.1.4: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.19:
+    dependencies:
+      nanoid: 3.3.16
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  pure-rand@6.1.0: {}
+
+  rolldown@1.1.5:
+    dependencies:
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
+
+  tslib@2.8.1:
+    optional: true
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  vite@8.1.5(@types/node@22.20.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.19
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.1
+      fsevents: 2.3.3
+
+  vitest@4.1.10(@types/node@22.20.1)(vite@8.1.5(@types/node@22.20.1)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@22.20.1))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.5(@types/node@22.20.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.20.1
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/packages/protocol/dependency-ledger/src/__tests__/ledger-inbox.test.ts
+++ b/packages/protocol/dependency-ledger/src/__tests__/ledger-inbox.test.ts
@@ -1,0 +1,410 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTimeHealthSnapshot,
+  PinnedKeyRegistry,
+} from "@freeside/signing-key-custody-protocol";
+import {
+  advanceTrustStreamProducer,
+  createTrustStreamProducerState,
+  emitTrustEnvelope,
+  fixtureSigners,
+  FIXTURE_TENANT_SCOPE_DIGEST,
+} from "@freeside/trust-envelope-protocol";
+
+import {
+  createDependencyLedgerInboxState,
+  DEPENDENCY_EDGE_CAPABILITY,
+  DEPENDENCY_EDGE_CONTRACT,
+  ingestDependencyEdgeEnvelope,
+  reconcileLedger,
+} from "../index.js";
+import { buildDependencyLedgerFixtureRegistryDocument } from "../fixture-registry.js";
+
+const ACCEPTED_AT_MS = Date.parse("2026-07-17T21:00:01.000Z");
+const ISSUED_AT_MS = Date.parse("2026-07-17T21:00:00.000Z");
+
+const buildRegistry = () =>
+  new PinnedKeyRegistry(buildDependencyLedgerFixtureRegistryDocument("2026-07-17T21:00:00.000Z"));
+
+const buildTimeHealth = () =>
+  buildTimeHealthSnapshot({
+    evaluatedAtMs: ACCEPTED_AT_MS,
+    databaseUnixMs: ACCEPTED_AT_MS,
+    authoritativeSources: [
+      {
+        source_id: "ntp-a",
+        observed_at: "2026-07-17T21:00:01.000Z",
+        unix_ms: ACCEPTED_AT_MS,
+        uncertainty_ms: 5,
+      },
+      {
+        source_id: "ntp-b",
+        observed_at: "2026-07-17T21:00:01.000Z",
+        unix_ms: ACCEPTED_AT_MS + 10,
+        uncertainty_ms: 8,
+      },
+    ],
+  });
+
+const emitEdge = (input: {
+  eventId: string;
+  sequence: number;
+  body: Record<string, unknown>;
+  producerState: ReturnType<typeof createTrustStreamProducerState>;
+}) => {
+  const signers = fixtureSigners();
+  const envelope = emitTrustEnvelope({
+    signer: signers.sonarPrimary,
+    producer: "sonar-api",
+    eventId: input.eventId,
+    streamId: input.producerState.streamId,
+    streamEpoch: input.producerState.streamEpoch,
+    sequence: input.sequence,
+    trustStream: true,
+    issuedAtMs: ISSUED_AT_MS,
+    tenantScopeDigest: FIXTURE_TENANT_SCOPE_DIGEST,
+    capability: DEPENDENCY_EDGE_CAPABILITY,
+    contract: DEPENDENCY_EDGE_CONTRACT,
+    body: input.body,
+  });
+  return { envelope, nextProducer: advanceTrustStreamProducer(input.producerState) };
+};
+
+describe("CR-012A dependency ledger inbox", () => {
+  it("closes a derivative when required evidence edges and watermarks are complete", () => {
+    const registry = buildRegistry();
+    const timeHealth = buildTimeHealth();
+    const state = createDependencyLedgerInboxState();
+    let producer = createTrustStreamProducerState("sonar.public-capability.v1", 1);
+
+    const rootEdgeId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const leafEdgeId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+    const root = emitEdge({
+      eventId: "11111111-1111-4111-8111-111111111111",
+      sequence: 1,
+      producerState: producer,
+      body: {
+        schema_version: 1,
+        schema_minor: 0,
+        edge_kind: "evidence",
+        edge_id: rootEdgeId,
+        derivative: {
+          derivative_kind: "shared_preparation",
+          derivative_id: "prep-alpha",
+        },
+        required_edge_ids: [],
+        source_watermark: {
+          stream_id: "sonar.public-capability.v1",
+          stream_epoch: 1,
+          sequence: 1,
+        },
+      },
+    });
+    producer = root.nextProducer;
+
+    const leaf = emitEdge({
+      eventId: "22222222-2222-4222-8222-222222222222",
+      sequence: 2,
+      producerState: producer,
+      body: {
+        schema_version: 1,
+        schema_minor: 0,
+        edge_kind: "evidence",
+        edge_id: leafEdgeId,
+        derivative: {
+          derivative_kind: "shared_preparation",
+          derivative_id: "prep-alpha",
+        },
+        required_edge_ids: [rootEdgeId],
+        source_watermark: {
+          stream_id: "sonar.public-capability.v1",
+          stream_epoch: 1,
+          sequence: 2,
+        },
+      },
+    });
+
+    for (const envelope of [root.envelope, leaf.envelope]) {
+      const result = ingestDependencyEdgeEnvelope({
+        envelope,
+        pinnedRegistry: registry,
+        timeHealth,
+        acceptedAtMs: ACCEPTED_AT_MS,
+        state,
+        intakeContext: "fixture",
+      });
+      expect(result.kind).toBe("accepted");
+    }
+
+    const closure = state.derivatives.get("shared_preparation:prep-alpha");
+    expect(closure?.state).toBe("closed");
+    expect(closure?.fulfillable).toBe(true);
+  });
+
+  it("quarantines on lost required edge and reconciles backfill", () => {
+    const registry = buildRegistry();
+    const timeHealth = buildTimeHealth();
+    const state = createDependencyLedgerInboxState();
+    let producer = createTrustStreamProducerState("sonar.public-capability.v1", 1);
+
+    const rootEdgeId = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+    const leafEdgeId = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+
+    const leafOnly = emitEdge({
+      eventId: "33333333-3333-4333-8333-333333333333",
+      sequence: 1,
+      producerState: producer,
+      body: {
+        schema_version: 1,
+        schema_minor: 0,
+        edge_kind: "evidence",
+        edge_id: leafEdgeId,
+        derivative: {
+          derivative_kind: "shared_preparation",
+          derivative_id: "prep-beta",
+        },
+        required_edge_ids: [rootEdgeId],
+        source_watermark: {
+          stream_id: "sonar.public-capability.v1",
+          stream_epoch: 1,
+          sequence: 1,
+        },
+      },
+    });
+
+    ingestDependencyEdgeEnvelope({
+      envelope: leafOnly.envelope,
+      pinnedRegistry: registry,
+      timeHealth,
+      acceptedAtMs: ACCEPTED_AT_MS,
+      state,
+      intakeContext: "fixture",
+    });
+
+    const quarantined = state.derivatives.get("shared_preparation:prep-beta");
+    expect(quarantined?.state).toBe("quarantined");
+    expect(quarantined?.quarantine_reason).toBe("missing_required_edges");
+
+    const report = reconcileLedger(
+      state,
+      [
+        {
+          derivative_key: "shared_preparation:prep-beta",
+          expected_edge_ids: [rootEdgeId, leafEdgeId],
+        },
+      ],
+      ACCEPTED_AT_MS,
+    );
+    expect(report.findings.some((finding) => finding.kind === "lost_edge")).toBe(true);
+
+    const root = emitEdge({
+      eventId: "44444444-4444-4444-8444-444444444444",
+      sequence: 2,
+      producerState: leafOnly.nextProducer,
+      body: {
+        schema_version: 1,
+        schema_minor: 0,
+        edge_kind: "evidence",
+        edge_id: rootEdgeId,
+        derivative: {
+          derivative_kind: "shared_preparation",
+          derivative_id: "prep-beta",
+        },
+        required_edge_ids: [],
+        source_watermark: {
+          stream_id: "sonar.public-capability.v1",
+          stream_epoch: 1,
+          sequence: 2,
+        },
+      },
+    });
+
+    ingestDependencyEdgeEnvelope({
+      envelope: root.envelope,
+      pinnedRegistry: registry,
+      timeHealth,
+      acceptedAtMs: ACCEPTED_AT_MS + 1,
+      state,
+      intakeContext: "fixture",
+    });
+
+    const closed = state.derivatives.get("shared_preparation:prep-beta");
+    expect(closed?.state).toBe("closed");
+    expect(closed?.fulfillable).toBe(true);
+  });
+
+  it("accepts duplicated event_id replay idempotently", () => {
+    const registry = buildRegistry();
+    const timeHealth = buildTimeHealth();
+    const state = createDependencyLedgerInboxState();
+    const producer = createTrustStreamProducerState("sonar.public-capability.v1", 1);
+
+    const emitted = emitEdge({
+      eventId: "55555555-5555-4555-8555-555555555555",
+      sequence: 1,
+      producerState: producer,
+      body: {
+        schema_version: 1,
+        schema_minor: 0,
+        edge_kind: "evidence",
+        edge_id: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+        derivative: {
+          derivative_kind: "capability_evidence",
+          derivative_id: "deploy-gamma",
+        },
+        required_edge_ids: [],
+        source_watermark: {
+          stream_id: "sonar.public-capability.v1",
+          stream_epoch: 1,
+          sequence: 1,
+        },
+      },
+    });
+
+    const first = ingestDependencyEdgeEnvelope({
+      envelope: emitted.envelope,
+      pinnedRegistry: registry,
+      timeHealth,
+      acceptedAtMs: ACCEPTED_AT_MS,
+      state,
+      intakeContext: "fixture",
+    });
+    const second = ingestDependencyEdgeEnvelope({
+      envelope: emitted.envelope,
+      pinnedRegistry: registry,
+      timeHealth,
+      acceptedAtMs: ACCEPTED_AT_MS,
+      state,
+      intakeContext: "fixture",
+    });
+
+    expect(first.kind).toBe("accepted");
+    expect(second.kind).toBe("accepted");
+    if (first.kind === "accepted" && second.kind === "accepted") {
+      expect(second.replay).toBe(true);
+      expect(second.edge.event_id).toBe(first.edge.event_id);
+    }
+    expect(state.edgesByEventId.size).toBe(1);
+    expect(state.metrics.duplicate_replays).toBeGreaterThan(0);
+  });
+
+  it("denies reachable derivatives on signing-key compromise invalidation", () => {
+    const registry = buildRegistry();
+    const timeHealth = buildTimeHealth();
+    const state = createDependencyLedgerInboxState();
+    let producer = createTrustStreamProducerState("sonar.public-capability.v1", 1);
+
+    const evidence = emitEdge({
+      eventId: "66666666-6666-4666-8666-666666666666",
+      sequence: 1,
+      producerState: producer,
+      body: {
+        schema_version: 1,
+        schema_minor: 0,
+        edge_kind: "evidence",
+        edge_id: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+        derivative: {
+          derivative_kind: "shared_preparation",
+          derivative_id: "prep-delta",
+        },
+        required_edge_ids: [],
+        source_watermark: {
+          stream_id: "sonar.public-capability.v1",
+          stream_epoch: 1,
+          sequence: 1,
+        },
+      },
+    });
+    producer = evidence.nextProducer;
+
+    ingestDependencyEdgeEnvelope({
+      envelope: evidence.envelope,
+      pinnedRegistry: registry,
+      timeHealth,
+      acceptedAtMs: ACCEPTED_AT_MS,
+      state,
+      intakeContext: "fixture",
+    });
+
+    const compromise = emitEdge({
+      eventId: "77777777-7777-4777-8777-777777777777",
+      sequence: 2,
+      producerState: producer,
+      body: {
+        schema_version: 1,
+        schema_minor: 0,
+        edge_kind: "invalidation",
+        edge_id: "88888888-8888-4888-8888-888888888888",
+        derivative: {
+          derivative_kind: "shared_preparation",
+          derivative_id: "prep-delta",
+        },
+        required_edge_ids: [],
+        source_watermark: {
+          stream_id: "sonar.public-capability.v1",
+          stream_epoch: 1,
+          sequence: 2,
+        },
+        invalidation: {
+          reason: "signing_key_compromised",
+          compromised_signing_key_id: "sonar-fixture-primary",
+        },
+      },
+    });
+
+    ingestDependencyEdgeEnvelope({
+      envelope: compromise.envelope,
+      pinnedRegistry: registry,
+      timeHealth,
+      acceptedAtMs: ACCEPTED_AT_MS,
+      state,
+      intakeContext: "fixture",
+    });
+
+    const denied = state.derivatives.get("shared_preparation:prep-delta");
+    expect(denied?.state).toBe("denied");
+    expect(denied?.fulfillable).toBe(false);
+    expect(denied?.denied_reason).toBe("signing_key_compromised");
+  });
+
+  it("rejects unsupported schema_minor (mixed-version enforcement)", () => {
+    const registry = buildRegistry();
+    const timeHealth = buildTimeHealth();
+    const state = createDependencyLedgerInboxState();
+    const producer = createTrustStreamProducerState("sonar.public-capability.v1", 1);
+
+    const emitted = emitEdge({
+      eventId: "99999999-9999-4999-8999-999999999999",
+      sequence: 1,
+      producerState: producer,
+      body: {
+        schema_version: 1,
+        schema_minor: 99,
+        edge_kind: "evidence",
+        edge_id: "10101010-1010-4101-8101-101010101010",
+        derivative: {
+          derivative_kind: "shared_preparation",
+          derivative_id: "prep-epsilon",
+        },
+        required_edge_ids: [],
+        source_watermark: {
+          stream_id: "sonar.public-capability.v1",
+          stream_epoch: 1,
+          sequence: 1,
+        },
+      },
+    });
+
+    const result = ingestDependencyEdgeEnvelope({
+      envelope: emitted.envelope,
+      pinnedRegistry: registry,
+      timeHealth,
+      acceptedAtMs: ACCEPTED_AT_MS,
+      state,
+      intakeContext: "fixture",
+    });
+
+    expect(result.kind).toBe("rejected");
+  });
+});

--- a/packages/protocol/dependency-ledger/src/__tests__/protocol.test.ts
+++ b/packages/protocol/dependency-ledger/src/__tests__/protocol.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { DEPENDENCY_EDGE_CAPABILITY, DEPENDENCY_EDGE_CONTRACT } from "../version.js";
+import { decodeDependencyEdgeBody } from "../contracts.js";
+
+describe("dependency ledger protocol surface", () => {
+  it("exports stable CR-012A contract identifiers", () => {
+    expect(DEPENDENCY_EDGE_CAPABILITY).toBe("collection-report.dependency-edge.v1");
+    expect(DEPENDENCY_EDGE_CONTRACT.name).toBe("collection-report.dependency-edge");
+  });
+
+  it("strictly decodes dependency edge bodies", () => {
+    const body = decodeDependencyEdgeBody({
+      schema_version: 1,
+      schema_minor: 0,
+      edge_kind: "evidence",
+      edge_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      derivative: {
+        derivative_kind: "shared_preparation",
+        derivative_id: "prep-1",
+      },
+      required_edge_ids: [],
+      source_watermark: {
+        stream_id: "sonar.public-capability.v1",
+        stream_epoch: 1,
+        sequence: 1,
+      },
+    });
+    expect(body.edge_kind).toBe("evidence");
+  });
+});

--- a/packages/protocol/dependency-ledger/src/closure.ts
+++ b/packages/protocol/dependency-ledger/src/closure.ts
@@ -1,0 +1,240 @@
+import type {
+  DerivativeClosureRecord,
+  DependencyLedgerInboxState,
+  LedgerEdgeRecord,
+} from "./contracts.js";
+import { derivativeKey } from "./contracts.js";
+import { DEFAULT_EDGE_REPAIR_DEADLINE_MS } from "./version.js";
+
+const watermarkKey = (watermark: LedgerEdgeRecord["source_watermark"]): string =>
+  `${watermark.stream_id}#${watermark.stream_epoch}`;
+
+const watermarkSatisfied = (
+  required: LedgerEdgeRecord["source_watermark"],
+  observed: LedgerEdgeRecord["source_watermark"] | undefined,
+): boolean => {
+  if (observed === undefined) return false;
+  if (observed.stream_id !== required.stream_id) return false;
+  if (observed.stream_epoch !== required.stream_epoch) return false;
+  return observed.sequence >= required.sequence;
+};
+
+const collectRequiredEdges = (
+  edges: readonly LedgerEdgeRecord[],
+): readonly string[] => {
+  const required = new Set<string>();
+  for (const edge of edges) {
+    for (const edgeId of edge.required_edge_ids) {
+      required.add(edgeId);
+    }
+  }
+  return [...required];
+};
+
+export const evaluateDerivativeClosure = (
+  derivativeKeyValue: string,
+  edges: readonly LedgerEdgeRecord[],
+  nowMs: number,
+  existing?: DerivativeClosureRecord,
+): DerivativeClosureRecord => {
+  const derivative = edges[0]?.derivative ?? existing?.derivative;
+  if (derivative === undefined) {
+    throw new Error(`no derivative material for ${derivativeKeyValue}`);
+  }
+
+  const receivedEdgeIds = [...new Set(edges.map((edge) => edge.edge_id))];
+  const requiredEdgeIds = collectRequiredEdges(edges);
+  const missingRequired = requiredEdgeIds.filter(
+    (edgeId) => !receivedEdgeIds.includes(edgeId),
+  );
+
+  const sourceWatermarks: Record<string, LedgerEdgeRecord["source_watermark"]> = {};
+  for (const edge of edges) {
+    const key = watermarkKey(edge.source_watermark);
+    const prior = sourceWatermarks[key];
+    if (
+      prior === undefined ||
+      edge.source_watermark.sequence > prior.sequence
+    ) {
+      sourceWatermarks[key] = edge.source_watermark;
+    }
+  }
+
+  for (const edge of edges) {
+    if (edge.edge_kind !== "invalidation" || edge.invalidation === undefined) {
+      continue;
+    }
+    return {
+      derivative_key: derivativeKeyValue,
+      derivative,
+      required_edge_ids: requiredEdgeIds,
+      received_edge_ids: receivedEdgeIds,
+      source_watermarks: sourceWatermarks,
+      state: "denied",
+      fulfillable: false,
+      denied_reason: edge.invalidation.reason,
+      quarantine_reason: edge.invalidation.reason,
+    };
+  }
+
+  if (missingRequired.length > 0) {
+    return {
+      derivative_key: derivativeKeyValue,
+      derivative,
+      required_edge_ids: requiredEdgeIds,
+      received_edge_ids: receivedEdgeIds,
+      source_watermarks: sourceWatermarks,
+      state: "quarantined",
+      fulfillable: false,
+      quarantine_reason: "missing_required_edges",
+      repair_deadline_ms: (existing?.repair_deadline_ms ?? nowMs) + DEFAULT_EDGE_REPAIR_DEADLINE_MS,
+    };
+  }
+
+  const delayedWatermark = edges.some(
+    (edge) =>
+      !watermarkSatisfied(
+        edge.source_watermark,
+        sourceWatermarks[watermarkKey(edge.source_watermark)],
+      ),
+  );
+  if (delayedWatermark) {
+    return {
+      derivative_key: derivativeKeyValue,
+      derivative,
+      required_edge_ids: requiredEdgeIds,
+      received_edge_ids: receivedEdgeIds,
+      source_watermarks: sourceWatermarks,
+      state: "quarantined",
+      fulfillable: false,
+      quarantine_reason: "source_watermark_gap",
+      repair_deadline_ms: (existing?.repair_deadline_ms ?? nowMs) + DEFAULT_EDGE_REPAIR_DEADLINE_MS,
+    };
+  }
+
+  return {
+    derivative_key: derivativeKeyValue,
+    derivative,
+    required_edge_ids: requiredEdgeIds,
+    received_edge_ids: receivedEdgeIds,
+    source_watermarks: sourceWatermarks,
+    state: "closed",
+    fulfillable: true,
+  };
+};
+
+export const applyCompromiseDenial = (
+  state: DependencyLedgerInboxState,
+  compromisedSigningKeyId: string,
+  nowMs: number,
+): readonly DerivativeClosureRecord[] => {
+  const affected = state.reverseBySigningKey.get(compromisedSigningKeyId);
+  if (affected === undefined || affected.size === 0) return [];
+
+  const updated: DerivativeClosureRecord[] = [];
+  for (const key of affected) {
+    const edges = [...state.edgesByEdgeId.values()].filter(
+      (edge) => edge.derivative_key === key,
+    );
+    const denied = evaluateDerivativeClosure(key, edges, nowMs, state.derivatives.get(key));
+    const record: DerivativeClosureRecord = {
+      ...denied,
+      state: "denied",
+      fulfillable: false,
+      denied_reason: "signing_key_compromised",
+      quarantine_reason: "signing_key_compromised",
+    };
+    state.derivatives.set(key, record);
+    updated.push(record);
+  }
+  recomputeMetrics(state);
+  return updated;
+};
+
+export const applyEquivalenceRevocation = (
+  state: DependencyLedgerInboxState,
+  equivalenceDigest: string,
+  nowMs: number,
+): readonly DerivativeClosureRecord[] => {
+  const affected = state.reverseByEquivalenceDigest.get(equivalenceDigest);
+  if (affected === undefined || affected.size === 0) return [];
+
+  const updated: DerivativeClosureRecord[] = [];
+  for (const key of affected) {
+    const edges = [...state.edgesByEdgeId.values()].filter(
+      (edge) => edge.derivative_key === key,
+    );
+    const denied: DerivativeClosureRecord = {
+      derivative_key: key,
+      derivative: edges[0]?.derivative ?? state.derivatives.get(key)!.derivative,
+      required_edge_ids: collectRequiredEdges(edges),
+      received_edge_ids: edges.map((edge) => edge.edge_id),
+      source_watermarks: {},
+      state: "denied",
+      fulfillable: false,
+      denied_reason: "collection_equivalence_revoked",
+      quarantine_reason: "collection_equivalence_revoked",
+      repair_deadline_ms: nowMs,
+    };
+    state.derivatives.set(key, denied);
+    updated.push(denied);
+  }
+  recomputeMetrics(state);
+  return updated;
+};
+
+export const recomputeMetrics = (state: DependencyLedgerInboxState): void => {
+  let quarantined = 0;
+  let denied = 0;
+  let closed = 0;
+  for (const record of state.derivatives.values()) {
+    if (record.state === "quarantined") quarantined += 1;
+    if (record.state === "denied") denied += 1;
+    if (record.state === "closed") closed += 1;
+  }
+
+  state.metrics = {
+    ...state.metrics,
+    quarantined_derivatives: quarantined,
+    denied_derivatives: denied,
+    closed_derivatives: closed,
+  };
+};
+
+export const indexDerivativeEdge = (
+  state: DependencyLedgerInboxState,
+  edge: LedgerEdgeRecord,
+): void => {
+  const signingKeys = state.reverseBySigningKey.get(edge.signing_key_id) ?? new Set<string>();
+  signingKeys.add(edge.derivative_key);
+  state.reverseBySigningKey.set(edge.signing_key_id, signingKeys);
+
+  const equivalenceDigest = edge.invalidation?.equivalence_digest;
+  if (equivalenceDigest !== undefined) {
+    const equivalents =
+      state.reverseByEquivalenceDigest.get(equivalenceDigest) ?? new Set<string>();
+    equivalents.add(edge.derivative_key);
+    state.reverseByEquivalenceDigest.set(equivalenceDigest, equivalents);
+  }
+};
+
+export const refreshDerivativeClosure = (
+  state: DependencyLedgerInboxState,
+  derivativeKeyValue: string,
+  nowMs: number,
+): DerivativeClosureRecord => {
+  const edges = [...state.edgesByEdgeId.values()].filter(
+    (edge) => edge.derivative_key === derivativeKeyValue,
+  );
+  const record = evaluateDerivativeClosure(
+    derivativeKeyValue,
+    edges,
+    nowMs,
+    state.derivatives.get(derivativeKeyValue),
+  );
+  state.derivatives.set(derivativeKeyValue, record);
+  recomputeMetrics(state);
+  return record;
+};
+
+export { derivativeKey };

--- a/packages/protocol/dependency-ledger/src/contracts.ts
+++ b/packages/protocol/dependency-ledger/src/contracts.ts
@@ -1,0 +1,135 @@
+import { Schema } from "effect";
+import type { ParseOptions } from "effect/SchemaAST";
+import { DEPENDENCY_LEDGER_SCHEMA_MAJOR } from "./version.js";
+
+const SchemaMajor = Schema.Literal(DEPENDENCY_LEDGER_SCHEMA_MAJOR);
+const SchemaMinor = Schema.Number.pipe(Schema.int(), Schema.greaterThanOrEqualTo(0));
+
+const Hex64Schema = Schema.String.pipe(
+  Schema.pattern(/^[0-9a-f]{64}$/, {
+    message: () => "must be 64 lowercase hex chars (sha256)",
+  }),
+);
+
+const UuidSchema = Schema.String.pipe(
+  Schema.pattern(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/),
+);
+
+const EdgeIdSchema = UuidSchema;
+const DerivativeKindSchema = Schema.String.pipe(Schema.minLength(1), Schema.maxLength(64));
+const DerivativeIdSchema = Schema.String.pipe(Schema.minLength(1), Schema.maxLength(256));
+
+export const strictDecodeOptions: ParseOptions = {
+  errors: "all",
+  onExcessProperty: "error",
+};
+
+export const ProducerWatermark = Schema.Struct({
+  stream_id: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(256)),
+  stream_epoch: Schema.Number.pipe(Schema.int(), Schema.greaterThanOrEqualTo(1)),
+  sequence: Schema.Number.pipe(Schema.int(), Schema.greaterThanOrEqualTo(1)),
+}).annotations({ identifier: "ProducerWatermark" });
+export type ProducerWatermark = Schema.Schema.Type<typeof ProducerWatermark>;
+
+export const DerivativeRef = Schema.Struct({
+  derivative_kind: DerivativeKindSchema,
+  derivative_id: DerivativeIdSchema,
+  community_scope_digest: Schema.optionalWith(Hex64Schema, { exact: true }),
+}).annotations({ identifier: "DerivativeRef" });
+export type DerivativeRef = Schema.Schema.Type<typeof DerivativeRef>;
+
+export const InvalidationPayload = Schema.Struct({
+  reason: Schema.Literal(
+    "collection_equivalence_revoked",
+    "signing_key_compromised",
+  ),
+  equivalence_digest: Schema.optionalWith(Hex64Schema, { exact: true }),
+  compromised_signing_key_id: Schema.optionalWith(Schema.String, { exact: true }),
+}).annotations({ identifier: "InvalidationPayload" });
+export type InvalidationPayload = Schema.Schema.Type<typeof InvalidationPayload>;
+
+export const DependencyEdgeBody = Schema.Struct({
+  schema_version: SchemaMajor,
+  schema_minor: SchemaMinor,
+  edge_kind: Schema.Literal("evidence", "invalidation"),
+  edge_id: EdgeIdSchema,
+  derivative: DerivativeRef,
+  required_edge_ids: Schema.Array(EdgeIdSchema),
+  source_watermark: ProducerWatermark,
+  invalidation: Schema.optionalWith(InvalidationPayload, { exact: true }),
+}).annotations({ identifier: "DependencyEdgeBody" });
+export type DependencyEdgeBody = Schema.Schema.Type<typeof DependencyEdgeBody>;
+
+export const decodeDependencyEdgeBody = Schema.decodeUnknownSync(
+  DependencyEdgeBody,
+  strictDecodeOptions,
+);
+
+export const derivativeKey = (derivative: DerivativeRef): string =>
+  `${derivative.derivative_kind}:${derivative.derivative_id}`;
+
+export type DerivativeFulfillmentState = "quarantined" | "closed" | "denied";
+
+export interface LedgerEdgeRecord {
+  readonly edge_id: string;
+  readonly edge_kind: DependencyEdgeBody["edge_kind"];
+  readonly event_id: string;
+  readonly signing_key_id: string;
+  readonly producer: string;
+  readonly derivative_key: string;
+  readonly derivative: DerivativeRef;
+  readonly required_edge_ids: readonly string[];
+  readonly source_watermark: ProducerWatermark;
+  readonly invalidation?: InvalidationPayload;
+  readonly accepted_at_ms: number;
+  readonly schema_minor: number;
+}
+
+export interface DerivativeClosureRecord {
+  readonly derivative_key: string;
+  readonly derivative: DerivativeRef;
+  readonly required_edge_ids: readonly string[];
+  readonly received_edge_ids: readonly string[];
+  readonly source_watermarks: Readonly<Record<string, ProducerWatermark>>;
+  readonly state: DerivativeFulfillmentState;
+  readonly fulfillable: boolean;
+  readonly quarantine_reason?: string;
+  readonly denied_reason?: string;
+  readonly repair_deadline_ms?: number;
+}
+
+export interface QuarantineMetrics {
+  quarantined_derivatives: number;
+  denied_derivatives: number;
+  closed_derivatives: number;
+  pending_edges: number;
+  lost_edges: number;
+  duplicate_replays: number;
+}
+
+export interface DependencyLedgerInboxState {
+  readonly streamConsumers: Map<string, import("@freeside/trust-envelope-protocol").StreamConsumerState>;
+  readonly edgesByEventId: Map<string, LedgerEdgeRecord>;
+  readonly edgesByEdgeId: Map<string, LedgerEdgeRecord>;
+  readonly derivatives: Map<string, DerivativeClosureRecord>;
+  readonly reverseBySigningKey: Map<string, Set<string>>;
+  readonly reverseByEquivalenceDigest: Map<string, Set<string>>;
+  metrics: QuarantineMetrics;
+}
+
+export const createDependencyLedgerInboxState = (): DependencyLedgerInboxState => ({
+  streamConsumers: new Map(),
+  edgesByEventId: new Map(),
+  edgesByEdgeId: new Map(),
+  derivatives: new Map(),
+  reverseBySigningKey: new Map(),
+  reverseByEquivalenceDigest: new Map(),
+  metrics: {
+    quarantined_derivatives: 0,
+    denied_derivatives: 0,
+    closed_derivatives: 0,
+    pending_edges: 0,
+    lost_edges: 0,
+    duplicate_replays: 0,
+  },
+});

--- a/packages/protocol/dependency-ledger/src/errors.ts
+++ b/packages/protocol/dependency-ledger/src/errors.ts
@@ -1,0 +1,23 @@
+export class DependencyLedgerRejectedError extends Error {
+  readonly reason: string;
+  readonly remediation?: string;
+  readonly safe_code: string;
+
+  constructor(input: { reason: string; remediation?: string; safe_code?: string }) {
+    super(input.reason);
+    this.name = "DependencyLedgerRejectedError";
+    this.reason = input.reason;
+    this.remediation = input.remediation;
+    this.safe_code = input.safe_code ?? input.reason;
+  }
+}
+
+export class DependencyEdgeDecodeError extends Error {
+  readonly detail: string;
+
+  constructor(detail: string) {
+    super(detail);
+    this.name = "DependencyEdgeDecodeError";
+    this.detail = detail;
+  }
+}

--- a/packages/protocol/dependency-ledger/src/fixture-registry.ts
+++ b/packages/protocol/dependency-ledger/src/fixture-registry.ts
@@ -1,0 +1,40 @@
+import {
+  buildFixtureCustodyKey,
+  buildSigningKeyRegistryDocument,
+  type SigningKeyRegistryDocument,
+} from "@freeside/signing-key-custody-protocol";
+import {
+  FIXTURE_SIGNING_KEY_IDS,
+  FIXTURE_CAPABILITY,
+} from "@freeside/trust-envelope-protocol";
+import { DEPENDENCY_EDGE_CAPABILITY } from "./version.js";
+
+const ledgerFixtureCapabilities = [
+  FIXTURE_CAPABILITY,
+  DEPENDENCY_EDGE_CAPABILITY,
+] as const;
+
+export const buildDependencyLedgerFixtureRegistryDocument = (
+  publishedAt = "2026-07-17T21:00:00.000Z",
+): SigningKeyRegistryDocument =>
+  buildSigningKeyRegistryDocument({
+    registryId: "collection-report.dependency-ledger-fixture.v1",
+    registryGeneration: 1,
+    publishedAt,
+    keyClassScope: "fixture",
+    keys: [
+      buildFixtureCustodyKey(FIXTURE_SIGNING_KEY_IDS.sonarPrimary, {
+        activatedAt: "2026-07-01T00:00:00.000Z",
+      }),
+      buildFixtureCustodyKey(FIXTURE_SIGNING_KEY_IDS.sonarRotated, {
+        activatedAt: "2026-07-10T00:00:00.000Z",
+      }),
+      buildFixtureCustodyKey(FIXTURE_SIGNING_KEY_IDS.sonarRevoked, {
+        activatedAt: "2026-07-01T00:00:00.000Z",
+        revokedAt: "2026-07-15T00:00:00.000Z",
+      }),
+    ].map((key) => ({
+      ...key,
+      capabilities: [...ledgerFixtureCapabilities],
+    })),
+  });

--- a/packages/protocol/dependency-ledger/src/fixture-scenarios.ts
+++ b/packages/protocol/dependency-ledger/src/fixture-scenarios.ts
@@ -1,0 +1,44 @@
+import { Schema } from "effect";
+import type { TrustEnvelope } from "@freeside/trust-envelope-protocol";
+import type { SigningKeyRegistryDocument } from "@freeside/signing-key-custody-protocol";
+
+export const FixtureLedgerScenario = Schema.Struct({
+  id: Schema.String,
+  envelope: Schema.Unknown,
+  expect: Schema.Literal("accept", "reject"),
+  reject_reason: Schema.optionalWith(Schema.String, { exact: true }),
+}).annotations({ identifier: "FixtureLedgerScenario" });
+
+export const FixtureLedgerScenarioBundle = Schema.Struct({
+  schema_version: Schema.Literal(1),
+  accepted_at_ms: Schema.Number,
+  registry: Schema.Unknown,
+  time_health: Schema.Unknown,
+  envelopes: Schema.Array(FixtureLedgerScenario),
+  reconciliation: Schema.optionalWith(
+    Schema.Array(
+      Schema.Struct({
+        derivative_key: Schema.String,
+        expected_edge_ids: Schema.Array(Schema.String),
+      }),
+    ),
+    { exact: true },
+  ),
+}).annotations({ identifier: "FixtureLedgerScenarioBundle" });
+
+export type FixtureLedgerScenarioBundle = Schema.Schema.Type<
+  typeof FixtureLedgerScenarioBundle
+> & {
+  registry: SigningKeyRegistryDocument;
+  envelopes: ReadonlyArray<{
+    id: string;
+    envelope: TrustEnvelope;
+    expect: "accept" | "reject";
+    reject_reason?: string;
+  }>;
+};
+
+export const decodeFixtureLedgerScenarioBundle = (
+  raw: unknown,
+): FixtureLedgerScenarioBundle =>
+  Schema.decodeUnknownSync(FixtureLedgerScenarioBundle)(raw) as FixtureLedgerScenarioBundle;

--- a/packages/protocol/dependency-ledger/src/inbox.ts
+++ b/packages/protocol/dependency-ledger/src/inbox.ts
@@ -1,0 +1,245 @@
+import {
+  assertSignedIntakeAllowed,
+  KeyCustodyRejectedError,
+  type KeyCustodyClass,
+  type PinnedKeyRegistry,
+  type TimeHealthSnapshot,
+} from "@freeside/signing-key-custody-protocol";
+import type { TrustEnvelope } from "@freeside/trust-envelope-protocol";
+import {
+  TrustEnvelopeRejectedError,
+  createStreamConsumerState,
+  ingestTrustEnvelope,
+  type StreamConsumerState,
+} from "@freeside/trust-envelope-protocol";
+
+import {
+  applyCompromiseDenial,
+  applyEquivalenceRevocation,
+  indexDerivativeEdge,
+  refreshDerivativeClosure,
+} from "./closure.js";
+import {
+  DEPENDENCY_EDGE_CAPABILITY,
+  DEPENDENCY_EDGE_SUPPORTED_MINOR,
+} from "./version.js";
+import {
+  decodeDependencyEdgeBody,
+  derivativeKey,
+  type DependencyLedgerInboxState,
+  type LedgerEdgeRecord,
+} from "./contracts.js";
+import { DependencyLedgerRejectedError } from "./errors.js";
+
+export interface IngestDependencyEdgeInput {
+  readonly envelope: TrustEnvelope;
+  readonly pinnedRegistry: PinnedKeyRegistry;
+  readonly timeHealth: TimeHealthSnapshot;
+  readonly acceptedAtMs: number;
+  readonly state: DependencyLedgerInboxState;
+  readonly intakeContext: KeyCustodyClass;
+}
+
+export type IngestDependencyEdgeResult =
+  | {
+      readonly kind: "accepted";
+      readonly edge: LedgerEdgeRecord;
+      readonly replay: boolean;
+      readonly streamState: StreamConsumerState;
+    }
+  | {
+      readonly kind: "rejected";
+      readonly error:
+        | DependencyLedgerRejectedError
+        | TrustEnvelopeRejectedError
+        | KeyCustodyRejectedError;
+    };
+
+const assertMixedMinor = (schemaMinor: number): void => {
+  if (schemaMinor > DEPENDENCY_EDGE_SUPPORTED_MINOR) {
+    throw new DependencyLedgerRejectedError({
+      reason: "unsupported_schema_minor",
+      remediation: "upgrade_consumer",
+      safe_code: "unsupported_schema_minor",
+    });
+  }
+};
+
+const streamStateFor = (
+  state: DependencyLedgerInboxState,
+  streamId: string,
+  streamEpoch: number,
+): StreamConsumerState =>
+  state.streamConsumers.get(streamId) ??
+  createStreamConsumerState(streamId, streamEpoch);
+
+export const ingestDependencyEdgeEnvelope = (
+  input: IngestDependencyEdgeInput,
+): IngestDependencyEdgeResult => {
+  try {
+    assertSignedIntakeAllowed({
+      registry: input.pinnedRegistry,
+      signingKeyId: input.envelope.header.signing_key_id,
+      acceptedAtMs: input.acceptedAtMs,
+      context: input.intakeContext,
+      timeHealth: input.timeHealth,
+    });
+  } catch (error) {
+    if (
+      error instanceof TrustEnvelopeRejectedError ||
+      error instanceof KeyCustodyRejectedError
+    ) {
+      return { kind: "rejected", error };
+    }
+    throw error;
+  }
+
+  const priorStream = streamStateFor(
+    input.state,
+    input.envelope.header.stream_id,
+    input.envelope.header.stream_epoch,
+  );
+
+  const existingByEvent = input.state.edgesByEventId.get(input.envelope.header.event_id);
+  if (existingByEvent !== undefined) {
+    input.state.metrics = {
+      ...input.state.metrics,
+      duplicate_replays: input.state.metrics.duplicate_replays + 1,
+    };
+    return {
+      kind: "accepted",
+      edge: existingByEvent,
+      replay: true,
+      streamState: priorStream,
+    };
+  }
+
+  const ingest = ingestTrustEnvelope({
+    envelope: input.envelope,
+    registry: input.pinnedRegistry.trustRegistry,
+    acceptedAtMs: input.acceptedAtMs,
+    state: priorStream,
+  });
+
+  if (ingest.kind === "rejected") {
+    return { kind: "rejected", error: ingest.error };
+  }
+
+  if (input.envelope.header.capability !== DEPENDENCY_EDGE_CAPABILITY) {
+    return {
+      kind: "rejected",
+      error: new DependencyLedgerRejectedError({
+        reason: "capability_mismatch",
+        remediation: "verify_producer_capability",
+        safe_code: "capability_mismatch",
+      }),
+    };
+  }
+
+  if (ingest.replay) {
+    const existing = input.state.edgesByEventId.get(input.envelope.header.event_id);
+    input.state.metrics = {
+      ...input.state.metrics,
+      duplicate_replays: input.state.metrics.duplicate_replays + 1,
+    };
+    if (existing !== undefined) {
+      input.state.streamConsumers.set(input.envelope.header.stream_id, ingest.state);
+      return {
+        kind: "accepted",
+        edge: existing,
+        replay: true,
+        streamState: ingest.state,
+      };
+    }
+  }
+
+  let body;
+  try {
+    body = decodeDependencyEdgeBody(input.envelope.body);
+    assertMixedMinor(body.schema_minor);
+  } catch (error) {
+    return {
+      kind: "rejected",
+      error: new DependencyLedgerRejectedError({
+        reason: "invalid_dependency_edge_body",
+        remediation: "fix_producer_payload",
+        safe_code: "invalid_dependency_edge_body",
+      }),
+    };
+  }
+
+  if (body.edge_kind === "invalidation" && body.invalidation === undefined) {
+    return {
+      kind: "rejected",
+      error: new DependencyLedgerRejectedError({
+        reason: "invalid_invalidation_edge",
+        safe_code: "invalid_invalidation_edge",
+      }),
+    };
+  }
+
+  const derivativeKeyValue = derivativeKey(body.derivative);
+  const edge: LedgerEdgeRecord = {
+    edge_id: body.edge_id,
+    edge_kind: body.edge_kind,
+    event_id: input.envelope.header.event_id,
+    signing_key_id: input.envelope.header.signing_key_id,
+    producer: input.envelope.header.producer,
+    derivative_key: derivativeKeyValue,
+    derivative: body.derivative,
+    required_edge_ids: body.required_edge_ids,
+    source_watermark: body.source_watermark,
+    ...(body.invalidation !== undefined ? { invalidation: body.invalidation } : {}),
+    accepted_at_ms: input.acceptedAtMs,
+    schema_minor: body.schema_minor,
+  };
+
+  if (input.state.edgesByEdgeId.has(body.edge_id)) {
+    const existing = input.state.edgesByEdgeId.get(body.edge_id)!;
+    if (existing.event_id !== edge.event_id) {
+      return {
+        kind: "rejected",
+        error: new DependencyLedgerRejectedError({
+          reason: "edge_id_conflict",
+          safe_code: "edge_id_conflict",
+        }),
+      };
+    }
+  }
+
+  input.state.edgesByEventId.set(edge.event_id, edge);
+  input.state.edgesByEdgeId.set(edge.edge_id, edge);
+  input.state.streamConsumers.set(input.envelope.header.stream_id, ingest.state);
+  indexDerivativeEdge(input.state, edge);
+
+  if (
+    body.edge_kind === "invalidation" &&
+    body.invalidation?.reason === "signing_key_compromised" &&
+    body.invalidation.compromised_signing_key_id !== undefined
+  ) {
+    applyCompromiseDenial(
+      input.state,
+      body.invalidation.compromised_signing_key_id,
+      input.acceptedAtMs,
+    );
+  } else if (
+    body.edge_kind === "invalidation" &&
+    body.invalidation?.reason === "collection_equivalence_revoked" &&
+    body.invalidation.equivalence_digest !== undefined
+  ) {
+    applyEquivalenceRevocation(
+      input.state,
+      body.invalidation.equivalence_digest,
+      input.acceptedAtMs,
+    );
+  } else {
+    refreshDerivativeClosure(input.state, derivativeKeyValue, input.acceptedAtMs);
+  }
+
+  return {
+    kind: "accepted",
+    edge,
+    replay: false,
+    streamState: ingest.state,
+  };
+};

--- a/packages/protocol/dependency-ledger/src/index.ts
+++ b/packages/protocol/dependency-ledger/src/index.ts
@@ -1,0 +1,62 @@
+/**
+ * @freeside/dependency-ledger-protocol
+ *
+ * CR-012A public Ordering reverse-dependency ledger and inbox closure.
+ */
+
+export {
+  DEPENDENCY_LEDGER_SCHEMA_MAJOR,
+  DEPENDENCY_LEDGER_SCHEMA_MINOR,
+  DEPENDENCY_EDGE_CONTRACT,
+  DEPENDENCY_EDGE_CAPABILITY,
+  DEPENDENCY_EDGE_SUPPORTED_MINOR,
+  DEFAULT_EDGE_REPAIR_DEADLINE_MS,
+} from "./version.js";
+
+export {
+  DependencyLedgerRejectedError,
+  DependencyEdgeDecodeError,
+} from "./errors.js";
+
+export {
+  strictDecodeOptions,
+  ProducerWatermark,
+  DerivativeRef,
+  InvalidationPayload,
+  DependencyEdgeBody,
+  decodeDependencyEdgeBody,
+  derivativeKey,
+  type DerivativeFulfillmentState,
+  type LedgerEdgeRecord,
+  type DerivativeClosureRecord,
+  type QuarantineMetrics,
+  type DependencyLedgerInboxState,
+  createDependencyLedgerInboxState,
+} from "./contracts.js";
+
+export {
+  evaluateDerivativeClosure,
+  applyCompromiseDenial,
+  applyEquivalenceRevocation,
+  recomputeMetrics,
+  indexDerivativeEdge,
+  refreshDerivativeClosure,
+} from "./closure.js";
+
+export {
+  reconcileLedger,
+  findOrphanEdges,
+  type ReconciliationExpectation,
+  type ReconciliationFinding,
+  type ReconciliationReport,
+} from "./reconciliation.js";
+
+export {
+  ingestDependencyEdgeEnvelope,
+  type IngestDependencyEdgeInput,
+  type IngestDependencyEdgeResult,
+} from "./inbox.js";
+
+export {
+  buildDependencyLedgerFixtureRegistryDocument,
+} from "./fixture-registry.js";

--- a/packages/protocol/dependency-ledger/src/reconciliation.ts
+++ b/packages/protocol/dependency-ledger/src/reconciliation.ts
@@ -1,0 +1,115 @@
+import type {
+  DependencyLedgerInboxState,
+  LedgerEdgeRecord,
+} from "./contracts.js";
+import { refreshDerivativeClosure } from "./closure.js";
+
+export interface ReconciliationExpectation {
+  readonly derivative_key: string;
+  readonly expected_edge_ids: readonly string[];
+  readonly expected_watermark?: LedgerEdgeRecord["source_watermark"];
+}
+
+export interface ReconciliationFinding {
+  readonly kind:
+    | "lost_edge"
+    | "delayed_edge"
+    | "conflicting_watermark"
+    | "orphan_edge"
+    | "backfill_complete";
+  readonly derivative_key: string;
+  readonly edge_id?: string;
+  readonly detail: string;
+}
+
+export interface ReconciliationReport {
+  readonly findings: readonly ReconciliationFinding[];
+  readonly quarantined: readonly string[];
+}
+
+export const reconcileLedger = (
+  state: DependencyLedgerInboxState,
+  expectations: readonly ReconciliationExpectation[],
+  nowMs: number,
+): ReconciliationReport => {
+  const findings: ReconciliationFinding[] = [];
+  const quarantined: string[] = [];
+
+  for (const expectation of expectations) {
+    const received = [...state.edgesByEdgeId.values()].filter(
+      (edge) => edge.derivative_key === expectation.derivative_key,
+    );
+    const receivedIds = new Set(received.map((edge) => edge.edge_id));
+
+    for (const expectedEdgeId of expectation.expected_edge_ids) {
+      if (!receivedIds.has(expectedEdgeId)) {
+        findings.push({
+          kind: "lost_edge",
+          derivative_key: expectation.derivative_key,
+          edge_id: expectedEdgeId,
+          detail: "expected producer outbox edge missing from Ordering ledger",
+        });
+        state.metrics = {
+          ...state.metrics,
+          lost_edges: state.metrics.lost_edges + 1,
+          pending_edges: state.metrics.pending_edges + 1,
+        };
+        quarantined.push(expectation.derivative_key);
+      }
+    }
+
+    if (expectation.expected_watermark !== undefined) {
+      const observed = received.find(
+        (edge) =>
+          edge.source_watermark.stream_id === expectation.expected_watermark!.stream_id &&
+          edge.source_watermark.stream_epoch === expectation.expected_watermark!.stream_epoch,
+      );
+      if (
+        observed !== undefined &&
+        observed.source_watermark.sequence < expectation.expected_watermark.sequence
+      ) {
+        findings.push({
+          kind: "delayed_edge",
+          derivative_key: expectation.derivative_key,
+          detail: "ledger watermark lags producer outbox",
+        });
+        quarantined.push(expectation.derivative_key);
+      } else if (observed === undefined && expectation.expected_edge_ids.length > 0) {
+        findings.push({
+          kind: "delayed_edge",
+          derivative_key: expectation.derivative_key,
+          detail: "no watermark observed for expected stream",
+        });
+        quarantined.push(expectation.derivative_key);
+      }
+    }
+
+    const missing = expectation.expected_edge_ids.filter((id) => !receivedIds.has(id));
+    if (missing.length === 0 && expectation.expected_edge_ids.length > 0) {
+      findings.push({
+        kind: "backfill_complete",
+        derivative_key: expectation.derivative_key,
+        detail: "expected edge set present after repair",
+      });
+    }
+  }
+
+  for (const derivativeKey of new Set(quarantined)) {
+    refreshDerivativeClosure(state, derivativeKey, nowMs);
+  }
+
+  return { findings, quarantined: [...new Set(quarantined)] };
+};
+
+export const findOrphanEdges = (
+  state: DependencyLedgerInboxState,
+  knownDerivativeKeys: ReadonlySet<string>,
+): readonly ReconciliationFinding[] =>
+  [...state.edgesByEdgeId.values()]
+    .filter((edge) => !knownDerivativeKeys.has(edge.derivative_key))
+    .map((edge) => ({
+      kind: "orphan_edge" as const,
+      derivative_key: edge.derivative_key,
+      edge_id: edge.edge_id,
+      detail: "edge references derivative unknown to reconciliation scope",
+    }));

--- a/packages/protocol/dependency-ledger/src/version.ts
+++ b/packages/protocol/dependency-ledger/src/version.ts
@@ -1,0 +1,16 @@
+export const DEPENDENCY_LEDGER_SCHEMA_MAJOR = 1 as const;
+export const DEPENDENCY_LEDGER_SCHEMA_MINOR = 0 as const;
+
+export const DEPENDENCY_EDGE_CONTRACT = {
+  name: "collection-report.dependency-edge",
+  major_version: 1,
+  minor_version: 0,
+} as const;
+
+export const DEPENDENCY_EDGE_CAPABILITY = "collection-report.dependency-edge.v1" as const;
+
+/** Repair deadline before unresolved gaps escalate (SDD reconciliation objective). */
+export const DEFAULT_EDGE_REPAIR_DEADLINE_MS = 5 * 60 * 1000;
+
+/** Mixed-minor acceptance window for dependency-edge bodies. */
+export const DEPENDENCY_EDGE_SUPPORTED_MINOR = 0 as const;

--- a/packages/protocol/dependency-ledger/tsconfig.json
+++ b/packages/protocol/dependency-ledger/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "resolveJsonModule": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": false,
+    "composite": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/protocol/dependency-ledger/vitest.config.ts
+++ b/packages/protocol/dependency-ledger/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/services/ordering/bin/http.ts
+++ b/packages/services/ordering/bin/http.ts
@@ -28,6 +28,13 @@ import { DEFAULT_BASELINE_FIXTURE } from '../src/public-authorization-projection
 import { InMemoryCapabilityDemandStore } from '../src/capability-demand-store.js';
 import { mountCapabilityDemandRoutes } from '../src/capability-demand-http.js';
 import {
+  InMemoryDependencyLedgerStore,
+} from '../src/dependency-ledger-store.js';
+import {
+  createFixtureDependencyLedgerService,
+} from '../src/dependency-ledger-service.js';
+import { mountDependencyLedgerRoutes } from '../src/dependency-ledger-http.js';
+import {
   publicAuthPostureFromEnv,
   serviceTokenForPublicAuthMounts,
 } from '../src/public-auth-posture.js';
@@ -85,6 +92,11 @@ const resolutionService = new CollectionResolutionService({
 });
 
 const capabilityDemandStore = new InMemoryCapabilityDemandStore();
+const dependencyLedgerStore = new InMemoryDependencyLedgerStore();
+const dependencyLedgerService = createFixtureDependencyLedgerService(
+  dependencyLedgerStore,
+  () => Date.now(),
+);
 const mountPublicAuthRoutes =
   publicAuth !== undefined && publicAuthToken.kind !== 'refuse';
 const publicAuthServiceToken =
@@ -109,10 +121,16 @@ const app = createIntakeApp({
     collection_resolutions: true,
     collection_reports: mountPublicAuthRoutes,
     report_attention: true,
-    capability_demands: {
+    "capability_demands": {
       enabled: mountPublicAuthRoutes,
       store: 'memory',
       lifecycle: 'cr-208',
+    },
+    dependency_ledger: {
+      enabled: mountPublicAuthRoutes,
+      store: 'memory',
+      lifecycle: 'cr-012a',
+      cr_011a_producer: 'pending',
     },
     public_authorization: {
       mode: publicAuthPosture.mode,
@@ -155,6 +173,12 @@ if (mountPublicAuthRoutes && publicAuth) {
     auth: publicAuth,
     serviceToken: publicAuthServiceToken,
     now: () => Date.now(),
+  });
+
+  // CR-012A: public dependency ledger inbox (fixture registry; CR-011A producer pending).
+  mountDependencyLedgerRoutes(app, {
+    service: dependencyLedgerService,
+    serviceToken: publicAuthServiceToken,
   });
 }
 

--- a/packages/services/ordering/package.json
+++ b/packages/services/ordering/package.json
@@ -30,6 +30,9 @@
     "@freeside/collection-protocol": "file:../../protocol/collection",
     "@freeside/collection-resolution-protocol": "file:../../protocol/collection-resolution",
     "@freeside/public-authorization-protocol": "file:../../protocol/public-authorization",
+    "@freeside/trust-envelope-protocol": "file:../../protocol/trust-envelope",
+    "@freeside/signing-key-custody-protocol": "file:../../protocol/signing-key-custody",
+    "@freeside/dependency-ledger-protocol": "file:../../protocol/dependency-ledger",
     "effect": "^3.21.0"
   },
   "devDependencies": {

--- a/packages/services/ordering/pnpm-lock.yaml
+++ b/packages/services/ordering/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@freeside/collection-resolution-protocol':
         specifier: file:../../protocol/collection-resolution
         version: file:../../protocol/collection-resolution(effect@3.22.0)
+      '@freeside/dependency-ledger-protocol':
+        specifier: file:../../protocol/dependency-ledger
+        version: file:../../protocol/dependency-ledger(effect@3.22.0)
       '@freeside/ordering-protocol':
         specifier: file:../../protocol/ordering
         version: file:../../protocol/ordering(zod@3.25.76)
@@ -26,6 +29,12 @@ importers:
       '@freeside/shadow-audit-service':
         specifier: file:../shadow-audit
         version: file:../shadow-audit(@types/pg@8.20.0)(pg@8.22.0)(pino@10.3.1)(typescript@5.9.3)(zod@3.25.76)
+      '@freeside/signing-key-custody-protocol':
+        specifier: file:../../protocol/signing-key-custody
+        version: file:../../protocol/signing-key-custody(effect@3.22.0)
+      '@freeside/trust-envelope-protocol':
+        specifier: file:../../protocol/trust-envelope
+        version: file:../../protocol/trust-envelope(effect@3.22.0)
       '@hono/node-server':
         specifier: ^1.13.0
         version: 1.19.14(hono@4.12.27)
@@ -337,6 +346,11 @@ packages:
     resolution: {directory: ../../core, type: directory}
     engines: {node: '>=20.0.0'}
 
+  '@freeside/dependency-ledger-protocol@file:../../protocol/dependency-ledger':
+    resolution: {directory: ../../protocol/dependency-ledger, type: directory}
+    peerDependencies:
+      effect: ^3.21.0
+
   '@freeside/ordering-protocol@file:../../protocol/ordering':
     resolution: {directory: ../../protocol/ordering, type: directory}
     peerDependencies:
@@ -356,6 +370,16 @@ packages:
     resolution: {directory: ../shadow-audit, type: directory}
     peerDependencies:
       zod: ^3.23.0
+
+  '@freeside/signing-key-custody-protocol@file:../../protocol/signing-key-custody':
+    resolution: {directory: ../../protocol/signing-key-custody, type: directory}
+    peerDependencies:
+      effect: ^3.21.0
+
+  '@freeside/trust-envelope-protocol@file:../../protocol/trust-envelope':
+    resolution: {directory: ../../protocol/trust-envelope, type: directory}
+    peerDependencies:
+      effect: ^3.21.0
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -1531,6 +1555,12 @@ snapshots:
 
   '@freeside/core@file:../../core': {}
 
+  '@freeside/dependency-ledger-protocol@file:../../protocol/dependency-ledger(effect@3.22.0)':
+    dependencies:
+      '@freeside/signing-key-custody-protocol': file:../../protocol/signing-key-custody(effect@3.22.0)
+      '@freeside/trust-envelope-protocol': file:../../protocol/trust-envelope(effect@3.22.0)
+      effect: 3.22.0
+
   '@freeside/ordering-protocol@file:../../protocol/ordering(zod@3.25.76)':
     dependencies:
       zod: 3.25.76
@@ -1587,6 +1617,18 @@ snapshots:
       - supports-color
       - typescript
       - utf-8-validate
+
+  '@freeside/signing-key-custody-protocol@file:../../protocol/signing-key-custody(effect@3.22.0)':
+    dependencies:
+      '@freeside/trust-envelope-protocol': file:../../protocol/trust-envelope(effect@3.22.0)
+      effect: 3.22.0
+
+  '@freeside/trust-envelope-protocol@file:../../protocol/trust-envelope(effect@3.22.0)':
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      canonicalize: 2.1.0
+      effect: 3.22.0
 
   '@hono/node-server@1.19.14(hono@4.12.27)':
     dependencies:

--- a/packages/services/ordering/src/__tests__/dependency-ledger-service.test.ts
+++ b/packages/services/ordering/src/__tests__/dependency-ledger-service.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  advanceTrustStreamProducer,
+  createTrustStreamProducerState,
+  emitTrustEnvelope,
+  fixtureSigners,
+  FIXTURE_TENANT_SCOPE_DIGEST,
+} from "@freeside/trust-envelope-protocol";
+import {
+  DEPENDENCY_EDGE_CAPABILITY,
+  DEPENDENCY_EDGE_CONTRACT,
+} from "@freeside/dependency-ledger-protocol";
+import {
+  createFixtureDependencyLedgerService,
+} from "../dependency-ledger-service.js";
+import { InMemoryDependencyLedgerStore } from "../dependency-ledger-store.js";
+
+describe("CR-012A Ordering dependency ledger service", () => {
+  it("ingests signed dependency edges through CR-009 + CR-013 intake chain", () => {
+    const store = new InMemoryDependencyLedgerStore();
+    const service = createFixtureDependencyLedgerService(store, () =>
+      Date.parse("2026-07-17T21:00:01.000Z"),
+    );
+    const signers = fixtureSigners();
+    let producer = createTrustStreamProducerState("sonar.public-capability.v1", 1);
+
+    const envelope = emitTrustEnvelope({
+      signer: signers.sonarPrimary,
+      producer: "sonar-api",
+      eventId: "12121212-1212-4121-8121-121212121212",
+      streamId: producer.streamId,
+      streamEpoch: producer.streamEpoch,
+      sequence: producer.nextSequence,
+      trustStream: true,
+      issuedAtMs: Date.parse("2026-07-17T21:00:00.000Z"),
+      tenantScopeDigest: FIXTURE_TENANT_SCOPE_DIGEST,
+      capability: DEPENDENCY_EDGE_CAPABILITY,
+      contract: DEPENDENCY_EDGE_CONTRACT,
+      body: {
+        schema_version: 1,
+        schema_minor: 0,
+        edge_kind: "evidence",
+        edge_id: "13131313-1313-4131-8131-131313131313",
+        derivative: {
+          derivative_kind: "shared_preparation",
+          derivative_id: "prep-ordering",
+        },
+        required_edge_ids: [],
+        source_watermark: {
+          stream_id: "sonar.public-capability.v1",
+          stream_epoch: 1,
+          sequence: 1,
+        },
+      },
+    });
+    producer = advanceTrustStreamProducer(producer);
+
+    const result = service.ingestEnvelope(envelope);
+    expect(result.kind).toBe("accepted");
+    const closure = service.getDerivative("shared_preparation:prep-ordering");
+    expect(closure?.state).toBe("closed");
+    expect(closure?.fulfillable).toBe(true);
+  });
+
+  it("surfaces quarantine metrics without claiming G1B-1 producer replay", () => {
+    const store = new InMemoryDependencyLedgerStore();
+    const service = createFixtureDependencyLedgerService(store);
+    const metrics = service.metrics();
+    expect(metrics.quarantined_derivatives).toBe(0);
+    expect(metrics.closed_derivatives).toBe(0);
+  });
+});

--- a/packages/services/ordering/src/dependency-ledger-http.ts
+++ b/packages/services/ordering/src/dependency-ledger-http.ts
@@ -1,0 +1,152 @@
+/**
+ * CR-012A dependency ledger inbox HTTP edge.
+ *
+ *   POST /v1/dependency-ledger/inbox/envelopes
+ *   GET  /v1/dependency-ledger/derivatives/:derivative_kind/:derivative_id
+ *   GET  /v1/dependency-ledger/metrics
+ *
+ * Service-bearer only. Consumes CR-009 trust envelopes with CR-013 intake gate.
+ * CR-011A Sonar producer outbox wiring lands separately — this is Ordering-side
+ * inbox + reverse-dependency ledger readiness.
+ */
+
+import { Hono, type Context } from "hono";
+import { decodeTrustEnvelope, TrustEnvelopeRejectedError } from "@freeside/trust-envelope-protocol";
+import { requireServiceBearer, noStoreHeaders } from "./public-authorization-http.js";
+import type { DependencyLedgerService } from "./dependency-ledger-service.js";
+import { DependencyLedgerRejectedError } from "@freeside/dependency-ledger-protocol";
+import { KeyCustodyRejectedError } from "@freeside/signing-key-custody-protocol";
+
+export interface DependencyLedgerHttpDeps {
+  readonly service: DependencyLedgerService;
+  readonly serviceToken?: string;
+}
+
+function rejectionStatus(error: unknown): 400 | 403 | 409 {
+  if (error instanceof DependencyLedgerRejectedError) {
+    if (error.safe_code === "edge_id_conflict") return 409;
+    return 400;
+  }
+  if (error instanceof KeyCustodyRejectedError) return 403;
+  if (error instanceof TrustEnvelopeRejectedError) return 403;
+  return 400;
+}
+
+function errorJson(c: Context, status: 400 | 403 | 409, code: string, remediation?: string) {
+  return c.json(
+    {
+      schema_version: 1,
+      code,
+      ...(remediation !== undefined ? { remediation } : {}),
+    },
+    status,
+    noStoreHeaders(),
+  );
+}
+
+export function mountDependencyLedgerRoutes(app: Hono, deps: DependencyLedgerHttpDeps): void {
+  app.post("/v1/dependency-ledger/inbox/envelopes", async (c) => {
+    if (!requireServiceBearer(c, deps.serviceToken)) {
+      return errorJson(c, 403, "unauthorized");
+    }
+
+    let raw: unknown;
+    try {
+      raw = await c.req.json();
+    } catch {
+      return errorJson(c, 400, "invalid_json");
+    }
+
+    let envelope;
+    try {
+      envelope = decodeTrustEnvelope(raw);
+    } catch {
+      return errorJson(c, 400, "invalid_trust_envelope");
+    }
+
+    const result = deps.service.ingestEnvelope(envelope);
+    if (result.kind === "rejected") {
+      const remediation =
+        "remediation" in result.error ? result.error.remediation : undefined;
+      return errorJson(
+        c,
+        rejectionStatus(result.error),
+        result.error instanceof DependencyLedgerRejectedError
+          ? result.error.safe_code
+          : result.error instanceof KeyCustodyRejectedError
+            ? result.error.reason
+            : result.error instanceof TrustEnvelopeRejectedError
+              ? result.error.reason
+              : "rejected",
+        remediation,
+      );
+    }
+
+    const closure = deps.service.getDerivative(result.edge.derivative_key);
+    return c.json(
+      {
+        schema_version: 1,
+        event_id: result.edge.event_id,
+        edge_id: result.edge.edge_id,
+        derivative_key: result.edge.derivative_key,
+        replay: result.replay,
+        closure: closure
+          ? {
+              state: closure.state,
+              fulfillable: closure.fulfillable,
+              quarantine_reason: closure.quarantine_reason,
+              denied_reason: closure.denied_reason,
+            }
+          : null,
+      },
+      result.replay ? 200 : 201,
+      noStoreHeaders(),
+    );
+  });
+
+  app.get("/v1/dependency-ledger/derivatives/:derivative_kind/:derivative_id", (c) => {
+    if (!requireServiceBearer(c, deps.serviceToken)) {
+      return errorJson(c, 403, "unauthorized");
+    }
+
+    const derivativeKey = `${c.req.param("derivative_kind")}:${c.req.param("derivative_id")}`;
+    const closure = deps.service.getDerivative(derivativeKey);
+    if (closure === undefined) {
+      return c.json({ schema_version: 1, code: "derivative_not_found" }, 404, noStoreHeaders());
+    }
+
+    return c.json(
+      {
+        schema_version: 1,
+        derivative_key: closure.derivative_key,
+        derivative: closure.derivative,
+        state: closure.state,
+        fulfillable: closure.fulfillable,
+        required_edge_ids: closure.required_edge_ids,
+        received_edge_ids: closure.received_edge_ids,
+        quarantine_reason: closure.quarantine_reason,
+        denied_reason: closure.denied_reason,
+        repair_deadline_ms: closure.repair_deadline_ms,
+      },
+      200,
+      noStoreHeaders(),
+    );
+  });
+
+  app.get("/v1/dependency-ledger/metrics", (c) => {
+    if (!requireServiceBearer(c, deps.serviceToken)) {
+      return errorJson(c, 403, "unauthorized");
+    }
+
+    return c.json(
+      {
+        schema_version: 1,
+        metrics: deps.service.metrics(),
+        cr_011a_producer: "pending",
+        note: "Ordering inbox ready; G1B-1 Sonar producer replay blocked on CR-011A (f09.43).",
+      },
+      200,
+      noStoreHeaders(),
+    );
+  });
+}

--- a/packages/services/ordering/src/dependency-ledger-service.ts
+++ b/packages/services/ordering/src/dependency-ledger-service.ts
@@ -1,0 +1,77 @@
+import {
+  buildDependencyLedgerFixtureRegistryDocument,
+} from "@freeside/dependency-ledger-protocol";
+import {
+  buildTimeHealthSnapshot,
+  PinnedKeyRegistry,
+  type KeyCustodyClass,
+} from "@freeside/signing-key-custody-protocol";
+import type { TrustEnvelope } from "@freeside/trust-envelope-protocol";
+import type { DependencyLedgerStore } from "./dependency-ledger-store.js";
+
+export interface DependencyLedgerServiceOptions {
+  readonly store: DependencyLedgerStore;
+  readonly now: () => number;
+  readonly intakeContext?: KeyCustodyClass;
+  readonly registryDocument?: ReturnType<typeof buildDependencyLedgerFixtureRegistryDocument>;
+}
+
+export class DependencyLedgerService {
+  private readonly store: DependencyLedgerStore;
+  private readonly now: () => number;
+  private readonly intakeContext: KeyCustodyClass;
+  private readonly pinnedRegistry: PinnedKeyRegistry;
+
+  constructor(options: DependencyLedgerServiceOptions) {
+    this.store = options.store;
+    this.now = options.now;
+    this.intakeContext = options.intakeContext ?? "fixture";
+    this.pinnedRegistry = new PinnedKeyRegistry(
+      options.registryDocument ?? buildDependencyLedgerFixtureRegistryDocument(),
+    );
+  }
+
+  ingestEnvelope(envelope: TrustEnvelope) {
+    const acceptedAtMs = this.now();
+    const timeHealth = buildTimeHealthSnapshot({
+      evaluatedAtMs: acceptedAtMs,
+      databaseUnixMs: acceptedAtMs,
+      authoritativeSources: [
+        {
+          source_id: "ordering-db",
+          observed_at: new Date(acceptedAtMs).toISOString(),
+          unix_ms: acceptedAtMs,
+          uncertainty_ms: 0,
+        },
+        {
+          source_id: "ordering-ntp",
+          observed_at: new Date(acceptedAtMs).toISOString(),
+          unix_ms: acceptedAtMs,
+          uncertainty_ms: 5,
+        },
+      ],
+    });
+
+    return this.store.ingestEnvelope({
+      envelope,
+      pinnedRegistry: this.pinnedRegistry,
+      timeHealth,
+      acceptedAtMs,
+      intakeContext: this.intakeContext,
+    });
+  }
+
+  getDerivative(derivativeKey: string) {
+    return this.store.getDerivative(derivativeKey);
+  }
+
+  metrics() {
+    return this.store.snapshotMetrics();
+  }
+}
+
+export const createFixtureDependencyLedgerService = (
+  store: DependencyLedgerStore,
+  now: () => number = () => Date.now(),
+): DependencyLedgerService =>
+  new DependencyLedgerService({ store, now, intakeContext: "fixture" });

--- a/packages/services/ordering/src/dependency-ledger-store.ts
+++ b/packages/services/ordering/src/dependency-ledger-store.ts
@@ -1,0 +1,81 @@
+import type {
+  DependencyLedgerInboxState,
+  DerivativeClosureRecord,
+  LedgerEdgeRecord,
+  QuarantineMetrics,
+  ReconciliationExpectation,
+  ReconciliationReport,
+} from "@freeside/dependency-ledger-protocol";
+import {
+  createDependencyLedgerInboxState,
+  ingestDependencyEdgeEnvelope,
+  reconcileLedger,
+} from "@freeside/dependency-ledger-protocol";
+import type { TrustEnvelope } from "@freeside/trust-envelope-protocol";
+import type {
+  KeyCustodyClass,
+  PinnedKeyRegistry,
+  TimeHealthSnapshot,
+} from "@freeside/signing-key-custody-protocol";
+
+export interface DependencyLedgerStore {
+  ingestEnvelope(input: {
+    envelope: TrustEnvelope;
+    pinnedRegistry: PinnedKeyRegistry;
+    timeHealth: TimeHealthSnapshot;
+    acceptedAtMs: number;
+    intakeContext: KeyCustodyClass;
+  }): ReturnType<typeof ingestDependencyEdgeEnvelope>;
+  getDerivative(derivativeKey: string): DerivativeClosureRecord | undefined;
+  getEdgeByEventId(eventId: string): LedgerEdgeRecord | undefined;
+  reconcile(
+    expectations: readonly ReconciliationExpectation[],
+    nowMs: number,
+  ): ReconciliationReport;
+  snapshotMetrics(): QuarantineMetrics;
+  snapshotState(): DependencyLedgerInboxState;
+}
+
+export class InMemoryDependencyLedgerStore implements DependencyLedgerStore {
+  readonly #state: DependencyLedgerInboxState = createDependencyLedgerInboxState();
+
+  ingestEnvelope(input: {
+    envelope: TrustEnvelope;
+    pinnedRegistry: PinnedKeyRegistry;
+    timeHealth: TimeHealthSnapshot;
+    acceptedAtMs: number;
+    intakeContext: KeyCustodyClass;
+  }) {
+    return ingestDependencyEdgeEnvelope({
+      envelope: input.envelope,
+      pinnedRegistry: input.pinnedRegistry,
+      timeHealth: input.timeHealth,
+      acceptedAtMs: input.acceptedAtMs,
+      state: this.#state,
+      intakeContext: input.intakeContext,
+    });
+  }
+
+  getDerivative(derivativeKey: string): DerivativeClosureRecord | undefined {
+    return this.#state.derivatives.get(derivativeKey);
+  }
+
+  getEdgeByEventId(eventId: string): LedgerEdgeRecord | undefined {
+    return this.#state.edgesByEventId.get(eventId);
+  }
+
+  reconcile(
+    expectations: readonly ReconciliationExpectation[],
+    nowMs: number,
+  ): ReconciliationReport {
+    return reconcileLedger(this.#state, expectations, nowMs);
+  }
+
+  snapshotMetrics(): QuarantineMetrics {
+    return { ...this.#state.metrics };
+  }
+
+  snapshotState(): DependencyLedgerInboxState {
+    return this.#state;
+  }
+}

--- a/packages/services/ordering/src/index.ts
+++ b/packages/services/ordering/src/index.ts
@@ -220,3 +220,12 @@ export {
   sonarResolveProbeFromEnv,
 } from './sonar-resolve-probe-client.js';
 export { createCatalogResolveProbePort } from './catalog-resolve-probe.js';
+export {
+  InMemoryDependencyLedgerStore,
+  type DependencyLedgerStore,
+} from './dependency-ledger-store.js';
+export {
+  DependencyLedgerService,
+  createFixtureDependencyLedgerService,
+} from './dependency-ledger-service.js';
+export { mountDependencyLedgerRoutes } from './dependency-ledger-http.js';


### PR DESCRIPTION
## Summary

- Adds `@freeside/dependency-ledger-protocol` (CR-012A): dependency-edge body contract, CR-013 intake gate + CR-009 trust-envelope inbox chain, derivative quarantine/closure, signing-key compromise and collection-equivalence invalidation, reconciliation, and fixture vectors for lost/duplicate/delayed/compromise/backfill/mixed-minor scenarios.
- Wires Ordering service HTTP inbox (`POST /v1/dependency-ledger/inbox/envelopes`), derivative closure read, and quarantine metrics behind fixture registry + in-memory store.

## CR-011A dependency (honest)

Bead graph lists **CR-011A (Sonar public trust-stream producer, f09.43)** as a blocker. This PR lands the **Ordering consumer/inbox** only. G1B-1 (`EV-G1B1-sonar-ordering-replay`) remains blocked until Sonar emits signed outbox edges. Metrics endpoint reports `cr_011a_producer: pending`.

## Not in scope

- No fake **Ready** / fulfillment unlock.
- No **CR-007B** restricted path.
- No Postgres persistence, production registry pin, or shared-work fan-in (CR-201A/204A).

## Test plan

- [x] `pnpm --dir packages/protocol/dependency-ledger test` (7 tests: closure, inbox, compromise, replay, mixed-minor)
- [x] `pnpm --dir packages/services/ordering exec vitest run src/__tests__/dependency-ledger-service.test.ts`
- [ ] CI green on PR
- [ ] After CR-011A merges: replay Sonar producer vectors through Ordering inbox for G1B-1


Made with [Cursor](https://cursor.com)