### PR TITLE
feat(ordering): CR-201A public shared preparation persistence

### DIFF
--- a/packages/services/ordering/migrations/007_shared_preparation_work.sql
+++ b/packages/services/ordering/migrations/007_shared_preparation_work.sql
@@ -45,7 +45,8 @@ CREATE TABLE IF NOT EXISTS shared_preparation_work (
   CONSTRAINT shared_preparation_work_unique_generation UNIQUE (work_key_digest, generation)
 );
 
-CREATE INDEX IF NOT EXISTS shared_preparation_work_key_active_idx
+-- Active is exactly queued/preparing/retry_wait; one active row per work key.
+CREATE UNIQUE INDEX IF NOT EXISTS shared_preparation_work_key_active_idx
   ON shared_preparation_work (work_key_digest)
   WHERE state IN ('queued', 'preparing', 'retry_wait');
 

--- a/packages/services/ordering/migrations/007_shared_preparation_work.sql
+++ b/packages/services/ordering/migrations/007_shared_preparation_work.sql
@@ -1,0 +1,100 @@
+-- CR-201A expand: public shared preparation persistence (T1 fixtures only).
+-- Expand-only: no destructive DDL. Restricted Discord/identity evidence is CR-201B.
+
+CREATE TABLE IF NOT EXISTS shared_preparation_work (
+  work_id                   TEXT PRIMARY KEY,
+  work_key_digest           TEXT NOT NULL,
+  deployment_set_digest     TEXT NOT NULL,
+  capability                TEXT NOT NULL,
+  capability_version        TEXT NOT NULL,
+  scope_class               TEXT NOT NULL DEFAULT 'deployment',
+  scope_digest              TEXT NOT NULL,
+  privacy_class             TEXT NOT NULL DEFAULT 'public_chain',
+  source_identity           JSONB NOT NULL,
+  readiness_policy_version  TEXT NOT NULL,
+  evidence_boundary_kind    TEXT NOT NULL,
+  evidence_boundary_digest  TEXT,
+  adapter_version           TEXT NOT NULL,
+  finality_policy_version   TEXT NOT NULL,
+  state                     TEXT NOT NULL,
+  generation                INTEGER NOT NULL,
+  readiness_evidence        JSONB,
+  attempt                   INTEGER NOT NULL DEFAULT 0,
+  next_attempt_at           TIMESTAMPTZ,
+  retry_deadline            TIMESTAMPTZ,
+  lease_until               TIMESTAMPTZ,
+  lease_epoch               BIGINT NOT NULL DEFAULT 0,
+  failure_reason            JSONB,
+  sharing_scope_kind        TEXT NOT NULL DEFAULT 'public',
+  work_tenant_scope_digest  TEXT,
+  created_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT shared_preparation_work_state_check CHECK (
+    state IN ('queued', 'preparing', 'retry_wait', 'ready', 'failed', 'abandoned', 'superseded')
+  ),
+  CONSTRAINT shared_preparation_work_privacy_public_only CHECK (
+    privacy_class = 'public_chain'
+  ),
+  CONSTRAINT shared_preparation_work_sharing_scope_public CHECK (
+    sharing_scope_kind = 'public' AND work_tenant_scope_digest IS NULL
+  ),
+  CONSTRAINT shared_preparation_work_capability_public CHECK (
+    capability IN ('collection_identity.v1', 'ownership_index.v1')
+  ),
+  CONSTRAINT shared_preparation_work_generation_positive CHECK (generation >= 1),
+  CONSTRAINT shared_preparation_work_unique_generation UNIQUE (work_key_digest, generation)
+);
+
+CREATE INDEX IF NOT EXISTS shared_preparation_work_key_active_idx
+  ON shared_preparation_work (work_key_digest)
+  WHERE state IN ('queued', 'preparing', 'retry_wait');
+
+CREATE INDEX IF NOT EXISTS shared_preparation_work_ready_idx
+  ON shared_preparation_work (work_key_digest, generation DESC)
+  WHERE state = 'ready';
+
+CREATE TABLE IF NOT EXISTS preparation_work_items (
+  work_item_id              TEXT PRIMARY KEY,
+  work_id                   TEXT NOT NULL REFERENCES shared_preparation_work (work_id),
+  deployment_id             JSONB NOT NULL,
+  capability                TEXT NOT NULL,
+  adapter_version           TEXT NOT NULL,
+  external_job_ref          TEXT,
+  state                     TEXT NOT NULL,
+  attempt                   INTEGER NOT NULL DEFAULT 0,
+  lease_epoch               BIGINT NOT NULL DEFAULT 0,
+  evidence_envelope         JSONB,
+  failure_reason            JSONB,
+  created_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT preparation_work_items_state_check CHECK (
+    state IN ('queued', 'preparing', 'retry_wait', 'ready', 'failed', 'abandoned', 'superseded')
+  ),
+  CONSTRAINT preparation_work_items_unique_deployment UNIQUE (work_id, deployment_id)
+);
+
+CREATE INDEX IF NOT EXISTS preparation_work_items_work_idx
+  ON preparation_work_items (work_id);
+
+CREATE TABLE IF NOT EXISTS report_work_links (
+  order_id                  TEXT NOT NULL REFERENCES orders (order_id),
+  work_id                   TEXT NOT NULL REFERENCES shared_preparation_work (work_id),
+  joined_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  detached_at               TIMESTAMPTZ,
+  generation                INTEGER NOT NULL,
+  order_tenant_scope_digest TEXT NOT NULL,
+  sharing_scope_kind        TEXT NOT NULL DEFAULT 'public',
+  work_tenant_scope_digest  TEXT,
+  PRIMARY KEY (order_id, work_id),
+  CONSTRAINT report_work_links_public_scope CHECK (
+    sharing_scope_kind = 'public' AND work_tenant_scope_digest IS NULL
+  )
+);
+
+CREATE INDEX IF NOT EXISTS report_work_links_work_active_idx
+  ON report_work_links (work_id)
+  WHERE detached_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS report_work_links_order_active_idx
+  ON report_work_links (order_id)
+  WHERE detached_at IS NULL;

--- a/packages/services/ordering/src/__tests__/shared-preparation-fixtures.ts
+++ b/packages/services/ordering/src/__tests__/shared-preparation-fixtures.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createHash } from "node:crypto";
+import { decodeCollectionCandidate } from "@freeside/collection-protocol";
+import { Effect } from "effect";
+import {
+  buildPublicWorkKeyMaterial,
+  digestPublicWorkKey,
+} from "../shared-preparation-work-key.js";
+import type {
+  PublicPreparationWorkKeyMaterial,
+  ReadinessEvidenceEnvelope,
+  VersionedDigest,
+} from "../shared-preparation-types.js";
+
+const fixtureDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../protocol/collection/fixtures",
+);
+
+function runEffect<A>(effect: Effect.Effect<A, unknown>): A {
+  return Effect.runSync(effect);
+}
+
+export function loadEvmFixtureCandidate() {
+  const raw = JSON.parse(readFileSync(join(fixtureDir, "evm-candidate.valid.json"), "utf8"));
+  return runEffect(decodeCollectionCandidate(raw));
+}
+
+export function fixturePublicWorkKey(input?: {
+  capability?: "collection_identity.v1" | "ownership_index.v1";
+  communityScopeDigest?: string;
+}): PublicPreparationWorkKeyMaterial {
+  const candidate = loadEvmFixtureCandidate();
+  const deploymentIds = candidate.identity.deployments.map((d) => d.deployment_id);
+  return buildPublicWorkKeyMaterial({
+    capability: input?.capability ?? "ownership_index.v1",
+    capability_version: "v1",
+    collection_id: candidate.identity.collection_id,
+    deployment_ids: deploymentIds,
+    finality_policies: candidate.finality_policies,
+    source_identity: {
+      schema_version: 1,
+      producer: "sonar-api.fixture",
+      upstream_evidence_source: "sonar.public-capability.v1",
+    },
+    readiness_policy_version: "gate-leak-public-prep.v1",
+    adapter_version: "sonar-kitchen.v1",
+  });
+}
+
+export function fixtureCommunityScopeDigest(communityRef: string): string {
+  return createHash("sha256").update(`community:${communityRef}`).digest("hex");
+}
+
+export function fixtureReadinessEvidence(deploymentIds: readonly VersionedDigest[]): ReadinessEvidenceEnvelope {
+  const digest = (domain: string, seed: string): VersionedDigest => ({
+    algorithm: "sha-256",
+    domain,
+    major_version: 1,
+    digest: createHash("sha256").update(seed).digest("hex"),
+  });
+  return {
+    schema_version: 1,
+    producer: "sonar-api.fixture",
+    schema: "collection.public-evidence.v1",
+    adapter: "sonar-kitchen.v1",
+    readiness_policy_version: "gate-leak-public-prep.v1",
+    privacy_scope: "public_chain",
+    deployment_coverage: [...deploymentIds],
+    observation_window: {
+      observed_at: "2026-07-17T21:00:00.000Z",
+      as_of: "2026-07-17T21:00:00.000Z",
+    },
+    freshness: {
+      qualified: true,
+      max_age_ms: 60_000,
+    },
+    source_digest: digest("collection.evidence-source", "fixture-source"),
+    evidence_digest: digest("collection.evidence", "fixture-evidence"),
+  };
+}
+
+export function fixtureWorkKeyDigest(key: PublicPreparationWorkKeyMaterial): string {
+  return digestPublicWorkKey(key);
+}

--- a/packages/services/ordering/src/__tests__/shared-preparation-migration.test.ts
+++ b/packages/services/ordering/src/__tests__/shared-preparation-migration.test.ts
@@ -12,7 +12,12 @@ describe("CR-201A migration rollback safety", () => {
     expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS shared_preparation_work/);
     expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS preparation_work_items/);
     expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS report_work_links/);
-    expect(sql).toMatch(/shared_preparation_work_key_active_idx/);
+    expect(sql).toMatch(
+      /CREATE UNIQUE INDEX IF NOT EXISTS shared_preparation_work_key_active_idx/,
+    );
+    expect(sql).toMatch(
+      /WHERE state IN \('queued', 'preparing', 'retry_wait'\)/,
+    );
     expect(sql).toMatch(/capability IN \('collection_identity\.v1', 'ownership_index\.v1'\)/);
     expect(sql).toMatch(/privacy_class = 'public_chain'/);
   });

--- a/packages/services/ordering/src/__tests__/shared-preparation-migration.test.ts
+++ b/packages/services/ordering/src/__tests__/shared-preparation-migration.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+describe("CR-201A migration rollback safety", () => {
+  it("007_shared_preparation_work.sql is expand-only", () => {
+    const dir = dirname(fileURLToPath(import.meta.url));
+    const sql = readFileSync(join(dir, "../../migrations/007_shared_preparation_work.sql"), "utf8");
+    expect(sql).not.toMatch(/\bDROP\b/i);
+    expect(sql).not.toMatch(/\bTRUNCATE\b/i);
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS shared_preparation_work/);
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS preparation_work_items/);
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS report_work_links/);
+    expect(sql).toMatch(/shared_preparation_work_key_active_idx/);
+    expect(sql).toMatch(/capability IN \('collection_identity\.v1', 'ownership_index\.v1'\)/);
+    expect(sql).toMatch(/privacy_class = 'public_chain'/);
+  });
+});

--- a/packages/services/ordering/src/__tests__/shared-preparation-postgres.test.ts
+++ b/packages/services/ordering/src/__tests__/shared-preparation-postgres.test.ts
@@ -1,0 +1,243 @@
+/**
+ * CR-201A Postgres behavioral suite (F4).
+ *
+ * Gated on ORDERING_PG_TEST_URL (or DATABASE_URL when ORDERING_PG_TEST=1).
+ * Skips cleanly when unset — no Docker required for unit CI.
+ *
+ *   ORDERING_PG_TEST_URL=postgres://… pnpm exec vitest run \
+ *     src/__tests__/shared-preparation-postgres.test.ts
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import pg from "pg";
+import { PostgresSharedPreparationStore } from "../shared-preparation-store-postgres.js";
+import { digestPublicWorkKey } from "../shared-preparation-work-key.js";
+import {
+  fixtureCommunityScopeDigest,
+  fixturePublicWorkKey,
+  fixtureReadinessEvidence,
+} from "./shared-preparation-fixtures.js";
+
+const pgUrl =
+  process.env.ORDERING_PG_TEST_URL ??
+  (process.env.ORDERING_PG_TEST === "1" ? process.env.DATABASE_URL : undefined);
+
+const describePg = describe.skipIf(!pgUrl);
+
+async function seedOrder(pool: pg.Pool, orderId: string): Promise<void> {
+  const now = Math.floor(Date.now() / 1000);
+  await pool.query(
+    `INSERT INTO orders (
+      order_id, product, placed_by, inputs, inputs_digest, state,
+      placed_at_unix, created_at_unix, updated_at_unix
+    ) VALUES ($1, 'collection-report', 'subject-fixture', '{}'::jsonb, 'digest', 'placed', $2, $2, $2)
+    ON CONFLICT (order_id) DO NOTHING`,
+    [orderId, now],
+  );
+}
+
+describePg("CR-201A Postgres shared preparation store", () => {
+  let store: PostgresSharedPreparationStore;
+  let pool: pg.Pool;
+
+  beforeAll(async () => {
+    store = await PostgresSharedPreparationStore.connect(pgUrl!, { migrate: true });
+    pool = store.getPool();
+    // Ensure unique index statement is present in applied migration text.
+    const migration = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "../../migrations/007_shared_preparation_work.sql"),
+      "utf8",
+    );
+    expect(migration).toMatch(/CREATE UNIQUE INDEX IF NOT EXISTS shared_preparation_work_key_active_idx/);
+  }, 60_000);
+
+  afterAll(async () => {
+    await store.close();
+  });
+
+  it("joins, leases, retries, abandons, and reaches ready under fencing", async () => {
+    const workKey = fixturePublicWorkKey({ capability: "collection_identity.v1" });
+    const orderA = `ord_pg_a_${Date.now()}`;
+    const orderB = `ord_pg_b_${Date.now()}`;
+    await seedOrder(pool, orderA);
+    await seedOrder(pool, orderB);
+
+    const joined = await store.joinPublicWork({
+      order_id: orderA,
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+      work_key: workKey,
+      now_ms: Date.now(),
+    });
+    expect(joined.kind).toBe("joined");
+    if (joined.kind !== "joined") return;
+
+    const fanIn = await store.joinPublicWork({
+      order_id: orderB,
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+      work_key: workKey,
+      now_ms: Date.now(),
+    });
+    expect(fanIn.kind).toBe("joined");
+    if (fanIn.kind !== "joined") return;
+    expect(fanIn.work.work_id).toBe(joined.work.work_id);
+    expect(fanIn.created).toBe(false);
+
+    const lease = await store.acquireLease({
+      work_id: joined.work.work_id,
+      worker_id: "pg-worker",
+      lease_duration_ms: 30_000,
+      now_ms: Date.now(),
+    });
+    expect(lease.kind).toBe("acquired");
+    if (lease.kind !== "acquired") return;
+
+    await store.transitionToPreparing({
+      work_id: joined.work.work_id,
+      expected_lease_epoch: lease.work.lease_epoch,
+      now_ms: Date.now(),
+    });
+
+    const failed = await store.recordRetryableFailure({
+      work_id: joined.work.work_id,
+      expected_lease_epoch: lease.work.lease_epoch,
+      next_attempt_at_unix_ms: Date.now() - 1,
+      retry_deadline_unix_ms: Date.now() + 86_400_000,
+      failure: { code: "dependency_unavailable", reason: "pg fixture" },
+      now_ms: Date.now(),
+    });
+    expect(failed.state).toBe("retry_wait");
+
+    const woke = await store.wakeRetryWait({
+      work_id: joined.work.work_id,
+      expected_attempt: failed.attempt,
+      now_ms: Date.now(),
+    });
+    expect(woke.kind).toBe("woke");
+
+    const lease2 = await store.acquireLease({
+      work_id: joined.work.work_id,
+      worker_id: "pg-worker-2",
+      lease_duration_ms: 30_000,
+      now_ms: Date.now(),
+    });
+    expect(lease2.kind === "acquired" || lease2.kind === "reclaimed").toBe(true);
+    if (lease2.kind !== "acquired" && lease2.kind !== "reclaimed") return;
+
+    await store.transitionToPreparing({
+      work_id: joined.work.work_id,
+      expected_lease_epoch: lease2.work.lease_epoch,
+      now_ms: Date.now(),
+    });
+
+    const evidence = fixtureReadinessEvidence(workKey.deployment_ids);
+    for (const item of await store.listWorkItems(joined.work.work_id)) {
+      await store.publishChildEvidence({
+        work_item_id: item.work_item_id,
+        expected_lease_epoch: lease2.work.lease_epoch,
+        evidence,
+        now_ms: Date.now(),
+      });
+    }
+
+    const ready = await store.finalizeReadyIfQualified({
+      work_id: joined.work.work_id,
+      expected_lease_epoch: lease2.work.lease_epoch,
+      readiness_evidence: evidence,
+      now_ms: Date.now(),
+    });
+    expect(ready.kind).toBe("ready");
+
+    await store.detachSubscriber({
+      order_id: orderA,
+      work_id: joined.work.work_id,
+      now_ms: Date.now(),
+    });
+    const stillReady = await store.getWork(joined.work.work_id);
+    expect(stillReady?.state).toBe("ready");
+  });
+
+  it("enforces unique active work key via partial unique index", async () => {
+    const workKey = fixturePublicWorkKey({ capability: "ownership_index.v1" });
+    const workKeyDigest = digestPublicWorkKey(workKey);
+    const orderId = `ord_pg_uniq_${Date.now()}`;
+    await seedOrder(pool, orderId);
+
+    const joined = await store.joinPublicWork({
+      order_id: orderId,
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+      work_key: workKey,
+      now_ms: Date.now(),
+    });
+    expect(joined.kind).toBe("joined");
+
+    await expect(
+      pool.query(
+        `INSERT INTO shared_preparation_work (
+          work_id, work_key_digest, deployment_set_digest, capability, capability_version,
+          scope_digest, source_identity, readiness_policy_version, evidence_boundary_kind,
+          adapter_version, finality_policy_version, state, generation, attempt, lease_epoch
+        ) VALUES (
+          $1, $2, 'depset', 'ownership_index.v1', 'v1',
+          'scope', '{}'::jsonb, 'gate-leak-public-prep.v1', 'continuous_latest',
+          'sonar-kitchen.v1', 'finality', 'queued', 99, 0, 0
+        )`,
+        [`spw_conflict_${Date.now()}`, workKeyDigest],
+      ),
+    ).rejects.toMatchObject({ code: "23505" });
+  });
+
+  it("does not abandon when a concurrent join reattaches before commit", async () => {
+    const workKey = fixturePublicWorkKey({ capability: "ownership_index.v1" });
+    const orderDetach = `ord_pg_det_${Date.now()}`;
+    const orderJoin = `ord_pg_join_${Date.now()}`;
+    await seedOrder(pool, orderDetach);
+    await seedOrder(pool, orderJoin);
+
+    const joined = await store.joinPublicWork({
+      order_id: orderDetach,
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+      work_key: workKey,
+      now_ms: Date.now(),
+    });
+    if (joined.kind !== "joined") throw new Error("join failed");
+
+    const [detachResult, joinResult] = await Promise.all([
+      store.detachSubscriber({
+        order_id: orderDetach,
+        work_id: joined.work.work_id,
+        now_ms: Date.now(),
+      }),
+      store.joinPublicWork({
+        order_id: orderJoin,
+        order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+        work_key: workKey,
+        now_ms: Date.now(),
+      }),
+    ]);
+
+    expect(detachResult.kind === "detached" || detachResult.kind === "not_linked").toBe(true);
+    expect(joinResult.kind === "joined" || joinResult.kind === "serialization_retry").toBe(true);
+
+    if (joinResult.kind === "joined") {
+      const work = await store.getWork(joinResult.work.work_id);
+      const links = await store.listActiveLinks(joinResult.work.work_id);
+      if (work && ["queued", "preparing", "retry_wait"].includes(work.state)) {
+        expect(links.length).toBeGreaterThan(0);
+        expect(work.state).not.toBe("abandoned");
+      }
+    }
+  });
+});
+
+describe("CR-201A Postgres suite gate", () => {
+  it("documents ORDERING_PG_TEST_URL skip behavior", () => {
+    if (!pgUrl) {
+      expect(pgUrl).toBeFalsy();
+    } else {
+      expect(pgUrl).toMatch(/^postgres/);
+    }
+  });
+});

--- a/packages/services/ordering/src/__tests__/shared-preparation-postgres.test.ts
+++ b/packages/services/ordering/src/__tests__/shared-preparation-postgres.test.ts
@@ -218,7 +218,11 @@ describePg("CR-201A Postgres shared preparation store", () => {
       }),
     ]);
 
-    expect(detachResult.kind === "detached" || detachResult.kind === "not_linked").toBe(true);
+    expect(
+      detachResult.kind === "detached" ||
+        detachResult.kind === "not_linked" ||
+        detachResult.kind === "serialization_retry",
+    ).toBe(true);
     expect(joinResult.kind === "joined" || joinResult.kind === "serialization_retry").toBe(true);
 
     if (joinResult.kind === "joined") {

--- a/packages/services/ordering/src/__tests__/shared-preparation-store.test.ts
+++ b/packages/services/ordering/src/__tests__/shared-preparation-store.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, it } from "vitest";
+import {
+  countActiveRows,
+  InMemorySharedPreparationStore,
+  SharedPreparationFencingError,
+} from "../shared-preparation-store.js";
+import { buildPublicWorkKeyMaterial } from "../shared-preparation-work-key.js";
+import { PUBLIC_PREP_CAPABILITIES } from "../shared-preparation-types.js";
+import {
+  fixtureCommunityScopeDigest,
+  fixturePublicWorkKey,
+  fixtureReadinessEvidence,
+  fixtureWorkKeyDigest,
+  loadEvmFixtureCandidate,
+} from "./shared-preparation-fixtures.js";
+
+describe("CR-201A public shared preparation store", () => {
+  it("enforces one active work row per work key under 100 equivalent joiners", async () => {
+    const store = new InMemorySharedPreparationStore();
+    const workKey = fixturePublicWorkKey();
+    const digest = fixtureWorkKeyDigest(workKey);
+    const now = Date.parse("2026-07-17T22:00:00.000Z");
+
+    const results = await Promise.all(
+      Array.from({ length: 100 }, (_, index) =>
+        store.joinPublicWork({
+          order_id: `ord_join_${index}`,
+          order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+          work_key: workKey,
+          now_ms: now + index,
+        }),
+      ),
+    );
+
+    for (const result of results) {
+      expect(result.kind).toBe("joined");
+      if (result.kind !== "joined") continue;
+      expect(result.work.work_key_digest).toBe(digest);
+    }
+
+    const workIds = new Set(
+      results
+        .filter((result): result is Extract<typeof result, { kind: "joined" }> => result.kind === "joined")
+        .map((result) => result.work.work_id),
+    );
+    expect(workIds.size).toBe(1);
+    expect(countActiveRows(store, digest)).toBe(1);
+
+    const links = await store.listActiveLinks([...workIds][0]!);
+    expect(links).toHaveLength(100);
+  });
+
+  it("does not share community-scoped keys across different scope digests", async () => {
+    const store = new InMemorySharedPreparationStore();
+    const candidate = loadEvmFixtureCandidate();
+    const deploymentIds = candidate.identity.deployments.map((d) => d.deployment_id);
+
+    const alphaKey = buildPublicWorkKeyMaterial({
+      capability: "ownership_index.v1",
+      capability_version: "v1",
+      collection_id: candidate.identity.collection_id,
+      deployment_ids: deploymentIds,
+      finality_policies: candidate.finality_policies,
+      source_identity: {
+        schema_version: 1,
+        producer: "sonar-api.fixture",
+        upstream_evidence_source: "sonar.public-capability.v1",
+      },
+      readiness_policy_version: "gate-leak-public-prep.v1",
+      adapter_version: "sonar-kitchen.v1",
+    });
+
+    const betaKey = buildPublicWorkKeyMaterial({
+      ...{
+        capability: "ownership_index.v1" as const,
+        capability_version: "v1",
+        collection_id: candidate.identity.collection_id,
+        deployment_ids: deploymentIds,
+        finality_policies: candidate.finality_policies,
+        source_identity: {
+          schema_version: 1,
+          producer: "sonar-api.fixture",
+          upstream_evidence_source: "sonar.public-capability.v1",
+        },
+        readiness_policy_version: "gate-leak-community-beta.v1",
+        adapter_version: "sonar-kitchen.v1",
+      },
+    });
+
+    expect(fixtureWorkKeyDigest(alphaKey)).not.toEqual(fixtureWorkKeyDigest(betaKey));
+
+    const first = await store.joinPublicWork({
+      order_id: "ord_alpha",
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+      work_key: alphaKey,
+      now_ms: 1,
+    });
+    const second = await store.joinPublicWork({
+      order_id: "ord_beta",
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-beta"),
+      work_key: betaKey,
+      now_ms: 2,
+    });
+
+    expect(first.kind).toBe("joined");
+    expect(second.kind).toBe("joined");
+    if (first.kind !== "joined" || second.kind !== "joined") return;
+    expect(first.work.work_id).not.toEqual(second.work.work_id);
+  });
+
+  it("increments lease epoch on reclaim and rejects stale fenced writes", async () => {
+    const store = new InMemorySharedPreparationStore();
+    const workKey = fixturePublicWorkKey();
+    const joined = await store.joinPublicWork({
+      order_id: "ord_lease",
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+      work_key: workKey,
+      now_ms: 1_000,
+    });
+    expect(joined.kind).toBe("joined");
+    if (joined.kind !== "joined") return;
+
+    const acquired = await store.acquireLease({
+      work_id: joined.work.work_id,
+      worker_id: "worker-a",
+      lease_duration_ms: 30_000,
+      now_ms: 2_000,
+    });
+    expect(acquired.kind).toBe("acquired");
+    if (acquired.kind !== "acquired") return;
+    expect(acquired.work.lease_epoch).toBe(1);
+
+    const preparing = await store.transitionToPreparing({
+      work_id: joined.work.work_id,
+      expected_lease_epoch: 1,
+      now_ms: 2_500,
+    });
+    expect(preparing.state).toBe("preparing");
+
+    const reclaimed = await store.acquireLease({
+      work_id: joined.work.work_id,
+      worker_id: "worker-b",
+      lease_duration_ms: 30_000,
+      now_ms: 40_000,
+    });
+    expect(reclaimed.kind).toBe("reclaimed");
+    if (reclaimed.kind !== "reclaimed") return;
+    expect(reclaimed.work.lease_epoch).toBe(2);
+
+    await expect(
+      store.publishChildEvidence({
+        work_item_id: (await store.listWorkItems(joined.work.work_id))[0]!.work_item_id,
+        expected_lease_epoch: 1,
+        evidence: fixtureReadinessEvidence(workKey.deployment_ids),
+        now_ms: 40_500,
+      }),
+    ).rejects.toBeInstanceOf(SharedPreparationFencingError);
+  });
+
+  it("persists retry scheduling with CAS wake and stale wake rejection", async () => {
+    const store = new InMemorySharedPreparationStore();
+    const workKey = fixturePublicWorkKey();
+    const joined = await store.joinPublicWork({
+      order_id: "ord_retry",
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+      work_key: workKey,
+      now_ms: 1_000,
+    });
+    if (joined.kind !== "joined") throw new Error("join failed");
+
+    const lease = await store.acquireLease({
+      work_id: joined.work.work_id,
+      worker_id: "worker-a",
+      lease_duration_ms: 30_000,
+      now_ms: 2_000,
+    });
+    if (lease.kind !== "acquired") throw new Error("lease failed");
+
+    await store.transitionToPreparing({
+      work_id: joined.work.work_id,
+      expected_lease_epoch: lease.work.lease_epoch,
+      now_ms: 2_500,
+    });
+
+    const failed = await store.recordRetryableFailure({
+      work_id: joined.work.work_id,
+      expected_lease_epoch: lease.work.lease_epoch,
+      next_attempt_at_unix_ms: 10_000,
+      retry_deadline_unix_ms: 604_800_000,
+      failure: { code: "dependency_unavailable", reason: "fixture capacity" },
+      now_ms: 3_000,
+    });
+    expect(failed.state).toBe("retry_wait");
+    expect(failed.attempt).toBe(1);
+    expect(failed.lease_until_unix_ms).toBeUndefined();
+
+    const staleWake = await store.wakeRetryWait({
+      work_id: joined.work.work_id,
+      expected_next_attempt_at_unix_ms: 9_000,
+      now_ms: 10_000,
+    });
+    expect(staleWake.kind).toBe("stale_wake");
+
+    const woke = await store.wakeRetryWait({
+      work_id: joined.work.work_id,
+      expected_next_attempt_at_unix_ms: 10_000,
+      now_ms: 10_000,
+    });
+    expect(woke.kind).toBe("woke");
+  });
+
+  it("fans subscriber transitions through shared work and abandons on zero subscribers", async () => {
+    const store = new InMemorySharedPreparationStore();
+    const workKey = fixturePublicWorkKey();
+    const joinedA = await store.joinPublicWork({
+      order_id: "ord_fan_a",
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+      work_key: workKey,
+      now_ms: 1,
+    });
+    const joinedB = await store.joinPublicWork({
+      order_id: "ord_fan_b",
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+      work_key: workKey,
+      now_ms: 2,
+    });
+    if (joinedA.kind !== "joined" || joinedB.kind !== "joined") throw new Error("join failed");
+    expect(joinedA.work.work_id).toBe(joinedB.work.work_id);
+
+    await store.detachSubscriber({
+      order_id: "ord_fan_a",
+      work_id: joinedA.work.work_id,
+      now_ms: 10,
+    });
+    const mid = await store.getWork(joinedA.work.work_id);
+    expect(mid?.state).toBe("queued");
+
+    const abandoned = await store.detachSubscriber({
+      order_id: "ord_fan_b",
+      work_id: joinedA.work.work_id,
+      now_ms: 11,
+    });
+    expect(abandoned.kind).toBe("detached");
+    expect(abandoned.kind === "detached" ? abandoned.work?.state : undefined).toBe("abandoned");
+  });
+
+  it("supersedes active generation atomically before inserting successor", async () => {
+    const store = new InMemorySharedPreparationStore();
+    const workKey = fixturePublicWorkKey();
+    const digest = fixtureWorkKeyDigest(workKey);
+    const first = await store.joinPublicWork({
+      order_id: "ord_gen_1",
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+      work_key: workKey,
+      now_ms: 1,
+    });
+    if (first.kind !== "joined") throw new Error("join failed");
+
+    const superseded = await store.supersedeActiveGeneration({
+      work_key_digest: digest,
+      now_ms: 2,
+    });
+    expect(superseded?.state).toBe("superseded");
+
+    const second = await store.joinPublicWork({
+      order_id: "ord_gen_2",
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+      work_key: workKey,
+      now_ms: 3,
+    });
+    if (second.kind !== "joined") throw new Error("join failed");
+    expect(second.work.generation).toBe(2);
+    expect(second.created).toBe(true);
+    expect(countActiveRows(store, digest)).toBe(1);
+  });
+
+  it("becomes ready only when all child deployments publish qualifying evidence", async () => {
+    const store = new InMemorySharedPreparationStore();
+    const workKey = fixturePublicWorkKey({ capability: "collection_identity.v1" });
+    const joined = await store.joinPublicWork({
+      order_id: "ord_ready",
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+      work_key: workKey,
+      now_ms: 1,
+    });
+    if (joined.kind !== "joined") throw new Error("join failed");
+
+    const lease = await store.acquireLease({
+      work_id: joined.work.work_id,
+      worker_id: "worker-a",
+      lease_duration_ms: 30_000,
+      now_ms: 2,
+    });
+    if (lease.kind !== "acquired") throw new Error("lease failed");
+    await store.transitionToPreparing({
+      work_id: joined.work.work_id,
+      expected_lease_epoch: lease.work.lease_epoch,
+      now_ms: 3,
+    });
+
+    const items = await store.listWorkItems(joined.work.work_id);
+    const evidence = fixtureReadinessEvidence(workKey.deployment_ids);
+    for (const item of items) {
+      await store.publishChildEvidence({
+        work_item_id: item.work_item_id,
+        expected_lease_epoch: lease.work.lease_epoch,
+        evidence,
+        now_ms: 4,
+      });
+    }
+
+    const pending = await store.finalizeReadyIfQualified({
+      work_id: joined.work.work_id,
+      expected_lease_epoch: lease.work.lease_epoch,
+      readiness_evidence: evidence,
+      now_ms: 5,
+    });
+    expect(pending.kind).toBe("ready");
+    expect(pending.kind === "ready" ? pending.work.state : undefined).toBe("ready");
+    expect(pending.kind === "ready" ? pending.work.readiness_evidence?.producer : undefined).toBe(
+      "sonar-api.fixture",
+    );
+  });
+
+  it("rejects restricted capabilities at work-key construction", () => {
+    const candidate = loadEvmFixtureCandidate();
+    expect(() =>
+      buildPublicWorkKeyMaterial({
+        capability: "discord_role_snapshot.v1",
+        capability_version: "v1",
+        collection_id: candidate.identity.collection_id,
+        deployment_ids: candidate.identity.deployments.map((d) => d.deployment_id),
+        finality_policies: candidate.finality_policies,
+        source_identity: {
+          schema_version: 1,
+          producer: "shadow-audit.fixture",
+          upstream_evidence_source: "shadow-audit.restricted",
+        },
+        readiness_policy_version: "gate-leak-public-prep.v1",
+        adapter_version: "shadow-audit.v1",
+      }),
+    ).toThrow(/non-public capability/);
+    expect(PUBLIC_PREP_CAPABILITIES).toEqual(["collection_identity.v1", "ownership_index.v1"]);
+  });
+});

--- a/packages/services/ordering/src/__tests__/shared-preparation-store.test.ts
+++ b/packages/services/ordering/src/__tests__/shared-preparation-store.test.ts
@@ -198,6 +198,15 @@ describe("CR-201A public shared preparation store", () => {
     expect(failed.attempt).toBe(1);
     expect(failed.lease_until_unix_ms).toBeUndefined();
 
+    // Cannot bypass wake / next_attempt_at by transitioning from retry_wait.
+    await expect(
+      store.transitionToPreparing({
+        work_id: joined.work.work_id,
+        expected_lease_epoch: lease.work.lease_epoch,
+        now_ms: 3_500,
+      }),
+    ).rejects.toBeInstanceOf(SharedPreparationStateError);
+
     const staleWake = await store.wakeRetryWait({
       work_id: joined.work.work_id,
       expected_attempt: 0,
@@ -218,6 +227,71 @@ describe("CR-201A public shared preparation store", () => {
       now_ms: 10_000,
     });
     expect(woke.kind).toBe("woke");
+    if (woke.kind !== "woke") return;
+    expect(woke.work.state).toBe("queued");
+
+    // After wake, preparing is allowed from queued.
+    const lease2 = await store.acquireLease({
+      work_id: joined.work.work_id,
+      worker_id: "worker-b",
+      lease_duration_ms: 30_000,
+      now_ms: 10_500,
+    });
+    expect(lease2.kind === "acquired" || lease2.kind === "reclaimed").toBe(true);
+    if (lease2.kind !== "acquired" && lease2.kind !== "reclaimed") return;
+    const preparing = await store.transitionToPreparing({
+      work_id: joined.work.work_id,
+      expected_lease_epoch: lease2.work.lease_epoch,
+      now_ms: 11_000,
+    });
+    expect(preparing.state).toBe("preparing");
+  });
+
+  it("allows only one winner under contested lease reclaim", async () => {
+    const store = new InMemorySharedPreparationStore();
+    const workKey = fixturePublicWorkKey();
+    const joined = await store.joinPublicWork({
+      order_id: "ord_lease_race",
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+      work_key: workKey,
+      now_ms: 1_000,
+    });
+    if (joined.kind !== "joined") throw new Error("join failed");
+
+    const first = await store.acquireLease({
+      work_id: joined.work.work_id,
+      worker_id: "worker-0",
+      lease_duration_ms: 5_000,
+      now_ms: 2_000,
+    });
+    expect(first.kind).toBe("acquired");
+    if (first.kind !== "acquired") return;
+    expect(first.work.lease_epoch).toBe(1);
+
+    const reclaimNow = 10_000; // past lease expiry
+    const results = await Promise.all(
+      Array.from({ length: 50 }, (_, index) =>
+        store.acquireLease({
+          work_id: joined.work.work_id,
+          worker_id: `worker-${index + 1}`,
+          lease_duration_ms: 30_000,
+          now_ms: reclaimNow,
+        }),
+      ),
+    );
+
+    const winners = results.filter(
+      (r) => r.kind === "reclaimed" || r.kind === "acquired",
+    );
+    const busy = results.filter((r) => r.kind === "busy");
+    expect(winners).toHaveLength(1);
+    expect(busy).toHaveLength(49);
+    expect(winners[0]!.kind).toBe("reclaimed");
+    if (winners[0]!.kind !== "reclaimed" && winners[0]!.kind !== "acquired") return;
+    expect(winners[0]!.work.lease_epoch).toBe(2);
+
+    const after = await store.getWork(joined.work.work_id);
+    expect(after?.lease_epoch).toBe(2);
   });
 
   it("fans subscriber transitions through shared work and abandons on zero subscribers", async () => {

--- a/packages/services/ordering/src/__tests__/shared-preparation-store.test.ts
+++ b/packages/services/ordering/src/__tests__/shared-preparation-store.test.ts
@@ -198,6 +198,15 @@ describe("CR-201A public shared preparation store", () => {
     expect(failed.attempt).toBe(1);
     expect(failed.lease_until_unix_ms).toBeUndefined();
 
+    // Cannot lease while in retry_wait — wake must run first.
+    const leaseDuringRetry = await store.acquireLease({
+      work_id: joined.work.work_id,
+      worker_id: "worker-retry",
+      lease_duration_ms: 30_000,
+      now_ms: 3_200,
+    });
+    expect(leaseDuringRetry.kind).toBe("not_active");
+
     // Cannot bypass wake / next_attempt_at by transitioning from retry_wait.
     await expect(
       store.transitionToPreparing({
@@ -616,6 +625,68 @@ describe("CR-201A public shared preparation store", () => {
         now_ms: 4,
       }),
     ).rejects.toBeInstanceOf(SharedPreparationStateError);
+  });
+
+  it("rejects child evidence when parent is not preparing", async () => {
+    const store = new InMemorySharedPreparationStore();
+    const workKey = fixturePublicWorkKey({ capability: "collection_identity.v1" });
+    const joined = await store.joinPublicWork({
+      order_id: "ord_parent_state",
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+      work_key: workKey,
+      now_ms: 1,
+    });
+    if (joined.kind !== "joined") throw new Error("join failed");
+
+    const lease = await store.acquireLease({
+      work_id: joined.work.work_id,
+      worker_id: "w",
+      lease_duration_ms: 30_000,
+      now_ms: 2,
+    });
+    if (lease.kind !== "acquired") throw new Error("lease failed");
+    await store.transitionToPreparing({
+      work_id: joined.work.work_id,
+      expected_lease_epoch: lease.work.lease_epoch,
+      now_ms: 3,
+    });
+    const item = (await store.listWorkItems(joined.work.work_id))[0]!;
+
+    await store.recordRetryableFailure({
+      work_id: joined.work.work_id,
+      expected_lease_epoch: lease.work.lease_epoch,
+      next_attempt_at_unix_ms: 100,
+      retry_deadline_unix_ms: 604_800_000,
+      failure: { code: "dependency_unavailable", reason: "parent left preparing" },
+      now_ms: 4,
+    });
+    // Children were reset to queued; parent is retry_wait — publish must fail.
+    await expect(
+      store.publishChildEvidence({
+        work_item_id: item.work_item_id,
+        expected_lease_epoch: lease.work.lease_epoch,
+        evidence: fixtureReadinessEvidence(workKey.deployment_ids),
+        now_ms: 5,
+      }),
+    ).rejects.toBeInstanceOf(SharedPreparationStateError);
+
+    await store.detachSubscriber({
+      order_id: "ord_parent_state",
+      work_id: joined.work.work_id,
+      now_ms: 6,
+    });
+    const abandoned = await store.getWork(joined.work.work_id);
+    expect(abandoned?.state).toBe("abandoned");
+    await expect(
+      store.publishChildEvidence({
+        work_item_id: item.work_item_id,
+        expected_lease_epoch: lease.work.lease_epoch,
+        evidence: fixtureReadinessEvidence(workKey.deployment_ids),
+        now_ms: 7,
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringMatching(/parent preparing/),
+    });
   });
 
   it("rejects unqualified finalize and does not reuse that row as ready", async () => {

--- a/packages/services/ordering/src/__tests__/shared-preparation-store.test.ts
+++ b/packages/services/ordering/src/__tests__/shared-preparation-store.test.ts
@@ -3,8 +3,12 @@ import {
   countActiveRows,
   InMemorySharedPreparationStore,
   SharedPreparationFencingError,
+  SharedPreparationStateError,
 } from "../shared-preparation-store.js";
-import { buildPublicWorkKeyMaterial } from "../shared-preparation-work-key.js";
+import {
+  buildPublicWorkKeyMaterial,
+  digestPublicWorkKey,
+} from "../shared-preparation-work-key.js";
 import { PUBLIC_PREP_CAPABILITIES } from "../shared-preparation-types.js";
 import {
   fixtureCommunityScopeDigest,
@@ -196,14 +200,21 @@ describe("CR-201A public shared preparation store", () => {
 
     const staleWake = await store.wakeRetryWait({
       work_id: joined.work.work_id,
-      expected_next_attempt_at_unix_ms: 9_000,
+      expected_attempt: 0,
       now_ms: 10_000,
     });
     expect(staleWake.kind).toBe("stale_wake");
 
+    const earlyWake = await store.wakeRetryWait({
+      work_id: joined.work.work_id,
+      expected_attempt: failed.attempt,
+      now_ms: 9_999,
+    });
+    expect(earlyWake.kind).toBe("stale_wake");
+
     const woke = await store.wakeRetryWait({
       work_id: joined.work.work_id,
-      expected_next_attempt_at_unix_ms: 10_000,
+      expected_attempt: failed.attempt,
       now_ms: 10_000,
     });
     expect(woke.kind).toBe("woke");
@@ -341,5 +352,142 @@ describe("CR-201A public shared preparation store", () => {
       }),
     ).toThrow(/non-public capability/);
     expect(PUBLIC_PREP_CAPABILITIES).toEqual(["collection_identity.v1", "ownership_index.v1"]);
+  });
+
+  it("canonicalizes deployment_ids and finality_policies before hashing", () => {
+    const candidate = loadEvmFixtureCandidate();
+    const a = candidate.identity.deployments[0]!.deployment_id;
+    const b = {
+      algorithm: "sha-256" as const,
+      domain: "collection.deployment",
+      major_version: 1,
+      digest: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    };
+    const policyEvm = candidate.finality_policies[0]!;
+    const policySol = {
+      schema_version: 1 as const,
+      network: {
+        schema_version: 1 as const,
+        network_namespace: "solana" as const,
+        network_reference: "mainnet-beta",
+      },
+      finality_policy_version: "solana-confirmed.v1",
+    };
+    const forward = buildPublicWorkKeyMaterial({
+      capability: "ownership_index.v1",
+      capability_version: "v1",
+      collection_id: candidate.identity.collection_id,
+      deployment_ids: [b, a],
+      finality_policies: [policySol, policyEvm],
+      source_identity: {
+        schema_version: 1,
+        producer: "sonar-api.fixture",
+        upstream_evidence_source: "sonar.public-capability.v1",
+      },
+      readiness_policy_version: "gate-leak-public-prep.v1",
+      adapter_version: "sonar-kitchen.v1",
+    });
+    const reverse = buildPublicWorkKeyMaterial({
+      capability: "ownership_index.v1",
+      capability_version: "v1",
+      collection_id: candidate.identity.collection_id,
+      deployment_ids: [a, b],
+      finality_policies: [policyEvm, policySol],
+      source_identity: {
+        schema_version: 1,
+        producer: "sonar-api.fixture",
+        upstream_evidence_source: "sonar.public-capability.v1",
+      },
+      readiness_policy_version: "gate-leak-public-prep.v1",
+      adapter_version: "sonar-kitchen.v1",
+    });
+    expect(digestPublicWorkKey(forward)).toBe(digestPublicWorkKey(reverse));
+    expect(forward.deployment_ids.map((d) => d.digest)).toEqual(
+      reverse.deployment_ids.map((d) => d.digest),
+    );
+    expect(forward.finality_policies.map((p) => p.network.network_namespace)).toEqual(
+      reverse.finality_policies.map((p) => p.network.network_namespace),
+    );
+  });
+
+  it("rejects child evidence and finalize outside preparing", async () => {
+    const store = new InMemorySharedPreparationStore();
+    const workKey = fixturePublicWorkKey();
+    const joined = await store.joinPublicWork({
+      order_id: "ord_state",
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+      work_key: workKey,
+      now_ms: 1,
+    });
+    if (joined.kind !== "joined") throw new Error("join failed");
+    const lease = await store.acquireLease({
+      work_id: joined.work.work_id,
+      worker_id: "w",
+      lease_duration_ms: 30_000,
+      now_ms: 2,
+    });
+    if (lease.kind !== "acquired") throw new Error("lease failed");
+    const item = (await store.listWorkItems(joined.work.work_id))[0]!;
+    await expect(
+      store.publishChildEvidence({
+        work_item_id: item.work_item_id,
+        expected_lease_epoch: lease.work.lease_epoch,
+        evidence: fixtureReadinessEvidence(workKey.deployment_ids),
+        now_ms: 3,
+      }),
+    ).rejects.toBeInstanceOf(SharedPreparationStateError);
+    await expect(
+      store.finalizeReadyIfQualified({
+        work_id: joined.work.work_id,
+        expected_lease_epoch: lease.work.lease_epoch,
+        readiness_evidence: fixtureReadinessEvidence(workKey.deployment_ids),
+        now_ms: 4,
+      }),
+    ).rejects.toBeInstanceOf(SharedPreparationStateError);
+  });
+
+  it("survives concurrent detach and join without abandoning an active subscriber", async () => {
+    const store = new InMemorySharedPreparationStore();
+    const workKey = fixturePublicWorkKey();
+    const first = await store.joinPublicWork({
+      order_id: "ord_race_a",
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+      work_key: workKey,
+      now_ms: 1,
+    });
+    if (first.kind !== "joined") throw new Error("join failed");
+
+    const rounds = await Promise.all(
+      Array.from({ length: 40 }, async (_, index) => {
+        if (index % 2 === 0) {
+          return store.detachSubscriber({
+            order_id: "ord_race_a",
+            work_id: first.work.work_id,
+            now_ms: 10 + index,
+          });
+        }
+        return store.joinPublicWork({
+          order_id: `ord_race_b_${index}`,
+          order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+          work_key: workKey,
+          now_ms: 10 + index,
+        });
+      }),
+    );
+
+    expect(rounds.length).toBe(40);
+    const digest = fixtureWorkKeyDigest(workKey);
+    const active = countActiveRows(store, digest);
+    // Either still active with ≥1 subscriber, or abandoned after last detach — never two actives.
+    expect(active).toBeLessThanOrEqual(1);
+    if (active === 1) {
+      const work = await store.getWork(first.work.work_id);
+      const links = work ? await store.listActiveLinks(work.work_id) : [];
+      // If the original row is still active it must have links; successor gens are ok too.
+      const surviving = (await store.getWork(first.work.work_id))?.state;
+      if (surviving && ["queued", "preparing", "retry_wait"].includes(surviving)) {
+        expect(links.length).toBeGreaterThan(0);
+      }
+    }
   });
 });

--- a/packages/services/ordering/src/__tests__/shared-preparation-store.test.ts
+++ b/packages/services/ordering/src/__tests__/shared-preparation-store.test.ts
@@ -247,6 +247,104 @@ describe("CR-201A public shared preparation store", () => {
     expect(preparing.state).toBe("preparing");
   });
 
+  it("resets ready children on retryable failure so finalize requires republish", async () => {
+    const store = new InMemorySharedPreparationStore();
+    const workKey = fixturePublicWorkKey({ capability: "collection_identity.v1" });
+    const joined = await store.joinPublicWork({
+      order_id: "ord_retry_children",
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+      work_key: workKey,
+      now_ms: 1,
+    });
+    if (joined.kind !== "joined") throw new Error("join failed");
+
+    const lease1 = await store.acquireLease({
+      work_id: joined.work.work_id,
+      worker_id: "worker-a",
+      lease_duration_ms: 30_000,
+      now_ms: 2,
+    });
+    if (lease1.kind !== "acquired") throw new Error("lease failed");
+    await store.transitionToPreparing({
+      work_id: joined.work.work_id,
+      expected_lease_epoch: lease1.work.lease_epoch,
+      now_ms: 3,
+    });
+
+    const evidence = fixtureReadinessEvidence(workKey.deployment_ids);
+    for (const item of await store.listWorkItems(joined.work.work_id)) {
+      await store.publishChildEvidence({
+        work_item_id: item.work_item_id,
+        expected_lease_epoch: lease1.work.lease_epoch,
+        evidence,
+        now_ms: 4,
+      });
+    }
+    const readyBefore = await store.listWorkItems(joined.work.work_id);
+    expect(readyBefore.every((item) => item.state === "ready")).toBe(true);
+
+    const failed = await store.recordRetryableFailure({
+      work_id: joined.work.work_id,
+      expected_lease_epoch: lease1.work.lease_epoch,
+      next_attempt_at_unix_ms: 100,
+      retry_deadline_unix_ms: 604_800_000,
+      failure: { code: "dependency_unavailable", reason: "force retry" },
+      now_ms: 5,
+    });
+    expect(failed.state).toBe("retry_wait");
+    const resetChildren = await store.listWorkItems(joined.work.work_id);
+    expect(resetChildren.every((item) => item.state === "queued")).toBe(true);
+    expect(resetChildren.every((item) => item.evidence_envelope === undefined)).toBe(true);
+
+    const woke = await store.wakeRetryWait({
+      work_id: joined.work.work_id,
+      expected_attempt: failed.attempt,
+      now_ms: 100,
+    });
+    expect(woke.kind).toBe("woke");
+
+    const lease2 = await store.acquireLease({
+      work_id: joined.work.work_id,
+      worker_id: "worker-b",
+      lease_duration_ms: 30_000,
+      now_ms: 110,
+    });
+    if (lease2.kind !== "acquired" && lease2.kind !== "reclaimed") {
+      throw new Error("second lease failed");
+    }
+    await store.transitionToPreparing({
+      work_id: joined.work.work_id,
+      expected_lease_epoch: lease2.work.lease_epoch,
+      now_ms: 120,
+    });
+    const preparingChildren = await store.listWorkItems(joined.work.work_id);
+    expect(preparingChildren.every((item) => item.state === "preparing")).toBe(true);
+
+    const pending = await store.finalizeReadyIfQualified({
+      work_id: joined.work.work_id,
+      expected_lease_epoch: lease2.work.lease_epoch,
+      readiness_evidence: evidence,
+      now_ms: 130,
+    });
+    expect(pending.kind).toBe("pending_children");
+
+    for (const item of await store.listWorkItems(joined.work.work_id)) {
+      await store.publishChildEvidence({
+        work_item_id: item.work_item_id,
+        expected_lease_epoch: lease2.work.lease_epoch,
+        evidence,
+        now_ms: 140,
+      });
+    }
+    const ready = await store.finalizeReadyIfQualified({
+      work_id: joined.work.work_id,
+      expected_lease_epoch: lease2.work.lease_epoch,
+      readiness_evidence: evidence,
+      now_ms: 150,
+    });
+    expect(ready.kind).toBe("ready");
+  });
+
   it("allows only one winner under contested lease reclaim", async () => {
     const store = new InMemorySharedPreparationStore();
     const workKey = fixturePublicWorkKey();

--- a/packages/services/ordering/src/__tests__/shared-preparation-store.test.ts
+++ b/packages/services/ordering/src/__tests__/shared-preparation-store.test.ts
@@ -618,6 +618,139 @@ describe("CR-201A public shared preparation store", () => {
     ).rejects.toBeInstanceOf(SharedPreparationStateError);
   });
 
+  it("rejects unqualified finalize and does not reuse that row as ready", async () => {
+    const store = new InMemorySharedPreparationStore();
+    const workKey = fixturePublicWorkKey({ capability: "collection_identity.v1" });
+    const joined = await store.joinPublicWork({
+      order_id: "ord_unqual_a",
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+      work_key: workKey,
+      now_ms: 1,
+    });
+    if (joined.kind !== "joined") throw new Error("join failed");
+
+    const lease = await store.acquireLease({
+      work_id: joined.work.work_id,
+      worker_id: "w",
+      lease_duration_ms: 30_000,
+      now_ms: 2,
+    });
+    if (lease.kind !== "acquired") throw new Error("lease failed");
+    await store.transitionToPreparing({
+      work_id: joined.work.work_id,
+      expected_lease_epoch: lease.work.lease_epoch,
+      now_ms: 3,
+    });
+    const evidence = fixtureReadinessEvidence(workKey.deployment_ids);
+    for (const item of await store.listWorkItems(joined.work.work_id)) {
+      await store.publishChildEvidence({
+        work_item_id: item.work_item_id,
+        expected_lease_epoch: lease.work.lease_epoch,
+        evidence,
+        now_ms: 4,
+      });
+    }
+
+    const unqualified = {
+      ...evidence,
+      freshness: { qualified: false, max_age_ms: 60_000 },
+    };
+    await expect(
+      store.finalizeReadyIfQualified({
+        work_id: joined.work.work_id,
+        expected_lease_epoch: lease.work.lease_epoch,
+        readiness_evidence: unqualified,
+        now_ms: 5,
+      }),
+    ).rejects.toBeInstanceOf(SharedPreparationStateError);
+
+    const stillPreparing = await store.getWork(joined.work.work_id);
+    expect(stillPreparing?.state).toBe("preparing");
+    expect(stillPreparing?.readiness_evidence).toBeUndefined();
+
+    const qualifiedReady = await store.finalizeReadyIfQualified({
+      work_id: joined.work.work_id,
+      expected_lease_epoch: lease.work.lease_epoch,
+      readiness_evidence: evidence,
+      now_ms: 6,
+    });
+    expect(qualifiedReady.kind).toBe("ready");
+
+    // Poison stored ready evidence — join must not reuse it as ready.
+    const works = (
+      store as unknown as {
+        works: Map<string, { readiness_evidence?: { freshness: { qualified: boolean } } }>;
+      }
+    ).works;
+    const stored = works.get(joined.work.work_id)!;
+    stored.readiness_evidence = {
+      ...evidence,
+      freshness: { qualified: false, max_age_ms: 60_000 },
+    };
+
+    const next = await store.joinPublicWork({
+      order_id: "ord_unqual_b",
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+      work_key: workKey,
+      now_ms: 8,
+    });
+    expect(next.kind).toBe("joined");
+    if (next.kind !== "joined") return;
+    expect(next.reused_ready).toBe(false);
+    expect(next.created).toBe(true);
+    expect(next.work.state).toBe("queued");
+    expect(next.work.work_id).not.toBe(joined.work.work_id);
+  });
+
+  it("surfaces detach serialization_retry distinctly from not_linked", async () => {
+    const store = new InMemorySharedPreparationStore();
+    const workKey = fixturePublicWorkKey();
+    const joined = await store.joinPublicWork({
+      order_id: "ord_detach_ser",
+      order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+      work_key: workKey,
+      now_ms: 1,
+    });
+    if (joined.kind !== "joined") throw new Error("join failed");
+
+    // Exhaust lock retries by forcing serialization_retry throws inside the critical section.
+    const digest = fixtureWorkKeyDigest(workKey);
+    const storeAny = store as unknown as {
+      withWorkKeyLock: <T>(
+        d: string,
+        fn: () => Promise<T>,
+      ) => Promise<T | { kind: "serialization_retry" }>;
+    };
+    const original = storeAny.withWorkKeyLock.bind(store);
+    storeAny.withWorkKeyLock = async () => ({ kind: "serialization_retry" as const });
+    try {
+      const result = await store.detachSubscriber({
+        order_id: "ord_detach_ser",
+        work_id: joined.work.work_id,
+        now_ms: 2,
+      });
+      expect(result.kind).toBe("serialization_retry");
+      expect(result.kind).not.toBe("not_linked");
+    } finally {
+      storeAny.withWorkKeyLock = original;
+    }
+
+    // Control: real detach after unlock still reports not_linked vs detached correctly.
+    const detached = await store.detachSubscriber({
+      order_id: "ord_detach_ser",
+      work_id: joined.work.work_id,
+      now_ms: 3,
+    });
+    expect(detached.kind).toBe("detached");
+    const missing = await store.detachSubscriber({
+      order_id: "ord_detach_ser",
+      work_id: joined.work.work_id,
+      now_ms: 4,
+    });
+    expect(missing.kind).toBe("not_linked");
+    expect(digest).toBeTruthy();
+  });
+
   it("survives concurrent detach and join without abandoning an active subscriber", async () => {
     const store = new InMemorySharedPreparationStore();
     const workKey = fixturePublicWorkKey();

--- a/packages/services/ordering/src/index.ts
+++ b/packages/services/ordering/src/index.ts
@@ -248,6 +248,7 @@ export {
   InMemorySharedPreparationStore,
   SharedPreparationFencingError,
   SharedPreparationStateError,
+  assertReadinessEvidenceQualified,
   type SharedPreparationStore,
   type JoinPublicWorkInput,
   type JoinPublicWorkResult,

--- a/packages/services/ordering/src/index.ts
+++ b/packages/services/ordering/src/index.ts
@@ -232,6 +232,8 @@ export { mountDependencyLedgerRoutes } from './dependency-ledger-http.js';
 export {
   PUBLIC_PREP_CAPABILITIES,
   PUBLIC_PREP_LIMITS,
+  LEASABLE_PUBLIC_WORK_STATES,
+  isLeasablePublicWorkState,
   type PublicPrepCapability,
   type PublicPreparationWorkKeyMaterial,
   type SharedPreparationWorkRecord,

--- a/packages/services/ordering/src/index.ts
+++ b/packages/services/ordering/src/index.ts
@@ -229,3 +229,33 @@ export {
   createFixtureDependencyLedgerService,
 } from './dependency-ledger-service.js';
 export { mountDependencyLedgerRoutes } from './dependency-ledger-http.js';
+export {
+  PUBLIC_PREP_CAPABILITIES,
+  PUBLIC_PREP_LIMITS,
+  type PublicPrepCapability,
+  type PublicPreparationWorkKeyMaterial,
+  type SharedPreparationWorkRecord,
+  type PreparationWorkItemRecord,
+  type ReportWorkLinkRecord,
+  type ReadinessEvidenceEnvelope,
+} from './shared-preparation-types.js';
+export {
+  buildPublicWorkKeyMaterial,
+  digestPublicWorkKey,
+  deploymentSetDigest,
+} from './shared-preparation-work-key.js';
+export {
+  InMemorySharedPreparationStore,
+  SharedPreparationFencingError,
+  SharedPreparationStateError,
+  type SharedPreparationStore,
+  type JoinPublicWorkInput,
+  type JoinPublicWorkResult,
+} from './shared-preparation-store.js';
+export {
+  PostgresSharedPreparationStore,
+} from './shared-preparation-store-postgres.js';
+export {
+  createSharedPreparationService,
+  type SharedPreparationService,
+} from './shared-preparation-service.js';

--- a/packages/services/ordering/src/shared-preparation-service.ts
+++ b/packages/services/ordering/src/shared-preparation-service.ts
@@ -1,0 +1,25 @@
+import type { SharedPreparationStore } from "./shared-preparation-store.js";
+import type { PublicPreparationWorkKeyMaterial } from "./shared-preparation-types.js";
+
+export interface SharedPreparationServiceDeps {
+  readonly store: SharedPreparationStore;
+  readonly now: () => number;
+}
+
+export function createSharedPreparationService(deps: SharedPreparationServiceDeps) {
+  return {
+    joinPublicWork(input: {
+      order_id: string;
+      order_tenant_scope_digest: string;
+      work_key: PublicPreparationWorkKeyMaterial;
+    }) {
+      return deps.store.joinPublicWork({
+        ...input,
+        now_ms: deps.now(),
+      });
+    },
+    store: deps.store,
+  };
+}
+
+export type SharedPreparationService = ReturnType<typeof createSharedPreparationService>;

--- a/packages/services/ordering/src/shared-preparation-store-postgres.ts
+++ b/packages/services/ordering/src/shared-preparation-store-postgres.ts
@@ -1,0 +1,602 @@
+/**
+ * CR-201A Postgres shared preparation adapter (expand-only migration 007).
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+import pg from "pg";
+import {
+  deploymentSetDigest,
+  digestPublicWorkKey,
+  finalityPolicyVersion,
+} from "./shared-preparation-work-key.js";
+import {
+  isActivePublicWorkState,
+  type PreparationWorkItemRecord,
+  type PublicPreparationWorkKeyMaterial,
+  type ReadinessEvidenceEnvelope,
+  type ReportWorkLinkRecord,
+  type SharedPreparationWorkRecord,
+} from "./shared-preparation-types.js";
+import {
+  SharedPreparationFencingError,
+  SharedPreparationStateError,
+  type JoinPublicWorkInput,
+  type JoinPublicWorkResult,
+  type SharedPreparationStore,
+} from "./shared-preparation-store.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function rowToWork(row: pg.QueryResultRow): SharedPreparationWorkRecord {
+  return {
+    work_id: row.work_id,
+    work_key_digest: row.work_key_digest,
+    deployment_set_digest: row.deployment_set_digest,
+    capability: row.capability,
+    capability_version: row.capability_version,
+    scope_class: "deployment",
+    scope_digest: row.scope_digest,
+    privacy_class: "public_chain",
+    source_identity: row.source_identity,
+    readiness_policy_version: row.readiness_policy_version,
+    evidence_boundary_kind: row.evidence_boundary_kind,
+    ...(row.evidence_boundary_digest != null
+      ? { evidence_boundary_digest: row.evidence_boundary_digest }
+      : {}),
+    adapter_version: row.adapter_version,
+    finality_policy_version: row.finality_policy_version,
+    state: row.state,
+    generation: Number(row.generation),
+    ...(row.readiness_evidence != null
+      ? { readiness_evidence: row.readiness_evidence as ReadinessEvidenceEnvelope }
+      : {}),
+    attempt: Number(row.attempt),
+    ...(row.next_attempt_at != null
+      ? { next_attempt_at_unix_ms: Date.parse(row.next_attempt_at as string) }
+      : {}),
+    ...(row.retry_deadline != null
+      ? { retry_deadline_unix_ms: Date.parse(row.retry_deadline as string) }
+      : {}),
+    ...(row.lease_until != null
+      ? { lease_until_unix_ms: Date.parse(row.lease_until as string) }
+      : {}),
+    lease_epoch: Number(row.lease_epoch),
+    ...(row.failure_reason != null
+      ? { failure_reason: row.failure_reason as { code: string; reason: string } }
+      : {}),
+    sharing_scope_kind: "public",
+    created_at_unix_ms: Date.parse(row.created_at as string),
+    updated_at_unix_ms: Date.parse(row.updated_at as string),
+  };
+}
+
+function rowToItem(row: pg.QueryResultRow): PreparationWorkItemRecord {
+  return {
+    work_item_id: row.work_item_id,
+    work_id: row.work_id,
+    deployment_id: row.deployment_id,
+    capability: row.capability,
+    adapter_version: row.adapter_version,
+    ...(row.external_job_ref != null ? { external_job_ref: row.external_job_ref } : {}),
+    state: row.state,
+    attempt: Number(row.attempt),
+    lease_epoch: Number(row.lease_epoch),
+    ...(row.evidence_envelope != null
+      ? { evidence_envelope: row.evidence_envelope as ReadinessEvidenceEnvelope }
+      : {}),
+    ...(row.failure_reason != null
+      ? { failure_reason: row.failure_reason as { code: string; reason: string } }
+      : {}),
+    created_at_unix_ms: Date.parse(row.created_at as string),
+    updated_at_unix_ms: Date.parse(row.updated_at as string),
+  };
+}
+
+function rowToLink(row: pg.QueryResultRow): ReportWorkLinkRecord {
+  return {
+    order_id: row.order_id,
+    work_id: row.work_id,
+    joined_at_unix_ms: Date.parse(row.joined_at as string),
+    ...(row.detached_at != null
+      ? { detached_at_unix_ms: Date.parse(row.detached_at as string) }
+      : {}),
+    generation: Number(row.generation),
+    order_tenant_scope_digest: row.order_tenant_scope_digest,
+    sharing_scope_kind: "public",
+  };
+}
+
+function msToIso(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+export interface PostgresSharedPreparationStoreOptions {
+  readonly pool: pg.Pool;
+}
+
+export class PostgresSharedPreparationStore implements SharedPreparationStore {
+  private readonly pool: pg.Pool;
+
+  constructor(opts: PostgresSharedPreparationStoreOptions) {
+    this.pool = opts.pool;
+  }
+
+  static async connect(
+    connectionString: string,
+    opts: { migrate?: boolean; pool?: pg.Pool } = {},
+  ): Promise<PostgresSharedPreparationStore> {
+    const pool = opts.pool ?? new pg.Pool({ connectionString, max: 10 });
+    const store = new PostgresSharedPreparationStore({ pool });
+    if (opts.migrate ?? process.env.RUN_MIGRATIONS === "true") {
+      await store.runMigrations();
+    }
+    return store;
+  }
+
+  async runMigrations(): Promise<void> {
+    const sql = readFileSync(join(__dirname, "../migrations/007_shared_preparation_work.sql"), "utf8");
+    await this.pool.query(sql);
+  }
+
+  async close(): Promise<void> {
+    await this.pool.end();
+  }
+
+  private async advisoryLock(client: pg.PoolClient, workKeyDigest: string): Promise<void> {
+    await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [workKeyDigest]);
+  }
+
+  async joinPublicWork(input: JoinPublicWorkInput): Promise<JoinPublicWorkResult> {
+    const workKeyDigest = digestPublicWorkKey(input.work_key);
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      await this.advisoryLock(client, workKeyDigest);
+
+      const readyResult = await client.query(
+        `SELECT * FROM shared_preparation_work
+         WHERE work_key_digest = $1
+           AND state = 'ready'
+           AND readiness_policy_version = $2
+           AND readiness_evidence IS NOT NULL
+           AND (readiness_evidence->'freshness'->>'qualified')::boolean = true
+         ORDER BY generation DESC
+         LIMIT 1`,
+        [workKeyDigest, input.work_key.readiness_policy_version],
+      );
+      if (readyResult.rows.length > 0) {
+        const work = rowToWork(readyResult.rows[0]);
+        await this.insertLink(client, input, work.work_id, work.generation);
+        await client.query("COMMIT");
+        return {
+          kind: "joined",
+          work,
+          links: await this.fetchActiveLinks(client, work.work_id),
+          created: false,
+          reused_ready: true,
+        };
+      }
+
+      const activeResult = await client.query(
+        `SELECT * FROM shared_preparation_work
+         WHERE work_key_digest = $1 AND state IN ('queued', 'preparing', 'retry_wait')
+         LIMIT 1`,
+        [workKeyDigest],
+      );
+      if (activeResult.rows.length > 0) {
+        const work = rowToWork(activeResult.rows[0]);
+        await this.insertLink(client, input, work.work_id, work.generation);
+        await client.query("COMMIT");
+        return {
+          kind: "joined",
+          work,
+          links: await this.fetchActiveLinks(client, work.work_id),
+          created: false,
+          reused_ready: false,
+        };
+      }
+
+      const maxGen = await client.query(
+        "SELECT COALESCE(MAX(generation), 0) AS max_generation FROM shared_preparation_work WHERE work_key_digest = $1",
+        [workKeyDigest],
+      );
+      const generation = Number(maxGen.rows[0].max_generation) + 1;
+      const workId = `spw_${randomUUID()}`;
+      const nowIso = msToIso(input.now_ms);
+      await client.query(
+        `INSERT INTO shared_preparation_work (
+          work_id, work_key_digest, deployment_set_digest, capability, capability_version,
+          scope_digest, source_identity, readiness_policy_version, evidence_boundary_kind,
+          evidence_boundary_digest, adapter_version, finality_policy_version, state, generation,
+          attempt, lease_epoch, created_at, updated_at
+        ) VALUES (
+          $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'queued',$13,0,0,$14,$14
+        )`,
+        [
+          workId,
+          workKeyDigest,
+          deploymentSetDigest(input.work_key.deployment_ids),
+          input.work_key.capability,
+          input.work_key.capability_version,
+          input.work_key.scope_digest,
+          JSON.stringify(input.work_key.source_identity),
+          input.work_key.readiness_policy_version,
+          input.work_key.evidence_boundary_kind,
+          input.work_key.evidence_boundary_digest ?? null,
+          input.work_key.adapter_version,
+          finalityPolicyVersion(input.work_key.finality_policies),
+          generation,
+          nowIso,
+        ],
+      );
+      for (const deploymentId of input.work_key.deployment_ids) {
+        await client.query(
+          `INSERT INTO preparation_work_items (
+            work_item_id, work_id, deployment_id, capability, adapter_version, state, attempt, lease_epoch, created_at, updated_at
+          ) VALUES ($1,$2,$3,$4,$5,'queued',0,0,$6,$6)`,
+          [
+            `pwi_${randomUUID()}`,
+            workId,
+            JSON.stringify(deploymentId),
+            input.work_key.capability,
+            input.work_key.adapter_version,
+            nowIso,
+          ],
+        );
+      }
+      await this.insertLink(client, input, workId, generation);
+      const workRow = await client.query(
+        "SELECT * FROM shared_preparation_work WHERE work_id = $1",
+        [workId],
+      );
+      await client.query("COMMIT");
+      const work = rowToWork(workRow.rows[0]);
+      return {
+        kind: "joined",
+        work,
+        links: await this.fetchActiveLinks(work.work_id),
+        created: true,
+        reused_ready: false,
+      };
+    } catch (err) {
+      await client.query("ROLLBACK");
+      if (err instanceof Error && err.message.includes("shared_preparation_work_key_active_idx")) {
+        return { kind: "serialization_retry" };
+      }
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  private async insertLink(
+    client: pg.PoolClient,
+    input: JoinPublicWorkInput,
+    workId: string,
+    generation: number,
+  ): Promise<void> {
+    await client.query(
+      `INSERT INTO report_work_links (
+        order_id, work_id, joined_at, generation, order_tenant_scope_digest
+      ) VALUES ($1,$2,$3,$4,$5)
+      ON CONFLICT (order_id, work_id) DO UPDATE SET
+        detached_at = NULL,
+        generation = EXCLUDED.generation,
+        joined_at = EXCLUDED.joined_at`,
+      [input.order_id, workId, msToIso(input.now_ms), generation, input.order_tenant_scope_digest],
+    );
+  }
+
+  private async fetchActiveLinks(
+    clientOrWorkId: pg.PoolClient | string,
+    workId?: string,
+  ): Promise<readonly ReportWorkLinkRecord[]> {
+    if (typeof clientOrWorkId === "string") {
+      const result = await this.pool.query(
+        "SELECT * FROM report_work_links WHERE work_id = $1 AND detached_at IS NULL",
+        [clientOrWorkId],
+      );
+      return result.rows.map(rowToLink);
+    }
+    const result = await clientOrWorkId.query(
+      "SELECT * FROM report_work_links WHERE work_id = $1 AND detached_at IS NULL",
+      [workId],
+    );
+    return result.rows.map(rowToLink);
+  }
+
+  async getWork(workId: string): Promise<SharedPreparationWorkRecord | undefined> {
+    const result = await this.pool.query(
+      "SELECT * FROM shared_preparation_work WHERE work_id = $1",
+      [workId],
+    );
+    return result.rows.length > 0 ? rowToWork(result.rows[0]) : undefined;
+  }
+
+  async listActiveLinks(workId: string): Promise<readonly ReportWorkLinkRecord[]> {
+    return this.fetchActiveLinks(workId);
+  }
+
+  async listWorkItems(workId: string): Promise<readonly PreparationWorkItemRecord[]> {
+    const result = await this.pool.query(
+      "SELECT * FROM preparation_work_items WHERE work_id = $1 ORDER BY created_at",
+      [workId],
+    );
+    return result.rows.map(rowToItem);
+  }
+
+  async acquireLease(input: {
+    work_id: string;
+    worker_id: string;
+    lease_duration_ms: number;
+    now_ms: number;
+  }) {
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      const result = await client.query(
+        "SELECT * FROM shared_preparation_work WHERE work_id = $1 FOR UPDATE",
+        [input.work_id],
+      );
+      if (result.rows.length === 0) {
+        await client.query("ROLLBACK");
+        return { kind: "not_active" as const };
+      }
+      const work = rowToWork(result.rows[0]);
+      if (!isActivePublicWorkState(work.state)) {
+        await client.query("ROLLBACK");
+        return { kind: "not_active" as const };
+      }
+      const leaseExpired =
+        work.lease_until_unix_ms === undefined || input.now_ms >= work.lease_until_unix_ms;
+      if (!leaseExpired) {
+        await client.query("ROLLBACK");
+        return { kind: "busy" as const };
+      }
+      const reclaimed = work.lease_until_unix_ms !== undefined;
+      const nextEpoch = work.lease_epoch + 1;
+      const leaseUntil = msToIso(input.now_ms + input.lease_duration_ms);
+      const nowIso = msToIso(input.now_ms);
+      await client.query(
+        `UPDATE shared_preparation_work
+         SET lease_epoch = $2, lease_until = $3, updated_at = $4
+         WHERE work_id = $1`,
+        [input.work_id, nextEpoch, leaseUntil, nowIso],
+      );
+      await client.query(
+        "UPDATE preparation_work_items SET lease_epoch = $2, updated_at = $3 WHERE work_id = $1",
+        [input.work_id, nextEpoch, nowIso],
+      );
+      await client.query("COMMIT");
+      return {
+        kind: reclaimed ? ("reclaimed" as const) : ("acquired" as const),
+        work: {
+          ...(await this.getWork(input.work_id))!,
+        },
+      };
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async transitionToPreparing(input: {
+    work_id: string;
+    expected_lease_epoch: number;
+    now_ms: number;
+  }): Promise<SharedPreparationWorkRecord> {
+    const result = await this.pool.query(
+      `UPDATE shared_preparation_work
+       SET state = 'preparing', updated_at = $3
+       WHERE work_id = $1 AND lease_epoch = $2 AND state IN ('queued', 'retry_wait')
+       RETURNING *`,
+      [input.work_id, input.expected_lease_epoch, msToIso(input.now_ms)],
+    );
+    if (result.rows.length === 0) {
+      const current = await this.getWork(input.work_id);
+      if (!current) throw new SharedPreparationStateError("work not found");
+      if (current.lease_epoch !== input.expected_lease_epoch) {
+        throw new SharedPreparationFencingError("stale lease epoch for preparing transition");
+      }
+      throw new SharedPreparationStateError(`cannot enter preparing from ${current.state}`);
+    }
+    await this.pool.query(
+      `UPDATE preparation_work_items
+       SET state = 'preparing', updated_at = $2
+       WHERE work_id = $1 AND state IN ('queued', 'retry_wait')`,
+      [input.work_id, msToIso(input.now_ms)],
+    );
+    return rowToWork(result.rows[0]);
+  }
+
+  async recordRetryableFailure(input: {
+    work_id: string;
+    expected_lease_epoch: number;
+    next_attempt_at_unix_ms: number;
+    retry_deadline_unix_ms: number;
+    failure: { code: string; reason: string };
+    now_ms: number;
+  }): Promise<SharedPreparationWorkRecord> {
+    const result = await this.pool.query(
+      `UPDATE shared_preparation_work
+       SET state = 'retry_wait',
+           attempt = attempt + 1,
+           next_attempt_at = $4,
+           retry_deadline = $5,
+           lease_until = NULL,
+           failure_reason = $6,
+           updated_at = $7
+       WHERE work_id = $1 AND lease_epoch = $2 AND state = 'preparing'
+       RETURNING *`,
+      [
+        input.work_id,
+        input.expected_lease_epoch,
+        input.expected_lease_epoch,
+        msToIso(input.next_attempt_at_unix_ms),
+        msToIso(input.retry_deadline_unix_ms),
+        JSON.stringify(input.failure),
+        msToIso(input.now_ms),
+      ],
+    );
+    if (result.rows.length === 0) {
+      throw new SharedPreparationFencingError("stale lease epoch for retryable failure");
+    }
+    return rowToWork(result.rows[0]);
+  }
+
+  async wakeRetryWait(input: {
+    work_id: string;
+    expected_next_attempt_at_unix_ms: number;
+    now_ms: number;
+  }) {
+    const result = await this.pool.query(
+      `UPDATE shared_preparation_work
+       SET state = 'queued', updated_at = $3
+       WHERE work_id = $1
+         AND state = 'retry_wait'
+         AND next_attempt_at = $2
+         AND next_attempt_at <= $4
+       RETURNING *`,
+      [
+        input.work_id,
+        msToIso(input.expected_next_attempt_at_unix_ms),
+        msToIso(input.now_ms),
+        msToIso(input.now_ms),
+      ],
+    );
+    if (result.rows.length === 0) return { kind: "stale_wake" as const };
+    return { kind: "woke" as const, work: rowToWork(result.rows[0]) };
+  }
+
+  async publishChildEvidence(input: {
+    work_item_id: string;
+    expected_lease_epoch: number;
+    evidence: ReadinessEvidenceEnvelope;
+    now_ms: number;
+  }): Promise<PreparationWorkItemRecord> {
+    const result = await this.pool.query(
+      `UPDATE preparation_work_items
+       SET state = 'ready', evidence_envelope = $4, updated_at = $5
+       WHERE work_item_id = $1 AND lease_epoch = $2
+       RETURNING *`,
+      [
+        input.work_item_id,
+        input.expected_lease_epoch,
+        input.expected_lease_epoch,
+        JSON.stringify(input.evidence),
+        msToIso(input.now_ms),
+      ],
+    );
+    if (result.rows.length === 0) {
+      throw new SharedPreparationFencingError("stale lease epoch for child evidence");
+    }
+    return rowToItem(result.rows[0]);
+  }
+
+  async finalizeReadyIfQualified(input: {
+    work_id: string;
+    expected_lease_epoch: number;
+    readiness_evidence: ReadinessEvidenceEnvelope;
+    now_ms: number;
+  }) {
+    const pending = await this.pool.query(
+      "SELECT COUNT(*)::int AS pending FROM preparation_work_items WHERE work_id = $1 AND state <> 'ready'",
+      [input.work_id],
+    );
+    if (Number(pending.rows[0].pending) > 0) {
+      return {
+        kind: "pending_children" as const,
+        work: (await this.getWork(input.work_id))!,
+      };
+    }
+    const result = await this.pool.query(
+      `UPDATE shared_preparation_work
+       SET state = 'ready',
+           readiness_evidence = $4,
+           lease_until = NULL,
+           updated_at = $5
+       WHERE work_id = $1 AND lease_epoch = $2
+       RETURNING *`,
+      [
+        input.work_id,
+        input.expected_lease_epoch,
+        input.expected_lease_epoch,
+        JSON.stringify(input.readiness_evidence),
+        msToIso(input.now_ms),
+      ],
+    );
+    if (result.rows.length === 0) {
+      throw new SharedPreparationFencingError("stale lease epoch for parent ready");
+    }
+    return { kind: "ready" as const, work: rowToWork(result.rows[0]) };
+  }
+
+  async detachSubscriber(input: { order_id: string; work_id: string; now_ms: number }) {
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      const linkResult = await client.query(
+        `UPDATE report_work_links
+         SET detached_at = $3
+         WHERE order_id = $1 AND work_id = $2 AND detached_at IS NULL
+         RETURNING *`,
+        [input.order_id, input.work_id, msToIso(input.now_ms)],
+      );
+      if (linkResult.rows.length === 0) {
+        await client.query("ROLLBACK");
+        return { kind: "not_linked" as const };
+      }
+      const remaining = await client.query(
+        "SELECT COUNT(*)::int AS count FROM report_work_links WHERE work_id = $1 AND detached_at IS NULL",
+        [input.work_id],
+      );
+      if (Number(remaining.rows[0].count) === 0) {
+        const abandoned = await client.query(
+          `UPDATE shared_preparation_work
+           SET state = 'abandoned', lease_until = NULL, updated_at = $2
+           WHERE work_id = $1 AND state IN ('queued', 'preparing', 'retry_wait')
+           RETURNING *`,
+          [input.work_id, msToIso(input.now_ms)],
+        );
+        await client.query("COMMIT");
+        if (abandoned.rows.length > 0) {
+          return { kind: "detached" as const, work: rowToWork(abandoned.rows[0]) };
+        }
+      }
+      await client.query("COMMIT");
+      return { kind: "detached" as const };
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async supersedeActiveGeneration(input: { work_key_digest: string; now_ms: number }) {
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      await this.advisoryLock(client, input.work_key_digest);
+      const result = await client.query(
+        `UPDATE shared_preparation_work
+         SET state = 'superseded', lease_until = NULL, updated_at = $2
+         WHERE work_key_digest = $1 AND state IN ('queued', 'preparing', 'retry_wait')
+         RETURNING *`,
+        [input.work_key_digest, msToIso(input.now_ms)],
+      );
+      await client.query("COMMIT");
+      return result.rows.length > 0 ? rowToWork(result.rows[0]) : undefined;
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/packages/services/ordering/src/shared-preparation-store-postgres.ts
+++ b/packages/services/ordering/src/shared-preparation-store-postgres.ts
@@ -15,7 +15,6 @@ import {
 import {
   isActivePublicWorkState,
   type PreparationWorkItemRecord,
-  type PublicPreparationWorkKeyMaterial,
   type ReadinessEvidenceEnvelope,
   type ReportWorkLinkRecord,
   type SharedPreparationWorkRecord,
@@ -29,6 +28,15 @@ import {
 } from "./shared-preparation-store.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function isUniqueActiveKeyViolation(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const pgErr = err as Error & { code?: string; constraint?: string };
+  return (
+    pgErr.code === "23505" ||
+    err.message.includes("shared_preparation_work_key_active_idx")
+  );
+}
 
 function rowToWork(row: pg.QueryResultRow): SharedPreparationWorkRecord {
   return {
@@ -137,16 +145,40 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
   }
 
   async runMigrations(): Promise<void> {
-    const sql = readFileSync(join(__dirname, "../migrations/007_shared_preparation_work.sql"), "utf8");
-    await this.pool.query(sql);
+    // Orders FK target for report_work_links.
+    for (const file of [
+      "001_orders.sql",
+      "007_shared_preparation_work.sql",
+    ]) {
+      const sql = readFileSync(join(__dirname, "../migrations", file), "utf8");
+      await this.pool.query(sql);
+    }
   }
 
   async close(): Promise<void> {
     await this.pool.end();
   }
 
+  /** Exposed for race harnesses that need a bare pool. */
+  getPool(): pg.Pool {
+    return this.pool;
+  }
+
   private async advisoryLock(client: pg.PoolClient, workKeyDigest: string): Promise<void> {
     await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [workKeyDigest]);
+  }
+
+  private async classifyZeroRowWorkUpdate(
+    workId: string,
+    expectedLeaseEpoch: number,
+    context: string,
+  ): Promise<never> {
+    const current = await this.getWork(workId);
+    if (!current) throw new SharedPreparationStateError("work not found");
+    if (current.lease_epoch !== expectedLeaseEpoch) {
+      throw new SharedPreparationFencingError(`stale lease epoch for ${context}`);
+    }
+    throw new SharedPreparationStateError(`cannot ${context} from ${current.state}`);
   }
 
   async joinPublicWork(input: JoinPublicWorkInput): Promise<JoinPublicWorkResult> {
@@ -170,11 +202,12 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
       if (readyResult.rows.length > 0) {
         const work = rowToWork(readyResult.rows[0]);
         await this.insertLink(client, input, work.work_id, work.generation);
+        const links = await this.fetchActiveLinks(client, work.work_id);
         await client.query("COMMIT");
         return {
           kind: "joined",
           work,
-          links: await this.fetchActiveLinks(client, work.work_id),
+          links,
           created: false,
           reused_ready: true,
         };
@@ -189,11 +222,12 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
       if (activeResult.rows.length > 0) {
         const work = rowToWork(activeResult.rows[0]);
         await this.insertLink(client, input, work.work_id, work.generation);
+        const links = await this.fetchActiveLinks(client, work.work_id);
         await client.query("COMMIT");
         return {
           kind: "joined",
           work,
-          links: await this.fetchActiveLinks(client, work.work_id),
+          links,
           created: false,
           reused_ready: false,
         };
@@ -252,18 +286,18 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
         "SELECT * FROM shared_preparation_work WHERE work_id = $1",
         [workId],
       );
+      const links = await this.fetchActiveLinks(client, workId);
       await client.query("COMMIT");
-      const work = rowToWork(workRow.rows[0]);
       return {
         kind: "joined",
-        work,
-        links: await this.fetchActiveLinks(work.work_id),
+        work: rowToWork(workRow.rows[0]),
+        links,
         created: true,
         reused_ready: false,
       };
     } catch (err) {
       await client.query("ROLLBACK");
-      if (err instanceof Error && err.message.includes("shared_preparation_work_key_active_idx")) {
+      if (isUniqueActiveKeyViolation(err)) {
         return { kind: "serialization_retry" };
       }
       throw err;
@@ -360,10 +394,11 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
       const nextEpoch = work.lease_epoch + 1;
       const leaseUntil = msToIso(input.now_ms + input.lease_duration_ms);
       const nowIso = msToIso(input.now_ms);
-      await client.query(
+      const updated = await client.query(
         `UPDATE shared_preparation_work
          SET lease_epoch = $2, lease_until = $3, updated_at = $4
-         WHERE work_id = $1`,
+         WHERE work_id = $1
+         RETURNING *`,
         [input.work_id, nextEpoch, leaseUntil, nowIso],
       );
       await client.query(
@@ -373,9 +408,7 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
       await client.query("COMMIT");
       return {
         kind: reclaimed ? ("reclaimed" as const) : ("acquired" as const),
-        work: {
-          ...(await this.getWork(input.work_id))!,
-        },
+        work: rowToWork(updated.rows[0]),
       };
     } catch (err) {
       await client.query("ROLLBACK");
@@ -390,28 +423,38 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
     expected_lease_epoch: number;
     now_ms: number;
   }): Promise<SharedPreparationWorkRecord> {
-    const result = await this.pool.query(
-      `UPDATE shared_preparation_work
-       SET state = 'preparing', updated_at = $3
-       WHERE work_id = $1 AND lease_epoch = $2 AND state IN ('queued', 'retry_wait')
-       RETURNING *`,
-      [input.work_id, input.expected_lease_epoch, msToIso(input.now_ms)],
-    );
-    if (result.rows.length === 0) {
-      const current = await this.getWork(input.work_id);
-      if (!current) throw new SharedPreparationStateError("work not found");
-      if (current.lease_epoch !== input.expected_lease_epoch) {
-        throw new SharedPreparationFencingError("stale lease epoch for preparing transition");
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      const result = await client.query(
+        `UPDATE shared_preparation_work
+         SET state = 'preparing', updated_at = $3
+         WHERE work_id = $1 AND lease_epoch = $2 AND state IN ('queued', 'retry_wait')
+         RETURNING *`,
+        [input.work_id, input.expected_lease_epoch, msToIso(input.now_ms)],
+      );
+      if (result.rows.length === 0) {
+        await client.query("ROLLBACK");
+        return this.classifyZeroRowWorkUpdate(
+          input.work_id,
+          input.expected_lease_epoch,
+          "preparing transition",
+        );
       }
-      throw new SharedPreparationStateError(`cannot enter preparing from ${current.state}`);
+      await client.query(
+        `UPDATE preparation_work_items
+         SET state = 'preparing', updated_at = $2
+         WHERE work_id = $1 AND state IN ('queued', 'retry_wait')`,
+        [input.work_id, msToIso(input.now_ms)],
+      );
+      await client.query("COMMIT");
+      return rowToWork(result.rows[0]);
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
     }
-    await this.pool.query(
-      `UPDATE preparation_work_items
-       SET state = 'preparing', updated_at = $2
-       WHERE work_id = $1 AND state IN ('queued', 'retry_wait')`,
-      [input.work_id, msToIso(input.now_ms)],
-    );
-    return rowToWork(result.rows[0]);
   }
 
   async recordRetryableFailure(input: {
@@ -426,16 +469,15 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
       `UPDATE shared_preparation_work
        SET state = 'retry_wait',
            attempt = attempt + 1,
-           next_attempt_at = $4,
-           retry_deadline = $5,
+           next_attempt_at = $3,
+           retry_deadline = $4,
            lease_until = NULL,
-           failure_reason = $6,
-           updated_at = $7
+           failure_reason = $5,
+           updated_at = $6
        WHERE work_id = $1 AND lease_epoch = $2 AND state = 'preparing'
        RETURNING *`,
       [
         input.work_id,
-        input.expected_lease_epoch,
         input.expected_lease_epoch,
         msToIso(input.next_attempt_at_unix_ms),
         msToIso(input.retry_deadline_unix_ms),
@@ -444,27 +486,33 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
       ],
     );
     if (result.rows.length === 0) {
-      throw new SharedPreparationFencingError("stale lease epoch for retryable failure");
+      return this.classifyZeroRowWorkUpdate(
+        input.work_id,
+        input.expected_lease_epoch,
+        "retryable failure",
+      );
     }
     return rowToWork(result.rows[0]);
   }
 
   async wakeRetryWait(input: {
     work_id: string;
-    expected_next_attempt_at_unix_ms: number;
+    expected_attempt: number;
     now_ms: number;
   }) {
+    // CAS on attempt (monotonic token), deadline as inequality — not timestamptz equality.
     const result = await this.pool.query(
       `UPDATE shared_preparation_work
        SET state = 'queued', updated_at = $3
        WHERE work_id = $1
          AND state = 'retry_wait'
-         AND next_attempt_at = $2
+         AND attempt = $2
+         AND next_attempt_at IS NOT NULL
          AND next_attempt_at <= $4
        RETURNING *`,
       [
         input.work_id,
-        msToIso(input.expected_next_attempt_at_unix_ms),
+        input.expected_attempt,
         msToIso(input.now_ms),
         msToIso(input.now_ms),
       ],
@@ -481,19 +529,33 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
   }): Promise<PreparationWorkItemRecord> {
     const result = await this.pool.query(
       `UPDATE preparation_work_items
-       SET state = 'ready', evidence_envelope = $4, updated_at = $5
-       WHERE work_item_id = $1 AND lease_epoch = $2
+       SET state = 'ready', evidence_envelope = $3, updated_at = $4
+       WHERE work_item_id = $1
+         AND lease_epoch = $2
+         AND state = 'preparing'
        RETURNING *`,
       [
         input.work_item_id,
-        input.expected_lease_epoch,
         input.expected_lease_epoch,
         JSON.stringify(input.evidence),
         msToIso(input.now_ms),
       ],
     );
     if (result.rows.length === 0) {
-      throw new SharedPreparationFencingError("stale lease epoch for child evidence");
+      const current = await this.pool.query(
+        "SELECT * FROM preparation_work_items WHERE work_item_id = $1",
+        [input.work_item_id],
+      );
+      if (current.rows.length === 0) {
+        throw new SharedPreparationStateError("work item not found");
+      }
+      const item = rowToItem(current.rows[0]);
+      if (item.lease_epoch !== input.expected_lease_epoch) {
+        throw new SharedPreparationFencingError("stale lease epoch for child evidence");
+      }
+      throw new SharedPreparationStateError(
+        `child evidence requires preparing, got ${item.state}`,
+      );
     }
     return rowToItem(result.rows[0]);
   }
@@ -504,42 +566,95 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
     readiness_evidence: ReadinessEvidenceEnvelope;
     now_ms: number;
   }) {
-    const pending = await this.pool.query(
-      "SELECT COUNT(*)::int AS pending FROM preparation_work_items WHERE work_id = $1 AND state <> 'ready'",
-      [input.work_id],
-    );
-    if (Number(pending.rows[0].pending) > 0) {
-      return {
-        kind: "pending_children" as const,
-        work: (await this.getWork(input.work_id))!,
-      };
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      const locked = await client.query(
+        `SELECT * FROM shared_preparation_work WHERE work_id = $1 FOR UPDATE`,
+        [input.work_id],
+      );
+      if (locked.rows.length === 0) {
+        await client.query("ROLLBACK");
+        throw new SharedPreparationStateError("work not found");
+      }
+      const work = rowToWork(locked.rows[0]);
+      if (work.lease_epoch !== input.expected_lease_epoch) {
+        await client.query("ROLLBACK");
+        throw new SharedPreparationFencingError("stale lease epoch for parent ready");
+      }
+      if (work.state !== "preparing") {
+        await client.query("ROLLBACK");
+        throw new SharedPreparationStateError(
+          `finalize ready requires preparing, got ${work.state}`,
+        );
+      }
+
+      const pending = await client.query(
+        "SELECT COUNT(*)::int AS pending FROM preparation_work_items WHERE work_id = $1 AND state <> 'ready'",
+        [input.work_id],
+      );
+      if (Number(pending.rows[0].pending) > 0) {
+        await client.query("COMMIT");
+        return { kind: "pending_children" as const, work };
+      }
+
+      const result = await client.query(
+        `UPDATE shared_preparation_work
+         SET state = 'ready',
+             readiness_evidence = $3,
+             lease_until = NULL,
+             updated_at = $4
+         WHERE work_id = $1
+           AND lease_epoch = $2
+           AND state = 'preparing'
+           AND NOT EXISTS (
+             SELECT 1 FROM preparation_work_items
+             WHERE work_id = $1 AND state <> 'ready'
+           )
+         RETURNING *`,
+        [
+          input.work_id,
+          input.expected_lease_epoch,
+          JSON.stringify(input.readiness_evidence),
+          msToIso(input.now_ms),
+        ],
+      );
+      if (result.rows.length === 0) {
+        await client.query("ROLLBACK");
+        return this.classifyZeroRowWorkUpdate(
+          input.work_id,
+          input.expected_lease_epoch,
+          "parent ready",
+        );
+      }
+      await client.query("COMMIT");
+      return { kind: "ready" as const, work: rowToWork(result.rows[0]) };
+    } catch (err) {
+      try {
+        await client.query("ROLLBACK");
+      } catch {
+        // already rolled back / committed
+      }
+      throw err;
+    } finally {
+      client.release();
     }
-    const result = await this.pool.query(
-      `UPDATE shared_preparation_work
-       SET state = 'ready',
-           readiness_evidence = $4,
-           lease_until = NULL,
-           updated_at = $5
-       WHERE work_id = $1 AND lease_epoch = $2
-       RETURNING *`,
-      [
-        input.work_id,
-        input.expected_lease_epoch,
-        input.expected_lease_epoch,
-        JSON.stringify(input.readiness_evidence),
-        msToIso(input.now_ms),
-      ],
-    );
-    if (result.rows.length === 0) {
-      throw new SharedPreparationFencingError("stale lease epoch for parent ready");
-    }
-    return { kind: "ready" as const, work: rowToWork(result.rows[0]) };
   }
 
   async detachSubscriber(input: { order_id: string; work_id: string; now_ms: number }) {
     const client = await this.pool.connect();
     try {
       await client.query("BEGIN");
+      const workRow = await client.query(
+        "SELECT work_key_digest FROM shared_preparation_work WHERE work_id = $1 FOR UPDATE",
+        [input.work_id],
+      );
+      if (workRow.rows.length === 0) {
+        await client.query("ROLLBACK");
+        return { kind: "not_linked" as const };
+      }
+      await this.advisoryLock(client, workRow.rows[0].work_key_digest as string);
+
       const linkResult = await client.query(
         `UPDATE report_work_links
          SET detached_at = $3
@@ -551,24 +666,24 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
         await client.query("ROLLBACK");
         return { kind: "not_linked" as const };
       }
-      const remaining = await client.query(
-        "SELECT COUNT(*)::int AS count FROM report_work_links WHERE work_id = $1 AND detached_at IS NULL",
-        [input.work_id],
+
+      // Re-check zero active links in the same statement that abandons.
+      const abandoned = await client.query(
+        `UPDATE shared_preparation_work AS w
+         SET state = 'abandoned', lease_until = NULL, updated_at = $2
+         WHERE w.work_id = $1
+           AND w.state IN ('queued', 'preparing', 'retry_wait')
+           AND NOT EXISTS (
+             SELECT 1 FROM report_work_links l
+             WHERE l.work_id = w.work_id AND l.detached_at IS NULL
+           )
+         RETURNING *`,
+        [input.work_id, msToIso(input.now_ms)],
       );
-      if (Number(remaining.rows[0].count) === 0) {
-        const abandoned = await client.query(
-          `UPDATE shared_preparation_work
-           SET state = 'abandoned', lease_until = NULL, updated_at = $2
-           WHERE work_id = $1 AND state IN ('queued', 'preparing', 'retry_wait')
-           RETURNING *`,
-          [input.work_id, msToIso(input.now_ms)],
-        );
-        await client.query("COMMIT");
-        if (abandoned.rows.length > 0) {
-          return { kind: "detached" as const, work: rowToWork(abandoned.rows[0]) };
-        }
-      }
       await client.query("COMMIT");
+      if (abandoned.rows.length > 0) {
+        return { kind: "detached" as const, work: rowToWork(abandoned.rows[0]) };
+      }
       return { kind: "detached" as const };
     } catch (err) {
       await client.query("ROLLBACK");

--- a/packages/services/ordering/src/shared-preparation-store-postgres.ts
+++ b/packages/services/ordering/src/shared-preparation-store-postgres.ts
@@ -466,34 +466,56 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
     failure: { code: string; reason: string };
     now_ms: number;
   }): Promise<SharedPreparationWorkRecord> {
-    const result = await this.pool.query(
-      `UPDATE shared_preparation_work
-       SET state = 'retry_wait',
-           attempt = attempt + 1,
-           next_attempt_at = $3,
-           retry_deadline = $4,
-           lease_until = NULL,
-           failure_reason = $5,
-           updated_at = $6
-       WHERE work_id = $1 AND lease_epoch = $2 AND state = 'preparing'
-       RETURNING *`,
-      [
-        input.work_id,
-        input.expected_lease_epoch,
-        msToIso(input.next_attempt_at_unix_ms),
-        msToIso(input.retry_deadline_unix_ms),
-        JSON.stringify(input.failure),
-        msToIso(input.now_ms),
-      ],
-    );
-    if (result.rows.length === 0) {
-      return this.classifyZeroRowWorkUpdate(
-        input.work_id,
-        input.expected_lease_epoch,
-        "retryable failure",
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      const result = await client.query(
+        `UPDATE shared_preparation_work
+         SET state = 'retry_wait',
+             attempt = attempt + 1,
+             next_attempt_at = $3,
+             retry_deadline = $4,
+             lease_until = NULL,
+             failure_reason = $5,
+             updated_at = $6
+         WHERE work_id = $1 AND lease_epoch = $2 AND state = 'preparing'
+         RETURNING *`,
+        [
+          input.work_id,
+          input.expected_lease_epoch,
+          msToIso(input.next_attempt_at_unix_ms),
+          msToIso(input.retry_deadline_unix_ms),
+          JSON.stringify(input.failure),
+          msToIso(input.now_ms),
+        ],
       );
+      if (result.rows.length === 0) {
+        await client.query("ROLLBACK");
+        return this.classifyZeroRowWorkUpdate(
+          input.work_id,
+          input.expected_lease_epoch,
+          "retryable failure",
+        );
+      }
+      // Invalidate child progress so finalize cannot reuse pre-retry evidence.
+      await client.query(
+        `UPDATE preparation_work_items
+         SET state = 'queued',
+             evidence_envelope = NULL,
+             failure_reason = NULL,
+             updated_at = $2
+         WHERE work_id = $1
+           AND state IN ('ready', 'preparing', 'failed', 'retry_wait')`,
+        [input.work_id, msToIso(input.now_ms)],
+      );
+      await client.query("COMMIT");
+      return rowToWork(result.rows[0]);
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
     }
-    return rowToWork(result.rows[0]);
   }
 
   async wakeRetryWait(input: {

--- a/packages/services/ordering/src/shared-preparation-store-postgres.ts
+++ b/packages/services/ordering/src/shared-preparation-store-postgres.ts
@@ -13,7 +13,7 @@ import {
   finalityPolicyVersion,
 } from "./shared-preparation-work-key.js";
 import {
-  isActivePublicWorkState,
+  isLeasablePublicWorkState,
   type PreparationWorkItemRecord,
   type ReadinessEvidenceEnvelope,
   type ReportWorkLinkRecord,
@@ -39,7 +39,29 @@ function isUniqueActiveKeyViolation(err: unknown): boolean {
   );
 }
 
+/** node-pg returns Date for TIMESTAMPTZ; tolerate string/null. */
+function pgTimestampMs(value: unknown): number | undefined {
+  if (value == null) return undefined;
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === "string" || typeof value === "number") {
+    const ms = typeof value === "number" ? value : Date.parse(value);
+    return Number.isFinite(ms) ? ms : undefined;
+  }
+  return undefined;
+}
+
+function requirePgTimestampMs(value: unknown, field: string): number {
+  const ms = pgTimestampMs(value);
+  if (ms === undefined) {
+    throw new Error(`invalid timestamptz for ${field}`);
+  }
+  return ms;
+}
+
 function rowToWork(row: pg.QueryResultRow): SharedPreparationWorkRecord {
+  const nextAttempt = pgTimestampMs(row.next_attempt_at);
+  const retryDeadline = pgTimestampMs(row.retry_deadline);
+  const leaseUntil = pgTimestampMs(row.lease_until);
   return {
     work_id: row.work_id,
     work_key_digest: row.work_key_digest,
@@ -63,22 +85,16 @@ function rowToWork(row: pg.QueryResultRow): SharedPreparationWorkRecord {
       ? { readiness_evidence: row.readiness_evidence as ReadinessEvidenceEnvelope }
       : {}),
     attempt: Number(row.attempt),
-    ...(row.next_attempt_at != null
-      ? { next_attempt_at_unix_ms: Date.parse(row.next_attempt_at as string) }
-      : {}),
-    ...(row.retry_deadline != null
-      ? { retry_deadline_unix_ms: Date.parse(row.retry_deadline as string) }
-      : {}),
-    ...(row.lease_until != null
-      ? { lease_until_unix_ms: Date.parse(row.lease_until as string) }
-      : {}),
+    ...(nextAttempt !== undefined ? { next_attempt_at_unix_ms: nextAttempt } : {}),
+    ...(retryDeadline !== undefined ? { retry_deadline_unix_ms: retryDeadline } : {}),
+    ...(leaseUntil !== undefined ? { lease_until_unix_ms: leaseUntil } : {}),
     lease_epoch: Number(row.lease_epoch),
     ...(row.failure_reason != null
       ? { failure_reason: row.failure_reason as { code: string; reason: string } }
       : {}),
     sharing_scope_kind: "public",
-    created_at_unix_ms: Date.parse(row.created_at as string),
-    updated_at_unix_ms: Date.parse(row.updated_at as string),
+    created_at_unix_ms: requirePgTimestampMs(row.created_at, "created_at"),
+    updated_at_unix_ms: requirePgTimestampMs(row.updated_at, "updated_at"),
   };
 }
 
@@ -99,19 +115,18 @@ function rowToItem(row: pg.QueryResultRow): PreparationWorkItemRecord {
     ...(row.failure_reason != null
       ? { failure_reason: row.failure_reason as { code: string; reason: string } }
       : {}),
-    created_at_unix_ms: Date.parse(row.created_at as string),
-    updated_at_unix_ms: Date.parse(row.updated_at as string),
+    created_at_unix_ms: requirePgTimestampMs(row.created_at, "created_at"),
+    updated_at_unix_ms: requirePgTimestampMs(row.updated_at, "updated_at"),
   };
 }
 
 function rowToLink(row: pg.QueryResultRow): ReportWorkLinkRecord {
+  const detached = pgTimestampMs(row.detached_at);
   return {
     order_id: row.order_id,
     work_id: row.work_id,
-    joined_at_unix_ms: Date.parse(row.joined_at as string),
-    ...(row.detached_at != null
-      ? { detached_at_unix_ms: Date.parse(row.detached_at as string) }
-      : {}),
+    joined_at_unix_ms: requirePgTimestampMs(row.joined_at, "joined_at"),
+    ...(detached !== undefined ? { detached_at_unix_ms: detached } : {}),
     generation: Number(row.generation),
     order_tenant_scope_digest: row.order_tenant_scope_digest,
     sharing_scope_kind: "public",
@@ -381,7 +396,8 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
         return { kind: "not_active" as const };
       }
       const work = rowToWork(result.rows[0]);
-      if (!isActivePublicWorkState(work.state)) {
+      // retry_wait is active but not leasable — wake must run first.
+      if (!isLeasablePublicWorkState(work.state)) {
         await client.query("ROLLBACK");
         return { kind: "not_active" as const };
       }
@@ -398,10 +414,14 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
       const updated = await client.query(
         `UPDATE shared_preparation_work
          SET lease_epoch = $2, lease_until = $3, updated_at = $4
-         WHERE work_id = $1
+         WHERE work_id = $1 AND state IN ('queued', 'preparing')
          RETURNING *`,
         [input.work_id, nextEpoch, leaseUntil, nowIso],
       );
+      if (updated.rows.length === 0) {
+        await client.query("ROLLBACK");
+        return { kind: "not_active" as const };
+      }
       await client.query(
         "UPDATE preparation_work_items SET lease_epoch = $2, updated_at = $3 WHERE work_id = $1",
         [input.work_id, nextEpoch, nowIso],
@@ -552,12 +572,15 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
     now_ms: number;
   }): Promise<PreparationWorkItemRecord> {
     const result = await this.pool.query(
-      `UPDATE preparation_work_items
+      `UPDATE preparation_work_items AS i
        SET state = 'ready', evidence_envelope = $3, updated_at = $4
-       WHERE work_item_id = $1
-         AND lease_epoch = $2
-         AND state = 'preparing'
-       RETURNING *`,
+       FROM shared_preparation_work AS w
+       WHERE i.work_item_id = $1
+         AND i.work_id = w.work_id
+         AND i.lease_epoch = $2
+         AND i.state = 'preparing'
+         AND w.state = 'preparing'
+       RETURNING i.*`,
       [
         input.work_item_id,
         input.expected_lease_epoch,
@@ -567,13 +590,22 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
     );
     if (result.rows.length === 0) {
       const current = await this.pool.query(
-        "SELECT * FROM preparation_work_items WHERE work_item_id = $1",
+        `SELECT i.*, w.state AS parent_state
+         FROM preparation_work_items i
+         LEFT JOIN shared_preparation_work w ON w.work_id = i.work_id
+         WHERE i.work_item_id = $1`,
         [input.work_item_id],
       );
       if (current.rows.length === 0) {
         throw new SharedPreparationStateError("work item not found");
       }
-      const item = rowToItem(current.rows[0]);
+      const row = current.rows[0];
+      const item = rowToItem(row);
+      if (row.parent_state !== "preparing") {
+        throw new SharedPreparationStateError(
+          `child evidence requires parent preparing, got ${row.parent_state ?? "missing"}`,
+        );
+      }
       if (item.lease_epoch !== input.expected_lease_epoch) {
         throw new SharedPreparationFencingError("stale lease epoch for child evidence");
       }

--- a/packages/services/ordering/src/shared-preparation-store-postgres.ts
+++ b/packages/services/ordering/src/shared-preparation-store-postgres.ts
@@ -426,10 +426,11 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
     const client = await this.pool.connect();
     try {
       await client.query("BEGIN");
+      // retry_wait → preparing only via wakeRetryWait → queued first.
       const result = await client.query(
         `UPDATE shared_preparation_work
          SET state = 'preparing', updated_at = $3
-         WHERE work_id = $1 AND lease_epoch = $2 AND state IN ('queued', 'retry_wait')
+         WHERE work_id = $1 AND lease_epoch = $2 AND state = 'queued'
          RETURNING *`,
         [input.work_id, input.expected_lease_epoch, msToIso(input.now_ms)],
       );
@@ -444,7 +445,7 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
       await client.query(
         `UPDATE preparation_work_items
          SET state = 'preparing', updated_at = $2
-         WHERE work_id = $1 AND state IN ('queued', 'retry_wait')`,
+         WHERE work_id = $1 AND state = 'queued'`,
         [input.work_id, msToIso(input.now_ms)],
       );
       await client.query("COMMIT");

--- a/packages/services/ordering/src/shared-preparation-store-postgres.ts
+++ b/packages/services/ordering/src/shared-preparation-store-postgres.ts
@@ -22,6 +22,7 @@ import {
 import {
   SharedPreparationFencingError,
   SharedPreparationStateError,
+  assertReadinessEvidenceQualified,
   type JoinPublicWorkInput,
   type JoinPublicWorkResult,
   type SharedPreparationStore,
@@ -611,6 +612,12 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
           `finalize ready requires preparing, got ${work.state}`,
         );
       }
+      try {
+        assertReadinessEvidenceQualified(input.readiness_evidence);
+      } catch (err) {
+        await client.query("ROLLBACK");
+        throw err;
+      }
 
       const pending = await client.query(
         "SELECT COUNT(*)::int AS pending FROM preparation_work_items WHERE work_id = $1 AND state <> 'ready'",
@@ -634,6 +641,7 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
              SELECT 1 FROM preparation_work_items
              WHERE work_id = $1 AND state <> 'ready'
            )
+           AND ($3::jsonb->'freshness'->>'qualified')::boolean = true
          RETURNING *`,
         [
           input.work_id,

--- a/packages/services/ordering/src/shared-preparation-store.ts
+++ b/packages/services/ordering/src/shared-preparation-store.ts
@@ -192,6 +192,32 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
     }
   }
 
+  /** Serialize all work mutations under the same work-key lock as join/detach. */
+  private async withWorkIdLock<T>(
+    workId: string,
+    fn: () => Promise<T>,
+  ): Promise<T | { kind: "serialization_retry" } | undefined> {
+    const work = this.works.get(workId);
+    if (!work) return undefined;
+    return this.withWorkKeyLock(work.work_key_digest, fn);
+  }
+
+  private unwrapLocked<T>(
+    locked: T | { kind: "serialization_retry" } | undefined,
+    missing: () => T,
+  ): T {
+    if (locked === undefined) return missing();
+    if (
+      locked &&
+      typeof locked === "object" &&
+      "kind" in locked &&
+      (locked as { kind: string }).kind === "serialization_retry"
+    ) {
+      throw new SharedPreparationStateError("work-key lock serialization exhausted");
+    }
+    return locked as T;
+  }
+
   private rowsForKey(workKeyDigest: string): MutableWork[] {
     return [...this.works.values()].filter((row) => row.work_key_digest === workKeyDigest);
   }
@@ -396,27 +422,35 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
     | { readonly kind: "busy" }
     | { readonly kind: "not_active" }
   > {
-    const work = this.works.get(input.work_id);
-    if (!work || !isActivePublicWorkState(work.state)) {
-      return { kind: "not_active" };
-    }
-    const leaseExpired =
-      work.lease_until_unix_ms === undefined || input.now_ms >= work.lease_until_unix_ms;
-    if (!leaseExpired && work.lease_until_unix_ms !== undefined) {
-      return { kind: "busy" };
-    }
-    const reclaimed = leaseExpired && work.lease_until_unix_ms !== undefined;
-    work.lease_epoch += 1;
-    work.lease_until_unix_ms = input.now_ms + input.lease_duration_ms;
-    work.updated_at_unix_ms = input.now_ms;
-    for (const item of this.itemsForWork(work.work_id)) {
-      item.lease_epoch = work.lease_epoch;
-      item.updated_at_unix_ms = input.now_ms;
-    }
-    return {
-      kind: reclaimed ? "reclaimed" : "acquired",
-      work: cloneWork(work),
-    };
+    type LeaseResult =
+      | { readonly kind: "acquired"; readonly work: SharedPreparationWorkRecord }
+      | { readonly kind: "reclaimed"; readonly work: SharedPreparationWorkRecord }
+      | { readonly kind: "busy" }
+      | { readonly kind: "not_active" };
+    const locked = await this.withWorkIdLock(input.work_id, async (): Promise<LeaseResult> => {
+      const work = this.works.get(input.work_id);
+      if (!work || !isActivePublicWorkState(work.state)) {
+        return { kind: "not_active" };
+      }
+      const leaseExpired =
+        work.lease_until_unix_ms === undefined || input.now_ms >= work.lease_until_unix_ms;
+      if (!leaseExpired && work.lease_until_unix_ms !== undefined) {
+        return { kind: "busy" };
+      }
+      const reclaimed = leaseExpired && work.lease_until_unix_ms !== undefined;
+      work.lease_epoch += 1;
+      work.lease_until_unix_ms = input.now_ms + input.lease_duration_ms;
+      work.updated_at_unix_ms = input.now_ms;
+      for (const item of this.itemsForWork(work.work_id)) {
+        item.lease_epoch = work.lease_epoch;
+        item.updated_at_unix_ms = input.now_ms;
+      }
+      return {
+        kind: reclaimed ? "reclaimed" : "acquired",
+        work: cloneWork(work),
+      };
+    });
+    return this.unwrapLocked(locked, () => ({ kind: "not_active" as const }));
   }
 
   async transitionToPreparing(input: {
@@ -424,23 +458,29 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
     expected_lease_epoch: number;
     now_ms: number;
   }): Promise<SharedPreparationWorkRecord> {
-    const work = this.works.get(input.work_id);
-    if (!work) throw new SharedPreparationStateError("work not found");
-    if (work.lease_epoch !== input.expected_lease_epoch) {
-      throw new SharedPreparationFencingError("stale lease epoch for preparing transition");
-    }
-    if (work.state !== "queued" && work.state !== "retry_wait") {
-      throw new SharedPreparationStateError(`cannot enter preparing from ${work.state}`);
-    }
-    work.state = "preparing";
-    work.updated_at_unix_ms = input.now_ms;
-    for (const item of this.itemsForWork(work.work_id)) {
-      if (item.state === "queued" || item.state === "retry_wait") {
-        item.state = "preparing";
-        item.updated_at_unix_ms = input.now_ms;
+    const locked = await this.withWorkIdLock(input.work_id, async () => {
+      const work = this.works.get(input.work_id);
+      if (!work) throw new SharedPreparationStateError("work not found");
+      if (work.lease_epoch !== input.expected_lease_epoch) {
+        throw new SharedPreparationFencingError("stale lease epoch for preparing transition");
       }
-    }
-    return cloneWork(work);
+      // retry_wait → preparing only via wakeRetryWait → queued first.
+      if (work.state !== "queued") {
+        throw new SharedPreparationStateError(`cannot enter preparing from ${work.state}`);
+      }
+      work.state = "preparing";
+      work.updated_at_unix_ms = input.now_ms;
+      for (const item of this.itemsForWork(work.work_id)) {
+        if (item.state === "queued") {
+          item.state = "preparing";
+          item.updated_at_unix_ms = input.now_ms;
+        }
+      }
+      return cloneWork(work);
+    });
+    return this.unwrapLocked(locked, () => {
+      throw new SharedPreparationStateError("work not found");
+    });
   }
 
   async recordRetryableFailure(input: {
@@ -451,22 +491,29 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
     failure: { code: string; reason: string };
     now_ms: number;
   }): Promise<SharedPreparationWorkRecord> {
-    const work = this.works.get(input.work_id);
-    if (!work) throw new SharedPreparationStateError("work not found");
-    if (work.lease_epoch !== input.expected_lease_epoch) {
-      throw new SharedPreparationFencingError("stale lease epoch for retryable failure");
-    }
-    if (work.state !== "preparing") {
-      throw new SharedPreparationStateError(`retryable failure requires preparing, got ${work.state}`);
-    }
-    work.state = "retry_wait";
-    work.attempt += 1;
-    work.next_attempt_at_unix_ms = input.next_attempt_at_unix_ms;
-    work.retry_deadline_unix_ms = input.retry_deadline_unix_ms;
-    work.lease_until_unix_ms = undefined;
-    work.failure_reason = { ...input.failure };
-    work.updated_at_unix_ms = input.now_ms;
-    return cloneWork(work);
+    const locked = await this.withWorkIdLock(input.work_id, async () => {
+      const work = this.works.get(input.work_id);
+      if (!work) throw new SharedPreparationStateError("work not found");
+      if (work.lease_epoch !== input.expected_lease_epoch) {
+        throw new SharedPreparationFencingError("stale lease epoch for retryable failure");
+      }
+      if (work.state !== "preparing") {
+        throw new SharedPreparationStateError(
+          `retryable failure requires preparing, got ${work.state}`,
+        );
+      }
+      work.state = "retry_wait";
+      work.attempt += 1;
+      work.next_attempt_at_unix_ms = input.next_attempt_at_unix_ms;
+      work.retry_deadline_unix_ms = input.retry_deadline_unix_ms;
+      work.lease_until_unix_ms = undefined;
+      work.failure_reason = { ...input.failure };
+      work.updated_at_unix_ms = input.now_ms;
+      return cloneWork(work);
+    });
+    return this.unwrapLocked(locked, () => {
+      throw new SharedPreparationStateError("work not found");
+    });
   }
 
   async wakeRetryWait(input: {
@@ -477,20 +524,26 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
     | { readonly kind: "woke"; readonly work: SharedPreparationWorkRecord }
     | { readonly kind: "stale_wake" }
   > {
-    const work = this.works.get(input.work_id);
-    if (!work || work.state !== "retry_wait") return { kind: "stale_wake" };
-    if (work.attempt !== input.expected_attempt) {
-      return { kind: "stale_wake" };
-    }
-    if (
-      work.next_attempt_at_unix_ms === undefined ||
-      input.now_ms < work.next_attempt_at_unix_ms
-    ) {
-      return { kind: "stale_wake" };
-    }
-    work.state = "queued";
-    work.updated_at_unix_ms = input.now_ms;
-    return { kind: "woke", work: cloneWork(work) };
+    type WakeResult =
+      | { readonly kind: "woke"; readonly work: SharedPreparationWorkRecord }
+      | { readonly kind: "stale_wake" };
+    const locked = await this.withWorkIdLock(input.work_id, async (): Promise<WakeResult> => {
+      const work = this.works.get(input.work_id);
+      if (!work || work.state !== "retry_wait") return { kind: "stale_wake" };
+      if (work.attempt !== input.expected_attempt) {
+        return { kind: "stale_wake" };
+      }
+      if (
+        work.next_attempt_at_unix_ms === undefined ||
+        input.now_ms < work.next_attempt_at_unix_ms
+      ) {
+        return { kind: "stale_wake" };
+      }
+      work.state = "queued";
+      work.updated_at_unix_ms = input.now_ms;
+      return { kind: "woke", work: cloneWork(work) };
+    });
+    return this.unwrapLocked(locked, () => ({ kind: "stale_wake" as const }));
   }
 
   async publishChildEvidence(input: {
@@ -499,20 +552,27 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
     evidence: ReadinessEvidenceEnvelope;
     now_ms: number;
   }): Promise<PreparationWorkItemRecord> {
-    const item = this.items.get(input.work_item_id);
-    if (!item) throw new SharedPreparationStateError("work item not found");
-    if (item.lease_epoch !== input.expected_lease_epoch) {
-      throw new SharedPreparationFencingError("stale lease epoch for child evidence");
-    }
-    if (item.state !== "preparing") {
-      throw new SharedPreparationStateError(
-        `child evidence requires preparing, got ${item.state}`,
-      );
-    }
-    item.state = "ready";
-    item.evidence_envelope = structuredClone(input.evidence);
-    item.updated_at_unix_ms = input.now_ms;
-    return cloneItem(item);
+    const itemLookup = this.items.get(input.work_item_id);
+    if (!itemLookup) throw new SharedPreparationStateError("work item not found");
+    const locked = await this.withWorkIdLock(itemLookup.work_id, async () => {
+      const item = this.items.get(input.work_item_id);
+      if (!item) throw new SharedPreparationStateError("work item not found");
+      if (item.lease_epoch !== input.expected_lease_epoch) {
+        throw new SharedPreparationFencingError("stale lease epoch for child evidence");
+      }
+      if (item.state !== "preparing") {
+        throw new SharedPreparationStateError(
+          `child evidence requires preparing, got ${item.state}`,
+        );
+      }
+      item.state = "ready";
+      item.evidence_envelope = structuredClone(input.evidence);
+      item.updated_at_unix_ms = input.now_ms;
+      return cloneItem(item);
+    });
+    return this.unwrapLocked(locked, () => {
+      throw new SharedPreparationStateError("work item not found");
+    });
   }
 
   async finalizeReadyIfQualified(input: {
@@ -524,25 +584,33 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
     | { readonly kind: "ready"; readonly work: SharedPreparationWorkRecord }
     | { readonly kind: "pending_children"; readonly work: SharedPreparationWorkRecord }
   > {
-    const work = this.works.get(input.work_id);
-    if (!work) throw new SharedPreparationStateError("work not found");
-    if (work.lease_epoch !== input.expected_lease_epoch) {
-      throw new SharedPreparationFencingError("stale lease epoch for parent ready");
-    }
-    if (work.state !== "preparing") {
-      throw new SharedPreparationStateError(
-        `finalize ready requires preparing, got ${work.state}`,
-      );
-    }
-    const children = this.itemsForWork(work.work_id);
-    if (!allChildrenReady(children)) {
-      return { kind: "pending_children", work: cloneWork(work) };
-    }
-    work.state = "ready";
-    work.readiness_evidence = structuredClone(input.readiness_evidence);
-    work.lease_until_unix_ms = undefined;
-    work.updated_at_unix_ms = input.now_ms;
-    return { kind: "ready", work: cloneWork(work) };
+    type FinalizeResult =
+      | { readonly kind: "ready"; readonly work: SharedPreparationWorkRecord }
+      | { readonly kind: "pending_children"; readonly work: SharedPreparationWorkRecord };
+    const locked = await this.withWorkIdLock(input.work_id, async (): Promise<FinalizeResult> => {
+      const work = this.works.get(input.work_id);
+      if (!work) throw new SharedPreparationStateError("work not found");
+      if (work.lease_epoch !== input.expected_lease_epoch) {
+        throw new SharedPreparationFencingError("stale lease epoch for parent ready");
+      }
+      if (work.state !== "preparing") {
+        throw new SharedPreparationStateError(
+          `finalize ready requires preparing, got ${work.state}`,
+        );
+      }
+      const children = this.itemsForWork(work.work_id);
+      if (!allChildrenReady(children)) {
+        return { kind: "pending_children", work: cloneWork(work) };
+      }
+      work.state = "ready";
+      work.readiness_evidence = structuredClone(input.readiness_evidence);
+      work.lease_until_unix_ms = undefined;
+      work.updated_at_unix_ms = input.now_ms;
+      return { kind: "ready", work: cloneWork(work) };
+    });
+    return this.unwrapLocked(locked, () => {
+      throw new SharedPreparationStateError("work not found");
+    });
   }
 
   async detachSubscriber(input: {

--- a/packages/services/ordering/src/shared-preparation-store.ts
+++ b/packages/services/ordering/src/shared-preparation-store.ts
@@ -112,6 +112,7 @@ export interface SharedPreparationStore {
   }): Promise<
     | { readonly kind: "detached"; readonly work?: SharedPreparationWorkRecord }
     | { readonly kind: "not_linked" }
+    | { readonly kind: "serialization_retry" }
   >;
   supersedeActiveGeneration(input: {
     work_key_digest: string;
@@ -143,6 +144,22 @@ function cloneLink(link: MutableLink): ReportWorkLinkRecord {
 
 function allChildrenReady(items: readonly MutableItem[]): boolean {
   return items.length > 0 && items.every((item) => item.state === "ready");
+}
+
+/** Same freshness gate join uses when reusing a ready row. */
+export function assertReadinessEvidenceQualified(
+  evidence: ReadinessEvidenceEnvelope,
+): void {
+  if (evidence.freshness.qualified !== true) {
+    throw new SharedPreparationStateError(
+      "finalize ready requires readiness_evidence.freshness.qualified",
+    );
+  }
+  if (evidence.privacy_scope !== "public_chain") {
+    throw new SharedPreparationStateError(
+      "finalize ready requires public_chain privacy_scope",
+    );
+  }
 }
 
 export class InMemorySharedPreparationStore implements SharedPreparationStore {
@@ -612,6 +629,7 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
           `finalize ready requires preparing, got ${work.state}`,
         );
       }
+      assertReadinessEvidenceQualified(input.readiness_evidence);
       const children = this.itemsForWork(work.work_id);
       if (!allChildrenReady(children)) {
         return { kind: "pending_children", work: cloneWork(work) };
@@ -634,7 +652,12 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
   }): Promise<
     | { readonly kind: "detached"; readonly work?: SharedPreparationWorkRecord }
     | { readonly kind: "not_linked" }
+    | { readonly kind: "serialization_retry" }
   > {
+    type DetachResult =
+      | { readonly kind: "detached"; readonly work?: SharedPreparationWorkRecord }
+      | { readonly kind: "not_linked" }
+      | { readonly kind: "serialization_retry" };
     const work = this.works.get(input.work_id);
     if (!work) return { kind: "not_linked" };
     const locked = await this.withWorkKeyLock(work.work_key_digest, async () => {
@@ -661,11 +684,9 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
       "kind" in locked &&
       locked.kind === "serialization_retry"
     ) {
-      return { kind: "not_linked" };
+      return { kind: "serialization_retry" };
     }
-    return locked as
-      | { readonly kind: "detached"; readonly work?: SharedPreparationWorkRecord }
-      | { readonly kind: "not_linked" };
+    return locked as DetachResult;
   }
 
   async supersedeActiveGeneration(input: {

--- a/packages/services/ordering/src/shared-preparation-store.ts
+++ b/packages/services/ordering/src/shared-preparation-store.ts
@@ -1,0 +1,578 @@
+/**
+ * CR-201A shared preparation store port + in-memory reference backend.
+ *
+ * Proves transactional join/create, lease fencing, retry CAS, subscriber fan-in,
+ * and deterministic zero-subscriber abandonment without remote calls under lock.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  deploymentSetDigest,
+  digestPublicWorkKey,
+  finalityPolicyVersion,
+} from "./shared-preparation-work-key.js";
+import {
+  isActivePublicWorkState,
+  type PreparationWorkItemRecord,
+  type PublicPreparationWorkKeyMaterial,
+  type PublicWorkState,
+  type ReadinessEvidenceEnvelope,
+  type ReportWorkLinkRecord,
+  type SharedPreparationWorkRecord,
+} from "./shared-preparation-types.js";
+
+export class SharedPreparationFencingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SharedPreparationFencingError";
+  }
+}
+
+export class SharedPreparationStateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SharedPreparationStateError";
+  }
+}
+
+export interface JoinPublicWorkInput {
+  readonly order_id: string;
+  readonly order_tenant_scope_digest: string;
+  readonly work_key: PublicPreparationWorkKeyMaterial;
+  readonly now_ms: number;
+}
+
+export type JoinPublicWorkResult =
+  | {
+      readonly kind: "joined";
+      readonly work: SharedPreparationWorkRecord;
+      readonly links: readonly ReportWorkLinkRecord[];
+      readonly created: boolean;
+      readonly reused_ready: boolean;
+    }
+  | { readonly kind: "serialization_retry" };
+
+export interface SharedPreparationStore {
+  joinPublicWork(input: JoinPublicWorkInput): Promise<JoinPublicWorkResult>;
+  getWork(workId: string): Promise<SharedPreparationWorkRecord | undefined>;
+  listActiveLinks(workId: string): Promise<readonly ReportWorkLinkRecord[]>;
+  listWorkItems(workId: string): Promise<readonly PreparationWorkItemRecord[]>;
+  acquireLease(input: {
+    work_id: string;
+    worker_id: string;
+    lease_duration_ms: number;
+    now_ms: number;
+  }): Promise<
+    | { readonly kind: "acquired"; readonly work: SharedPreparationWorkRecord }
+    | { readonly kind: "reclaimed"; readonly work: SharedPreparationWorkRecord }
+    | { readonly kind: "busy" }
+    | { readonly kind: "not_active" }
+  >;
+  transitionToPreparing(input: {
+    work_id: string;
+    expected_lease_epoch: number;
+    now_ms: number;
+  }): Promise<SharedPreparationWorkRecord>;
+  recordRetryableFailure(input: {
+    work_id: string;
+    expected_lease_epoch: number;
+    next_attempt_at_unix_ms: number;
+    retry_deadline_unix_ms: number;
+    failure: { code: string; reason: string };
+    now_ms: number;
+  }): Promise<SharedPreparationWorkRecord>;
+  wakeRetryWait(input: {
+    work_id: string;
+    expected_next_attempt_at_unix_ms: number;
+    now_ms: number;
+  }): Promise<
+    | { readonly kind: "woke"; readonly work: SharedPreparationWorkRecord }
+    | { readonly kind: "stale_wake" }
+  >;
+  publishChildEvidence(input: {
+    work_item_id: string;
+    expected_lease_epoch: number;
+    evidence: ReadinessEvidenceEnvelope;
+    now_ms: number;
+  }): Promise<PreparationWorkItemRecord>;
+  finalizeReadyIfQualified(input: {
+    work_id: string;
+    expected_lease_epoch: number;
+    readiness_evidence: ReadinessEvidenceEnvelope;
+    now_ms: number;
+  }): Promise<
+    | { readonly kind: "ready"; readonly work: SharedPreparationWorkRecord }
+    | { readonly kind: "pending_children"; readonly work: SharedPreparationWorkRecord }
+  >;
+  detachSubscriber(input: {
+    order_id: string;
+    work_id: string;
+    now_ms: number;
+  }): Promise<
+    | { readonly kind: "detached"; readonly work?: SharedPreparationWorkRecord }
+    | { readonly kind: "not_linked" }
+  >;
+  supersedeActiveGeneration(input: {
+    work_key_digest: string;
+    now_ms: number;
+  }): Promise<SharedPreparationWorkRecord | undefined>;
+}
+
+type MutableWork = {
+  -readonly [K in keyof SharedPreparationWorkRecord]: SharedPreparationWorkRecord[K];
+};
+type MutableItem = {
+  -readonly [K in keyof PreparationWorkItemRecord]: PreparationWorkItemRecord[K];
+};
+type MutableLink = {
+  -readonly [K in keyof ReportWorkLinkRecord]: ReportWorkLinkRecord[K];
+};
+
+function cloneWork(work: MutableWork): SharedPreparationWorkRecord {
+  return structuredClone(work);
+}
+
+function cloneItem(item: MutableItem): PreparationWorkItemRecord {
+  return structuredClone(item);
+}
+
+function cloneLink(link: MutableLink): ReportWorkLinkRecord {
+  return structuredClone(link);
+}
+
+function allChildrenReady(items: readonly MutableItem[]): boolean {
+  return items.length > 0 && items.every((item) => item.state === "ready");
+}
+
+export class InMemorySharedPreparationStore implements SharedPreparationStore {
+  private readonly works = new Map<string, MutableWork>();
+  private readonly items = new Map<string, MutableItem>();
+  private readonly links = new Map<string, MutableLink>();
+  private readonly locks = new Map<string, Promise<void>>();
+  private readonly maxSerializationRetries = 8;
+
+  private linkKey(orderId: string, workId: string): string {
+    return `${orderId}\0${workId}`;
+  }
+
+  private async withWorkKeyLock<T>(
+    workKeyDigest: string,
+    fn: () => Promise<T>,
+  ): Promise<T | { kind: "serialization_retry" }> {
+    const prior = this.locks.get(workKeyDigest) ?? Promise.resolve();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.locks.set(workKeyDigest, prior.then(() => gate));
+
+    await prior;
+    try {
+      for (let attempt = 0; attempt < this.maxSerializationRetries; attempt += 1) {
+        try {
+          return await fn();
+        } catch (err) {
+          if (
+            err instanceof Error &&
+            err.message === "serialization_retry" &&
+            attempt + 1 < this.maxSerializationRetries
+          ) {
+            continue;
+          }
+          throw err;
+        }
+      }
+      return { kind: "serialization_retry" };
+    } finally {
+      release();
+      if (this.locks.get(workKeyDigest) === gate) {
+        this.locks.delete(workKeyDigest);
+      }
+    }
+  }
+
+  private rowsForKey(workKeyDigest: string): MutableWork[] {
+    return [...this.works.values()].filter((row) => row.work_key_digest === workKeyDigest);
+  }
+
+  private activeRow(workKeyDigest: string): MutableWork | undefined {
+    return this.rowsForKey(workKeyDigest).find((row) => isActivePublicWorkState(row.state));
+  }
+
+  private highestReadyRow(
+    workKeyDigest: string,
+    readinessPolicyVersion: string,
+  ): MutableWork | undefined {
+    const ready = this.rowsForKey(workKeyDigest)
+      .filter(
+        (row) =>
+          row.state === "ready" &&
+          row.readiness_policy_version === readinessPolicyVersion &&
+          row.readiness_evidence?.freshness.qualified === true,
+      )
+      .sort((a, b) => b.generation - a.generation);
+    return ready[0];
+  }
+
+  private itemsForWork(workId: string): MutableItem[] {
+    return [...this.items.values()].filter((item) => item.work_id === workId);
+  }
+
+  private activeLinksForWork(workId: string): MutableLink[] {
+    return [...this.links.values()].filter(
+      (link) => link.work_id === workId && link.detached_at_unix_ms === undefined,
+    );
+  }
+
+  private createWorkAndChildren(input: {
+    work_key: PublicPreparationWorkKeyMaterial;
+    generation: number;
+    now_ms: number;
+  }): MutableWork {
+    const workId = `spw_${randomUUID()}`;
+    const workKeyDigest = digestPublicWorkKey(input.work_key);
+    const work: MutableWork = {
+      work_id: workId,
+      work_key_digest: workKeyDigest,
+      deployment_set_digest: deploymentSetDigest(input.work_key.deployment_ids),
+      capability: input.work_key.capability,
+      capability_version: input.work_key.capability_version,
+      scope_class: "deployment",
+      scope_digest: input.work_key.scope_digest,
+      privacy_class: "public_chain",
+      source_identity: structuredClone(input.work_key.source_identity),
+      readiness_policy_version: input.work_key.readiness_policy_version,
+      evidence_boundary_kind: input.work_key.evidence_boundary_kind,
+      ...(input.work_key.evidence_boundary_digest !== undefined
+        ? { evidence_boundary_digest: input.work_key.evidence_boundary_digest }
+        : {}),
+      adapter_version: input.work_key.adapter_version,
+      finality_policy_version: finalityPolicyVersion(input.work_key.finality_policies),
+      state: "queued",
+      generation: input.generation,
+      attempt: 0,
+      lease_epoch: 0,
+      sharing_scope_kind: "public",
+      created_at_unix_ms: input.now_ms,
+      updated_at_unix_ms: input.now_ms,
+    };
+    this.works.set(workId, work);
+    for (const deploymentId of input.work_key.deployment_ids) {
+      const itemId = `pwi_${randomUUID()}`;
+      const item: MutableItem = {
+        work_item_id: itemId,
+        work_id: workId,
+        deployment_id: structuredClone(deploymentId),
+        capability: input.work_key.capability,
+        adapter_version: input.work_key.adapter_version,
+        state: "queued",
+        attempt: 0,
+        lease_epoch: 0,
+        created_at_unix_ms: input.now_ms,
+        updated_at_unix_ms: input.now_ms,
+      };
+      this.items.set(itemId, item);
+    }
+    return work;
+  }
+
+  private attachLink(input: {
+    order_id: string;
+    work_id: string;
+    generation: number;
+    order_tenant_scope_digest: string;
+    now_ms: number;
+  }): ReportWorkLinkRecord {
+    const key = this.linkKey(input.order_id, input.work_id);
+    const existing = this.links.get(key);
+    if (existing && existing.detached_at_unix_ms === undefined) {
+      return cloneLink(existing);
+    }
+    const link: MutableLink = {
+      order_id: input.order_id,
+      work_id: input.work_id,
+      joined_at_unix_ms: input.now_ms,
+      generation: input.generation,
+      order_tenant_scope_digest: input.order_tenant_scope_digest,
+      sharing_scope_kind: "public",
+    };
+    this.links.set(key, link);
+    return cloneLink(link);
+  }
+
+  async joinPublicWork(input: JoinPublicWorkInput): Promise<JoinPublicWorkResult> {
+    const workKeyDigest = digestPublicWorkKey(input.work_key);
+    const locked = await this.withWorkKeyLock(workKeyDigest, async () => {
+      const ready = this.highestReadyRow(workKeyDigest, input.work_key.readiness_policy_version);
+      if (ready) {
+        this.attachLink({
+          order_id: input.order_id,
+          work_id: ready.work_id,
+          generation: ready.generation,
+          order_tenant_scope_digest: input.order_tenant_scope_digest,
+          now_ms: input.now_ms,
+        });
+        return {
+          kind: "joined" as const,
+          work: cloneWork(ready),
+          links: this.activeLinksForWork(ready.work_id).map(cloneLink),
+          created: false,
+          reused_ready: true,
+        };
+      }
+
+      const active = this.activeRow(workKeyDigest);
+      if (active) {
+        this.attachLink({
+          order_id: input.order_id,
+          work_id: active.work_id,
+          generation: active.generation,
+          order_tenant_scope_digest: input.order_tenant_scope_digest,
+          now_ms: input.now_ms,
+        });
+        return {
+          kind: "joined" as const,
+          work: cloneWork(active),
+          links: this.activeLinksForWork(active.work_id).map(cloneLink),
+          created: false,
+          reused_ready: false,
+        };
+      }
+
+      const prior = this.rowsForKey(workKeyDigest);
+      const generation = prior.reduce((max, row) => Math.max(max, row.generation), 0) + 1;
+      if (this.activeRow(workKeyDigest)) {
+        throw new Error("serialization_retry");
+      }
+      const created = this.createWorkAndChildren({
+        work_key: input.work_key,
+        generation,
+        now_ms: input.now_ms,
+      });
+      this.attachLink({
+        order_id: input.order_id,
+        work_id: created.work_id,
+        generation: created.generation,
+        order_tenant_scope_digest: input.order_tenant_scope_digest,
+        now_ms: input.now_ms,
+      });
+      return {
+        kind: "joined" as const,
+        work: cloneWork(created),
+        links: this.activeLinksForWork(created.work_id).map(cloneLink),
+        created: true,
+        reused_ready: false,
+      };
+    });
+
+    if (locked && typeof locked === "object" && "kind" in locked && locked.kind === "serialization_retry") {
+      return locked;
+    }
+    return locked as JoinPublicWorkResult;
+  }
+
+  async getWork(workId: string): Promise<SharedPreparationWorkRecord | undefined> {
+    const work = this.works.get(workId);
+    return work ? cloneWork(work) : undefined;
+  }
+
+  async listActiveLinks(workId: string): Promise<readonly ReportWorkLinkRecord[]> {
+    return this.activeLinksForWork(workId).map(cloneLink);
+  }
+
+  async listWorkItems(workId: string): Promise<readonly PreparationWorkItemRecord[]> {
+    return this.itemsForWork(workId).map(cloneItem);
+  }
+
+  async acquireLease(input: {
+    work_id: string;
+    worker_id: string;
+    lease_duration_ms: number;
+    now_ms: number;
+  }): Promise<
+    | { readonly kind: "acquired"; readonly work: SharedPreparationWorkRecord }
+    | { readonly kind: "reclaimed"; readonly work: SharedPreparationWorkRecord }
+    | { readonly kind: "busy" }
+    | { readonly kind: "not_active" }
+  > {
+    const work = this.works.get(input.work_id);
+    if (!work || !isActivePublicWorkState(work.state)) {
+      return { kind: "not_active" };
+    }
+    const leaseExpired =
+      work.lease_until_unix_ms === undefined || input.now_ms >= work.lease_until_unix_ms;
+    if (!leaseExpired && work.lease_until_unix_ms !== undefined) {
+      return { kind: "busy" };
+    }
+    const reclaimed = leaseExpired && work.lease_until_unix_ms !== undefined;
+    work.lease_epoch += 1;
+    work.lease_until_unix_ms = input.now_ms + input.lease_duration_ms;
+    work.updated_at_unix_ms = input.now_ms;
+    for (const item of this.itemsForWork(work.work_id)) {
+      item.lease_epoch = work.lease_epoch;
+      item.updated_at_unix_ms = input.now_ms;
+    }
+    return {
+      kind: reclaimed ? "reclaimed" : "acquired",
+      work: cloneWork(work),
+    };
+  }
+
+  async transitionToPreparing(input: {
+    work_id: string;
+    expected_lease_epoch: number;
+    now_ms: number;
+  }): Promise<SharedPreparationWorkRecord> {
+    const work = this.works.get(input.work_id);
+    if (!work) throw new SharedPreparationStateError("work not found");
+    if (work.lease_epoch !== input.expected_lease_epoch) {
+      throw new SharedPreparationFencingError("stale lease epoch for preparing transition");
+    }
+    if (work.state !== "queued" && work.state !== "retry_wait") {
+      throw new SharedPreparationStateError(`cannot enter preparing from ${work.state}`);
+    }
+    work.state = "preparing";
+    work.updated_at_unix_ms = input.now_ms;
+    for (const item of this.itemsForWork(work.work_id)) {
+      if (item.state === "queued" || item.state === "retry_wait") {
+        item.state = "preparing";
+        item.updated_at_unix_ms = input.now_ms;
+      }
+    }
+    return cloneWork(work);
+  }
+
+  async recordRetryableFailure(input: {
+    work_id: string;
+    expected_lease_epoch: number;
+    next_attempt_at_unix_ms: number;
+    retry_deadline_unix_ms: number;
+    failure: { code: string; reason: string };
+    now_ms: number;
+  }): Promise<SharedPreparationWorkRecord> {
+    const work = this.works.get(input.work_id);
+    if (!work) throw new SharedPreparationStateError("work not found");
+    if (work.lease_epoch !== input.expected_lease_epoch) {
+      throw new SharedPreparationFencingError("stale lease epoch for retryable failure");
+    }
+    if (work.state !== "preparing") {
+      throw new SharedPreparationStateError(`retryable failure requires preparing, got ${work.state}`);
+    }
+    work.state = "retry_wait";
+    work.attempt += 1;
+    work.next_attempt_at_unix_ms = input.next_attempt_at_unix_ms;
+    work.retry_deadline_unix_ms = input.retry_deadline_unix_ms;
+    work.lease_until_unix_ms = undefined;
+    work.failure_reason = { ...input.failure };
+    work.updated_at_unix_ms = input.now_ms;
+    return cloneWork(work);
+  }
+
+  async wakeRetryWait(input: {
+    work_id: string;
+    expected_next_attempt_at_unix_ms: number;
+    now_ms: number;
+  }): Promise<
+    | { readonly kind: "woke"; readonly work: SharedPreparationWorkRecord }
+    | { readonly kind: "stale_wake" }
+  > {
+    const work = this.works.get(input.work_id);
+    if (!work || work.state !== "retry_wait") return { kind: "stale_wake" };
+    if (work.next_attempt_at_unix_ms !== input.expected_next_attempt_at_unix_ms) {
+      return { kind: "stale_wake" };
+    }
+    if (input.now_ms < input.expected_next_attempt_at_unix_ms) {
+      return { kind: "stale_wake" };
+    }
+    work.state = "queued";
+    work.updated_at_unix_ms = input.now_ms;
+    return { kind: "woke", work: cloneWork(work) };
+  }
+
+  async publishChildEvidence(input: {
+    work_item_id: string;
+    expected_lease_epoch: number;
+    evidence: ReadinessEvidenceEnvelope;
+    now_ms: number;
+  }): Promise<PreparationWorkItemRecord> {
+    const item = this.items.get(input.work_item_id);
+    if (!item) throw new SharedPreparationStateError("work item not found");
+    if (item.lease_epoch !== input.expected_lease_epoch) {
+      throw new SharedPreparationFencingError("stale lease epoch for child evidence");
+    }
+    item.state = "ready";
+    item.evidence_envelope = structuredClone(input.evidence);
+    item.updated_at_unix_ms = input.now_ms;
+    return cloneItem(item);
+  }
+
+  async finalizeReadyIfQualified(input: {
+    work_id: string;
+    expected_lease_epoch: number;
+    readiness_evidence: ReadinessEvidenceEnvelope;
+    now_ms: number;
+  }): Promise<
+    | { readonly kind: "ready"; readonly work: SharedPreparationWorkRecord }
+    | { readonly kind: "pending_children"; readonly work: SharedPreparationWorkRecord }
+  > {
+    const work = this.works.get(input.work_id);
+    if (!work) throw new SharedPreparationStateError("work not found");
+    if (work.lease_epoch !== input.expected_lease_epoch) {
+      throw new SharedPreparationFencingError("stale lease epoch for parent ready");
+    }
+    const children = this.itemsForWork(work.work_id);
+    if (!allChildrenReady(children)) {
+      return { kind: "pending_children", work: cloneWork(work) };
+    }
+    work.state = "ready";
+    work.readiness_evidence = structuredClone(input.readiness_evidence);
+    work.lease_until_unix_ms = undefined;
+    work.updated_at_unix_ms = input.now_ms;
+    return { kind: "ready", work: cloneWork(work) };
+  }
+
+  async detachSubscriber(input: {
+    order_id: string;
+    work_id: string;
+    now_ms: number;
+  }): Promise<
+    | { readonly kind: "detached"; readonly work?: SharedPreparationWorkRecord }
+    | { readonly kind: "not_linked" }
+  > {
+    const key = this.linkKey(input.order_id, input.work_id);
+    const link = this.links.get(key);
+    if (!link || link.detached_at_unix_ms !== undefined) {
+      return { kind: "not_linked" };
+    }
+    link.detached_at_unix_ms = input.now_ms;
+    const work = this.works.get(input.work_id);
+    if (!work) return { kind: "detached" };
+    const remaining = this.activeLinksForWork(input.work_id);
+    if (remaining.length === 0 && isActivePublicWorkState(work.state)) {
+      work.state = "abandoned";
+      work.updated_at_unix_ms = input.now_ms;
+      work.lease_until_unix_ms = undefined;
+      return { kind: "detached", work: cloneWork(work) };
+    }
+    return { kind: "detached" };
+  }
+
+  async supersedeActiveGeneration(input: {
+    work_key_digest: string;
+    now_ms: number;
+  }): Promise<SharedPreparationWorkRecord | undefined> {
+    return this.withWorkKeyLock(input.work_key_digest, async () => {
+      const active = this.activeRow(input.work_key_digest);
+      if (!active) return undefined;
+      active.state = "superseded";
+      active.updated_at_unix_ms = input.now_ms;
+      active.lease_until_unix_ms = undefined;
+      return cloneWork(active);
+    }) as Promise<SharedPreparationWorkRecord | undefined>;
+  }
+}
+
+export function countActiveRows(store: InMemorySharedPreparationStore, workKeyDigest: string): number {
+  return (store as unknown as { rowsForKey(d: string): MutableWork[] }).rowsForKey(workKeyDigest)
+    .filter((row) => isActivePublicWorkState(row.state)).length;
+}

--- a/packages/services/ordering/src/shared-preparation-store.ts
+++ b/packages/services/ordering/src/shared-preparation-store.ts
@@ -509,6 +509,20 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
       work.lease_until_unix_ms = undefined;
       work.failure_reason = { ...input.failure };
       work.updated_at_unix_ms = input.now_ms;
+      // Invalidate child progress so finalize cannot reuse pre-retry evidence.
+      for (const item of this.itemsForWork(work.work_id)) {
+        if (
+          item.state === "ready" ||
+          item.state === "preparing" ||
+          item.state === "failed" ||
+          item.state === "retry_wait"
+        ) {
+          item.state = "queued";
+          item.evidence_envelope = undefined;
+          item.failure_reason = undefined;
+          item.updated_at_unix_ms = input.now_ms;
+        }
+      }
       return cloneWork(work);
     });
     return this.unwrapLocked(locked, () => {

--- a/packages/services/ordering/src/shared-preparation-store.ts
+++ b/packages/services/ordering/src/shared-preparation-store.ts
@@ -83,7 +83,8 @@ export interface SharedPreparationStore {
   }): Promise<SharedPreparationWorkRecord>;
   wakeRetryWait(input: {
     work_id: string;
-    expected_next_attempt_at_unix_ms: number;
+    /** CAS token: wake only when attempt still matches the scheduled failure. */
+    expected_attempt: number;
     now_ms: number;
   }): Promise<
     | { readonly kind: "woke"; readonly work: SharedPreparationWorkRecord }
@@ -470,7 +471,7 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
 
   async wakeRetryWait(input: {
     work_id: string;
-    expected_next_attempt_at_unix_ms: number;
+    expected_attempt: number;
     now_ms: number;
   }): Promise<
     | { readonly kind: "woke"; readonly work: SharedPreparationWorkRecord }
@@ -478,10 +479,13 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
   > {
     const work = this.works.get(input.work_id);
     if (!work || work.state !== "retry_wait") return { kind: "stale_wake" };
-    if (work.next_attempt_at_unix_ms !== input.expected_next_attempt_at_unix_ms) {
+    if (work.attempt !== input.expected_attempt) {
       return { kind: "stale_wake" };
     }
-    if (input.now_ms < input.expected_next_attempt_at_unix_ms) {
+    if (
+      work.next_attempt_at_unix_ms === undefined ||
+      input.now_ms < work.next_attempt_at_unix_ms
+    ) {
       return { kind: "stale_wake" };
     }
     work.state = "queued";
@@ -499,6 +503,11 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
     if (!item) throw new SharedPreparationStateError("work item not found");
     if (item.lease_epoch !== input.expected_lease_epoch) {
       throw new SharedPreparationFencingError("stale lease epoch for child evidence");
+    }
+    if (item.state !== "preparing") {
+      throw new SharedPreparationStateError(
+        `child evidence requires preparing, got ${item.state}`,
+      );
     }
     item.state = "ready";
     item.evidence_envelope = structuredClone(input.evidence);
@@ -520,6 +529,11 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
     if (work.lease_epoch !== input.expected_lease_epoch) {
       throw new SharedPreparationFencingError("stale lease epoch for parent ready");
     }
+    if (work.state !== "preparing") {
+      throw new SharedPreparationStateError(
+        `finalize ready requires preparing, got ${work.state}`,
+      );
+    }
     const children = this.itemsForWork(work.work_id);
     if (!allChildrenReady(children)) {
       return { kind: "pending_children", work: cloneWork(work) };
@@ -539,36 +553,60 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
     | { readonly kind: "detached"; readonly work?: SharedPreparationWorkRecord }
     | { readonly kind: "not_linked" }
   > {
-    const key = this.linkKey(input.order_id, input.work_id);
-    const link = this.links.get(key);
-    if (!link || link.detached_at_unix_ms !== undefined) {
+    const work = this.works.get(input.work_id);
+    if (!work) return { kind: "not_linked" };
+    const locked = await this.withWorkKeyLock(work.work_key_digest, async () => {
+      const key = this.linkKey(input.order_id, input.work_id);
+      const link = this.links.get(key);
+      if (!link || link.detached_at_unix_ms !== undefined) {
+        return { kind: "not_linked" as const };
+      }
+      link.detached_at_unix_ms = input.now_ms;
+      const current = this.works.get(input.work_id);
+      if (!current) return { kind: "detached" as const };
+      const remaining = this.activeLinksForWork(input.work_id);
+      if (remaining.length === 0 && isActivePublicWorkState(current.state)) {
+        current.state = "abandoned";
+        current.updated_at_unix_ms = input.now_ms;
+        current.lease_until_unix_ms = undefined;
+        return { kind: "detached" as const, work: cloneWork(current) };
+      }
+      return { kind: "detached" as const };
+    });
+    if (
+      locked &&
+      typeof locked === "object" &&
+      "kind" in locked &&
+      locked.kind === "serialization_retry"
+    ) {
       return { kind: "not_linked" };
     }
-    link.detached_at_unix_ms = input.now_ms;
-    const work = this.works.get(input.work_id);
-    if (!work) return { kind: "detached" };
-    const remaining = this.activeLinksForWork(input.work_id);
-    if (remaining.length === 0 && isActivePublicWorkState(work.state)) {
-      work.state = "abandoned";
-      work.updated_at_unix_ms = input.now_ms;
-      work.lease_until_unix_ms = undefined;
-      return { kind: "detached", work: cloneWork(work) };
-    }
-    return { kind: "detached" };
+    return locked as
+      | { readonly kind: "detached"; readonly work?: SharedPreparationWorkRecord }
+      | { readonly kind: "not_linked" };
   }
 
   async supersedeActiveGeneration(input: {
     work_key_digest: string;
     now_ms: number;
   }): Promise<SharedPreparationWorkRecord | undefined> {
-    return this.withWorkKeyLock(input.work_key_digest, async () => {
+    const locked = await this.withWorkKeyLock(input.work_key_digest, async () => {
       const active = this.activeRow(input.work_key_digest);
       if (!active) return undefined;
       active.state = "superseded";
       active.updated_at_unix_ms = input.now_ms;
       active.lease_until_unix_ms = undefined;
       return cloneWork(active);
-    }) as Promise<SharedPreparationWorkRecord | undefined>;
+    });
+    if (
+      locked &&
+      typeof locked === "object" &&
+      "kind" in locked &&
+      locked.kind === "serialization_retry"
+    ) {
+      return undefined;
+    }
+    return locked as SharedPreparationWorkRecord | undefined;
   }
 }
 

--- a/packages/services/ordering/src/shared-preparation-store.ts
+++ b/packages/services/ordering/src/shared-preparation-store.ts
@@ -13,6 +13,7 @@ import {
 } from "./shared-preparation-work-key.js";
 import {
   isActivePublicWorkState,
+  isLeasablePublicWorkState,
   type PreparationWorkItemRecord,
   type PublicPreparationWorkKeyMaterial,
   type PublicWorkState,
@@ -446,7 +447,8 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
       | { readonly kind: "not_active" };
     const locked = await this.withWorkIdLock(input.work_id, async (): Promise<LeaseResult> => {
       const work = this.works.get(input.work_id);
-      if (!work || !isActivePublicWorkState(work.state)) {
+      // retry_wait is active but not leasable — wake must run first.
+      if (!work || !isLeasablePublicWorkState(work.state)) {
         return { kind: "not_active" };
       }
       const leaseExpired =
@@ -588,6 +590,13 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
     const locked = await this.withWorkIdLock(itemLookup.work_id, async () => {
       const item = this.items.get(input.work_item_id);
       if (!item) throw new SharedPreparationStateError("work item not found");
+      const parent = this.works.get(item.work_id);
+      if (!parent) throw new SharedPreparationStateError("work not found");
+      if (parent.state !== "preparing") {
+        throw new SharedPreparationStateError(
+          `child evidence requires parent preparing, got ${parent.state}`,
+        );
+      }
       if (item.lease_epoch !== input.expected_lease_epoch) {
         throw new SharedPreparationFencingError("stale lease epoch for child evidence");
       }

--- a/packages/services/ordering/src/shared-preparation-types.ts
+++ b/packages/services/ordering/src/shared-preparation-types.ts
@@ -20,6 +20,11 @@ export const ACTIVE_PUBLIC_WORK_STATES = [
 
 export type ActivePublicWorkState = (typeof ACTIVE_PUBLIC_WORK_STATES)[number];
 
+/** States that may hold a worker lease. retry_wait is active but not leasable. */
+export const LEASABLE_PUBLIC_WORK_STATES = ["queued", "preparing"] as const;
+
+export type LeasablePublicWorkState = (typeof LEASABLE_PUBLIC_WORK_STATES)[number];
+
 export const PUBLIC_WORK_STATES = [
   ...ACTIVE_PUBLIC_WORK_STATES,
   "ready",
@@ -161,6 +166,12 @@ export interface ReportWorkLinkRecord {
 
 export function isActivePublicWorkState(state: PublicWorkState): state is ActivePublicWorkState {
   return (ACTIVE_PUBLIC_WORK_STATES as readonly string[]).includes(state);
+}
+
+export function isLeasablePublicWorkState(
+  state: PublicWorkState,
+): state is LeasablePublicWorkState {
+  return (LEASABLE_PUBLIC_WORK_STATES as readonly string[]).includes(state);
 }
 
 export function assertPublicPrepCapability(capability: string): asserts capability is PublicPrepCapability {

--- a/packages/services/ordering/src/shared-preparation-types.ts
+++ b/packages/services/ordering/src/shared-preparation-types.ts
@@ -1,0 +1,170 @@
+/**
+ * CR-201A public shared preparation types.
+ *
+ * T1 controlled public-chain fixtures only. No restricted Discord/identity
+ * evidence and no customer Gate Leak artifact semantics in this module.
+ */
+
+export const PUBLIC_PREP_CAPABILITIES = [
+  "collection_identity.v1",
+  "ownership_index.v1",
+] as const;
+
+export type PublicPrepCapability = (typeof PUBLIC_PREP_CAPABILITIES)[number];
+
+export const ACTIVE_PUBLIC_WORK_STATES = [
+  "queued",
+  "preparing",
+  "retry_wait",
+] as const;
+
+export type ActivePublicWorkState = (typeof ACTIVE_PUBLIC_WORK_STATES)[number];
+
+export const PUBLIC_WORK_STATES = [
+  ...ACTIVE_PUBLIC_WORK_STATES,
+  "ready",
+  "failed",
+  "abandoned",
+  "superseded",
+] as const;
+
+export type PublicWorkState = (typeof PUBLIC_WORK_STATES)[number];
+
+export const EVIDENCE_BOUNDARY_KINDS = [
+  "continuous_latest",
+  "server_time_bucket",
+  "exact_snapshot",
+] as const;
+
+export type EvidenceBoundaryKind = (typeof EVIDENCE_BOUNDARY_KINDS)[number];
+
+/** V1 ceilings from sprint.md §4 release gates. */
+export const PUBLIC_PREP_LIMITS = {
+  maxDeployments: 16,
+  maxCapabilities: 8,
+  maxRootReferences: 32,
+  maxDagNodes: 160,
+} as const;
+
+export interface VersionedDigest {
+  readonly algorithm: "sha-256";
+  readonly domain: string;
+  readonly major_version: number;
+  readonly digest: string;
+}
+
+export interface PublicSourceIdentity {
+  readonly schema_version: 1;
+  readonly producer: string;
+  readonly upstream_evidence_source: string;
+}
+
+export interface PublicPreparationWorkKeyMaterial {
+  readonly schema_version: 1;
+  readonly capability: PublicPrepCapability;
+  readonly capability_version: string;
+  readonly collection_id: VersionedDigest;
+  readonly deployment_ids: readonly VersionedDigest[];
+  readonly finality_policies: readonly {
+    readonly schema_version: 1;
+    readonly network: {
+      readonly schema_version: 1;
+      readonly network_namespace: string;
+      readonly network_reference: string;
+    };
+    readonly finality_policy_version: string;
+  }[];
+  readonly scope_class: "deployment";
+  readonly scope_digest: string;
+  readonly privacy_class: "public_chain";
+  readonly source_identity: PublicSourceIdentity;
+  readonly evidence_boundary_kind: EvidenceBoundaryKind;
+  readonly evidence_boundary_digest?: string;
+  readonly readiness_policy_version: string;
+  readonly adapter_version: string;
+}
+
+export interface ReadinessEvidenceEnvelope {
+  readonly schema_version: 1;
+  readonly producer: string;
+  readonly schema: string;
+  readonly adapter: string;
+  readonly readiness_policy_version: string;
+  readonly privacy_scope: "public_chain";
+  readonly deployment_coverage: readonly VersionedDigest[];
+  readonly observation_window: {
+    readonly observed_at: string;
+    readonly as_of: string;
+  };
+  readonly freshness: {
+    readonly qualified: boolean;
+    readonly max_age_ms: number;
+  };
+  readonly source_digest: VersionedDigest;
+  readonly evidence_digest: VersionedDigest;
+}
+
+export interface SharedPreparationWorkRecord {
+  readonly work_id: string;
+  readonly work_key_digest: string;
+  readonly deployment_set_digest: string;
+  readonly capability: PublicPrepCapability;
+  readonly capability_version: string;
+  readonly scope_class: "deployment";
+  readonly scope_digest: string;
+  readonly privacy_class: "public_chain";
+  readonly source_identity: PublicSourceIdentity;
+  readonly readiness_policy_version: string;
+  readonly evidence_boundary_kind: EvidenceBoundaryKind;
+  readonly evidence_boundary_digest?: string;
+  readonly adapter_version: string;
+  readonly finality_policy_version: string;
+  readonly state: PublicWorkState;
+  readonly generation: number;
+  readonly readiness_evidence?: ReadinessEvidenceEnvelope;
+  readonly attempt: number;
+  readonly next_attempt_at_unix_ms?: number;
+  readonly retry_deadline_unix_ms?: number;
+  readonly lease_until_unix_ms?: number;
+  readonly lease_epoch: number;
+  readonly failure_reason?: { readonly code: string; readonly reason: string };
+  readonly sharing_scope_kind: "public";
+  readonly created_at_unix_ms: number;
+  readonly updated_at_unix_ms: number;
+}
+
+export interface PreparationWorkItemRecord {
+  readonly work_item_id: string;
+  readonly work_id: string;
+  readonly deployment_id: VersionedDigest;
+  readonly capability: PublicPrepCapability;
+  readonly adapter_version: string;
+  readonly external_job_ref?: string;
+  readonly state: PublicWorkState;
+  readonly attempt: number;
+  readonly lease_epoch: number;
+  readonly evidence_envelope?: ReadinessEvidenceEnvelope;
+  readonly failure_reason?: { readonly code: string; readonly reason: string };
+  readonly created_at_unix_ms: number;
+  readonly updated_at_unix_ms: number;
+}
+
+export interface ReportWorkLinkRecord {
+  readonly order_id: string;
+  readonly work_id: string;
+  readonly joined_at_unix_ms: number;
+  readonly detached_at_unix_ms?: number;
+  readonly generation: number;
+  readonly order_tenant_scope_digest: string;
+  readonly sharing_scope_kind: "public";
+}
+
+export function isActivePublicWorkState(state: PublicWorkState): state is ActivePublicWorkState {
+  return (ACTIVE_PUBLIC_WORK_STATES as readonly string[]).includes(state);
+}
+
+export function assertPublicPrepCapability(capability: string): asserts capability is PublicPrepCapability {
+  if (!(PUBLIC_PREP_CAPABILITIES as readonly string[]).includes(capability)) {
+    throw new Error(`CR-201A rejects non-public capability: ${capability}`);
+  }
+}

--- a/packages/services/ordering/src/shared-preparation-work-key.ts
+++ b/packages/services/ordering/src/shared-preparation-work-key.ts
@@ -1,0 +1,114 @@
+import { createHash } from "node:crypto";
+import {
+  digestCollectionWorkKey,
+  type CollectionWorkKeyMaterial,
+  type CollectionCandidate,
+} from "@freeside/collection-protocol";
+import { Effect } from "effect";
+import {
+  PUBLIC_PREP_LIMITS,
+  type PublicPreparationWorkKeyMaterial,
+  type VersionedDigest,
+  assertPublicPrepCapability,
+} from "./shared-preparation-types.js";
+
+function digestKey(digest: VersionedDigest): string {
+  return `${digest.domain}:${digest.major_version}:${digest.digest}`;
+}
+
+function sortedDeploymentSetDigest(deploymentIds: readonly VersionedDigest[]): string {
+  const keys = deploymentIds.map(digestKey).sort();
+  return createHash("sha256").update(keys.join("\n")).digest("hex");
+}
+
+function runEffect<A>(effect: Effect.Effect<A, unknown>): A {
+  return Effect.runSync(effect);
+}
+
+export function buildPublicWorkKeyMaterial(input: {
+  capability: string;
+  capability_version: string;
+  collection_id: VersionedDigest;
+  deployment_ids: readonly VersionedDigest[];
+  finality_policies: CollectionCandidate["finality_policies"];
+  source_identity: PublicPreparationWorkKeyMaterial["source_identity"];
+  readiness_policy_version: string;
+  adapter_version: string;
+  evidence_boundary_kind?: PublicPreparationWorkKeyMaterial["evidence_boundary_kind"];
+  evidence_boundary_digest?: string;
+}): PublicPreparationWorkKeyMaterial {
+  assertPublicPrepCapability(input.capability);
+  if (input.deployment_ids.length === 0) {
+    throw new Error("deployment_ids must be non-empty");
+  }
+  if (input.deployment_ids.length > PUBLIC_PREP_LIMITS.maxDeployments) {
+    throw new Error(`deployment ceiling ${PUBLIC_PREP_LIMITS.maxDeployments} exceeded`);
+  }
+
+  const collectionWorkKey: CollectionWorkKeyMaterial = {
+    schema_version: 1,
+    capability: input.capability.replace(".v1", ""),
+    capability_version: input.capability_version,
+    collection_id: input.collection_id,
+    deployment_ids: input.deployment_ids,
+    finality_policies: input.finality_policies,
+  };
+
+  const collectionDigest = runEffect(digestCollectionWorkKey(collectionWorkKey));
+
+  return {
+    schema_version: 1,
+    capability: input.capability,
+    capability_version: input.capability_version,
+    collection_id: input.collection_id,
+    deployment_ids: input.deployment_ids,
+    finality_policies: input.finality_policies,
+    scope_class: "deployment",
+    scope_digest: collectionDigest.digest,
+    privacy_class: "public_chain",
+    source_identity: input.source_identity,
+    evidence_boundary_kind: input.evidence_boundary_kind ?? "continuous_latest",
+    ...(input.evidence_boundary_digest !== undefined
+      ? { evidence_boundary_digest: input.evidence_boundary_digest }
+      : {}),
+    readiness_policy_version: input.readiness_policy_version,
+    adapter_version: input.adapter_version,
+  };
+}
+
+export function digestPublicWorkKey(material: PublicPreparationWorkKeyMaterial): string {
+  const canonical = {
+    schema_version: material.schema_version,
+    capability: material.capability,
+    capability_version: material.capability_version,
+    collection_id: material.collection_id,
+    deployment_ids: material.deployment_ids,
+    finality_policies: material.finality_policies,
+    scope_class: material.scope_class,
+    scope_digest: material.scope_digest,
+    privacy_class: material.privacy_class,
+    source_identity: material.source_identity,
+    evidence_boundary_kind: material.evidence_boundary_kind,
+    ...(material.evidence_boundary_digest !== undefined
+      ? { evidence_boundary_digest: material.evidence_boundary_digest }
+      : {}),
+    readiness_policy_version: material.readiness_policy_version,
+    adapter_version: material.adapter_version,
+  };
+  return createHash("sha256")
+    .update(JSON.stringify(canonical))
+    .digest("hex");
+}
+
+export function deploymentSetDigest(deploymentIds: readonly VersionedDigest[]): string {
+  return sortedDeploymentSetDigest(deploymentIds);
+}
+
+export function finalityPolicyVersion(
+  finalityPolicies: PublicPreparationWorkKeyMaterial["finality_policies"],
+): string {
+  return finalityPolicies
+    .map((policy) => `${policy.network.network_namespace}:${policy.network.network_reference}:${policy.finality_policy_version}`)
+    .sort()
+    .join("|");
+}

--- a/packages/services/ordering/src/shared-preparation-work-key.ts
+++ b/packages/services/ordering/src/shared-preparation-work-key.ts
@@ -16,8 +16,24 @@ function digestKey(digest: VersionedDigest): string {
   return `${digest.domain}:${digest.major_version}:${digest.digest}`;
 }
 
+function sortDeploymentIds(
+  deploymentIds: readonly VersionedDigest[],
+): VersionedDigest[] {
+  return [...deploymentIds].sort((a, b) => digestKey(a).localeCompare(digestKey(b)));
+}
+
+function sortFinalityPolicies(
+  policies: CollectionCandidate["finality_policies"],
+): CollectionCandidate["finality_policies"] {
+  return [...policies].sort((a, b) => {
+    const left = `${a.network.network_namespace}:${a.network.network_reference}:${a.finality_policy_version}`;
+    const right = `${b.network.network_namespace}:${b.network.network_reference}:${b.finality_policy_version}`;
+    return left.localeCompare(right);
+  });
+}
+
 function sortedDeploymentSetDigest(deploymentIds: readonly VersionedDigest[]): string {
-  const keys = deploymentIds.map(digestKey).sort();
+  const keys = sortDeploymentIds(deploymentIds).map(digestKey);
   return createHash("sha256").update(keys.join("\n")).digest("hex");
 }
 
@@ -45,13 +61,16 @@ export function buildPublicWorkKeyMaterial(input: {
     throw new Error(`deployment ceiling ${PUBLIC_PREP_LIMITS.maxDeployments} exceeded`);
   }
 
+  const deployment_ids = sortDeploymentIds(input.deployment_ids);
+  const finality_policies = sortFinalityPolicies(input.finality_policies);
+
   const collectionWorkKey: CollectionWorkKeyMaterial = {
     schema_version: 1,
     capability: input.capability.replace(".v1", ""),
     capability_version: input.capability_version,
     collection_id: input.collection_id,
-    deployment_ids: input.deployment_ids,
-    finality_policies: input.finality_policies,
+    deployment_ids,
+    finality_policies,
   };
 
   const collectionDigest = runEffect(digestCollectionWorkKey(collectionWorkKey));
@@ -61,8 +80,8 @@ export function buildPublicWorkKeyMaterial(input: {
     capability: input.capability,
     capability_version: input.capability_version,
     collection_id: input.collection_id,
-    deployment_ids: input.deployment_ids,
-    finality_policies: input.finality_policies,
+    deployment_ids,
+    finality_policies,
     scope_class: "deployment",
     scope_digest: collectionDigest.digest,
     privacy_class: "public_chain",
@@ -77,13 +96,15 @@ export function buildPublicWorkKeyMaterial(input: {
 }
 
 export function digestPublicWorkKey(material: PublicPreparationWorkKeyMaterial): string {
+  const deployment_ids = sortDeploymentIds(material.deployment_ids);
+  const finality_policies = sortFinalityPolicies(material.finality_policies);
   const canonical = {
     schema_version: material.schema_version,
     capability: material.capability,
     capability_version: material.capability_version,
     collection_id: material.collection_id,
-    deployment_ids: material.deployment_ids,
-    finality_policies: material.finality_policies,
+    deployment_ids,
+    finality_policies,
     scope_class: material.scope_class,
     scope_digest: material.scope_digest,
     privacy_class: material.privacy_class,
@@ -107,8 +128,10 @@ export function deploymentSetDigest(deploymentIds: readonly VersionedDigest[]): 
 export function finalityPolicyVersion(
   finalityPolicies: PublicPreparationWorkKeyMaterial["finality_policies"],
 ): string {
-  return finalityPolicies
-    .map((policy) => `${policy.network.network_namespace}:${policy.network.network_reference}:${policy.finality_policy_version}`)
-    .sort()
+  return sortFinalityPolicies(finalityPolicies)
+    .map(
+      (policy) =>
+        `${policy.network.network_namespace}:${policy.network.network_reference}:${policy.finality_policy_version}`,
+    )
     .join("|");
 }

--- a/packages/services/ordering/src/store-postgres.ts
+++ b/packages/services/ordering/src/store-postgres.ts
@@ -74,6 +74,7 @@ export class PostgresOrderStore implements OrderStore {
       '004_collection_resolutions.sql',
       '005_collection_report_list.sql',
       '006_report_attention_receipts.sql',
+      '007_shared_preparation_work.sql',
     ]) {
       const sql = readFileSync(join(__dirname, '../migrations', file), 'utf8');
       await this.pool.query(sql);


### PR DESCRIPTION
## Summary

- Adds expand-only migration `007_shared_preparation_work.sql` for `shared_preparation_work`, `preparation_work_items`, and `report_work_links` with public-only capability CHECK constraints (`collection_identity.v1`, `ownership_index.v1`) and partial unique index on active work keys.
- Implements in-memory + Postgres store ports with transactional join/create, lease reclaim fencing (`lease_epoch`), retry CAS (`retry_wait` → `queued`), subscriber fan-in (100 joiners → one active row), zero-subscriber abandonment, and multi-deployment child evidence gating before parent `ready`.
- Exports shared-preparation types/service from `@freeside/ordering-service` for downstream CR-201C/CR-204A wiring.

## Test plan

- [x] `pnpm exec vitest run src/__tests__/shared-preparation-migration.test.ts src/__tests__/shared-preparation-store.test.ts` (9 tests)
- [x] Migration expand-only / rollback-safety static check
- [x] 100 concurrent equivalent joiners → one active work row + 100 links
- [x] Lease reclaim increments epoch; stale fenced child write rejected
- [x] Retry scheduling + stale wake rejection
- [x] Subscriber detachment → deterministic abandonment
- [x] Supersession before successor generation
- [x] Parent ready only after all child deployment evidence

## Gaps (honest)

- Not yet wired into collection-report intake / orchestrator (orders still idle in `producing` without shared-work links).
- No live Postgres integration test harness in CI (Postgres adapter is mechanical behind the same port).
- CR-201C admission capacity reservation and CR-204A Sonar dispatch remain downstream.
- 100–1000 joiner Postgres latency proof and mixed-version migration tests deferred to CR-201C/CR-209A.
- No customer Gate Leak artifact / no restricted Discord or identity evidence (by design for T1).


Made with [Cursor](https://cursor.com)