### PR TITLE
feat(ordering): CR-201C atomic admission capacity reservation

### DIFF
--- a/packages/services/ordering/migrations/008_admission_capacity.sql
+++ b/packages/services/ordering/migrations/008_admission_capacity.sql
@@ -1,13 +1,17 @@
 -- CR-201C expand: atomic admission capacity reservation (three ledgers).
 -- Expand-only: no destructive DDL. No separate pre-admission reservation state —
 -- capacity consumption commits in the same transaction as order + work links.
+--
+-- Fan-in markers use state='transferred' with quantity=0 (no pool units).
+-- Held envelopes keep quantity > 0. Public pool scope uses community_ref=''
+-- (NOT NULL) so UNIQUE cannot admit duplicate NULL-scoped rows.
 
 CREATE TABLE IF NOT EXISTS admission_capacity_pools (
   pool_id           TEXT PRIMARY KEY,
   ledger_kind       TEXT NOT NULL,
   network_ref       TEXT NOT NULL DEFAULT '',
   capability        TEXT NOT NULL DEFAULT '',
-  community_ref     TEXT,
+  community_ref     TEXT NOT NULL DEFAULT '',
   limit_units       BIGINT NOT NULL,
   consumed_units    BIGINT NOT NULL DEFAULT 0,
   version           BIGINT NOT NULL DEFAULT 0,
@@ -45,16 +49,25 @@ CREATE TABLE IF NOT EXISTS admission_capacity_reservations (
   CONSTRAINT admission_capacity_reservations_state_check CHECK (
     state IN ('held', 'released', 'transferred', 'expired')
   ),
-  CONSTRAINT admission_capacity_reservations_qty_positive CHECK (quantity > 0)
+  -- Fan-in markers are quantity=0 + state=transferred; held envelopes quantity>0.
+  CONSTRAINT admission_capacity_reservations_qty_nonneg CHECK (quantity >= 0),
+  CONSTRAINT admission_capacity_reservations_held_qty_check CHECK (
+    state <> 'held' OR quantity > 0
+  )
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS admission_capacity_reservations_order_ledger_held_idx
   ON admission_capacity_reservations (order_id, ledger_kind)
   WHERE state = 'held' AND ledger_kind IN ('admission_rate', 'queued_work');
 
-CREATE INDEX IF NOT EXISTS admission_capacity_reservations_work_held_idx
+-- At most one held queued envelope per work key (fan-in shares it).
+CREATE UNIQUE INDEX IF NOT EXISTS admission_capacity_reservations_work_held_unique_idx
   ON admission_capacity_reservations (work_key_digest)
-  WHERE state = 'held' AND ledger_kind = 'queued_work';
+  WHERE state = 'held' AND ledger_kind = 'queued_work' AND work_key_digest IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS admission_capacity_reservations_work_active_idx
+  ON admission_capacity_reservations (work_key_digest)
+  WHERE state IN ('held', 'transferred') AND ledger_kind = 'queued_work';
 
 CREATE INDEX IF NOT EXISTS admission_capacity_reservations_lease_idx
   ON admission_capacity_reservations (lease_until)

--- a/packages/services/ordering/migrations/008_admission_capacity.sql
+++ b/packages/services/ordering/migrations/008_admission_capacity.sql
@@ -1,0 +1,85 @@
+-- CR-201C expand: atomic admission capacity reservation (three ledgers).
+-- Expand-only: no destructive DDL. No separate pre-admission reservation state —
+-- capacity consumption commits in the same transaction as order + work links.
+
+CREATE TABLE IF NOT EXISTS admission_capacity_pools (
+  pool_id           TEXT PRIMARY KEY,
+  ledger_kind       TEXT NOT NULL,
+  network_ref       TEXT NOT NULL DEFAULT '',
+  capability        TEXT NOT NULL DEFAULT '',
+  community_ref     TEXT,
+  limit_units       BIGINT NOT NULL,
+  consumed_units    BIGINT NOT NULL DEFAULT 0,
+  version           BIGINT NOT NULL DEFAULT 0,
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT admission_capacity_pools_ledger_check CHECK (
+    ledger_kind IN ('admission_rate', 'queued_work', 'active_execution')
+  ),
+  CONSTRAINT admission_capacity_pools_nonneg CHECK (
+    limit_units >= 0 AND consumed_units >= 0 AND consumed_units <= limit_units
+  ),
+  CONSTRAINT admission_capacity_pools_scope_unique UNIQUE (
+    ledger_kind, network_ref, capability, community_ref
+  )
+);
+
+CREATE INDEX IF NOT EXISTS admission_capacity_pools_ledger_idx
+  ON admission_capacity_pools (ledger_kind);
+
+CREATE TABLE IF NOT EXISTS admission_capacity_reservations (
+  reservation_id    TEXT PRIMARY KEY,
+  order_id          TEXT NOT NULL REFERENCES orders (order_id),
+  pool_id           TEXT NOT NULL REFERENCES admission_capacity_pools (pool_id),
+  ledger_kind       TEXT NOT NULL,
+  quantity          BIGINT NOT NULL,
+  reservation_version BIGINT NOT NULL DEFAULT 1,
+  state             TEXT NOT NULL,
+  identity_digest   TEXT NOT NULL,
+  work_key_digest   TEXT,
+  lease_until       TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  released_at       TIMESTAMPTZ,
+  CONSTRAINT admission_capacity_reservations_ledger_check CHECK (
+    ledger_kind IN ('admission_rate', 'queued_work', 'active_execution')
+  ),
+  CONSTRAINT admission_capacity_reservations_state_check CHECK (
+    state IN ('held', 'released', 'transferred', 'expired')
+  ),
+  CONSTRAINT admission_capacity_reservations_qty_positive CHECK (quantity > 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS admission_capacity_reservations_order_ledger_held_idx
+  ON admission_capacity_reservations (order_id, ledger_kind)
+  WHERE state = 'held' AND ledger_kind IN ('admission_rate', 'queued_work');
+
+CREATE INDEX IF NOT EXISTS admission_capacity_reservations_work_held_idx
+  ON admission_capacity_reservations (work_key_digest)
+  WHERE state = 'held' AND ledger_kind = 'queued_work';
+
+CREATE INDEX IF NOT EXISTS admission_capacity_reservations_lease_idx
+  ON admission_capacity_reservations (lease_until)
+  WHERE state = 'held' AND ledger_kind = 'active_execution';
+
+CREATE TABLE IF NOT EXISTS admission_capacity_transfer_log (
+  event_id          TEXT PRIMARY KEY,
+  reservation_id    TEXT NOT NULL REFERENCES admission_capacity_reservations (reservation_id),
+  from_state        TEXT NOT NULL,
+  to_state          TEXT NOT NULL,
+  reason            TEXT NOT NULL,
+  event_version     BIGINT NOT NULL,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT admission_capacity_transfer_log_version_unique UNIQUE (reservation_id, event_version)
+);
+
+CREATE TABLE IF NOT EXISTS order_admission_idempotency (
+  requester_subject TEXT NOT NULL,
+  client_request_id TEXT NOT NULL,
+  body_digest       TEXT NOT NULL,
+  order_id          TEXT NOT NULL REFERENCES orders (order_id),
+  reservation_ids   JSONB NOT NULL DEFAULT '[]'::jsonb,
+  stored_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (requester_subject, client_request_id)
+);
+
+CREATE INDEX IF NOT EXISTS order_admission_idempotency_stored_idx
+  ON order_admission_idempotency (stored_at);

--- a/packages/services/ordering/src/__tests__/admission-capacity-linearizability.test.ts
+++ b/packages/services/ordering/src/__tests__/admission-capacity-linearizability.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryAdmissionCapacityStore } from "../admission-capacity-store.js";
+import { fixtureGateLeakCertificate } from "../recipe-expansion-certificate.js";
+import { InMemorySharedPreparationStore } from "../shared-preparation-store.js";
+import { InMemoryOrderStore } from "../store.js";
+import {
+  fixtureCommunityScopeDigest,
+  fixturePublicWorkKey,
+} from "./shared-preparation-fixtures.js";
+
+function buildHarness(limits?: {
+  admission_rate?: number;
+  queued_work?: number;
+  active_execution?: number;
+}) {
+  const orderStore = new InMemoryOrderStore({ now: () => 1_700_000_000 });
+  const preparationStore = new InMemorySharedPreparationStore();
+  const capacity = new InMemoryAdmissionCapacityStore({
+    orderStore,
+    preparationStore,
+    defaultLimits: limits,
+  });
+  const work_key = fixturePublicWorkKey();
+  const certificate = fixtureGateLeakCertificate(2);
+  const pool_scope = {
+    network_ref: "eip155:1",
+    capability: "ownership_index.v1" as const,
+  };
+  const tenant = fixtureCommunityScopeDigest("community-alpha");
+
+  return {
+    orderStore,
+    preparationStore,
+    capacity,
+    work_key,
+    certificate,
+    pool_scope,
+    tenant,
+    admitEquivalent(n: number, clientRequestId: string) {
+      return Promise.all(
+        Array.from({ length: n }, (_, i) =>
+          capacity.admitOrder({
+            requester_subject: "subject-alice",
+            client_request_id: clientRequestId,
+            order: {
+              product: "collection-report",
+              placed_by: "subject-alice",
+              inputs: { client_request_id: clientRequestId },
+              placed_at_unix: 1_700_000_000,
+              inputs_digest: `d-${clientRequestId}`,
+            },
+            body: { client_request_id: clientRequestId },
+            certificate,
+            work_key,
+            order_tenant_scope_digest: tenant,
+            pool_scope,
+            now_ms: 1_000 + i,
+          }),
+        ),
+      );
+    },
+    admitDistinct(n: number) {
+      return Promise.all(
+        Array.from({ length: n }, (_, i) =>
+          capacity.admitOrder({
+            requester_subject: `subject-${i}`,
+            client_request_id: `req-${i}`,
+            order: {
+              product: "collection-report",
+              placed_by: `subject-${i}`,
+              inputs: { client_request_id: `req-${i}` },
+              placed_at_unix: 1_700_000_000,
+              inputs_digest: `d-${i}`,
+            },
+            body: { client_request_id: `req-${i}` },
+            certificate,
+            work_key,
+            order_tenant_scope_digest: tenant,
+            pool_scope,
+            now_ms: 1_000 + i,
+          }),
+        ),
+      );
+    },
+  };
+}
+
+describe("CR-201C admission capacity linearizability", () => {
+  for (const n of [100, 500, 1_000] as const) {
+    it(`${n} concurrent equivalent requests: one order, no over-admission, safe replay`, async () => {
+      const h = buildHarness();
+      const started = performance.now();
+      const results = await h.admitEquivalent(n, "shared-idem");
+      const elapsed = performance.now() - started;
+
+      const admitted = results.filter((r) => r.kind === "admitted");
+      expect(admitted).toHaveLength(n);
+      const orderIds = new Set(
+        admitted.map((r) => (r.kind === "admitted" ? r.order.order_id : "")),
+      );
+      expect(orderIds.size).toBe(1);
+
+      const accounting = await h.capacity.snapshotAccounting();
+      expect(accounting.admission_rate.consumed).toBe(1);
+      expect(accounting.queued_work.consumed).toBe(1);
+
+      const workIds = new Set(
+        admitted.map((r) => (r.kind === "admitted" ? r.work_id : "")),
+      );
+      expect(workIds.size).toBe(1);
+      // Bound: serializable mutex should finish well under a few seconds in-memory.
+      expect(elapsed).toBeLessThan(15_000);
+    });
+
+    it(`${n} concurrent distinct requests: fan-in one envelope, exact accounting`, async () => {
+      const h = buildHarness({ admission_rate: n + 10, queued_work: 10 });
+      const started = performance.now();
+      const results = await h.admitDistinct(n);
+      const elapsed = performance.now() - started;
+
+      const admitted = results.filter((r) => r.kind === "admitted");
+      expect(admitted).toHaveLength(n);
+
+      const orderIds = new Set(
+        admitted.map((r) => (r.kind === "admitted" ? r.order.order_id : "")),
+      );
+      expect(orderIds.size).toBe(n);
+
+      const workIds = new Set(
+        admitted.map((r) => (r.kind === "admitted" ? r.work_id : "")),
+      );
+      expect(workIds.size).toBe(1);
+
+      const workId = [...workIds][0]!;
+      const links = await h.preparationStore.listActiveLinks(workId);
+      expect(links).toHaveLength(n);
+
+      const accounting = await h.capacity.snapshotAccounting();
+      expect(accounting.admission_rate.consumed).toBe(n);
+      expect(accounting.queued_work.consumed).toBe(1);
+      expect(accounting.active_execution.consumed).toBe(0);
+      expect(elapsed).toBeLessThan(30_000);
+    });
+  }
+
+  it("capacity ceiling: no over-admission under concurrent pressure", async () => {
+    const limit = 50;
+    const h = buildHarness({ admission_rate: limit, queued_work: 100 });
+    const results = await h.admitDistinct(200);
+    const admitted = results.filter((r) => r.kind === "admitted");
+    const denied = results.filter((r) => r.kind === "capacity_unavailable");
+    expect(admitted).toHaveLength(limit);
+    expect(denied).toHaveLength(200 - limit);
+
+    const accounting = await h.capacity.snapshotAccounting();
+    expect(accounting.admission_rate.consumed).toBe(limit);
+    expect(accounting.queued_work.consumed).toBe(1);
+  });
+
+  it("release + retry + lease expiry cannot double-spend", async () => {
+    const h = buildHarness({ admission_rate: 2, queued_work: 2, active_execution: 1 });
+    const a = await h.capacity.admitOrder({
+      requester_subject: "subject-a",
+      client_request_id: "a",
+      order: {
+        product: "collection-report",
+        placed_by: "subject-a",
+        inputs: {},
+        placed_at_unix: 1,
+        inputs_digest: "a",
+      },
+      body: { k: "a" },
+      certificate: h.certificate,
+      work_key: h.work_key,
+      order_tenant_scope_digest: h.tenant,
+      pool_scope: h.pool_scope,
+      now_ms: 1,
+    });
+    expect(a.kind).toBe("admitted");
+    if (a.kind !== "admitted") return;
+
+    const lease = await h.capacity.acquireActiveExecutionLease({
+      order_id: a.order.order_id,
+      pool_scope: h.pool_scope,
+      lease_duration_ms: 100,
+      now_ms: 1_000,
+    });
+    expect(lease.kind).toBe("acquired");
+
+    await h.capacity.reconcileExpiredActiveLeases({ now_ms: 2_000 });
+    await h.capacity.releaseOrderCapacity({
+      order_id: a.order.order_id,
+      reason: "terminal_failure",
+      now_ms: 3_000,
+    });
+    // Second release is a no-op (no double-spend).
+    await h.capacity.releaseOrderCapacity({
+      order_id: a.order.order_id,
+      reason: "terminal_failure",
+      now_ms: 3_001,
+    });
+
+    const accounting = await h.capacity.snapshotAccounting();
+    expect(accounting.admission_rate.consumed).toBe(0);
+    expect(accounting.queued_work.consumed).toBe(0);
+    expect(accounting.active_execution.consumed).toBe(0);
+
+    // Retry after release succeeds.
+    const retry = await h.capacity.admitOrder({
+      requester_subject: "subject-a",
+      client_request_id: "a-retry",
+      order: {
+        product: "collection-report",
+        placed_by: "subject-a",
+        inputs: {},
+        placed_at_unix: 1,
+        inputs_digest: "a2",
+      },
+      body: { k: "a2" },
+      certificate: h.certificate,
+      work_key: h.work_key,
+      order_tenant_scope_digest: h.tenant,
+      pool_scope: h.pool_scope,
+      now_ms: 4_000,
+    });
+    expect(retry.kind).toBe("admitted");
+  });
+
+  it("rejected request after shed creates neither order nor reservation", async () => {
+    const h = buildHarness();
+    const denied = await h.capacity.admitOrder({
+      requester_subject: "subject-x",
+      client_request_id: "shed",
+      order: {
+        product: "collection-report",
+        placed_by: "subject-x",
+        inputs: {},
+        placed_at_unix: 1,
+        inputs_digest: "x",
+      },
+      body: { k: "x" },
+      certificate: h.certificate,
+      work_key: h.work_key,
+      order_tenant_scope_digest: h.tenant,
+      pool_scope: h.pool_scope,
+      now_ms: 1,
+      advisory_shed: true,
+    });
+    expect(denied.kind).toBe("capacity_unavailable");
+    expect(await h.orderStore.listByState("placed")).toHaveLength(0);
+    expect(await h.capacity.getIdempotency("subject-x", "shed")).toBeUndefined();
+    const accounting = await h.capacity.snapshotAccounting();
+    expect(accounting.admission_rate.consumed).toBe(0);
+  });
+});

--- a/packages/services/ordering/src/__tests__/admission-capacity-migration.test.ts
+++ b/packages/services/ordering/src/__tests__/admission-capacity-migration.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const dir = dirname(fileURLToPath(import.meta.url));
+
+describe("CR-201C migration rollback safety", () => {
+  it("008_admission_capacity.sql is expand-only", () => {
+    const sql = readFileSync(join(dir, "../../migrations/008_admission_capacity.sql"), "utf8");
+    expect(sql).not.toMatch(/\bDROP\b/i);
+    expect(sql).not.toMatch(/\bALTER\s+TABLE\b[\s\S]*\bDROP\b/i);
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS admission_capacity_pools/);
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS admission_capacity_reservations/);
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS order_admission_idempotency/);
+    expect(sql).toMatch(/admission_rate/);
+    expect(sql).toMatch(/queued_work/);
+    expect(sql).toMatch(/active_execution/);
+  });
+});

--- a/packages/services/ordering/src/__tests__/admission-capacity-migration.test.ts
+++ b/packages/services/ordering/src/__tests__/admission-capacity-migration.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 const dir = dirname(fileURLToPath(import.meta.url));
 
 describe("CR-201C migration rollback safety", () => {
-  it("008_admission_capacity.sql is expand-only", () => {
+  it("008_admission_capacity.sql is expand-only with fan-in-safe constraints", () => {
     const sql = readFileSync(join(dir, "../../migrations/008_admission_capacity.sql"), "utf8");
     expect(sql).not.toMatch(/\bDROP\b/i);
     expect(sql).not.toMatch(/\bALTER\s+TABLE\b[\s\S]*\bDROP\b/i);
@@ -16,5 +16,13 @@ describe("CR-201C migration rollback safety", () => {
     expect(sql).toMatch(/admission_rate/);
     expect(sql).toMatch(/queued_work/);
     expect(sql).toMatch(/active_execution/);
+    // Fan-in markers: quantity >= 0; held rows require quantity > 0.
+    expect(sql).toMatch(/admission_capacity_reservations_qty_nonneg CHECK \(quantity >= 0\)/);
+    expect(sql).toMatch(/admission_capacity_reservations_held_qty_check/);
+    expect(sql).not.toMatch(/reservations_qty_positive/);
+    // Public scope cannot duplicate via NULL community_ref.
+    expect(sql).toMatch(/community_ref\s+TEXT NOT NULL DEFAULT ''/);
+    expect(sql).toMatch(/admission_capacity_pools_scope_unique/);
+    expect(sql).toMatch(/admission_capacity_reservations_work_held_unique_idx/);
   });
 });

--- a/packages/services/ordering/src/__tests__/admission-capacity-store.test.ts
+++ b/packages/services/ordering/src/__tests__/admission-capacity-store.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryAdmissionCapacityStore } from "../admission-capacity-store.js";
+import { fixtureGateLeakCertificate } from "../recipe-expansion-certificate.js";
+import { InMemorySharedPreparationStore } from "../shared-preparation-store.js";
+import { InMemoryOrderStore } from "../store.js";
+import {
+  fixtureCommunityScopeDigest,
+  fixturePublicWorkKey,
+} from "./shared-preparation-fixtures.js";
+
+function makeStore(limits?: {
+  admission_rate?: number;
+  queued_work?: number;
+  active_execution?: number;
+}) {
+  const orderStore = new InMemoryOrderStore({ now: () => 1_700_000_000 });
+  const preparationStore = new InMemorySharedPreparationStore();
+  const capacity = new InMemoryAdmissionCapacityStore({
+    orderStore,
+    preparationStore,
+    defaultLimits: limits,
+  });
+  return { orderStore, preparationStore, capacity };
+}
+
+function admitInput(
+  overrides: Partial<{
+    client_request_id: string;
+    requester_subject: string;
+    now_ms: number;
+    advisory_shed: boolean;
+    simulated_lock_wait_ms: number;
+    capacity_weight: number;
+  }> = {},
+) {
+  const work_key = fixturePublicWorkKey();
+  const body = {
+    resolution_id: "res_fixture",
+    client_request_id: overrides.client_request_id ?? "req-1",
+  };
+  return {
+    requester_subject: overrides.requester_subject ?? "subject-alice",
+    client_request_id: overrides.client_request_id ?? "req-1",
+    order: {
+      product: "collection-report" as const,
+      placed_by: overrides.requester_subject ?? "subject-alice",
+      inputs: body,
+      placed_at_unix: 1_700_000_000,
+      inputs_digest: "digest-placeholder",
+    },
+    body,
+    certificate: fixtureGateLeakCertificate(2),
+    work_key,
+    order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+    pool_scope: {
+      network_ref: "eip155:1",
+      capability: "ownership_index.v1",
+    },
+    now_ms: overrides.now_ms ?? 1_000,
+    ...(overrides.advisory_shed !== undefined
+      ? { advisory_shed: overrides.advisory_shed }
+      : {}),
+    ...(overrides.simulated_lock_wait_ms !== undefined
+      ? { simulated_lock_wait_ms: overrides.simulated_lock_wait_ms }
+      : {}),
+  };
+}
+
+describe("CR-201C admission capacity store", () => {
+  it("admits atomically: order + work link + capacity reservations + outbox", async () => {
+    const { capacity, orderStore, preparationStore } = makeStore();
+    const result = await capacity.admitOrder(admitInput());
+    expect(result.kind).toBe("admitted");
+    if (result.kind !== "admitted") return;
+
+    expect(result.created).toBe(true);
+    expect(result.work_created).toBe(true);
+    expect(result.reservation_ids).toHaveLength(2);
+
+    const order = await orderStore.get(result.order.order_id);
+    expect(order?.state).toBe("placed");
+    const outbox = await orderStore.pendingOutbox();
+    expect(outbox.some((e) => e.order_id === result.order.order_id)).toBe(true);
+
+    const work = await preparationStore.getWork(result.work_id);
+    expect(work?.state).toBe("queued");
+    const links = await preparationStore.listActiveLinks(result.work_id);
+    expect(links).toHaveLength(1);
+
+    const accounting = await capacity.snapshotAccounting();
+    expect(accounting.admission_rate.consumed).toBe(1);
+    expect(accounting.queued_work.consumed).toBe(1);
+    expect(accounting.active_execution.consumed).toBe(0);
+  });
+
+  it("fan-in consumes admission_rate per order but not a second queued envelope", async () => {
+    const { capacity, preparationStore } = makeStore();
+    const first = await capacity.admitOrder(admitInput({ client_request_id: "a" }));
+    const second = await capacity.admitOrder(
+      admitInput({ client_request_id: "b", requester_subject: "subject-bob", now_ms: 2 }),
+    );
+    expect(first.kind).toBe("admitted");
+    expect(second.kind).toBe("admitted");
+    if (first.kind !== "admitted" || second.kind !== "admitted") return;
+
+    expect(first.work_id).toBe(second.work_id);
+    expect(first.work_created).toBe(true);
+    expect(second.work_created).toBe(false);
+
+    const links = await preparationStore.listActiveLinks(first.work_id);
+    expect(links).toHaveLength(2);
+
+    const accounting = await capacity.snapshotAccounting();
+    expect(accounting.admission_rate.consumed).toBe(2);
+    expect(accounting.queued_work.consumed).toBe(1);
+  });
+
+  it("idempotent replay returns the same order/reservations; conflict on body mismatch", async () => {
+    const { capacity } = makeStore();
+    const first = await capacity.admitOrder(admitInput({ client_request_id: "idem-1" }));
+    expect(first.kind).toBe("admitted");
+    if (first.kind !== "admitted") return;
+
+    const replay = await capacity.admitOrder(admitInput({ client_request_id: "idem-1", now_ms: 5 }));
+    expect(replay.kind).toBe("admitted");
+    if (replay.kind !== "admitted") return;
+    expect(replay.replay).toBe(true);
+    expect(replay.order.order_id).toBe(first.order.order_id);
+    expect(replay.reservation_ids).toEqual(first.reservation_ids);
+
+    const conflict = await capacity.admitOrder({
+      ...admitInput({ client_request_id: "idem-1", now_ms: 6 }),
+      body: { resolution_id: "different", client_request_id: "idem-1" },
+    });
+    expect(conflict.kind).toBe("idempotency_conflict");
+
+    const accounting = await capacity.snapshotAccounting();
+    expect(accounting.admission_rate.consumed).toBe(1);
+  });
+
+  it("rejects with capacity_unavailable and creates neither order nor reservation", async () => {
+    const { capacity, orderStore } = makeStore({ admission_rate: 1, queued_work: 10 });
+    const first = await capacity.admitOrder(admitInput({ client_request_id: "ok" }));
+    expect(first.kind).toBe("admitted");
+
+    const denied = await capacity.admitOrder(
+      admitInput({ client_request_id: "deny", requester_subject: "subject-bob", now_ms: 2 }),
+    );
+    expect(denied.kind).toBe("capacity_unavailable");
+    if (denied.kind !== "capacity_unavailable") return;
+    expect(denied.reason).toBe("insufficient_admission_rate");
+
+    const orders = await orderStore.listByState("placed");
+    expect(orders).toHaveLength(1);
+    expect(await capacity.getIdempotency("subject-bob", "deny")).toBeUndefined();
+
+    const accounting = await capacity.snapshotAccounting();
+    expect(accounting.admission_rate.consumed).toBe(1);
+  });
+
+  it("advisory shed and lock-wait shed before txn create nothing", async () => {
+    const { capacity, orderStore } = makeStore();
+    const shed = await capacity.admitOrder(admitInput({ advisory_shed: true }));
+    expect(shed).toEqual({ kind: "capacity_unavailable", reason: "advisory_shed" });
+
+    const lock = await capacity.admitOrder(
+      admitInput({ client_request_id: "lock", simulated_lock_wait_ms: 999 }),
+    );
+    expect(lock).toEqual({ kind: "capacity_unavailable", reason: "lock_timeout" });
+
+    expect(await orderStore.listByState("placed")).toHaveLength(0);
+    const accounting = await capacity.snapshotAccounting();
+    expect(accounting.admission_rate.consumed).toBe(0);
+  });
+
+  it("active-execution leases are separate and reconcile on expiry exactly once", async () => {
+    const { capacity } = makeStore({ active_execution: 2 });
+    const admitted = await capacity.admitOrder(admitInput());
+    expect(admitted.kind).toBe("admitted");
+    if (admitted.kind !== "admitted") return;
+
+    const lease = await capacity.acquireActiveExecutionLease({
+      order_id: admitted.order.order_id,
+      pool_scope: { network_ref: "eip155:1", capability: "ownership_index.v1" },
+      lease_duration_ms: 1_000,
+      now_ms: 10_000,
+    });
+    expect(lease.kind).toBe("acquired");
+    if (lease.kind !== "acquired") return;
+
+    let accounting = await capacity.snapshotAccounting();
+    expect(accounting.active_execution.consumed).toBe(1);
+
+    const expired = await capacity.reconcileExpiredActiveLeases({ now_ms: 12_000 });
+    expect(expired.expired).toBe(1);
+    accounting = await capacity.snapshotAccounting();
+    expect(accounting.active_execution.consumed).toBe(0);
+
+    const again = await capacity.reconcileExpiredActiveLeases({ now_ms: 13_000 });
+    expect(again.expired).toBe(0);
+  });
+
+  it("terminal release frees admission + queued envelope exactly once", async () => {
+    const { capacity } = makeStore();
+    const admitted = await capacity.admitOrder(admitInput());
+    expect(admitted.kind).toBe("admitted");
+    if (admitted.kind !== "admitted") return;
+
+    const first = await capacity.releaseOrderCapacity({
+      order_id: admitted.order.order_id,
+      reason: "fulfilled",
+      now_ms: 50,
+    });
+    expect(first.released).toBeGreaterThanOrEqual(1);
+
+    const second = await capacity.releaseOrderCapacity({
+      order_id: admitted.order.order_id,
+      reason: "fulfilled",
+      now_ms: 51,
+    });
+    expect(second.released).toBe(0);
+
+    const accounting = await capacity.snapshotAccounting();
+    expect(accounting.admission_rate.consumed).toBe(0);
+    expect(accounting.queued_work.consumed).toBe(0);
+  });
+
+  it("cancel after fan-in does not strand or double-spend the shared envelope", async () => {
+    const { capacity } = makeStore();
+    const a = await capacity.admitOrder(admitInput({ client_request_id: "fan-a" }));
+    const b = await capacity.admitOrder(
+      admitInput({ client_request_id: "fan-b", requester_subject: "subject-bob", now_ms: 2 }),
+    );
+    expect(a.kind).toBe("admitted");
+    expect(b.kind).toBe("admitted");
+    if (a.kind !== "admitted" || b.kind !== "admitted") return;
+
+    await capacity.releaseOrderCapacity({
+      order_id: a.order.order_id,
+      reason: "cancelled",
+      now_ms: 10,
+    });
+    let accounting = await capacity.snapshotAccounting();
+    // Shared envelope still held by B; admission for A released.
+    expect(accounting.admission_rate.consumed).toBe(1);
+    expect(accounting.queued_work.consumed).toBe(1);
+
+    await capacity.releaseOrderCapacity({
+      order_id: b.order.order_id,
+      reason: "cancelled",
+      now_ms: 11,
+    });
+    accounting = await capacity.snapshotAccounting();
+    expect(accounting.admission_rate.consumed).toBe(0);
+    expect(accounting.queued_work.consumed).toBe(0);
+  });
+});

--- a/packages/services/ordering/src/__tests__/admission-capacity-store.test.ts
+++ b/packages/services/ordering/src/__tests__/admission-capacity-store.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { InMemoryAdmissionCapacityStore } from "../admission-capacity-store.js";
 import {
   isHeldEnvelopeUniqueViolation,
+  isPoolScopeUniqueViolation,
   shouldRetryAdmissionTxn,
 } from "../admission-capacity-pg-errors.js";
 import { fixtureGateLeakCertificate } from "../recipe-expansion-certificate.js";
@@ -281,14 +282,21 @@ describe("CR-201C admission capacity store", () => {
     expect(accounting.queued_work.consumed).toBe(0);
   });
 
-  it("F2: concurrent held-envelope unique violation maps to admission retry", () => {
+  it("F2: concurrent held-envelope / pool-scope unique violations map to admission retry", () => {
     const uniqueErr = {
       code: "23505",
       constraint: "admission_capacity_reservations_work_held_unique_idx",
       detail: "Key (work_key_digest)=(abc) already exists.",
     };
+    const poolUnique = {
+      code: "23505",
+      constraint: "admission_capacity_pools_scope_unique",
+      detail: "Key (ledger_kind, network_ref, capability, community_ref)=(...) already exists.",
+    };
     expect(isHeldEnvelopeUniqueViolation(uniqueErr)).toBe(true);
+    expect(isPoolScopeUniqueViolation(poolUnique)).toBe(true);
     expect(shouldRetryAdmissionTxn(uniqueErr)).toBe(true);
+    expect(shouldRetryAdmissionTxn(poolUnique)).toBe(true);
     expect(shouldRetryAdmissionTxn(new Error("serialization_retry"))).toBe(true);
     expect(shouldRetryAdmissionTxn({ code: "40001" })).toBe(true);
     expect(shouldRetryAdmissionTxn({ code: "23505", constraint: "orders_pkey" })).toBe(false);

--- a/packages/services/ordering/src/__tests__/admission-capacity-store.test.ts
+++ b/packages/services/ordering/src/__tests__/admission-capacity-store.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { InMemoryAdmissionCapacityStore } from "../admission-capacity-store.js";
+import {
+  isHeldEnvelopeUniqueViolation,
+  shouldRetryAdmissionTxn,
+} from "../admission-capacity-pg-errors.js";
 import { fixtureGateLeakCertificate } from "../recipe-expansion-certificate.js";
 import { InMemorySharedPreparationStore } from "../shared-preparation-store.js";
 import { InMemoryOrderStore } from "../store.js";
@@ -275,5 +279,136 @@ describe("CR-201C admission capacity store", () => {
     accounting = await capacity.snapshotAccounting();
     expect(accounting.admission_rate.consumed).toBe(0);
     expect(accounting.queued_work.consumed).toBe(0);
+  });
+
+  it("F2: concurrent held-envelope unique violation maps to admission retry", () => {
+    const uniqueErr = {
+      code: "23505",
+      constraint: "admission_capacity_reservations_work_held_unique_idx",
+      detail: "Key (work_key_digest)=(abc) already exists.",
+    };
+    expect(isHeldEnvelopeUniqueViolation(uniqueErr)).toBe(true);
+    expect(shouldRetryAdmissionTxn(uniqueErr)).toBe(true);
+    expect(shouldRetryAdmissionTxn(new Error("serialization_retry"))).toBe(true);
+    expect(shouldRetryAdmissionTxn({ code: "40001" })).toBe(true);
+    expect(shouldRetryAdmissionTxn({ code: "23505", constraint: "orders_pkey" })).toBe(false);
+  });
+
+  it("F1: releasing envelope owner promotes peer to held with quantity", async () => {
+    const { capacity } = makeStore();
+    const a = await capacity.admitOrder(admitInput({ client_request_id: "own-a" }));
+    const b = await capacity.admitOrder(
+      admitInput({ client_request_id: "own-b", requester_subject: "subject-bob", now_ms: 2 }),
+    );
+    expect(a.kind).toBe("admitted");
+    expect(b.kind).toBe("admitted");
+    if (a.kind !== "admitted" || b.kind !== "admitted") return;
+
+    const aQueued = (await capacity.listHeldReservations(a.order.order_id)).find(
+      (r) => r.ledger_kind === "queued_work",
+    );
+    // Owner holds the envelope; fan-in peer is transferred.
+    expect(aQueued?.state).toBe("held");
+    expect(aQueued?.quantity).toBeGreaterThan(0);
+
+    await capacity.releaseOrderCapacity({
+      order_id: a.order.order_id,
+      reason: "cancelled",
+      now_ms: 10,
+    });
+
+    const bHeld = (await capacity.listHeldReservations(b.order.order_id)).find(
+      (r) => r.ledger_kind === "queued_work",
+    );
+    expect(bHeld?.state).toBe("held");
+    expect(bHeld?.quantity).toBeGreaterThan(0);
+
+    // Subsequent admit must share the promoted held envelope (not create a second).
+    const c = await capacity.admitOrder(
+      admitInput({ client_request_id: "own-c", requester_subject: "subject-carol", now_ms: 11 }),
+    );
+    expect(c.kind).toBe("admitted");
+    if (c.kind !== "admitted") return;
+    expect(c.work_created).toBe(false);
+    const accounting = await capacity.snapshotAccounting();
+    expect(accounting.queued_work.consumed).toBe(1);
+    expect(accounting.admission_rate.consumed).toBe(2); // B + C (A released)
+  });
+
+  it("F3: sole held envelope is not folded away when join reuses work", async () => {
+    const { capacity, preparationStore } = makeStore();
+    // Pre-create ready/active work so the next admit joins without creating work,
+    // but is still the sole capacity envelope owner.
+    const seed = await capacity.admitOrder(admitInput({ client_request_id: "seed" }));
+    expect(seed.kind).toBe("admitted");
+    if (seed.kind !== "admitted") return;
+
+    // Detach seed order's capacity while leaving the shared work row active so a
+    // later admit joins existing work (created=false) as the new sole envelope.
+    await capacity.releaseOrderCapacity({
+      order_id: seed.order.order_id,
+      reason: "cancelled",
+      now_ms: 5,
+    });
+    // Work row may still be active with zero subscribers — admit again with a
+    // stubbed join that reports reused work while we are the only capacity holder.
+    const realJoin = preparationStore.joinPublicWork.bind(preparationStore);
+    let soleAdmit = false;
+    preparationStore.joinPublicWork = async (input) => {
+      const result = await realJoin(input);
+      if (result.kind === "joined" && soleAdmit) {
+        return { ...result, created: false };
+      }
+      return result;
+    };
+
+    soleAdmit = true;
+    const only = await capacity.admitOrder(
+      admitInput({ client_request_id: "sole", requester_subject: "subject-bob", now_ms: 6 }),
+    );
+    expect(only.kind).toBe("admitted");
+    if (only.kind !== "admitted") return;
+
+    const held = (await capacity.listHeldReservations(only.order.order_id)).find(
+      (r) => r.ledger_kind === "queued_work",
+    );
+    expect(held?.state).toBe("held");
+    expect(held?.quantity).toBeGreaterThan(0);
+    const accounting = await capacity.snapshotAccounting();
+    expect(accounting.queued_work.consumed).toBe(1);
+  });
+
+  it("F4: releaseReservation on shared envelope promotes peer instead of double-free", async () => {
+    const { capacity } = makeStore();
+    const a = await capacity.admitOrder(admitInput({ client_request_id: "rsv-a" }));
+    const b = await capacity.admitOrder(
+      admitInput({ client_request_id: "rsv-b", requester_subject: "subject-bob", now_ms: 2 }),
+    );
+    expect(a.kind).toBe("admitted");
+    expect(b.kind).toBe("admitted");
+    if (a.kind !== "admitted" || b.kind !== "admitted") return;
+
+    const aQueued = (await capacity.listHeldReservations(a.order.order_id)).find(
+      (r) => r.ledger_kind === "queued_work",
+    );
+    expect(aQueued).toBeDefined();
+    if (!aQueued) return;
+
+    const released = await capacity.releaseReservation({
+      reservation_id: aQueued.reservation_id,
+      expected_version: aQueued.reservation_version,
+      reason: "cancel_queued",
+      now_ms: 10,
+    });
+    expect(released.kind).toBe("released");
+
+    const accounting = await capacity.snapshotAccounting();
+    expect(accounting.queued_work.consumed).toBe(1);
+
+    const bHeld = (await capacity.listHeldReservations(b.order.order_id)).find(
+      (r) => r.ledger_kind === "queued_work",
+    );
+    expect(bHeld?.state).toBe("held");
+    expect(bHeld?.quantity).toBeGreaterThan(0);
   });
 });

--- a/packages/services/ordering/src/__tests__/admission-capacity-store.test.ts
+++ b/packages/services/ordering/src/__tests__/admission-capacity-store.test.ts
@@ -225,6 +225,28 @@ describe("CR-201C admission capacity store", () => {
     expect(accounting.queued_work.consumed).toBe(0);
   });
 
+  it("join failure rolls back capacity and leaves no orphan order", async () => {
+    const orderStore = new InMemoryOrderStore({ now: () => 1_700_000_000 });
+    const preparationStore = new InMemorySharedPreparationStore();
+    preparationStore.joinPublicWork = async () => ({ kind: "serialization_retry" });
+    const capacity = new InMemoryAdmissionCapacityStore({
+      orderStore,
+      preparationStore,
+    });
+
+    const denied = await capacity.admitOrder(admitInput({ client_request_id: "join-fail" }));
+    expect(denied.kind).toBe("capacity_unavailable");
+    if (denied.kind === "capacity_unavailable") {
+      expect(denied.reason).toBe("lock_timeout");
+    }
+
+    expect(await orderStore.listByState("placed")).toHaveLength(0);
+    expect(await capacity.getIdempotency("subject-alice", "join-fail")).toBeUndefined();
+    const accounting = await capacity.snapshotAccounting();
+    expect(accounting.admission_rate.consumed).toBe(0);
+    expect(accounting.queued_work.consumed).toBe(0);
+  });
+
   it("cancel after fan-in does not strand or double-spend the shared envelope", async () => {
     const { capacity } = makeStore();
     const a = await capacity.admitOrder(admitInput({ client_request_id: "fan-a" }));

--- a/packages/services/ordering/src/admission-capacity-constants.ts
+++ b/packages/services/ordering/src/admission-capacity-constants.ts
@@ -1,0 +1,19 @@
+/** V1 admission capacity ceilings (CR-201C / SDD §6.6). */
+
+export const V1_MAX_RECIPE_NODES = 160;
+export const V1_MAX_ROOT_REFERENCES = 32;
+export const V1_MAX_DEPLOYMENTS = 16;
+
+/** Default pool limits for in-memory / fixture admission. */
+export const DEFAULT_ADMISSION_RATE_LIMIT = 10_000;
+export const DEFAULT_QUEUED_WORK_LIMIT = 1_000;
+export const DEFAULT_ACTIVE_EXECUTION_LIMIT = 64;
+
+/** Active-execution lease TTL (ms). Queued envelopes do not expire. */
+export const ACTIVE_EXECUTION_LEASE_MS = 30_000;
+
+/** Advisory shed: refuse before opening the txn when simulated lock wait exceeds this. */
+export const ADVISORY_LOCK_WAIT_BUDGET_MS = 250;
+
+/** Bounded serialization retries inside the admission transaction. */
+export const ADMISSION_SERIALIZATION_RETRIES = 8;

--- a/packages/services/ordering/src/admission-capacity-pg-errors.ts
+++ b/packages/services/ordering/src/admission-capacity-pg-errors.ts
@@ -21,10 +21,31 @@ export function isHeldEnvelopeUniqueViolation(err: unknown): boolean {
   );
 }
 
+/** Unique violation on capacity pool scope (concurrent pool create race). */
+export function isPoolScopeUniqueViolation(err: unknown): boolean {
+  if (typeof err !== "object" || err === null || !("code" in err)) return false;
+  const pgErr = err as { code: string; constraint?: string; detail?: string };
+  if (pgErr.code !== "23505") return false;
+  const hay = `${pgErr.constraint ?? ""} ${pgErr.detail ?? ""}`;
+  return (
+    hay.includes("admission_capacity_pools_scope_unique") ||
+    (hay.includes("ledger_kind") && hay.includes("network_ref") && hay.includes("capability"))
+  );
+}
+
 export function shouldRetryAdmissionTxn(err: unknown): boolean {
   return (
     (err instanceof Error && err.message === "serialization_retry") ||
     isHeldEnvelopeUniqueViolation(err) ||
+    isPoolScopeUniqueViolation(err) ||
     isPgSerializationFailure(err)
   );
+}
+
+export async function safeRollback(client: { query: (sql: string) => Promise<unknown> }): Promise<void> {
+  try {
+    await client.query("ROLLBACK");
+  } catch {
+    // Transaction may already be closed — never mask the original error.
+  }
 }

--- a/packages/services/ordering/src/admission-capacity-pg-errors.ts
+++ b/packages/services/ordering/src/admission-capacity-pg-errors.ts
@@ -1,0 +1,30 @@
+/** Postgres error classifiers for CR-201C admission capacity. */
+
+export function isPgSerializationFailure(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code: string }).code === "40001"
+  );
+}
+
+/** Unique violation on held queued envelope per work_key (concurrent fan-in race). */
+export function isHeldEnvelopeUniqueViolation(err: unknown): boolean {
+  if (typeof err !== "object" || err === null || !("code" in err)) return false;
+  const pgErr = err as { code: string; constraint?: string; detail?: string };
+  if (pgErr.code !== "23505") return false;
+  const hay = `${pgErr.constraint ?? ""} ${pgErr.detail ?? ""}`;
+  return (
+    hay.includes("admission_capacity_reservations_work_held_unique_idx") ||
+    (hay.includes("work_key_digest") && hay.includes("held"))
+  );
+}
+
+export function shouldRetryAdmissionTxn(err: unknown): boolean {
+  return (
+    (err instanceof Error && err.message === "serialization_retry") ||
+    isHeldEnvelopeUniqueViolation(err) ||
+    isPgSerializationFailure(err)
+  );
+}

--- a/packages/services/ordering/src/admission-capacity-service.ts
+++ b/packages/services/ordering/src/admission-capacity-service.ts
@@ -1,0 +1,45 @@
+import type {
+  AdmissionCapacityStore,
+  AdmitOrderInput,
+  AdmitOrderResult,
+} from "./admission-capacity-store.js";
+
+export interface AdmissionCapacityServiceDeps {
+  readonly store: AdmissionCapacityStore;
+  readonly now: () => number;
+}
+
+/**
+ * Thin facade over the CR-201C admission capacity store.
+ * Advisory shed may run before admitOrder; locked counters remain authoritative.
+ */
+export function createAdmissionCapacityService(deps: AdmissionCapacityServiceDeps) {
+  return {
+    admitOrder(
+      input: Omit<AdmitOrderInput, "now_ms"> & { now_ms?: number },
+    ): Promise<AdmitOrderResult> {
+      return deps.store.admitOrder({
+        ...input,
+        now_ms: input.now_ms ?? deps.now(),
+      });
+    },
+    acquireActiveExecutionLease(
+      input: Parameters<AdmissionCapacityStore["acquireActiveExecutionLease"]>[0],
+    ) {
+      return deps.store.acquireActiveExecutionLease(input);
+    },
+    releaseOrderCapacity(
+      input: Parameters<AdmissionCapacityStore["releaseOrderCapacity"]>[0],
+    ) {
+      return deps.store.releaseOrderCapacity(input);
+    },
+    reconcileExpiredActiveLeases(now_ms?: number) {
+      return deps.store.reconcileExpiredActiveLeases({
+        now_ms: now_ms ?? deps.now(),
+      });
+    },
+    store: deps.store,
+  };
+}
+
+export type AdmissionCapacityService = ReturnType<typeof createAdmissionCapacityService>;

--- a/packages/services/ordering/src/admission-capacity-store-postgres.ts
+++ b/packages/services/ordering/src/admission-capacity-store-postgres.ts
@@ -158,12 +158,14 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
     client: pg.PoolClient,
     input: EnsurePoolInput & { now_ms: number },
   ): Promise<CapacityPoolRecord> {
+    // Sentinel '' for public/default scope — UNIQUE forbids duplicate NULL rows.
+    const communityRef = input.community_ref ?? "";
     const existing = await client.query(
       `SELECT * FROM admission_capacity_pools
        WHERE ledger_kind = $1 AND network_ref = $2 AND capability = $3
-         AND community_ref IS NOT DISTINCT FROM $4
+         AND community_ref = $4
        FOR UPDATE`,
-      [input.ledger_kind, input.network_ref, input.capability, input.community_ref ?? null],
+      [input.ledger_kind, input.network_ref, input.capability, communityRef],
     );
     if (existing.rows.length > 0) return rowToPool(existing.rows[0]);
     const pool_id = `cap_${input.ledger_kind}_${randomUUID()}`;
@@ -178,7 +180,7 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
         input.ledger_kind,
         input.network_ref,
         input.capability,
-        input.community_ref ?? null,
+        communityRef,
         input.limit_units,
         input.now_ms,
       ],
@@ -691,18 +693,126 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
     reason: "fulfilled" | "terminal_failure" | "cancelled" | "abandoned";
     now_ms: number;
   }): Promise<{ readonly released: number }> {
-    const held = await this.listHeldReservations(input.order_id);
-    let released = 0;
-    for (const r of held) {
-      const result = await this.releaseReservation({
-        reservation_id: r.reservation_id,
-        expected_version: r.reservation_version,
-        reason: input.reason,
-        now_ms: input.now_ms,
-      });
-      if (result.kind === "released") released += 1;
+    /**
+     * Fan-in-aware release (matches in-memory):
+     * - admission_rate / active_execution: free units when held
+     * - queued_work: free shared envelope only when last subscriber leaves;
+     *   otherwise reassign held envelope ownership and leave pool units consumed
+     */
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE");
+      const rows = await client.query(
+        `SELECT * FROM admission_capacity_reservations
+         WHERE order_id = $1 AND state IN ('held', 'transferred')
+         FOR UPDATE`,
+        [input.order_id],
+      );
+      let released = 0;
+
+      const markReleased = async (
+        reservationId: string,
+        fromState: string,
+        version: number,
+      ) => {
+        await client.query(
+          `UPDATE admission_capacity_reservations
+           SET state = 'released',
+               reservation_version = reservation_version + 1,
+               released_at = to_timestamp($2/1000.0)
+           WHERE reservation_id = $1`,
+          [reservationId, input.now_ms],
+        );
+        await client.query(
+          `INSERT INTO admission_capacity_transfer_log (
+            event_id, reservation_id, from_state, to_state, reason, event_version, created_at
+          ) VALUES ($1,$2,$3,'released',$4,$5,to_timestamp($6/1000.0))`,
+          [
+            `cte_${randomUUID()}`,
+            reservationId,
+            fromState,
+            input.reason,
+            version + 1,
+            input.now_ms,
+          ],
+        );
+      };
+
+      for (const raw of rows.rows) {
+        const row = rowToReservation(raw);
+
+        if (row.ledger_kind === "queued_work" && row.work_key_digest) {
+          const others = await client.query(
+            `SELECT reservation_id, quantity, state FROM admission_capacity_reservations
+             WHERE work_key_digest = $1
+               AND ledger_kind = 'queued_work'
+               AND order_id <> $2
+               AND state IN ('held', 'transferred')
+               AND reservation_id <> $3
+             FOR UPDATE`,
+            [row.work_key_digest, input.order_id, row.reservation_id],
+          );
+
+          if (others.rows.length > 0) {
+            // Shared envelope remains — do not free pool units.
+            if (row.state === "held" && row.quantity > 0) {
+              const peer = others.rows[0]!;
+              const envelopeQty = row.quantity;
+              // Demote owner first so unique held-work-key index allows peer promote.
+              await client.query(
+                `UPDATE admission_capacity_reservations
+                 SET state = 'transferred',
+                     quantity = 0,
+                     reservation_version = reservation_version + 1
+                 WHERE reservation_id = $1`,
+                [row.reservation_id],
+              );
+              await client.query(
+                `UPDATE admission_capacity_reservations
+                 SET state = 'held',
+                     quantity = $2,
+                     reservation_version = reservation_version + 1
+                 WHERE reservation_id = $1`,
+                [peer.reservation_id, envelopeQty],
+              );
+            }
+          } else if (row.quantity > 0) {
+            // Last subscriber owns the envelope — free pool units exactly once.
+            await client.query(
+              `UPDATE admission_capacity_pools
+               SET consumed_units = GREATEST(0, consumed_units - $2), version = version + 1
+               WHERE pool_id = $1`,
+              [row.pool_id, row.quantity],
+            );
+          }
+          // Last subscriber with only a transferred marker (qty 0): units already
+          // live on a held peer that was released in the same order's batch, or
+          // ownership was moved onto this row earlier — if still qty 0, nothing to free.
+
+          await markReleased(row.reservation_id, row.state, row.reservation_version);
+          released += 1;
+          continue;
+        }
+
+        if (row.state === "held" && row.quantity > 0) {
+          await client.query(
+            `UPDATE admission_capacity_pools
+             SET consumed_units = GREATEST(0, consumed_units - $2), version = version + 1
+             WHERE pool_id = $1`,
+            [row.pool_id, row.quantity],
+          );
+        }
+        await markReleased(row.reservation_id, row.state, row.reservation_version);
+        released += 1;
+      }
+      await client.query("COMMIT");
+      return { released };
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
     }
-    return { released };
   }
 
   async reconcileExpiredActiveLeases(input: {

--- a/packages/services/ordering/src/admission-capacity-store-postgres.ts
+++ b/packages/services/ordering/src/admission-capacity-store-postgres.ts
@@ -31,7 +31,12 @@ import type {
   OrderAdmissionIdempotencyRecord,
 } from "./admission-capacity-types.js";
 import { CapacityUnavailableError } from "./admission-capacity-types.js";
-import { shouldRetryAdmissionTxn } from "./admission-capacity-pg-errors.js";
+import {
+  isPoolScopeUniqueViolation,
+  isPgSerializationFailure,
+  safeRollback,
+  shouldRetryAdmissionTxn,
+} from "./admission-capacity-pg-errors.js";
 import { assertCertificateAdmissible } from "./recipe-expansion-certificate.js";
 import { digestOf } from "./digest.js";
 import { PostgresSharedPreparationStore } from "./shared-preparation-store-postgres.js";
@@ -163,32 +168,67 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
   ): Promise<CapacityPoolRecord> {
     // Sentinel '' for public/default scope — UNIQUE forbids duplicate NULL rows.
     const communityRef = input.community_ref ?? "";
-    const existing = await client.query(
-      `SELECT * FROM admission_capacity_pools
-       WHERE ledger_kind = $1 AND network_ref = $2 AND capability = $3
-         AND community_ref = $4
-       FOR UPDATE`,
-      [input.ledger_kind, input.network_ref, input.capability, communityRef],
-    );
+    const selectForUpdate = () =>
+      client.query(
+        `SELECT * FROM admission_capacity_pools
+         WHERE ledger_kind = $1 AND network_ref = $2 AND capability = $3
+           AND community_ref = $4
+         FOR UPDATE`,
+        [input.ledger_kind, input.network_ref, input.capability, communityRef],
+      );
+
+    const existing = await selectForUpdate();
     if (existing.rows.length > 0) return rowToPool(existing.rows[0]);
     const pool_id = `cap_${input.ledger_kind}_${randomUUID()}`;
-    const inserted = await client.query(
-      `INSERT INTO admission_capacity_pools (
-        pool_id, ledger_kind, network_ref, capability, community_ref,
-        limit_units, consumed_units, version, updated_at
-      ) VALUES ($1,$2,$3,$4,$5,$6,0,0,to_timestamp($7/1000.0))
-      RETURNING *`,
-      [
-        pool_id,
-        input.ledger_kind,
-        input.network_ref,
-        input.capability,
-        communityRef,
-        input.limit_units,
-        input.now_ms,
-      ],
-    );
-    return rowToPool(inserted.rows[0]);
+    try {
+      const inserted = await client.query(
+        `INSERT INTO admission_capacity_pools (
+          pool_id, ledger_kind, network_ref, capability, community_ref,
+          limit_units, consumed_units, version, updated_at
+        ) VALUES ($1,$2,$3,$4,$5,$6,0,0,to_timestamp($7/1000.0))
+        RETURNING *`,
+        [
+          pool_id,
+          input.ledger_kind,
+          input.network_ref,
+          input.capability,
+          communityRef,
+          input.limit_units,
+          input.now_ms,
+        ],
+      );
+      return rowToPool(inserted.rows[0]);
+    } catch (err) {
+      // Concurrent creator won — re-select the existing pool row.
+      if (isPoolScopeUniqueViolation(err)) {
+        const raced = await selectForUpdate();
+        if (raced.rows.length > 0) return rowToPool(raced.rows[0]);
+      }
+      throw err;
+    }
+  }
+
+  /** Bounded SERIALIZABLE retry for mutating capacity methods. */
+  private async withSerializableRetry<T>(fn: () => Promise<T>): Promise<T> {
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < ADMISSION_TXN_RETRIES; attempt += 1) {
+      try {
+        return await fn();
+      } catch (err) {
+        lastErr = err;
+        if (
+          isPgSerializationFailure(err) ||
+          (err instanceof Error && err.message === "serialization_retry") ||
+          isPoolScopeUniqueViolation(err)
+        ) {
+          continue;
+        }
+        throw err;
+      }
+    }
+    throw lastErr instanceof Error
+      ? lastErr
+      : new Error("serialization_retry");
   }
 
   private async consumePool(
@@ -223,15 +263,23 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
 
   async ensurePool(input: EnsurePoolInput & { now_ms: number }): Promise<CapacityPoolRecord> {
     const client = await this.pool.connect();
+    let txnClosed = false;
     try {
       await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE");
       const pool = await this.lockOrCreatePool(client, input);
       await client.query("COMMIT");
+      txnClosed = true;
       return pool;
     } catch (err) {
-      await client.query("ROLLBACK");
+      if (!txnClosed) {
+        await safeRollback(client);
+        txnClosed = true;
+      }
       throw err;
     } finally {
+      if (!txnClosed) {
+        await safeRollback(client);
+      }
       client.release();
     }
   }
@@ -330,12 +378,24 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
 
   private async admitOrderAttempt(input: AdmitOrderInput): Promise<AdmitOrderResult> {
     const client = await this.pool.connect();
+    /** Tracks whether COMMIT/ROLLBACK already ran — finally always cleans open txns. */
+    let txnClosed = false;
+    const commit = async () => {
+      await client.query("COMMIT");
+      txnClosed = true;
+    };
+    const rollback = async () => {
+      await safeRollback(client);
+      txnClosed = true;
+    };
+
     try {
       await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE");
+
       try {
         assertCertificateAdmissible(input.certificate);
       } catch (err) {
-        await client.query("ROLLBACK");
+        await rollback();
         if (err instanceof CapacityUnavailableError) {
           return { kind: "capacity_unavailable", reason: err.reason };
         }
@@ -352,7 +412,7 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
       if (prior.rows.length > 0) {
         const row = prior.rows[0];
         if (row.body_digest !== body_digest) {
-          await client.query("ROLLBACK");
+          await rollback();
           return { kind: "idempotency_conflict" };
         }
         const orderRes = await client.query("SELECT * FROM orders WHERE order_id = $1", [
@@ -365,10 +425,11 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
           now_ms: input.now_ms,
         });
         if (join.kind !== "joined") {
-          await client.query("ROLLBACK");
-          return { kind: "capacity_unavailable", reason: "lock_timeout" };
+          // Route through outer admission retry loop (do not bypass as typed deny).
+          await rollback();
+          throw new Error("serialization_retry");
         }
-        await client.query("COMMIT");
+        await commit();
         return {
           kind: "admitted",
           order: rowToOrder(orderRes.rows[0]),
@@ -397,181 +458,187 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
       const workKeyDigest = digestPublicWorkKey(input.work_key);
       const order_id = input.order.order_id ?? `ord_${randomUUID()}`;
 
-      try {
-        await this.consumePool(client, admission, 1, input.now_ms);
+      await this.consumePool(client, admission, 1, input.now_ms);
 
-        const heldEnvelope = await client.query(
-          `SELECT * FROM admission_capacity_reservations
-           WHERE work_key_digest = $1 AND ledger_kind = 'queued_work' AND state = 'held'
-           FOR UPDATE`,
-          [workKeyDigest],
-        );
+      const heldEnvelope = await client.query(
+        `SELECT * FROM admission_capacity_reservations
+         WHERE work_key_digest = $1 AND ledger_kind = 'queued_work' AND state = 'held'
+         FOR UPDATE`,
+        [workKeyDigest],
+      );
 
-        const reservationIds: string[] = [];
-        let queuedQty = 0;
-        let queuedState: "held" | "transferred" = "held";
-        if (heldEnvelope.rows.length > 0) {
-          queuedState = "transferred";
-          queuedQty = 0;
-        } else {
-          await this.consumePool(client, queued, input.certificate.capacity_weight, input.now_ms);
-          queuedQty = input.certificate.capacity_weight;
-        }
-
-        const admissionRsv = `rsv_${randomUUID()}`;
-        const queuedRsv = `rsv_${randomUUID()}`;
-        reservationIds.push(admissionRsv, queuedRsv);
-
-        const identity = (ledger: CapacityLedgerKind, poolId: string, qty: number) =>
-          createHash("sha256")
-            .update(JSON.stringify({ order_id, ledger_kind: ledger, pool_id: poolId, quantity: qty, work_key_digest: workKeyDigest }))
-            .digest("hex");
-
-        const ts = Math.floor(input.now_ms / 1000);
-        const placedEvent: OrderPlaced = {
-          order_id,
-          product: input.order.product,
-          inputs_digest: input.order.inputs_digest,
-        };
-        const orderInsert = await client.query(
-          `INSERT INTO orders (
-            order_id, product, placed_by, inputs, inputs_digest, state,
-            placed_at_unix, created_at_unix, updated_at_unix, ingredients,
-            ingredient_jobs, operator_audit
-          ) VALUES ($1,$2,$3,$4,$5,'placed',$6,$7,$7,$8,'[]'::jsonb,'[]'::jsonb)
-          RETURNING *`,
-          [
-            order_id,
-            input.order.product,
-            input.order.placed_by,
-            JSON.stringify(input.order.inputs),
-            input.order.inputs_digest,
-            input.order.placed_at_unix,
-            ts,
-            null,
-          ],
-        );
-        await client.query(
-          `INSERT INTO order_outbox (order_id, subject, payload, published)
-           VALUES ($1,$2,$3,FALSE)`,
-          [
-            order_id,
-            ORDER_LIFECYCLE_SUBJECTS.placed,
-            JSON.stringify(placedEvent),
-          ],
-        );
-
-        await client.query(
-          `INSERT INTO admission_capacity_reservations (
-            reservation_id, order_id, pool_id, ledger_kind, quantity,
-            reservation_version, state, identity_digest, work_key_digest, created_at
-          ) VALUES
-            ($1,$2,$3,'admission_rate',1,1,'held',$4,NULL,to_timestamp($7/1000.0)),
-            ($5,$2,$6,'queued_work',$8,1,$9,$10,$11,to_timestamp($7/1000.0))`,
-          [
-            admissionRsv,
-            order_id,
-            admission.pool_id,
-            identity("admission_rate", admission.pool_id, 1),
-            queuedRsv,
-            queued.pool_id,
-            input.now_ms,
-            queuedQty,
-            queuedState,
-            identity("queued_work", queued.pool_id, queuedQty),
-            workKeyDigest,
-          ],
-        );
-        await client.query(
-          `INSERT INTO admission_capacity_transfer_log (
-            event_id, reservation_id, from_state, to_state, reason, event_version, created_at
-          ) VALUES
-            ($1,$2,'held','held','created',1,to_timestamp($4/1000.0)),
-            ($3,$5,'held',$6,$7,1,to_timestamp($4/1000.0))`,
-          [
-            `cte_${randomUUID()}`,
-            admissionRsv,
-            `cte_${randomUUID()}`,
-            input.now_ms,
-            queuedRsv,
-            queuedState,
-            queuedState === "transferred" ? "fan_in_share_envelope" : "created",
-          ],
-        );
-
-        const join = await this.preparationStore.joinPublicWorkInTransaction(client, {
-          order_id,
-          order_tenant_scope_digest: input.order_tenant_scope_digest,
-          work_key: input.work_key,
-          now_ms: input.now_ms,
-        });
-        if (join.kind !== "joined") {
-          throw new Error("serialization_retry");
-        }
-
-        // Fold only when another held envelope already exists for this work key.
-        // Never refund/zero the sole held envelope just because join reused work.
-        if (!join.created && queuedState === "held" && queuedQty > 0) {
-          const otherHeld = await client.query(
-            `SELECT reservation_id FROM admission_capacity_reservations
-             WHERE work_key_digest = $1
-               AND ledger_kind = 'queued_work'
-               AND state = 'held'
-               AND reservation_id <> $2
-             FOR UPDATE`,
-            [workKeyDigest, queuedRsv],
-          );
-          if (otherHeld.rows.length > 0) {
-            await client.query(
-              `UPDATE admission_capacity_pools
-               SET consumed_units = consumed_units - $2, version = version + 1
-               WHERE pool_id = $1`,
-              [queued.pool_id, queuedQty],
-            );
-            await client.query(
-              `UPDATE admission_capacity_reservations
-               SET state = 'transferred', quantity = 0, reservation_version = reservation_version + 1
-               WHERE reservation_id = $1`,
-              [queuedRsv],
-            );
-          }
-        }
-
-        await client.query(
-          `INSERT INTO order_admission_idempotency (
-            requester_subject, client_request_id, body_digest, order_id, reservation_ids, stored_at
-          ) VALUES ($1,$2,$3,$4,$5::jsonb,to_timestamp($6/1000.0))`,
-          [
-            input.requester_subject,
-            input.client_request_id,
-            body_digest,
-            order_id,
-            JSON.stringify(reservationIds),
-            input.now_ms,
-          ],
-        );
-
-        await client.query("COMMIT");
-        return {
-          kind: "admitted",
-          order: rowToOrder(orderInsert.rows[0]),
-          created: true,
-          work_created: join.created,
-          work_id: join.work.work_id,
-          reservation_ids: reservationIds,
-          replay: false,
-        };
-      } catch (err) {
-        await client.query("ROLLBACK");
-        if (err instanceof CapacityUnavailableError) {
-          return { kind: "capacity_unavailable", reason: err.reason };
-        }
-        if (shouldRetryAdmissionTxn(err)) {
-          throw new Error("serialization_retry");
-        }
-        throw err;
+      const reservationIds: string[] = [];
+      let queuedQty = 0;
+      let queuedState: "held" | "transferred" = "held";
+      if (heldEnvelope.rows.length > 0) {
+        queuedState = "transferred";
+        queuedQty = 0;
+      } else {
+        await this.consumePool(client, queued, input.certificate.capacity_weight, input.now_ms);
+        queuedQty = input.certificate.capacity_weight;
       }
+
+      const admissionRsv = `rsv_${randomUUID()}`;
+      const queuedRsv = `rsv_${randomUUID()}`;
+      reservationIds.push(admissionRsv, queuedRsv);
+
+      const identity = (ledger: CapacityLedgerKind, poolId: string, qty: number) =>
+        createHash("sha256")
+          .update(
+            JSON.stringify({
+              order_id,
+              ledger_kind: ledger,
+              pool_id: poolId,
+              quantity: qty,
+              work_key_digest: workKeyDigest,
+            }),
+          )
+          .digest("hex");
+
+      const ts = Math.floor(input.now_ms / 1000);
+      const placedEvent: OrderPlaced = {
+        order_id,
+        product: input.order.product,
+        inputs_digest: input.order.inputs_digest,
+      };
+      const orderInsert = await client.query(
+        `INSERT INTO orders (
+          order_id, product, placed_by, inputs, inputs_digest, state,
+          placed_at_unix, created_at_unix, updated_at_unix, ingredients,
+          ingredient_jobs, operator_audit
+        ) VALUES ($1,$2,$3,$4,$5,'placed',$6,$7,$7,$8,'[]'::jsonb,'[]'::jsonb)
+        RETURNING *`,
+        [
+          order_id,
+          input.order.product,
+          input.order.placed_by,
+          JSON.stringify(input.order.inputs),
+          input.order.inputs_digest,
+          input.order.placed_at_unix,
+          ts,
+          null,
+        ],
+      );
+      await client.query(
+        `INSERT INTO order_outbox (order_id, subject, payload, published)
+         VALUES ($1,$2,$3,FALSE)`,
+        [order_id, ORDER_LIFECYCLE_SUBJECTS.placed, JSON.stringify(placedEvent)],
+      );
+
+      await client.query(
+        `INSERT INTO admission_capacity_reservations (
+          reservation_id, order_id, pool_id, ledger_kind, quantity,
+          reservation_version, state, identity_digest, work_key_digest, created_at
+        ) VALUES
+          ($1,$2,$3,'admission_rate',1,1,'held',$4,NULL,to_timestamp($7/1000.0)),
+          ($5,$2,$6,'queued_work',$8,1,$9,$10,$11,to_timestamp($7/1000.0))`,
+        [
+          admissionRsv,
+          order_id,
+          admission.pool_id,
+          identity("admission_rate", admission.pool_id, 1),
+          queuedRsv,
+          queued.pool_id,
+          input.now_ms,
+          queuedQty,
+          queuedState,
+          identity("queued_work", queued.pool_id, queuedQty),
+          workKeyDigest,
+        ],
+      );
+      await client.query(
+        `INSERT INTO admission_capacity_transfer_log (
+          event_id, reservation_id, from_state, to_state, reason, event_version, created_at
+        ) VALUES
+          ($1,$2,'held','held','created',1,to_timestamp($4/1000.0)),
+          ($3,$5,'held',$6,$7,1,to_timestamp($4/1000.0))`,
+        [
+          `cte_${randomUUID()}`,
+          admissionRsv,
+          `cte_${randomUUID()}`,
+          input.now_ms,
+          queuedRsv,
+          queuedState,
+          queuedState === "transferred" ? "fan_in_share_envelope" : "created",
+        ],
+      );
+
+      const join = await this.preparationStore.joinPublicWorkInTransaction(client, {
+        order_id,
+        order_tenant_scope_digest: input.order_tenant_scope_digest,
+        work_key: input.work_key,
+        now_ms: input.now_ms,
+      });
+      if (join.kind !== "joined") {
+        throw new Error("serialization_retry");
+      }
+
+      // Fold only when another held envelope already exists for this work key.
+      if (!join.created && queuedState === "held" && queuedQty > 0) {
+        const otherHeld = await client.query(
+          `SELECT reservation_id FROM admission_capacity_reservations
+           WHERE work_key_digest = $1
+             AND ledger_kind = 'queued_work'
+             AND state = 'held'
+             AND reservation_id <> $2
+           FOR UPDATE`,
+          [workKeyDigest, queuedRsv],
+        );
+        if (otherHeld.rows.length > 0) {
+          await client.query(
+            `UPDATE admission_capacity_pools
+             SET consumed_units = consumed_units - $2, version = version + 1
+             WHERE pool_id = $1`,
+            [queued.pool_id, queuedQty],
+          );
+          await client.query(
+            `UPDATE admission_capacity_reservations
+             SET state = 'transferred', quantity = 0, reservation_version = reservation_version + 1
+             WHERE reservation_id = $1`,
+            [queuedRsv],
+          );
+        }
+      }
+
+      await client.query(
+        `INSERT INTO order_admission_idempotency (
+          requester_subject, client_request_id, body_digest, order_id, reservation_ids, stored_at
+        ) VALUES ($1,$2,$3,$4,$5::jsonb,to_timestamp($6/1000.0))`,
+        [
+          input.requester_subject,
+          input.client_request_id,
+          body_digest,
+          order_id,
+          JSON.stringify(reservationIds),
+          input.now_ms,
+        ],
+      );
+
+      await commit();
+      return {
+        kind: "admitted",
+        order: rowToOrder(orderInsert.rows[0]),
+        created: true,
+        work_created: join.created,
+        work_id: join.work.work_id,
+        reservation_ids: reservationIds,
+        replay: false,
+      };
+    } catch (err) {
+      if (!txnClosed) {
+        await rollback();
+      }
+      if (err instanceof CapacityUnavailableError) {
+        return { kind: "capacity_unavailable", reason: err.reason };
+      }
+      if (shouldRetryAdmissionTxn(err)) {
+        throw new Error("serialization_retry");
+      }
+      throw err;
     } finally {
+      if (!txnClosed) {
+        await safeRollback(client);
+      }
       client.release();
     }
   }
@@ -587,58 +654,66 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
     | { readonly kind: "capacity_unavailable"; readonly reason: string }
     | { readonly kind: "order_not_found" }
   > {
-    const client = await this.pool.connect();
-    try {
-      await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE");
-      const order = await client.query("SELECT order_id FROM orders WHERE order_id = $1", [
-        input.order_id,
-      ]);
-      if (order.rows.length === 0) {
-        await client.query("ROLLBACK");
-        return { kind: "order_not_found" };
-      }
-      const active = await this.lockOrCreatePool(client, {
-        ledger_kind: "active_execution",
-        ...input.pool_scope,
-        limit_units: this.defaults.active_execution,
-        now_ms: input.now_ms,
-      });
-      const quantity = input.quantity ?? 1;
+    return this.withSerializableRetry(async () => {
+      const client = await this.pool.connect();
+      let txnClosed = false;
       try {
-        await this.consumePool(client, active, quantity, input.now_ms);
-      } catch (err) {
-        await client.query("ROLLBACK");
-        if (err instanceof CapacityUnavailableError) {
-          return { kind: "capacity_unavailable", reason: err.reason };
-        }
-        throw err;
-      }
-      const reservation_id = `rsv_${randomUUID()}`;
-      const leaseUntil = input.now_ms + (input.lease_duration_ms ?? ACTIVE_EXECUTION_LEASE_MS);
-      const inserted = await client.query(
-        `INSERT INTO admission_capacity_reservations (
-          reservation_id, order_id, pool_id, ledger_kind, quantity,
-          reservation_version, state, identity_digest, lease_until, created_at
-        ) VALUES ($1,$2,$3,'active_execution',$4,1,'held',$5,to_timestamp($6/1000.0),to_timestamp($7/1000.0))
-        RETURNING *`,
-        [
-          reservation_id,
+        await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE");
+        const order = await client.query("SELECT order_id FROM orders WHERE order_id = $1", [
           input.order_id,
-          active.pool_id,
-          quantity,
-          createHash("sha256").update(`${input.order_id}:active:${quantity}`).digest("hex"),
-          leaseUntil,
-          input.now_ms,
-        ],
-      );
-      await client.query("COMMIT");
-      return { kind: "acquired", reservation: rowToReservation(inserted.rows[0]) };
-    } catch (err) {
-      await client.query("ROLLBACK");
-      throw err;
-    } finally {
-      client.release();
-    }
+        ]);
+        if (order.rows.length === 0) {
+          await safeRollback(client);
+          txnClosed = true;
+          return { kind: "order_not_found" as const };
+        }
+        const active = await this.lockOrCreatePool(client, {
+          ledger_kind: "active_execution",
+          ...input.pool_scope,
+          limit_units: this.defaults.active_execution,
+          now_ms: input.now_ms,
+        });
+        const quantity = input.quantity ?? 1;
+        try {
+          await this.consumePool(client, active, quantity, input.now_ms);
+        } catch (err) {
+          await safeRollback(client);
+          txnClosed = true;
+          if (err instanceof CapacityUnavailableError) {
+            return { kind: "capacity_unavailable" as const, reason: err.reason };
+          }
+          throw err;
+        }
+        const reservation_id = `rsv_${randomUUID()}`;
+        const leaseUntil = input.now_ms + (input.lease_duration_ms ?? ACTIVE_EXECUTION_LEASE_MS);
+        const inserted = await client.query(
+          `INSERT INTO admission_capacity_reservations (
+            reservation_id, order_id, pool_id, ledger_kind, quantity,
+            reservation_version, state, identity_digest, lease_until, created_at
+          ) VALUES ($1,$2,$3,'active_execution',$4,1,'held',$5,to_timestamp($6/1000.0),to_timestamp($7/1000.0))
+          RETURNING *`,
+          [
+            reservation_id,
+            input.order_id,
+            active.pool_id,
+            quantity,
+            createHash("sha256").update(`${input.order_id}:active:${quantity}`).digest("hex"),
+            leaseUntil,
+            input.now_ms,
+          ],
+        );
+        await client.query("COMMIT");
+        txnClosed = true;
+        return { kind: "acquired" as const, reservation: rowToReservation(inserted.rows[0]) };
+      } catch (err) {
+        if (!txnClosed) await safeRollback(client);
+        txnClosed = true;
+        throw err;
+      } finally {
+        if (!txnClosed) await safeRollback(client);
+        client.release();
+      }
+    });
   }
 
   /**
@@ -754,76 +829,86 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
     | { readonly kind: "version_mismatch" }
     | { readonly kind: "not_found" }
   > {
-    const client = await this.pool.connect();
-    try {
-      await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE");
-      const res = await client.query(
-        `SELECT * FROM admission_capacity_reservations WHERE reservation_id = $1 FOR UPDATE`,
-        [input.reservation_id],
-      );
-      if (res.rows.length === 0) {
-        await client.query("ROLLBACK");
-        return { kind: "not_found" };
-      }
-      const row = rowToReservation(res.rows[0]);
-      if (row.state !== "held" && row.state !== "transferred") {
-        await client.query("COMMIT");
-        return { kind: "already_released", reservation: row };
-      }
-      if (row.reservation_version !== input.expected_version) {
-        await client.query("ROLLBACK");
-        return { kind: "version_mismatch" };
-      }
-
-      if (row.ledger_kind === "queued_work" && row.work_key_digest) {
-        const released = await this.releaseQueuedEnvelopeOnClient(
-          client,
-          row,
-          input.reason,
-          input.now_ms,
+    return this.withSerializableRetry(async () => {
+      const client = await this.pool.connect();
+      let txnClosed = false;
+      try {
+        await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE");
+        const res = await client.query(
+          `SELECT * FROM admission_capacity_reservations WHERE reservation_id = $1 FOR UPDATE`,
+          [input.reservation_id],
         );
-        await client.query("COMMIT");
-        return { kind: "released", reservation: released };
-      }
+        if (res.rows.length === 0) {
+          await safeRollback(client);
+          txnClosed = true;
+          return { kind: "not_found" as const };
+        }
+        const row = rowToReservation(res.rows[0]);
+        if (row.state !== "held" && row.state !== "transferred") {
+          await client.query("COMMIT");
+          txnClosed = true;
+          return { kind: "already_released" as const, reservation: row };
+        }
+        if (row.reservation_version !== input.expected_version) {
+          await safeRollback(client);
+          txnClosed = true;
+          return { kind: "version_mismatch" as const };
+        }
 
-      if (row.quantity > 0 && row.state === "held") {
+        if (row.ledger_kind === "queued_work" && row.work_key_digest) {
+          const released = await this.releaseQueuedEnvelopeOnClient(
+            client,
+            row,
+            input.reason,
+            input.now_ms,
+          );
+          await client.query("COMMIT");
+          txnClosed = true;
+          return { kind: "released" as const, reservation: released };
+        }
+
+        if (row.quantity > 0 && row.state === "held") {
+          await client.query(
+            `UPDATE admission_capacity_pools
+             SET consumed_units = GREATEST(0, consumed_units - $2), version = version + 1
+             WHERE pool_id = $1`,
+            [row.pool_id, row.quantity],
+          );
+        }
+        const updated = await client.query(
+          `UPDATE admission_capacity_reservations
+           SET state = 'released',
+               reservation_version = reservation_version + 1,
+               released_at = to_timestamp($2/1000.0)
+           WHERE reservation_id = $1
+           RETURNING *`,
+          [input.reservation_id, input.now_ms],
+        );
         await client.query(
-          `UPDATE admission_capacity_pools
-           SET consumed_units = GREATEST(0, consumed_units - $2), version = version + 1
-           WHERE pool_id = $1`,
-          [row.pool_id, row.quantity],
+          `INSERT INTO admission_capacity_transfer_log (
+            event_id, reservation_id, from_state, to_state, reason, event_version, created_at
+          ) VALUES ($1,$2,$3,'released',$4,$5,to_timestamp($6/1000.0))`,
+          [
+            `cte_${randomUUID()}`,
+            input.reservation_id,
+            row.state,
+            input.reason,
+            row.reservation_version + 1,
+            input.now_ms,
+          ],
         );
+        await client.query("COMMIT");
+        txnClosed = true;
+        return { kind: "released" as const, reservation: rowToReservation(updated.rows[0]) };
+      } catch (err) {
+        if (!txnClosed) await safeRollback(client);
+        txnClosed = true;
+        throw err;
+      } finally {
+        if (!txnClosed) await safeRollback(client);
+        client.release();
       }
-      const updated = await client.query(
-        `UPDATE admission_capacity_reservations
-         SET state = 'released',
-             reservation_version = reservation_version + 1,
-             released_at = to_timestamp($2/1000.0)
-         WHERE reservation_id = $1
-         RETURNING *`,
-        [input.reservation_id, input.now_ms],
-      );
-      await client.query(
-        `INSERT INTO admission_capacity_transfer_log (
-          event_id, reservation_id, from_state, to_state, reason, event_version, created_at
-        ) VALUES ($1,$2,$3,'released',$4,$5,to_timestamp($6/1000.0))`,
-        [
-          `cte_${randomUUID()}`,
-          input.reservation_id,
-          row.state,
-          input.reason,
-          row.reservation_version + 1,
-          input.now_ms,
-        ],
-      );
-      await client.query("COMMIT");
-      return { kind: "released", reservation: rowToReservation(updated.rows[0]) };
-    } catch (err) {
-      await client.query("ROLLBACK");
-      throw err;
-    } finally {
-      client.release();
-    }
+    });
   }
 
   async releaseOrderCapacity(input: {
@@ -837,85 +922,98 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
      * - queued_work: free shared envelope only when last subscriber leaves;
      *   otherwise reassign held envelope ownership and leave pool units consumed
      */
-    const client = await this.pool.connect();
-    try {
-      await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE");
-      const rows = await client.query(
-        `SELECT * FROM admission_capacity_reservations
-         WHERE order_id = $1 AND state IN ('held', 'transferred')
-         FOR UPDATE`,
-        [input.order_id],
-      );
-      let released = 0;
-
-      const markReleased = async (
-        reservationId: string,
-        fromState: string,
-        version: number,
-      ) => {
-        await client.query(
-          `UPDATE admission_capacity_reservations
-           SET state = 'released',
-               reservation_version = reservation_version + 1,
-               released_at = to_timestamp($2/1000.0)
-           WHERE reservation_id = $1`,
-          [reservationId, input.now_ms],
+    return this.withSerializableRetry(async () => {
+      const client = await this.pool.connect();
+      let txnClosed = false;
+      try {
+        await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE");
+        const rows = await client.query(
+          `SELECT * FROM admission_capacity_reservations
+           WHERE order_id = $1 AND state IN ('held', 'transferred')
+           FOR UPDATE`,
+          [input.order_id],
         );
-        await client.query(
-          `INSERT INTO admission_capacity_transfer_log (
-            event_id, reservation_id, from_state, to_state, reason, event_version, created_at
-          ) VALUES ($1,$2,$3,'released',$4,$5,to_timestamp($6/1000.0))`,
-          [
-            `cte_${randomUUID()}`,
-            reservationId,
-            fromState,
-            input.reason,
-            version + 1,
-            input.now_ms,
-          ],
-        );
-      };
+        let released = 0;
 
-      for (const raw of rows.rows) {
-        const row = rowToReservation(raw);
-
-        if (row.ledger_kind === "queued_work" && row.work_key_digest) {
-          const others = await client.query(
-            `SELECT reservation_id, quantity, state FROM admission_capacity_reservations
-             WHERE work_key_digest = $1
-               AND ledger_kind = 'queued_work'
-               AND order_id <> $2
-               AND state IN ('held', 'transferred')
-               AND reservation_id <> $3
-             FOR UPDATE`,
-            [row.work_key_digest, input.order_id, row.reservation_id],
+        const markReleased = async (
+          reservationId: string,
+          fromState: string,
+          version: number,
+        ) => {
+          await client.query(
+            `UPDATE admission_capacity_reservations
+             SET state = 'released',
+                 reservation_version = reservation_version + 1,
+                 released_at = to_timestamp($2/1000.0)
+             WHERE reservation_id = $1`,
+            [reservationId, input.now_ms],
           );
+          await client.query(
+            `INSERT INTO admission_capacity_transfer_log (
+              event_id, reservation_id, from_state, to_state, reason, event_version, created_at
+            ) VALUES ($1,$2,$3,'released',$4,$5,to_timestamp($6/1000.0))`,
+            [
+              `cte_${randomUUID()}`,
+              reservationId,
+              fromState,
+              input.reason,
+              version + 1,
+              input.now_ms,
+            ],
+          );
+        };
 
-          if (others.rows.length > 0) {
-            // Shared envelope remains — do not free pool units.
-            if (row.state === "held" && row.quantity > 0) {
-              const peer = others.rows[0]!;
-              const envelopeQty = row.quantity;
-              // Demote owner first so unique held-work-key index allows peer promote.
+        for (const raw of rows.rows) {
+          const row = rowToReservation(raw);
+
+          if (row.ledger_kind === "queued_work" && row.work_key_digest) {
+            const others = await client.query(
+              `SELECT reservation_id, quantity, state FROM admission_capacity_reservations
+               WHERE work_key_digest = $1
+                 AND ledger_kind = 'queued_work'
+                 AND order_id <> $2
+                 AND state IN ('held', 'transferred')
+                 AND reservation_id <> $3
+               FOR UPDATE`,
+              [row.work_key_digest, input.order_id, row.reservation_id],
+            );
+
+            if (others.rows.length > 0) {
+              if (row.state === "held" && row.quantity > 0) {
+                const peer = others.rows[0]!;
+                const envelopeQty = row.quantity;
+                await client.query(
+                  `UPDATE admission_capacity_reservations
+                   SET state = 'transferred',
+                       quantity = 0,
+                       reservation_version = reservation_version + 1
+                   WHERE reservation_id = $1`,
+                  [row.reservation_id],
+                );
+                await client.query(
+                  `UPDATE admission_capacity_reservations
+                   SET state = 'held',
+                       quantity = $2,
+                       reservation_version = reservation_version + 1
+                   WHERE reservation_id = $1`,
+                  [peer.reservation_id, envelopeQty],
+                );
+              }
+            } else if (row.quantity > 0) {
               await client.query(
-                `UPDATE admission_capacity_reservations
-                 SET state = 'transferred',
-                     quantity = 0,
-                     reservation_version = reservation_version + 1
-                 WHERE reservation_id = $1`,
-                [row.reservation_id],
-              );
-              await client.query(
-                `UPDATE admission_capacity_reservations
-                 SET state = 'held',
-                     quantity = $2,
-                     reservation_version = reservation_version + 1
-                 WHERE reservation_id = $1`,
-                [peer.reservation_id, envelopeQty],
+                `UPDATE admission_capacity_pools
+                 SET consumed_units = GREATEST(0, consumed_units - $2), version = version + 1
+                 WHERE pool_id = $1`,
+                [row.pool_id, row.quantity],
               );
             }
-          } else if (row.quantity > 0) {
-            // Last subscriber owns the envelope — free pool units exactly once.
+
+            await markReleased(row.reservation_id, row.state, row.reservation_version);
+            released += 1;
+            continue;
+          }
+
+          if (row.state === "held" && row.quantity > 0) {
             await client.query(
               `UPDATE admission_capacity_pools
                SET consumed_units = GREATEST(0, consumed_units - $2), version = version + 1
@@ -923,75 +1021,68 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
               [row.pool_id, row.quantity],
             );
           }
-          // Last subscriber with only a transferred marker (qty 0): units already
-          // live on a held peer that was released in the same order's batch, or
-          // ownership was moved onto this row earlier — if still qty 0, nothing to free.
-
           await markReleased(row.reservation_id, row.state, row.reservation_version);
           released += 1;
-          continue;
         }
-
-        if (row.state === "held" && row.quantity > 0) {
-          await client.query(
-            `UPDATE admission_capacity_pools
-             SET consumed_units = GREATEST(0, consumed_units - $2), version = version + 1
-             WHERE pool_id = $1`,
-            [row.pool_id, row.quantity],
-          );
-        }
-        await markReleased(row.reservation_id, row.state, row.reservation_version);
-        released += 1;
+        await client.query("COMMIT");
+        txnClosed = true;
+        return { released };
+      } catch (err) {
+        if (!txnClosed) await safeRollback(client);
+        txnClosed = true;
+        throw err;
+      } finally {
+        if (!txnClosed) await safeRollback(client);
+        client.release();
       }
-      await client.query("COMMIT");
-      return { released };
-    } catch (err) {
-      await client.query("ROLLBACK");
-      throw err;
-    } finally {
-      client.release();
-    }
+    });
   }
 
   async reconcileExpiredActiveLeases(input: {
     now_ms: number;
   }): Promise<{ readonly expired: number }> {
-    const client = await this.pool.connect();
-    try {
-      await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE");
-      const expired = await client.query(
-        `SELECT * FROM admission_capacity_reservations
-         WHERE state = 'held' AND ledger_kind = 'active_execution'
-           AND lease_until IS NOT NULL AND lease_until <= to_timestamp($1/1000.0)
-         FOR UPDATE`,
-        [input.now_ms],
-      );
-      for (const row of expired.rows) {
-        if (Number(row.quantity) > 0) {
+    return this.withSerializableRetry(async () => {
+      const client = await this.pool.connect();
+      let txnClosed = false;
+      try {
+        await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE");
+        const expired = await client.query(
+          `SELECT * FROM admission_capacity_reservations
+           WHERE state = 'held' AND ledger_kind = 'active_execution'
+             AND lease_until IS NOT NULL AND lease_until <= to_timestamp($1/1000.0)
+           FOR UPDATE`,
+          [input.now_ms],
+        );
+        for (const row of expired.rows) {
+          if (Number(row.quantity) > 0) {
+            await client.query(
+              `UPDATE admission_capacity_pools
+               SET consumed_units = GREATEST(0, consumed_units - $2), version = version + 1
+               WHERE pool_id = $1`,
+              [row.pool_id, row.quantity],
+            );
+          }
           await client.query(
-            `UPDATE admission_capacity_pools
-             SET consumed_units = GREATEST(0, consumed_units - $2), version = version + 1
-             WHERE pool_id = $1`,
-            [row.pool_id, row.quantity],
+            `UPDATE admission_capacity_reservations
+             SET state = 'expired',
+                 reservation_version = reservation_version + 1,
+                 released_at = to_timestamp($2/1000.0)
+             WHERE reservation_id = $1`,
+            [row.reservation_id, input.now_ms],
           );
         }
-        await client.query(
-          `UPDATE admission_capacity_reservations
-           SET state = 'expired',
-               reservation_version = reservation_version + 1,
-               released_at = to_timestamp($2/1000.0)
-           WHERE reservation_id = $1`,
-          [row.reservation_id, input.now_ms],
-        );
+        await client.query("COMMIT");
+        txnClosed = true;
+        return { expired: expired.rows.length };
+      } catch (err) {
+        if (!txnClosed) await safeRollback(client);
+        txnClosed = true;
+        throw err;
+      } finally {
+        if (!txnClosed) await safeRollback(client);
+        client.release();
       }
-      await client.query("COMMIT");
-      return { expired: expired.rows.length };
-    } catch (err) {
-      await client.query("ROLLBACK");
-      throw err;
-    } finally {
-      client.release();
-    }
+    });
   }
 
   async snapshotAccounting(): Promise<{

--- a/packages/services/ordering/src/admission-capacity-store-postgres.ts
+++ b/packages/services/ordering/src/admission-capacity-store-postgres.ts
@@ -31,6 +31,7 @@ import type {
   OrderAdmissionIdempotencyRecord,
 } from "./admission-capacity-types.js";
 import { CapacityUnavailableError } from "./admission-capacity-types.js";
+import { shouldRetryAdmissionTxn } from "./admission-capacity-pg-errors.js";
 import { assertCertificateAdmissible } from "./recipe-expansion-certificate.js";
 import { digestOf } from "./digest.js";
 import { PostgresSharedPreparationStore } from "./shared-preparation-store-postgres.js";
@@ -38,6 +39,8 @@ import { digestPublicWorkKey } from "./shared-preparation-work-key.js";
 import type { OrderRecord } from "./store.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const ADMISSION_TXN_RETRIES = 8;
 
 function rowToPool(row: pg.QueryResultRow): CapacityPoolRecord {
   return {
@@ -309,6 +312,23 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
     if (input.advisory_shed) {
       return { kind: "capacity_unavailable", reason: "advisory_shed" };
     }
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < ADMISSION_TXN_RETRIES; attempt += 1) {
+      try {
+        return await this.admitOrderAttempt(input);
+      } catch (err) {
+        lastErr = err;
+        if (shouldRetryAdmissionTxn(err)) {
+          continue;
+        }
+        throw err;
+      }
+    }
+    void lastErr;
+    return { kind: "capacity_unavailable", reason: "lock_timeout" };
+  }
+
+  private async admitOrderAttempt(input: AdmitOrderInput): Promise<AdmitOrderResult> {
     const client = await this.pool.connect();
     try {
       await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE");
@@ -489,20 +509,32 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
           throw new Error("serialization_retry");
         }
 
-        // If we created a queued envelope but join reused work, fold into fan-in.
+        // Fold only when another held envelope already exists for this work key.
+        // Never refund/zero the sole held envelope just because join reused work.
         if (!join.created && queuedState === "held" && queuedQty > 0) {
-          await client.query(
-            `UPDATE admission_capacity_pools
-             SET consumed_units = consumed_units - $2, version = version + 1
-             WHERE pool_id = $1`,
-            [queued.pool_id, queuedQty],
+          const otherHeld = await client.query(
+            `SELECT reservation_id FROM admission_capacity_reservations
+             WHERE work_key_digest = $1
+               AND ledger_kind = 'queued_work'
+               AND state = 'held'
+               AND reservation_id <> $2
+             FOR UPDATE`,
+            [workKeyDigest, queuedRsv],
           );
-          await client.query(
-            `UPDATE admission_capacity_reservations
-             SET state = 'transferred', quantity = 0, reservation_version = reservation_version + 1
-             WHERE reservation_id = $1`,
-            [queuedRsv],
-          );
+          if (otherHeld.rows.length > 0) {
+            await client.query(
+              `UPDATE admission_capacity_pools
+               SET consumed_units = consumed_units - $2, version = version + 1
+               WHERE pool_id = $1`,
+              [queued.pool_id, queuedQty],
+            );
+            await client.query(
+              `UPDATE admission_capacity_reservations
+               SET state = 'transferred', quantity = 0, reservation_version = reservation_version + 1
+               WHERE reservation_id = $1`,
+              [queuedRsv],
+            );
+          }
         }
 
         await client.query(
@@ -534,17 +566,8 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
         if (err instanceof CapacityUnavailableError) {
           return { kind: "capacity_unavailable", reason: err.reason };
         }
-        if (err instanceof Error && err.message === "serialization_retry") {
-          return { kind: "capacity_unavailable", reason: "lock_timeout" };
-        }
-        // Postgres serialization failure
-        if (
-          err &&
-          typeof err === "object" &&
-          "code" in err &&
-          (err as { code: string }).code === "40001"
-        ) {
-          return { kind: "capacity_unavailable", reason: "lock_timeout" };
+        if (shouldRetryAdmissionTxn(err)) {
+          throw new Error("serialization_retry");
         }
         throw err;
       }
@@ -618,6 +641,108 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
     }
   }
 
+  /**
+   * Fan-in-aware queued envelope release on an open client (F1/F4).
+   * Promotes a peer to held+quantity, or frees pool units only for last subscriber.
+   */
+  private async releaseQueuedEnvelopeOnClient(
+    client: pg.PoolClient,
+    row: CapacityReservationRecord,
+    reason: string,
+    now_ms: number,
+  ): Promise<CapacityReservationRecord> {
+    if (!row.work_key_digest) {
+      const updated = await client.query(
+        `UPDATE admission_capacity_reservations
+         SET state = 'released',
+             reservation_version = reservation_version + 1,
+             released_at = to_timestamp($2/1000.0)
+         WHERE reservation_id = $1
+         RETURNING *`,
+        [row.reservation_id, now_ms],
+      );
+      return rowToReservation(updated.rows[0]);
+    }
+
+    const others = await client.query(
+      `SELECT reservation_id, quantity, state, reservation_version
+       FROM admission_capacity_reservations
+       WHERE work_key_digest = $1
+         AND ledger_kind = 'queued_work'
+         AND state IN ('held', 'transferred')
+         AND reservation_id <> $2
+       FOR UPDATE`,
+      [row.work_key_digest, row.reservation_id],
+    );
+
+    if (others.rows.length > 0) {
+      if (row.state === "held" && row.quantity > 0) {
+        const peer = others.rows[0]!;
+        const envelopeQty = row.quantity;
+        await client.query(
+          `UPDATE admission_capacity_reservations
+           SET state = 'transferred',
+               quantity = 0,
+               reservation_version = reservation_version + 1
+           WHERE reservation_id = $1`,
+          [row.reservation_id],
+        );
+        const promoted = await client.query(
+          `UPDATE admission_capacity_reservations
+           SET state = 'held',
+               quantity = $2,
+               reservation_version = reservation_version + 1
+           WHERE reservation_id = $1
+           RETURNING reservation_version`,
+          [peer.reservation_id, envelopeQty],
+        );
+        await client.query(
+          `INSERT INTO admission_capacity_transfer_log (
+            event_id, reservation_id, from_state, to_state, reason, event_version, created_at
+          ) VALUES ($1,$2,$3,'held','envelope_ownership_promote',$4,to_timestamp($5/1000.0))`,
+          [
+            `cte_${randomUUID()}`,
+            peer.reservation_id,
+            peer.state,
+            Number(promoted.rows[0]?.reservation_version ?? 1),
+            now_ms,
+          ],
+        );
+      }
+    } else if (row.quantity > 0) {
+      await client.query(
+        `UPDATE admission_capacity_pools
+         SET consumed_units = GREATEST(0, consumed_units - $2), version = version + 1
+         WHERE pool_id = $1`,
+        [row.pool_id, row.quantity],
+      );
+    }
+
+    const updated = await client.query(
+      `UPDATE admission_capacity_reservations
+       SET state = 'released',
+           reservation_version = reservation_version + 1,
+           released_at = to_timestamp($2/1000.0)
+       WHERE reservation_id = $1
+       RETURNING *`,
+      [row.reservation_id, now_ms],
+    );
+    await client.query(
+      `INSERT INTO admission_capacity_transfer_log (
+        event_id, reservation_id, from_state, to_state, reason, event_version, created_at
+      ) VALUES ($1,$2,$3,'released',$4,$5,to_timestamp($6/1000.0))`,
+      [
+        `cte_${randomUUID()}`,
+        row.reservation_id,
+        row.state,
+        reason,
+        row.reservation_version + 1,
+        now_ms,
+      ],
+    );
+    return rowToReservation(updated.rows[0]);
+  }
+
   async releaseReservation(input: {
     reservation_id: string;
     expected_version: number;
@@ -641,7 +766,7 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
         return { kind: "not_found" };
       }
       const row = rowToReservation(res.rows[0]);
-      if (row.state !== "held") {
+      if (row.state !== "held" && row.state !== "transferred") {
         await client.query("COMMIT");
         return { kind: "already_released", reservation: row };
       }
@@ -649,7 +774,19 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
         await client.query("ROLLBACK");
         return { kind: "version_mismatch" };
       }
-      if (row.quantity > 0) {
+
+      if (row.ledger_kind === "queued_work" && row.work_key_digest) {
+        const released = await this.releaseQueuedEnvelopeOnClient(
+          client,
+          row,
+          input.reason,
+          input.now_ms,
+        );
+        await client.query("COMMIT");
+        return { kind: "released", reservation: released };
+      }
+
+      if (row.quantity > 0 && row.state === "held") {
         await client.query(
           `UPDATE admission_capacity_pools
            SET consumed_units = GREATEST(0, consumed_units - $2), version = version + 1
@@ -669,10 +806,11 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
       await client.query(
         `INSERT INTO admission_capacity_transfer_log (
           event_id, reservation_id, from_state, to_state, reason, event_version, created_at
-        ) VALUES ($1,$2,'held','released',$3,$4,to_timestamp($5/1000.0))`,
+        ) VALUES ($1,$2,$3,'released',$4,$5,to_timestamp($6/1000.0))`,
         [
           `cte_${randomUUID()}`,
           input.reservation_id,
+          row.state,
           input.reason,
           row.reservation_version + 1,
           input.now_ms,

--- a/packages/services/ordering/src/admission-capacity-store-postgres.ts
+++ b/packages/services/ordering/src/admission-capacity-store-postgres.ts
@@ -1,0 +1,772 @@
+/**
+ * CR-201C Postgres adapter — SERIALIZABLE admission transaction.
+ * Capacity counters, idempotency, order, root work/links, and reservations
+ * commit together. Advisory shed is caller-side before opening the txn.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createHash, randomUUID } from "node:crypto";
+import pg from "pg";
+import { ORDER_LIFECYCLE_SUBJECTS, type OrderPlaced } from "@freeside/ordering-protocol";
+import {
+  ACTIVE_EXECUTION_LEASE_MS,
+  DEFAULT_ACTIVE_EXECUTION_LIMIT,
+  DEFAULT_ADMISSION_RATE_LIMIT,
+  DEFAULT_QUEUED_WORK_LIMIT,
+} from "./admission-capacity-constants.js";
+import type {
+  AdmissionCapacityStore,
+  AdmitOrderInput,
+  AdmitOrderResult,
+  EnsurePoolInput,
+} from "./admission-capacity-store.js";
+import type {
+  CapacityLedgerKind,
+  CapacityPoolRecord,
+  CapacityPoolScope,
+  CapacityReservationRecord,
+  CapacityTransferEvent,
+  OrderAdmissionIdempotencyRecord,
+} from "./admission-capacity-types.js";
+import { CapacityUnavailableError } from "./admission-capacity-types.js";
+import { assertCertificateAdmissible } from "./recipe-expansion-certificate.js";
+import { digestOf } from "./digest.js";
+import { PostgresSharedPreparationStore } from "./shared-preparation-store-postgres.js";
+import { digestPublicWorkKey } from "./shared-preparation-work-key.js";
+import type { OrderRecord } from "./store.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function rowToPool(row: pg.QueryResultRow): CapacityPoolRecord {
+  return {
+    pool_id: row.pool_id,
+    ledger_kind: row.ledger_kind,
+    network_ref: row.network_ref,
+    capability: row.capability,
+    ...(row.community_ref != null ? { community_ref: row.community_ref } : {}),
+    limit_units: Number(row.limit_units),
+    consumed_units: Number(row.consumed_units),
+    version: Number(row.version),
+    updated_at_unix_ms: new Date(row.updated_at).getTime(),
+  };
+}
+
+function rowToReservation(row: pg.QueryResultRow): CapacityReservationRecord {
+  return {
+    reservation_id: row.reservation_id,
+    order_id: row.order_id,
+    pool_id: row.pool_id,
+    ledger_kind: row.ledger_kind,
+    quantity: Number(row.quantity),
+    reservation_version: Number(row.reservation_version),
+    state: row.state,
+    identity_digest: row.identity_digest,
+    ...(row.work_key_digest != null ? { work_key_digest: row.work_key_digest } : {}),
+    ...(row.lease_until != null
+      ? { lease_until_unix_ms: new Date(row.lease_until).getTime() }
+      : {}),
+    created_at_unix_ms: new Date(row.created_at).getTime(),
+    ...(row.released_at != null
+      ? { released_at_unix_ms: new Date(row.released_at).getTime() }
+      : {}),
+  };
+}
+
+function rowToOrder(row: pg.QueryResultRow): OrderRecord {
+  return {
+    order_id: row.order_id,
+    product: row.product,
+    placed_by: row.placed_by,
+    inputs: row.inputs,
+    placed_at_unix: Number(row.placed_at_unix),
+    state: row.state,
+    inputs_digest: row.inputs_digest,
+    ingredients: row.ingredients ?? undefined,
+    ingredient_jobs: row.ingredient_jobs ?? [],
+    operator_audit: row.operator_audit ?? [],
+    created_at_unix: Number(row.created_at_unix),
+    updated_at_unix: Number(row.updated_at_unix),
+  };
+}
+
+export interface PostgresAdmissionCapacityStoreOptions {
+  readonly pool: pg.Pool;
+  readonly preparationStore: PostgresSharedPreparationStore;
+  readonly defaultLimits?: {
+    admission_rate?: number;
+    queued_work?: number;
+    active_execution?: number;
+  };
+}
+
+export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
+  private readonly pool: pg.Pool;
+  private readonly preparationStore: PostgresSharedPreparationStore;
+  private readonly defaults: Required<
+    NonNullable<PostgresAdmissionCapacityStoreOptions["defaultLimits"]>
+  >;
+
+  constructor(opts: PostgresAdmissionCapacityStoreOptions) {
+    this.pool = opts.pool;
+    this.preparationStore = opts.preparationStore;
+    this.defaults = {
+      admission_rate: opts.defaultLimits?.admission_rate ?? DEFAULT_ADMISSION_RATE_LIMIT,
+      queued_work: opts.defaultLimits?.queued_work ?? DEFAULT_QUEUED_WORK_LIMIT,
+      active_execution: opts.defaultLimits?.active_execution ?? DEFAULT_ACTIVE_EXECUTION_LIMIT,
+    };
+  }
+
+  static async connect(
+    connectionString: string,
+    opts: {
+      migrate?: boolean;
+      preparationStore?: PostgresSharedPreparationStore;
+    } = {},
+  ): Promise<PostgresAdmissionCapacityStore> {
+    const pool = new pg.Pool({ connectionString, max: 10 });
+    const preparationStore =
+      opts.preparationStore ??
+      (await PostgresSharedPreparationStore.connect(connectionString, {
+        pool,
+        migrate: opts.migrate ?? process.env.RUN_MIGRATIONS === "true",
+      }));
+    const store = new PostgresAdmissionCapacityStore({ pool, preparationStore });
+    if (opts.migrate ?? process.env.RUN_MIGRATIONS === "true") {
+      await store.runMigrations();
+    }
+    return store;
+  }
+
+  async runMigrations(): Promise<void> {
+    for (const file of [
+      "001_orders.sql",
+      "007_shared_preparation_work.sql",
+      "008_admission_capacity.sql",
+    ]) {
+      const sql = readFileSync(join(__dirname, "../migrations", file), "utf8");
+      await this.pool.query(sql);
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.pool.end();
+  }
+
+  private async lockOrCreatePool(
+    client: pg.PoolClient,
+    input: EnsurePoolInput & { now_ms: number },
+  ): Promise<CapacityPoolRecord> {
+    const existing = await client.query(
+      `SELECT * FROM admission_capacity_pools
+       WHERE ledger_kind = $1 AND network_ref = $2 AND capability = $3
+         AND community_ref IS NOT DISTINCT FROM $4
+       FOR UPDATE`,
+      [input.ledger_kind, input.network_ref, input.capability, input.community_ref ?? null],
+    );
+    if (existing.rows.length > 0) return rowToPool(existing.rows[0]);
+    const pool_id = `cap_${input.ledger_kind}_${randomUUID()}`;
+    const inserted = await client.query(
+      `INSERT INTO admission_capacity_pools (
+        pool_id, ledger_kind, network_ref, capability, community_ref,
+        limit_units, consumed_units, version, updated_at
+      ) VALUES ($1,$2,$3,$4,$5,$6,0,0,to_timestamp($7/1000.0))
+      RETURNING *`,
+      [
+        pool_id,
+        input.ledger_kind,
+        input.network_ref,
+        input.capability,
+        input.community_ref ?? null,
+        input.limit_units,
+        input.now_ms,
+      ],
+    );
+    return rowToPool(inserted.rows[0]);
+  }
+
+  private async consumePool(
+    client: pg.PoolClient,
+    pool: CapacityPoolRecord,
+    quantity: number,
+    now_ms: number,
+  ): Promise<CapacityPoolRecord> {
+    if (pool.consumed_units + quantity > pool.limit_units) {
+      const reason =
+        pool.ledger_kind === "admission_rate"
+          ? "insufficient_admission_rate"
+          : pool.ledger_kind === "queued_work"
+            ? "insufficient_queued_work"
+            : "insufficient_active_execution";
+      throw new CapacityUnavailableError(reason);
+    }
+    const updated = await client.query(
+      `UPDATE admission_capacity_pools
+       SET consumed_units = consumed_units + $2,
+           version = version + 1,
+           updated_at = to_timestamp($3/1000.0)
+       WHERE pool_id = $1 AND version = $4
+       RETURNING *`,
+      [pool.pool_id, quantity, now_ms, pool.version],
+    );
+    if (updated.rows.length === 0) {
+      throw new Error("serialization_retry");
+    }
+    return rowToPool(updated.rows[0]);
+  }
+
+  async ensurePool(input: EnsurePoolInput & { now_ms: number }): Promise<CapacityPoolRecord> {
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE");
+      const pool = await this.lockOrCreatePool(client, input);
+      await client.query("COMMIT");
+      return pool;
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async getPool(poolId: string): Promise<CapacityPoolRecord | undefined> {
+    const res = await this.pool.query(
+      "SELECT * FROM admission_capacity_pools WHERE pool_id = $1",
+      [poolId],
+    );
+    return res.rows[0] ? rowToPool(res.rows[0]) : undefined;
+  }
+
+  async listPools(): Promise<readonly CapacityPoolRecord[]> {
+    const res = await this.pool.query("SELECT * FROM admission_capacity_pools");
+    return res.rows.map(rowToPool);
+  }
+
+  async getReservation(
+    reservationId: string,
+  ): Promise<CapacityReservationRecord | undefined> {
+    const res = await this.pool.query(
+      "SELECT * FROM admission_capacity_reservations WHERE reservation_id = $1",
+      [reservationId],
+    );
+    return res.rows[0] ? rowToReservation(res.rows[0]) : undefined;
+  }
+
+  async listHeldReservations(
+    orderId: string,
+  ): Promise<readonly CapacityReservationRecord[]> {
+    const res = await this.pool.query(
+      `SELECT * FROM admission_capacity_reservations
+       WHERE order_id = $1 AND state = 'held'`,
+      [orderId],
+    );
+    return res.rows.map(rowToReservation);
+  }
+
+  async listTransferLog(reservationId: string): Promise<readonly CapacityTransferEvent[]> {
+    const res = await this.pool.query(
+      `SELECT * FROM admission_capacity_transfer_log
+       WHERE reservation_id = $1 ORDER BY event_version`,
+      [reservationId],
+    );
+    return res.rows.map((row) => ({
+      event_id: row.event_id,
+      reservation_id: row.reservation_id,
+      from_state: row.from_state,
+      to_state: row.to_state,
+      reason: row.reason,
+      event_version: Number(row.event_version),
+      created_at_unix_ms: new Date(row.created_at).getTime(),
+    }));
+  }
+
+  async getIdempotency(
+    requester: string,
+    clientRequestId: string,
+  ): Promise<OrderAdmissionIdempotencyRecord | undefined> {
+    const res = await this.pool.query(
+      `SELECT * FROM order_admission_idempotency
+       WHERE requester_subject = $1 AND client_request_id = $2`,
+      [requester, clientRequestId],
+    );
+    if (!res.rows[0]) return undefined;
+    const row = res.rows[0];
+    return {
+      requester_subject: row.requester_subject,
+      client_request_id: row.client_request_id,
+      body_digest: row.body_digest,
+      order_id: row.order_id,
+      reservation_ids: row.reservation_ids,
+      stored_at_unix_ms: new Date(row.stored_at).getTime(),
+    };
+  }
+
+  async admitOrder(input: AdmitOrderInput): Promise<AdmitOrderResult> {
+    if (input.advisory_shed) {
+      return { kind: "capacity_unavailable", reason: "advisory_shed" };
+    }
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE");
+      try {
+        assertCertificateAdmissible(input.certificate);
+      } catch (err) {
+        await client.query("ROLLBACK");
+        if (err instanceof CapacityUnavailableError) {
+          return { kind: "capacity_unavailable", reason: err.reason };
+        }
+        throw err;
+      }
+
+      const body_digest = digestOf(input.body);
+      const prior = await client.query(
+        `SELECT * FROM order_admission_idempotency
+         WHERE requester_subject = $1 AND client_request_id = $2
+         FOR UPDATE`,
+        [input.requester_subject, input.client_request_id],
+      );
+      if (prior.rows.length > 0) {
+        const row = prior.rows[0];
+        if (row.body_digest !== body_digest) {
+          await client.query("ROLLBACK");
+          return { kind: "idempotency_conflict" };
+        }
+        const orderRes = await client.query("SELECT * FROM orders WHERE order_id = $1", [
+          row.order_id,
+        ]);
+        const join = await this.preparationStore.joinPublicWorkInTransaction(client, {
+          order_id: row.order_id,
+          order_tenant_scope_digest: input.order_tenant_scope_digest,
+          work_key: input.work_key,
+          now_ms: input.now_ms,
+        });
+        if (join.kind !== "joined") {
+          await client.query("ROLLBACK");
+          return { kind: "capacity_unavailable", reason: "lock_timeout" };
+        }
+        await client.query("COMMIT");
+        return {
+          kind: "admitted",
+          order: rowToOrder(orderRes.rows[0]),
+          created: false,
+          work_created: false,
+          work_id: join.work.work_id,
+          reservation_ids: row.reservation_ids,
+          replay: true,
+        };
+      }
+
+      const scope = input.pool_scope;
+      const admission = await this.lockOrCreatePool(client, {
+        ledger_kind: "admission_rate",
+        ...scope,
+        limit_units: this.defaults.admission_rate,
+        now_ms: input.now_ms,
+      });
+      const queued = await this.lockOrCreatePool(client, {
+        ledger_kind: "queued_work",
+        ...scope,
+        limit_units: this.defaults.queued_work,
+        now_ms: input.now_ms,
+      });
+
+      const workKeyDigest = digestPublicWorkKey(input.work_key);
+      const order_id = input.order.order_id ?? `ord_${randomUUID()}`;
+
+      try {
+        await this.consumePool(client, admission, 1, input.now_ms);
+
+        const heldEnvelope = await client.query(
+          `SELECT * FROM admission_capacity_reservations
+           WHERE work_key_digest = $1 AND ledger_kind = 'queued_work' AND state = 'held'
+           FOR UPDATE`,
+          [workKeyDigest],
+        );
+
+        const reservationIds: string[] = [];
+        let queuedQty = 0;
+        let queuedState: "held" | "transferred" = "held";
+        if (heldEnvelope.rows.length > 0) {
+          queuedState = "transferred";
+          queuedQty = 0;
+        } else {
+          await this.consumePool(client, queued, input.certificate.capacity_weight, input.now_ms);
+          queuedQty = input.certificate.capacity_weight;
+        }
+
+        const admissionRsv = `rsv_${randomUUID()}`;
+        const queuedRsv = `rsv_${randomUUID()}`;
+        reservationIds.push(admissionRsv, queuedRsv);
+
+        const identity = (ledger: CapacityLedgerKind, poolId: string, qty: number) =>
+          createHash("sha256")
+            .update(JSON.stringify({ order_id, ledger_kind: ledger, pool_id: poolId, quantity: qty, work_key_digest: workKeyDigest }))
+            .digest("hex");
+
+        const ts = Math.floor(input.now_ms / 1000);
+        const placedEvent: OrderPlaced = {
+          order_id,
+          product: input.order.product,
+          inputs_digest: input.order.inputs_digest,
+        };
+        const orderInsert = await client.query(
+          `INSERT INTO orders (
+            order_id, product, placed_by, inputs, inputs_digest, state,
+            placed_at_unix, created_at_unix, updated_at_unix, ingredients,
+            ingredient_jobs, operator_audit
+          ) VALUES ($1,$2,$3,$4,$5,'placed',$6,$7,$7,$8,'[]'::jsonb,'[]'::jsonb)
+          RETURNING *`,
+          [
+            order_id,
+            input.order.product,
+            input.order.placed_by,
+            JSON.stringify(input.order.inputs),
+            input.order.inputs_digest,
+            input.order.placed_at_unix,
+            ts,
+            null,
+          ],
+        );
+        await client.query(
+          `INSERT INTO order_outbox (order_id, subject, payload, published)
+           VALUES ($1,$2,$3,FALSE)`,
+          [
+            order_id,
+            ORDER_LIFECYCLE_SUBJECTS.placed,
+            JSON.stringify(placedEvent),
+          ],
+        );
+
+        await client.query(
+          `INSERT INTO admission_capacity_reservations (
+            reservation_id, order_id, pool_id, ledger_kind, quantity,
+            reservation_version, state, identity_digest, work_key_digest, created_at
+          ) VALUES
+            ($1,$2,$3,'admission_rate',1,1,'held',$4,NULL,to_timestamp($7/1000.0)),
+            ($5,$2,$6,'queued_work',$8,1,$9,$10,$11,to_timestamp($7/1000.0))`,
+          [
+            admissionRsv,
+            order_id,
+            admission.pool_id,
+            identity("admission_rate", admission.pool_id, 1),
+            queuedRsv,
+            queued.pool_id,
+            input.now_ms,
+            queuedQty,
+            queuedState,
+            identity("queued_work", queued.pool_id, queuedQty),
+            workKeyDigest,
+          ],
+        );
+        await client.query(
+          `INSERT INTO admission_capacity_transfer_log (
+            event_id, reservation_id, from_state, to_state, reason, event_version, created_at
+          ) VALUES
+            ($1,$2,'held','held','created',1,to_timestamp($4/1000.0)),
+            ($3,$5,'held',$6,$7,1,to_timestamp($4/1000.0))`,
+          [
+            `cte_${randomUUID()}`,
+            admissionRsv,
+            `cte_${randomUUID()}`,
+            input.now_ms,
+            queuedRsv,
+            queuedState,
+            queuedState === "transferred" ? "fan_in_share_envelope" : "created",
+          ],
+        );
+
+        const join = await this.preparationStore.joinPublicWorkInTransaction(client, {
+          order_id,
+          order_tenant_scope_digest: input.order_tenant_scope_digest,
+          work_key: input.work_key,
+          now_ms: input.now_ms,
+        });
+        if (join.kind !== "joined") {
+          throw new Error("serialization_retry");
+        }
+
+        // If we created a queued envelope but join reused work, fold into fan-in.
+        if (!join.created && queuedState === "held" && queuedQty > 0) {
+          await client.query(
+            `UPDATE admission_capacity_pools
+             SET consumed_units = consumed_units - $2, version = version + 1
+             WHERE pool_id = $1`,
+            [queued.pool_id, queuedQty],
+          );
+          await client.query(
+            `UPDATE admission_capacity_reservations
+             SET state = 'transferred', quantity = 0, reservation_version = reservation_version + 1
+             WHERE reservation_id = $1`,
+            [queuedRsv],
+          );
+        }
+
+        await client.query(
+          `INSERT INTO order_admission_idempotency (
+            requester_subject, client_request_id, body_digest, order_id, reservation_ids, stored_at
+          ) VALUES ($1,$2,$3,$4,$5::jsonb,to_timestamp($6/1000.0))`,
+          [
+            input.requester_subject,
+            input.client_request_id,
+            body_digest,
+            order_id,
+            JSON.stringify(reservationIds),
+            input.now_ms,
+          ],
+        );
+
+        await client.query("COMMIT");
+        return {
+          kind: "admitted",
+          order: rowToOrder(orderInsert.rows[0]),
+          created: true,
+          work_created: join.created,
+          work_id: join.work.work_id,
+          reservation_ids: reservationIds,
+          replay: false,
+        };
+      } catch (err) {
+        await client.query("ROLLBACK");
+        if (err instanceof CapacityUnavailableError) {
+          return { kind: "capacity_unavailable", reason: err.reason };
+        }
+        if (err instanceof Error && err.message === "serialization_retry") {
+          return { kind: "capacity_unavailable", reason: "lock_timeout" };
+        }
+        // Postgres serialization failure
+        if (
+          err &&
+          typeof err === "object" &&
+          "code" in err &&
+          (err as { code: string }).code === "40001"
+        ) {
+          return { kind: "capacity_unavailable", reason: "lock_timeout" };
+        }
+        throw err;
+      }
+    } finally {
+      client.release();
+    }
+  }
+
+  async acquireActiveExecutionLease(input: {
+    order_id: string;
+    pool_scope: CapacityPoolScope;
+    quantity?: number;
+    lease_duration_ms?: number;
+    now_ms: number;
+  }): Promise<
+    | { readonly kind: "acquired"; readonly reservation: CapacityReservationRecord }
+    | { readonly kind: "capacity_unavailable"; readonly reason: string }
+    | { readonly kind: "order_not_found" }
+  > {
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE");
+      const order = await client.query("SELECT order_id FROM orders WHERE order_id = $1", [
+        input.order_id,
+      ]);
+      if (order.rows.length === 0) {
+        await client.query("ROLLBACK");
+        return { kind: "order_not_found" };
+      }
+      const active = await this.lockOrCreatePool(client, {
+        ledger_kind: "active_execution",
+        ...input.pool_scope,
+        limit_units: this.defaults.active_execution,
+        now_ms: input.now_ms,
+      });
+      const quantity = input.quantity ?? 1;
+      try {
+        await this.consumePool(client, active, quantity, input.now_ms);
+      } catch (err) {
+        await client.query("ROLLBACK");
+        if (err instanceof CapacityUnavailableError) {
+          return { kind: "capacity_unavailable", reason: err.reason };
+        }
+        throw err;
+      }
+      const reservation_id = `rsv_${randomUUID()}`;
+      const leaseUntil = input.now_ms + (input.lease_duration_ms ?? ACTIVE_EXECUTION_LEASE_MS);
+      const inserted = await client.query(
+        `INSERT INTO admission_capacity_reservations (
+          reservation_id, order_id, pool_id, ledger_kind, quantity,
+          reservation_version, state, identity_digest, lease_until, created_at
+        ) VALUES ($1,$2,$3,'active_execution',$4,1,'held',$5,to_timestamp($6/1000.0),to_timestamp($7/1000.0))
+        RETURNING *`,
+        [
+          reservation_id,
+          input.order_id,
+          active.pool_id,
+          quantity,
+          createHash("sha256").update(`${input.order_id}:active:${quantity}`).digest("hex"),
+          leaseUntil,
+          input.now_ms,
+        ],
+      );
+      await client.query("COMMIT");
+      return { kind: "acquired", reservation: rowToReservation(inserted.rows[0]) };
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async releaseReservation(input: {
+    reservation_id: string;
+    expected_version: number;
+    reason: string;
+    now_ms: number;
+  }): Promise<
+    | { readonly kind: "released"; readonly reservation: CapacityReservationRecord }
+    | { readonly kind: "already_released"; readonly reservation: CapacityReservationRecord }
+    | { readonly kind: "version_mismatch" }
+    | { readonly kind: "not_found" }
+  > {
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE");
+      const res = await client.query(
+        `SELECT * FROM admission_capacity_reservations WHERE reservation_id = $1 FOR UPDATE`,
+        [input.reservation_id],
+      );
+      if (res.rows.length === 0) {
+        await client.query("ROLLBACK");
+        return { kind: "not_found" };
+      }
+      const row = rowToReservation(res.rows[0]);
+      if (row.state !== "held") {
+        await client.query("COMMIT");
+        return { kind: "already_released", reservation: row };
+      }
+      if (row.reservation_version !== input.expected_version) {
+        await client.query("ROLLBACK");
+        return { kind: "version_mismatch" };
+      }
+      if (row.quantity > 0) {
+        await client.query(
+          `UPDATE admission_capacity_pools
+           SET consumed_units = GREATEST(0, consumed_units - $2), version = version + 1
+           WHERE pool_id = $1`,
+          [row.pool_id, row.quantity],
+        );
+      }
+      const updated = await client.query(
+        `UPDATE admission_capacity_reservations
+         SET state = 'released',
+             reservation_version = reservation_version + 1,
+             released_at = to_timestamp($2/1000.0)
+         WHERE reservation_id = $1
+         RETURNING *`,
+        [input.reservation_id, input.now_ms],
+      );
+      await client.query(
+        `INSERT INTO admission_capacity_transfer_log (
+          event_id, reservation_id, from_state, to_state, reason, event_version, created_at
+        ) VALUES ($1,$2,'held','released',$3,$4,to_timestamp($5/1000.0))`,
+        [
+          `cte_${randomUUID()}`,
+          input.reservation_id,
+          input.reason,
+          row.reservation_version + 1,
+          input.now_ms,
+        ],
+      );
+      await client.query("COMMIT");
+      return { kind: "released", reservation: rowToReservation(updated.rows[0]) };
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async releaseOrderCapacity(input: {
+    order_id: string;
+    reason: "fulfilled" | "terminal_failure" | "cancelled" | "abandoned";
+    now_ms: number;
+  }): Promise<{ readonly released: number }> {
+    const held = await this.listHeldReservations(input.order_id);
+    let released = 0;
+    for (const r of held) {
+      const result = await this.releaseReservation({
+        reservation_id: r.reservation_id,
+        expected_version: r.reservation_version,
+        reason: input.reason,
+        now_ms: input.now_ms,
+      });
+      if (result.kind === "released") released += 1;
+    }
+    return { released };
+  }
+
+  async reconcileExpiredActiveLeases(input: {
+    now_ms: number;
+  }): Promise<{ readonly expired: number }> {
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE");
+      const expired = await client.query(
+        `SELECT * FROM admission_capacity_reservations
+         WHERE state = 'held' AND ledger_kind = 'active_execution'
+           AND lease_until IS NOT NULL AND lease_until <= to_timestamp($1/1000.0)
+         FOR UPDATE`,
+        [input.now_ms],
+      );
+      for (const row of expired.rows) {
+        if (Number(row.quantity) > 0) {
+          await client.query(
+            `UPDATE admission_capacity_pools
+             SET consumed_units = GREATEST(0, consumed_units - $2), version = version + 1
+             WHERE pool_id = $1`,
+            [row.pool_id, row.quantity],
+          );
+        }
+        await client.query(
+          `UPDATE admission_capacity_reservations
+           SET state = 'expired',
+               reservation_version = reservation_version + 1,
+               released_at = to_timestamp($2/1000.0)
+           WHERE reservation_id = $1`,
+          [row.reservation_id, input.now_ms],
+        );
+      }
+      await client.query("COMMIT");
+      return { expired: expired.rows.length };
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async snapshotAccounting(): Promise<{
+    readonly admission_rate: { consumed: number; limit: number };
+    readonly queued_work: { consumed: number; limit: number };
+    readonly active_execution: { consumed: number; limit: number };
+  }> {
+    const sum = async (kind: CapacityLedgerKind) => {
+      const res = await this.pool.query(
+        `SELECT COALESCE(SUM(consumed_units),0) AS consumed,
+                COALESCE(SUM(limit_units),0) AS limit_units
+         FROM admission_capacity_pools WHERE ledger_kind = $1`,
+        [kind],
+      );
+      return {
+        consumed: Number(res.rows[0].consumed),
+        limit: Number(res.rows[0].limit_units),
+      };
+    };
+    return {
+      admission_rate: await sum("admission_rate"),
+      queued_work: await sum("queued_work"),
+      active_execution: await sum("active_execution"),
+    };
+  }
+}

--- a/packages/services/ordering/src/admission-capacity-store.ts
+++ b/packages/services/ordering/src/admission-capacity-store.ts
@@ -584,13 +584,9 @@ export class InMemoryAdmissionCapacityStore implements AdmissionCapacityStore {
             throw new Error("serialization_retry");
           }
 
-          // Join reused existing work after we allocated a new envelope → fold into fan-in.
+          // Fold only when another held envelope already exists for this work key.
+          // Never refund/zero the sole held envelope just because join reused work.
           if (!join.created && createdQueuedEnvelope && queuedReservation) {
-            this.releaseUnits(pools.queued, queuedReservation.quantity, input.now_ms);
-            const meta = this.queuedEnvelopeByWork.get(workKeyDigest);
-            if (meta?.reservation_id === queuedReservation.reservation_id) {
-              this.queuedEnvelopeByWork.delete(workKeyDigest);
-            }
             const existing = [...this.reservations.values()].find(
               (r) =>
                 r.ledger_kind === "queued_work" &&
@@ -600,18 +596,22 @@ export class InMemoryAdmissionCapacityStore implements AdmissionCapacityStore {
                 r.reservation_id !== queuedReservation!.reservation_id,
             );
             if (existing) {
-              this.queuedEnvelopeByWork.set(workKeyDigest, {
-                reservation_id: existing.reservation_id,
-                quantity: existing.quantity,
-              });
+              this.releaseUnits(pools.queued, queuedReservation.quantity, input.now_ms);
+              const meta = this.queuedEnvelopeByWork.get(workKeyDigest);
+              if (meta?.reservation_id === queuedReservation.reservation_id) {
+                this.queuedEnvelopeByWork.set(workKeyDigest, {
+                  reservation_id: existing.reservation_id,
+                  quantity: existing.quantity,
+                });
+              }
+              this.transitionReservation(
+                queuedReservation,
+                "transferred",
+                "fan_in_after_join",
+                input.now_ms,
+              );
+              queuedReservation.quantity = 0;
             }
-            this.transitionReservation(
-              queuedReservation,
-              "transferred",
-              "fan_in_after_join",
-              input.now_ms,
-            );
-            queuedReservation.quantity = 0;
           }
 
           const placedEvent: OrderPlaced = {
@@ -742,6 +742,83 @@ export class InMemoryAdmissionCapacityStore implements AdmissionCapacityStore {
     });
   }
 
+  /**
+   * Fan-in-aware queued-envelope release: promote a peer to held owner with the
+   * envelope quantity, or free pool units only when this is the last subscriber.
+   */
+  private releaseQueuedEnvelopeLocked(
+    row: MutableReservation,
+    reason: string,
+    now_ms: number,
+  ): void {
+    if (!row.work_key_digest) {
+      this.transitionReservation(row, "released", reason, now_ms);
+      return;
+    }
+    const workKeyDigest = row.work_key_digest;
+    const pool = this.pools.get(row.pool_id);
+    const otherSubscribers = [...this.reservations.values()].filter(
+      (r) =>
+        r.reservation_id !== row.reservation_id &&
+        r.work_key_digest === workKeyDigest &&
+        r.ledger_kind === "queued_work" &&
+        (r.state === "held" || r.state === "transferred"),
+    );
+    const meta = this.queuedEnvelopeByWork.get(workKeyDigest);
+    const envelopeQty =
+      (meta?.reservation_id === row.reservation_id ? meta.quantity : undefined) ??
+      (row.state === "held" && row.quantity > 0 ? row.quantity : undefined) ??
+      meta?.quantity ??
+      0;
+
+    if (otherSubscribers.length > 0) {
+      // Shared envelope remains — promote a peer to held owner with quantity.
+      const peer = otherSubscribers[0]!;
+      if (envelopeQty > 0) {
+        if (row.state === "held") {
+          row.quantity = 0;
+          this.transitionReservation(row, "transferred", "envelope_ownership_handoff", now_ms);
+        }
+        if (peer.state !== "held" || peer.quantity !== envelopeQty) {
+          const from = peer.state;
+          peer.state = "held";
+          peer.quantity = envelopeQty;
+          peer.reservation_version += 1;
+          this.transferLog.push({
+            event_id: `cte_${randomUUID()}`,
+            reservation_id: peer.reservation_id,
+            from_state: from,
+            to_state: "held",
+            reason: "envelope_ownership_promote",
+            event_version: peer.reservation_version,
+            created_at_unix_ms: now_ms,
+          });
+        }
+        this.queuedEnvelopeByWork.set(workKeyDigest, {
+          reservation_id: peer.reservation_id,
+          quantity: envelopeQty,
+        });
+      } else if (meta && meta.reservation_id === row.reservation_id) {
+        this.queuedEnvelopeByWork.set(workKeyDigest, {
+          reservation_id: peer.reservation_id,
+          quantity: meta.quantity,
+        });
+      }
+      if (row.state !== "released") {
+        this.transitionReservation(row, "released", reason, now_ms);
+      }
+      return;
+    }
+
+    // Last subscriber: free the shared envelope quantity exactly once.
+    const qty = envelopeQty > 0 ? envelopeQty : row.quantity;
+    if (pool && qty > 0) {
+      this.releaseUnits(pool, qty, now_ms);
+    }
+    this.queuedEnvelopeByWork.delete(workKeyDigest);
+    this.transitionReservation(row, "released", reason, now_ms);
+  }
+
   async releaseReservation(input: {
     reservation_id: string;
     expected_version: number;
@@ -756,21 +833,19 @@ export class InMemoryAdmissionCapacityStore implements AdmissionCapacityStore {
     return this.withSerializableTxn(async () => {
       const row = this.reservations.get(input.reservation_id);
       if (!row) return { kind: "not_found" };
-      if (row.state !== "held") {
+      if (row.state !== "held" && row.state !== "transferred") {
         return { kind: "already_released", reservation: structuredClone(row) };
       }
       if (row.reservation_version !== input.expected_version) {
         return { kind: "version_mismatch" };
       }
-      const pool = this.pools.get(row.pool_id);
-      if (pool && row.quantity > 0) {
-        this.releaseUnits(pool, row.quantity, input.now_ms);
-      }
       if (row.ledger_kind === "queued_work" && row.work_key_digest) {
-        const meta = this.queuedEnvelopeByWork.get(row.work_key_digest);
-        if (meta?.reservation_id === row.reservation_id) {
-          this.queuedEnvelopeByWork.delete(row.work_key_digest);
-        }
+        this.releaseQueuedEnvelopeLocked(row, input.reason, input.now_ms);
+        return { kind: "released", reservation: structuredClone(row) };
+      }
+      const pool = this.pools.get(row.pool_id);
+      if (pool && row.quantity > 0 && row.state === "held") {
+        this.releaseUnits(pool, row.quantity, input.now_ms);
       }
       this.transitionReservation(row, "released", input.reason, input.now_ms);
       return { kind: "released", reservation: structuredClone(row) };
@@ -790,39 +865,13 @@ export class InMemoryAdmissionCapacityStore implements AdmissionCapacityStore {
           (r.state === "held" || r.state === "transferred"),
       );
       for (const row of rows) {
-        const pool = this.pools.get(row.pool_id);
-
         if (row.ledger_kind === "queued_work" && row.work_key_digest) {
-          const otherSubscribers = [...this.reservations.values()].filter(
-            (r) =>
-              r.reservation_id !== row.reservation_id &&
-              r.work_key_digest === row.work_key_digest &&
-              r.ledger_kind === "queued_work" &&
-              r.order_id !== input.order_id &&
-              (r.state === "held" || r.state === "transferred"),
-          );
-          const meta = this.queuedEnvelopeByWork.get(row.work_key_digest);
-          if (otherSubscribers.length > 0) {
-            // Shared envelope remains; do not free units. Reassign owner bookkeeping.
-            if (meta && meta.reservation_id === row.reservation_id) {
-              this.queuedEnvelopeByWork.set(row.work_key_digest, {
-                reservation_id: otherSubscribers[0]!.reservation_id,
-                quantity: meta.quantity,
-              });
-            }
-          } else {
-            // Last subscriber: free the shared envelope quantity exactly once.
-            const qty = meta?.quantity ?? row.quantity;
-            if (pool && qty > 0) {
-              this.releaseUnits(pool, qty, input.now_ms);
-            }
-            this.queuedEnvelopeByWork.delete(row.work_key_digest);
-          }
-          this.transitionReservation(row, "released", input.reason, input.now_ms);
+          this.releaseQueuedEnvelopeLocked(row, input.reason, input.now_ms);
           released += 1;
           continue;
         }
 
+        const pool = this.pools.get(row.pool_id);
         if (pool && row.quantity > 0 && row.state === "held") {
           this.releaseUnits(pool, row.quantity, input.now_ms);
         }

--- a/packages/services/ordering/src/admission-capacity-store.ts
+++ b/packages/services/ordering/src/admission-capacity-store.ts
@@ -1,0 +1,857 @@
+/**
+ * CR-201C admission capacity store + in-memory serializable admission transaction.
+ *
+ * One transaction locks authoritative counters, checks the recipe certificate,
+ * and atomically writes capacity consumption, idempotency, order, root work/links,
+ * and outbox events. There is no separate pre-admission reservation state.
+ *
+ * Three ledgers are non-interchangeable:
+ *  - admission_rate: one-time tokens per accepted order
+ *  - queued_work: durable envelopes held until fulfillment/terminal/cancel
+ *  - active_execution: short leases acquired only at dispatch
+ *
+ * Subscriber fan-in consumes admission_rate per order but never duplicates the
+ * shared-work queued envelope (one envelope per work_key_digest while held).
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+import {
+  ACTIVE_EXECUTION_LEASE_MS,
+  ADMISSION_SERIALIZATION_RETRIES,
+  ADVISORY_LOCK_WAIT_BUDGET_MS,
+  DEFAULT_ACTIVE_EXECUTION_LIMIT,
+  DEFAULT_ADMISSION_RATE_LIMIT,
+  DEFAULT_QUEUED_WORK_LIMIT,
+} from "./admission-capacity-constants.js";
+import {
+  AdmissionIdempotencyConflictError,
+  CapacityUnavailableError,
+  type CapacityLedgerKind,
+  type CapacityPoolRecord,
+  type CapacityPoolScope,
+  type CapacityReservationRecord,
+  type CapacityTransferEvent,
+  type OrderAdmissionIdempotencyRecord,
+  type RecipeExpansionCertificate,
+} from "./admission-capacity-types.js";
+import { assertCertificateAdmissible } from "./recipe-expansion-certificate.js";
+import { digestOf } from "./digest.js";
+import type { NewOrder, OrderRecord, OrderStore, OutboxEvent } from "./store.js";
+import type {
+  JoinPublicWorkResult,
+  SharedPreparationStore,
+} from "./shared-preparation-store.js";
+import type { PublicPreparationWorkKeyMaterial } from "./shared-preparation-types.js";
+import { digestPublicWorkKey } from "./shared-preparation-work-key.js";
+import { ORDER_LIFECYCLE_SUBJECTS, type OrderPlaced } from "@freeside/ordering-protocol";
+
+export interface EnsurePoolInput extends CapacityPoolScope {
+  readonly ledger_kind: CapacityLedgerKind;
+  readonly limit_units: number;
+}
+
+export interface AdmitOrderInput {
+  readonly requester_subject: string;
+  readonly client_request_id: string;
+  readonly order: Omit<NewOrder, "order_id"> & { order_id?: string };
+  readonly body: Record<string, unknown>;
+  readonly certificate: RecipeExpansionCertificate;
+  readonly work_key: PublicPreparationWorkKeyMaterial;
+  readonly order_tenant_scope_digest: string;
+  readonly pool_scope: CapacityPoolScope;
+  readonly now_ms: number;
+  /** When true, shed before opening the transaction (advisory only). */
+  readonly advisory_shed?: boolean;
+  /** Simulated lock-wait ms for advisory shed tests. */
+  readonly simulated_lock_wait_ms?: number;
+}
+
+export type AdmitOrderResult =
+  | {
+      readonly kind: "admitted";
+      readonly order: OrderRecord;
+      readonly created: boolean;
+      readonly work_created: boolean;
+      readonly work_id: string;
+      readonly reservation_ids: readonly string[];
+      readonly replay: boolean;
+    }
+  | { readonly kind: "capacity_unavailable"; readonly reason: string }
+  | { readonly kind: "idempotency_conflict" };
+
+export interface AdmissionCapacityStore {
+  ensurePool(input: EnsurePoolInput & { now_ms: number }): Promise<CapacityPoolRecord>;
+  getPool(poolId: string): Promise<CapacityPoolRecord | undefined>;
+  listPools(): Promise<readonly CapacityPoolRecord[]>;
+  getReservation(reservationId: string): Promise<CapacityReservationRecord | undefined>;
+  listHeldReservations(orderId: string): Promise<readonly CapacityReservationRecord[]>;
+  listTransferLog(reservationId: string): Promise<readonly CapacityTransferEvent[]>;
+  getIdempotency(
+    requester: string,
+    clientRequestId: string,
+  ): Promise<OrderAdmissionIdempotencyRecord | undefined>;
+  admitOrder(input: AdmitOrderInput): Promise<AdmitOrderResult>;
+  acquireActiveExecutionLease(input: {
+    order_id: string;
+    pool_scope: CapacityPoolScope;
+    quantity?: number;
+    lease_duration_ms?: number;
+    now_ms: number;
+  }): Promise<
+    | { readonly kind: "acquired"; readonly reservation: CapacityReservationRecord }
+    | { readonly kind: "capacity_unavailable"; readonly reason: string }
+    | { readonly kind: "order_not_found" }
+  >;
+  releaseReservation(input: {
+    reservation_id: string;
+    expected_version: number;
+    reason: string;
+    now_ms: number;
+  }): Promise<
+    | { readonly kind: "released"; readonly reservation: CapacityReservationRecord }
+    | { readonly kind: "already_released"; readonly reservation: CapacityReservationRecord }
+    | { readonly kind: "version_mismatch" }
+    | { readonly kind: "not_found" }
+  >;
+  releaseOrderCapacity(input: {
+    order_id: string;
+    reason: "fulfilled" | "terminal_failure" | "cancelled" | "abandoned";
+    now_ms: number;
+  }): Promise<{ readonly released: number }>;
+  reconcileExpiredActiveLeases(input: {
+    now_ms: number;
+  }): Promise<{ readonly expired: number }>;
+  snapshotAccounting(): Promise<{
+    readonly admission_rate: { consumed: number; limit: number };
+    readonly queued_work: { consumed: number; limit: number };
+    readonly active_execution: { consumed: number; limit: number };
+  }>;
+}
+
+type MutablePool = {
+  -readonly [K in keyof CapacityPoolRecord]: CapacityPoolRecord[K];
+};
+type MutableReservation = {
+  -readonly [K in keyof CapacityReservationRecord]: CapacityReservationRecord[K];
+};
+
+function poolKey(kind: CapacityLedgerKind, scope: CapacityPoolScope): string {
+  return `${kind}\0${scope.network_ref}\0${scope.capability}\0${scope.community_ref ?? ""}`;
+}
+
+function reservationIdentity(input: {
+  order_id: string;
+  ledger_kind: CapacityLedgerKind;
+  pool_id: string;
+  quantity: number;
+  work_key_digest?: string;
+}): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        order_id: input.order_id,
+        ledger_kind: input.ledger_kind,
+        pool_id: input.pool_id,
+        quantity: input.quantity,
+        work_key_digest: input.work_key_digest ?? null,
+      }),
+    )
+    .digest("hex");
+}
+
+export interface InMemoryAdmissionCapacityStoreOptions {
+  readonly orderStore: OrderStore;
+  readonly preparationStore: SharedPreparationStore;
+  readonly defaultLimits?: {
+    admission_rate?: number;
+    queued_work?: number;
+    active_execution?: number;
+  };
+}
+
+export class InMemoryAdmissionCapacityStore implements AdmissionCapacityStore {
+  private readonly pools = new Map<string, MutablePool>();
+  private readonly poolsByScope = new Map<string, string>();
+  private readonly reservations = new Map<string, MutableReservation>();
+  private readonly transferLog: CapacityTransferEvent[] = [];
+  private readonly idempotency = new Map<string, OrderAdmissionIdempotencyRecord>();
+  /** work_key_digest → shared queued envelope owner + quantity. */
+  private readonly queuedEnvelopeByWork = new Map<
+    string,
+    { reservation_id: string; quantity: number }
+  >();
+  private readonly orderStore: OrderStore;
+  private readonly preparationStore: SharedPreparationStore;
+  private readonly defaults: Required<
+    NonNullable<InMemoryAdmissionCapacityStoreOptions["defaultLimits"]>
+  >;
+  private txnTail: Promise<void> = Promise.resolve();
+  private readonly maxRetries = ADMISSION_SERIALIZATION_RETRIES;
+
+  constructor(opts: InMemoryAdmissionCapacityStoreOptions) {
+    this.orderStore = opts.orderStore;
+    this.preparationStore = opts.preparationStore;
+    this.defaults = {
+      admission_rate: opts.defaultLimits?.admission_rate ?? DEFAULT_ADMISSION_RATE_LIMIT,
+      queued_work: opts.defaultLimits?.queued_work ?? DEFAULT_QUEUED_WORK_LIMIT,
+      active_execution: opts.defaultLimits?.active_execution ?? DEFAULT_ACTIVE_EXECUTION_LIMIT,
+    };
+  }
+
+  private idemKey(requester: string, clientRequestId: string): string {
+    return `${requester}\0${clientRequestId}`;
+  }
+
+  private async withSerializableTxn<T>(fn: () => Promise<T>): Promise<T> {
+    const prior = this.txnTail;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.txnTail = prior.then(() => gate);
+    await prior;
+    try {
+      let lastErr: unknown;
+      for (let attempt = 0; attempt < this.maxRetries; attempt += 1) {
+        try {
+          return await fn();
+        } catch (err) {
+          if (err instanceof Error && err.message === "serialization_retry") {
+            lastErr = err;
+            continue;
+          }
+          throw err;
+        }
+      }
+      throw lastErr instanceof Error
+        ? new CapacityUnavailableError("lock_timeout", lastErr.message)
+        : new CapacityUnavailableError("lock_timeout");
+    } finally {
+      release();
+    }
+  }
+
+  private ensurePoolLocked(input: EnsurePoolInput & { now_ms: number }): MutablePool {
+    const key = poolKey(input.ledger_kind, input);
+    const existingId = this.poolsByScope.get(key);
+    if (existingId) {
+      const existing = this.pools.get(existingId);
+      if (existing) return existing;
+    }
+    const pool_id = `cap_${input.ledger_kind}_${randomUUID()}`;
+    const pool: MutablePool = {
+      pool_id,
+      ledger_kind: input.ledger_kind,
+      network_ref: input.network_ref,
+      capability: input.capability,
+      ...(input.community_ref !== undefined ? { community_ref: input.community_ref } : {}),
+      limit_units: input.limit_units,
+      consumed_units: 0,
+      version: 0,
+      updated_at_unix_ms: input.now_ms,
+    };
+    this.pools.set(pool_id, pool);
+    this.poolsByScope.set(key, pool_id);
+    return pool;
+  }
+
+  private getOrCreateDefaultPools(scope: CapacityPoolScope, now_ms: number): {
+    admission: MutablePool;
+    queued: MutablePool;
+    active: MutablePool;
+  } {
+    return {
+      admission: this.ensurePoolLocked({
+        ledger_kind: "admission_rate",
+        ...scope,
+        limit_units: this.defaults.admission_rate,
+        now_ms,
+      }),
+      queued: this.ensurePoolLocked({
+        ledger_kind: "queued_work",
+        ...scope,
+        limit_units: this.defaults.queued_work,
+        now_ms,
+      }),
+      active: this.ensurePoolLocked({
+        ledger_kind: "active_execution",
+        ...scope,
+        limit_units: this.defaults.active_execution,
+        now_ms,
+      }),
+    };
+  }
+
+  private consume(
+    pool: MutablePool,
+    quantity: number,
+    now_ms: number,
+  ): void {
+    if (pool.consumed_units + quantity > pool.limit_units) {
+      const reason =
+        pool.ledger_kind === "admission_rate"
+          ? "insufficient_admission_rate"
+          : pool.ledger_kind === "queued_work"
+            ? "insufficient_queued_work"
+            : "insufficient_active_execution";
+      throw new CapacityUnavailableError(reason);
+    }
+    pool.consumed_units += quantity;
+    pool.version += 1;
+    pool.updated_at_unix_ms = now_ms;
+  }
+
+  private releaseUnits(pool: MutablePool, quantity: number, now_ms: number): void {
+    pool.consumed_units = Math.max(0, pool.consumed_units - quantity);
+    pool.version += 1;
+    pool.updated_at_unix_ms = now_ms;
+  }
+
+  /** Fan-in marker: order capacity consumed; shared queued envelope not duplicated. */
+  private markFanInTransfer(input: {
+    order_id: string;
+    pool: MutablePool;
+    work_key_digest: string;
+    now_ms: number;
+  }): MutableReservation {
+    const reservation_id = `rsv_${randomUUID()}`;
+    const row: MutableReservation = {
+      reservation_id,
+      order_id: input.order_id,
+      pool_id: input.pool.pool_id,
+      ledger_kind: "queued_work",
+      quantity: 0,
+      reservation_version: 1,
+      state: "transferred",
+      identity_digest: reservationIdentity({
+        order_id: input.order_id,
+        ledger_kind: "queued_work",
+        pool_id: input.pool.pool_id,
+        quantity: 0,
+        work_key_digest: input.work_key_digest,
+      }),
+      work_key_digest: input.work_key_digest,
+      created_at_unix_ms: input.now_ms,
+    };
+    this.reservations.set(reservation_id, row);
+    this.transferLog.push({
+      event_id: `cte_${randomUUID()}`,
+      reservation_id,
+      from_state: "held",
+      to_state: "transferred",
+      reason: "fan_in_share_envelope",
+      event_version: 1,
+      created_at_unix_ms: input.now_ms,
+    });
+    return row;
+  }
+
+  private holdReservation(input: {
+    order_id: string;
+    pool: MutablePool;
+    quantity: number;
+    work_key_digest?: string;
+    lease_until_unix_ms?: number;
+    now_ms: number;
+  }): MutableReservation {
+    const reservation_id = `rsv_${randomUUID()}`;
+    const identity_digest = reservationIdentity({
+      order_id: input.order_id,
+      ledger_kind: input.pool.ledger_kind,
+      pool_id: input.pool.pool_id,
+      quantity: input.quantity,
+      work_key_digest: input.work_key_digest,
+    });
+    const row: MutableReservation = {
+      reservation_id,
+      order_id: input.order_id,
+      pool_id: input.pool.pool_id,
+      ledger_kind: input.pool.ledger_kind,
+      quantity: input.quantity,
+      reservation_version: 1,
+      state: "held",
+      identity_digest,
+      ...(input.work_key_digest !== undefined
+        ? { work_key_digest: input.work_key_digest }
+        : {}),
+      ...(input.lease_until_unix_ms !== undefined
+        ? { lease_until_unix_ms: input.lease_until_unix_ms }
+        : {}),
+      created_at_unix_ms: input.now_ms,
+    };
+    this.reservations.set(reservation_id, row);
+    this.transferLog.push({
+      event_id: `cte_${randomUUID()}`,
+      reservation_id,
+      from_state: "held",
+      to_state: "held",
+      reason: "created",
+      event_version: 1,
+      created_at_unix_ms: input.now_ms,
+    });
+    return row;
+  }
+
+  private transitionReservation(
+    row: MutableReservation,
+    to: CapacityReservationRecord["state"],
+    reason: string,
+    now_ms: number,
+  ): void {
+    const from = row.state;
+    row.state = to;
+    row.reservation_version += 1;
+    if (to === "released" || to === "expired") {
+      row.released_at_unix_ms = now_ms;
+    }
+    this.transferLog.push({
+      event_id: `cte_${randomUUID()}`,
+      reservation_id: row.reservation_id,
+      from_state: from,
+      to_state: to,
+      reason,
+      event_version: row.reservation_version,
+      created_at_unix_ms: now_ms,
+    });
+  }
+
+  async ensurePool(input: EnsurePoolInput & { now_ms: number }): Promise<CapacityPoolRecord> {
+    return this.withSerializableTxn(async () => {
+      return structuredClone(this.ensurePoolLocked(input));
+    });
+  }
+
+  async getPool(poolId: string): Promise<CapacityPoolRecord | undefined> {
+    const pool = this.pools.get(poolId);
+    return pool ? structuredClone(pool) : undefined;
+  }
+
+  async listPools(): Promise<readonly CapacityPoolRecord[]> {
+    return [...this.pools.values()].map((p) => structuredClone(p));
+  }
+
+  async getReservation(
+    reservationId: string,
+  ): Promise<CapacityReservationRecord | undefined> {
+    const row = this.reservations.get(reservationId);
+    return row ? structuredClone(row) : undefined;
+  }
+
+  async listHeldReservations(
+    orderId: string,
+  ): Promise<readonly CapacityReservationRecord[]> {
+    return [...this.reservations.values()]
+      .filter((r) => r.order_id === orderId && r.state === "held")
+      .map((r) => structuredClone(r));
+  }
+
+  async listTransferLog(reservationId: string): Promise<readonly CapacityTransferEvent[]> {
+    return this.transferLog
+      .filter((e) => e.reservation_id === reservationId)
+      .map((e) => structuredClone(e));
+  }
+
+  async getIdempotency(
+    requester: string,
+    clientRequestId: string,
+  ): Promise<OrderAdmissionIdempotencyRecord | undefined> {
+    const row = this.idempotency.get(this.idemKey(requester, clientRequestId));
+    return row ? structuredClone(row) : undefined;
+  }
+
+  async admitOrder(input: AdmitOrderInput): Promise<AdmitOrderResult> {
+    // Advisory shed before opening the transaction — never decides capacity alone.
+    if (input.advisory_shed) {
+      return { kind: "capacity_unavailable", reason: "advisory_shed" };
+    }
+    if (
+      input.simulated_lock_wait_ms !== undefined &&
+      input.simulated_lock_wait_ms > ADVISORY_LOCK_WAIT_BUDGET_MS
+    ) {
+      return { kind: "capacity_unavailable", reason: "lock_timeout" };
+    }
+
+    try {
+      return await this.withSerializableTxn(async () => {
+        try {
+          assertCertificateAdmissible(input.certificate);
+        } catch (err) {
+          if (err instanceof CapacityUnavailableError) {
+            return { kind: "capacity_unavailable", reason: err.reason };
+          }
+          throw err;
+        }
+
+        const body_digest = digestOf(input.body);
+        const idemKey = this.idemKey(input.requester_subject, input.client_request_id);
+        const prior = this.idempotency.get(idemKey);
+        if (prior) {
+          if (prior.body_digest !== body_digest) {
+            return { kind: "idempotency_conflict" };
+          }
+          const order = await this.orderStore.get(prior.order_id);
+          if (!order) {
+            throw new Error("serialization_retry");
+          }
+          const join = await this.preparationStore.joinPublicWork({
+            order_id: prior.order_id,
+            order_tenant_scope_digest: input.order_tenant_scope_digest,
+            work_key: input.work_key,
+            now_ms: input.now_ms,
+          });
+          if (join.kind !== "joined") {
+            throw new Error("serialization_retry");
+          }
+          return {
+            kind: "admitted",
+            order,
+            created: false,
+            work_created: false,
+            work_id: join.work.work_id,
+            reservation_ids: prior.reservation_ids,
+            replay: true,
+          };
+        }
+
+        const pools = this.getOrCreateDefaultPools(input.pool_scope, input.now_ms);
+        const workKeyDigest = digestPublicWorkKey(input.work_key);
+        const order_id = input.order.order_id ?? `ord_${randomUUID()}`;
+
+        // Snapshot for rollback — rejected requests create neither reservation nor order.
+        const snap = {
+          admission: pools.admission.consumed_units,
+          admissionVer: pools.admission.version,
+          queued: pools.queued.consumed_units,
+          queuedVer: pools.queued.version,
+          envelope: this.queuedEnvelopeByWork.get(workKeyDigest),
+        };
+        const createdReservationIds: string[] = [];
+
+        try {
+          this.consume(pools.admission, 1, input.now_ms);
+
+          // Fan-in: reuse existing queued envelope for this work key; never duplicate.
+          let queuedReservation: MutableReservation | undefined;
+          let createdQueuedEnvelope = false;
+          const existingMeta = this.queuedEnvelopeByWork.get(workKeyDigest);
+          const existingEnvelope = existingMeta
+            ? this.reservations.get(existingMeta.reservation_id)
+            : undefined;
+          if (existingEnvelope && existingEnvelope.state === "held") {
+            queuedReservation = this.markFanInTransfer({
+              order_id,
+              pool: pools.queued,
+              work_key_digest: workKeyDigest,
+              now_ms: input.now_ms,
+            });
+            createdReservationIds.push(queuedReservation.reservation_id);
+          } else {
+            this.consume(pools.queued, input.certificate.capacity_weight, input.now_ms);
+            queuedReservation = this.holdReservation({
+              order_id,
+              pool: pools.queued,
+              quantity: input.certificate.capacity_weight,
+              work_key_digest: workKeyDigest,
+              now_ms: input.now_ms,
+            });
+            this.queuedEnvelopeByWork.set(workKeyDigest, {
+              reservation_id: queuedReservation.reservation_id,
+              quantity: input.certificate.capacity_weight,
+            });
+            createdQueuedEnvelope = true;
+            createdReservationIds.push(queuedReservation.reservation_id);
+          }
+
+          const admissionReservation = this.holdReservation({
+            order_id,
+            pool: pools.admission,
+            quantity: 1,
+            now_ms: input.now_ms,
+          });
+          createdReservationIds.push(admissionReservation.reservation_id);
+
+          const placedEvent: OrderPlaced = {
+            order_id,
+            product: input.order.product,
+            inputs_digest: input.order.inputs_digest,
+          };
+          const placed = await this.orderStore.placeOrder(
+            {
+              ...input.order,
+              order_id,
+            },
+            {
+              subject: ORDER_LIFECYCLE_SUBJECTS.placed,
+              payload: placedEvent,
+            } satisfies OutboxEvent,
+          );
+
+          const join: JoinPublicWorkResult = await this.preparationStore.joinPublicWork({
+            order_id,
+            order_tenant_scope_digest: input.order_tenant_scope_digest,
+            work_key: input.work_key,
+            now_ms: input.now_ms,
+          });
+          if (join.kind !== "joined") {
+            throw new Error("serialization_retry");
+          }
+
+          // Join reused existing work after we allocated a new envelope → fold into fan-in.
+          if (!join.created && createdQueuedEnvelope && queuedReservation) {
+            this.releaseUnits(pools.queued, queuedReservation.quantity, input.now_ms);
+            const meta = this.queuedEnvelopeByWork.get(workKeyDigest);
+            if (meta?.reservation_id === queuedReservation.reservation_id) {
+              this.queuedEnvelopeByWork.delete(workKeyDigest);
+            }
+            const existing = [...this.reservations.values()].find(
+              (r) =>
+                r.ledger_kind === "queued_work" &&
+                r.state === "held" &&
+                r.quantity > 0 &&
+                r.work_key_digest === workKeyDigest &&
+                r.reservation_id !== queuedReservation!.reservation_id,
+            );
+            if (existing) {
+              this.queuedEnvelopeByWork.set(workKeyDigest, {
+                reservation_id: existing.reservation_id,
+                quantity: existing.quantity,
+              });
+            }
+            this.transitionReservation(
+              queuedReservation,
+              "transferred",
+              "fan_in_after_join",
+              input.now_ms,
+            );
+            queuedReservation.quantity = 0;
+          }
+
+          const reservation_ids = [
+            admissionReservation.reservation_id,
+            queuedReservation.reservation_id,
+          ];
+
+          this.idempotency.set(idemKey, {
+            requester_subject: input.requester_subject,
+            client_request_id: input.client_request_id,
+            body_digest,
+            order_id,
+            reservation_ids,
+            stored_at_unix_ms: input.now_ms,
+          });
+
+          return {
+            kind: "admitted",
+            order: placed.record,
+            created: placed.created,
+            work_created: join.created,
+            work_id: join.work.work_id,
+            reservation_ids,
+            replay: false,
+          };
+        } catch (err) {
+          // Roll back — no reservation/order survives a rejected or aborted txn.
+          pools.admission.consumed_units = snap.admission;
+          pools.admission.version = snap.admissionVer;
+          pools.queued.consumed_units = snap.queued;
+          pools.queued.version = snap.queuedVer;
+          if (snap.envelope === undefined) {
+            this.queuedEnvelopeByWork.delete(workKeyDigest);
+          } else {
+            this.queuedEnvelopeByWork.set(workKeyDigest, snap.envelope);
+          }
+          for (const id of createdReservationIds) {
+            this.reservations.delete(id);
+          }
+          if (err instanceof CapacityUnavailableError) {
+            return { kind: "capacity_unavailable", reason: err.reason };
+          }
+          throw err;
+        }
+      });
+    } catch (err) {
+      if (err instanceof CapacityUnavailableError) {
+        return { kind: "capacity_unavailable", reason: err.reason };
+      }
+      if (err instanceof AdmissionIdempotencyConflictError) {
+        return { kind: "idempotency_conflict" };
+      }
+      throw err;
+    }
+  }
+
+  async acquireActiveExecutionLease(input: {
+    order_id: string;
+    pool_scope: CapacityPoolScope;
+    quantity?: number;
+    lease_duration_ms?: number;
+    now_ms: number;
+  }): Promise<
+    | { readonly kind: "acquired"; readonly reservation: CapacityReservationRecord }
+    | { readonly kind: "capacity_unavailable"; readonly reason: string }
+    | { readonly kind: "order_not_found" }
+  > {
+    return this.withSerializableTxn(async () => {
+      const order = await this.orderStore.get(input.order_id);
+      if (!order) return { kind: "order_not_found" };
+      const pools = this.getOrCreateDefaultPools(input.pool_scope, input.now_ms);
+      const quantity = input.quantity ?? 1;
+      try {
+        this.consume(pools.active, quantity, input.now_ms);
+      } catch (err) {
+        if (err instanceof CapacityUnavailableError) {
+          return { kind: "capacity_unavailable", reason: err.reason };
+        }
+        throw err;
+      }
+      const lease_until =
+        input.now_ms + (input.lease_duration_ms ?? ACTIVE_EXECUTION_LEASE_MS);
+      const reservation = this.holdReservation({
+        order_id: input.order_id,
+        pool: pools.active,
+        quantity,
+        lease_until_unix_ms: lease_until,
+        now_ms: input.now_ms,
+      });
+      return { kind: "acquired", reservation: structuredClone(reservation) };
+    });
+  }
+
+  async releaseReservation(input: {
+    reservation_id: string;
+    expected_version: number;
+    reason: string;
+    now_ms: number;
+  }): Promise<
+    | { readonly kind: "released"; readonly reservation: CapacityReservationRecord }
+    | { readonly kind: "already_released"; readonly reservation: CapacityReservationRecord }
+    | { readonly kind: "version_mismatch" }
+    | { readonly kind: "not_found" }
+  > {
+    return this.withSerializableTxn(async () => {
+      const row = this.reservations.get(input.reservation_id);
+      if (!row) return { kind: "not_found" };
+      if (row.state !== "held") {
+        return { kind: "already_released", reservation: structuredClone(row) };
+      }
+      if (row.reservation_version !== input.expected_version) {
+        return { kind: "version_mismatch" };
+      }
+      const pool = this.pools.get(row.pool_id);
+      if (pool && row.quantity > 0) {
+        this.releaseUnits(pool, row.quantity, input.now_ms);
+      }
+      if (row.ledger_kind === "queued_work" && row.work_key_digest) {
+        const meta = this.queuedEnvelopeByWork.get(row.work_key_digest);
+        if (meta?.reservation_id === row.reservation_id) {
+          this.queuedEnvelopeByWork.delete(row.work_key_digest);
+        }
+      }
+      this.transitionReservation(row, "released", input.reason, input.now_ms);
+      return { kind: "released", reservation: structuredClone(row) };
+    });
+  }
+
+  async releaseOrderCapacity(input: {
+    order_id: string;
+    reason: "fulfilled" | "terminal_failure" | "cancelled" | "abandoned";
+    now_ms: number;
+  }): Promise<{ readonly released: number }> {
+    return this.withSerializableTxn(async () => {
+      let released = 0;
+      const rows = [...this.reservations.values()].filter(
+        (r) =>
+          r.order_id === input.order_id &&
+          (r.state === "held" || r.state === "transferred"),
+      );
+      for (const row of rows) {
+        const pool = this.pools.get(row.pool_id);
+
+        if (row.ledger_kind === "queued_work" && row.work_key_digest) {
+          const otherSubscribers = [...this.reservations.values()].filter(
+            (r) =>
+              r.reservation_id !== row.reservation_id &&
+              r.work_key_digest === row.work_key_digest &&
+              r.ledger_kind === "queued_work" &&
+              r.order_id !== input.order_id &&
+              (r.state === "held" || r.state === "transferred"),
+          );
+          const meta = this.queuedEnvelopeByWork.get(row.work_key_digest);
+          if (otherSubscribers.length > 0) {
+            // Shared envelope remains; do not free units. Reassign owner bookkeeping.
+            if (meta && meta.reservation_id === row.reservation_id) {
+              this.queuedEnvelopeByWork.set(row.work_key_digest, {
+                reservation_id: otherSubscribers[0]!.reservation_id,
+                quantity: meta.quantity,
+              });
+            }
+          } else {
+            // Last subscriber: free the shared envelope quantity exactly once.
+            const qty = meta?.quantity ?? row.quantity;
+            if (pool && qty > 0) {
+              this.releaseUnits(pool, qty, input.now_ms);
+            }
+            this.queuedEnvelopeByWork.delete(row.work_key_digest);
+          }
+          this.transitionReservation(row, "released", input.reason, input.now_ms);
+          released += 1;
+          continue;
+        }
+
+        if (pool && row.quantity > 0 && row.state === "held") {
+          this.releaseUnits(pool, row.quantity, input.now_ms);
+        }
+        this.transitionReservation(row, "released", input.reason, input.now_ms);
+        released += 1;
+      }
+      return { released };
+    });
+  }
+
+  async reconcileExpiredActiveLeases(input: {
+    now_ms: number;
+  }): Promise<{ readonly expired: number }> {
+    return this.withSerializableTxn(async () => {
+      let expired = 0;
+      for (const row of this.reservations.values()) {
+        if (
+          row.state !== "held" ||
+          row.ledger_kind !== "active_execution" ||
+          row.lease_until_unix_ms === undefined ||
+          row.lease_until_unix_ms > input.now_ms
+        ) {
+          continue;
+        }
+        const pool = this.pools.get(row.pool_id);
+        if (pool && row.quantity > 0) {
+          this.releaseUnits(pool, row.quantity, input.now_ms);
+        }
+        this.transitionReservation(row, "expired", "lease_expiry_reconcile", input.now_ms);
+        expired += 1;
+      }
+      return { expired };
+    });
+  }
+
+  async snapshotAccounting(): Promise<{
+    readonly admission_rate: { consumed: number; limit: number };
+    readonly queued_work: { consumed: number; limit: number };
+    readonly active_execution: { consumed: number; limit: number };
+  }> {
+    const sum = (kind: CapacityLedgerKind) => {
+      let consumed = 0;
+      let limit = 0;
+      for (const p of this.pools.values()) {
+        if (p.ledger_kind !== kind) continue;
+        consumed += p.consumed_units;
+        limit += p.limit_units;
+      }
+      return { consumed, limit };
+    };
+    return {
+      admission_rate: sum("admission_rate"),
+      queued_work: sum("queued_work"),
+      active_execution: sum("active_execution"),
+    };
+  }
+}

--- a/packages/services/ordering/src/admission-capacity-store.ts
+++ b/packages/services/ordering/src/admission-capacity-store.ts
@@ -37,6 +37,7 @@ import {
 import { assertCertificateAdmissible } from "./recipe-expansion-certificate.js";
 import { digestOf } from "./digest.js";
 import type { NewOrder, OrderRecord, OrderStore, OutboxEvent } from "./store.js";
+import { InMemoryOrderStore } from "./store.js";
 import type {
   JoinPublicWorkResult,
   SharedPreparationStore,
@@ -570,22 +571,9 @@ export class InMemoryAdmissionCapacityStore implements AdmissionCapacityStore {
           });
           createdReservationIds.push(admissionReservation.reservation_id);
 
-          const placedEvent: OrderPlaced = {
-            order_id,
-            product: input.order.product,
-            inputs_digest: input.order.inputs_digest,
-          };
-          const placed = await this.orderStore.placeOrder(
-            {
-              ...input.order,
-              order_id,
-            },
-            {
-              subject: ORDER_LIFECYCLE_SUBJECTS.placed,
-              payload: placedEvent,
-            } satisfies OutboxEvent,
-          );
-
+          // Join before placeOrder so a failed join never leaves an orphan order.
+          // (Postgres FK requires order-first inside one SERIALIZABLE txn; in-memory
+          // has no FK — join-then-place keeps the logical txn atomic.)
           const join: JoinPublicWorkResult = await this.preparationStore.joinPublicWork({
             order_id,
             order_tenant_scope_digest: input.order_tenant_scope_digest,
@@ -626,29 +614,62 @@ export class InMemoryAdmissionCapacityStore implements AdmissionCapacityStore {
             queuedReservation.quantity = 0;
           }
 
-          const reservation_ids = [
-            admissionReservation.reservation_id,
-            queuedReservation.reservation_id,
-          ];
-
-          this.idempotency.set(idemKey, {
-            requester_subject: input.requester_subject,
-            client_request_id: input.client_request_id,
-            body_digest,
+          const placedEvent: OrderPlaced = {
             order_id,
-            reservation_ids,
-            stored_at_unix_ms: input.now_ms,
-          });
-
-          return {
-            kind: "admitted",
-            order: placed.record,
-            created: placed.created,
-            work_created: join.created,
-            work_id: join.work.work_id,
-            reservation_ids,
-            replay: false,
+            product: input.order.product,
+            inputs_digest: input.order.inputs_digest,
           };
+          let placedOrderId: string | undefined;
+          try {
+            const placed = await this.orderStore.placeOrder(
+              {
+                ...input.order,
+                order_id,
+              },
+              {
+                subject: ORDER_LIFECYCLE_SUBJECTS.placed,
+                payload: placedEvent,
+              } satisfies OutboxEvent,
+            );
+            placedOrderId = placed.record.order_id;
+
+            const reservation_ids = [
+              admissionReservation.reservation_id,
+              queuedReservation.reservation_id,
+            ];
+
+            this.idempotency.set(idemKey, {
+              requester_subject: input.requester_subject,
+              client_request_id: input.client_request_id,
+              body_digest,
+              order_id,
+              reservation_ids,
+              stored_at_unix_ms: input.now_ms,
+            });
+
+            return {
+              kind: "admitted",
+              order: placed.record,
+              created: placed.created,
+              work_created: join.created,
+              work_id: join.work.work_id,
+              reservation_ids,
+              replay: false,
+            };
+          } catch (placeErr) {
+            if (
+              placedOrderId &&
+              this.orderStore instanceof InMemoryOrderStore
+            ) {
+              this.orderStore.removePlacedOrder(placedOrderId);
+            }
+            await this.preparationStore.detachSubscriber({
+              order_id,
+              work_id: join.work.work_id,
+              now_ms: input.now_ms,
+            });
+            throw placeErr;
+          }
         } catch (err) {
           // Roll back — no reservation/order survives a rejected or aborted txn.
           pools.admission.consumed_units = snap.admission;
@@ -662,6 +683,10 @@ export class InMemoryAdmissionCapacityStore implements AdmissionCapacityStore {
           }
           for (const id of createdReservationIds) {
             this.reservations.delete(id);
+          }
+          // Compensating delete if placeOrder succeeded then a later step failed.
+          if (this.orderStore instanceof InMemoryOrderStore) {
+            this.orderStore.removePlacedOrder(order_id);
           }
           if (err instanceof CapacityUnavailableError) {
             return { kind: "capacity_unavailable", reason: err.reason };

--- a/packages/services/ordering/src/admission-capacity-types.ts
+++ b/packages/services/ordering/src/admission-capacity-types.ts
@@ -1,0 +1,110 @@
+/**
+ * CR-201C — three non-interchangeable capacity ledgers + admission artifacts.
+ */
+
+export const CAPACITY_LEDGER_KINDS = [
+  "admission_rate",
+  "queued_work",
+  "active_execution",
+] as const;
+export type CapacityLedgerKind = (typeof CAPACITY_LEDGER_KINDS)[number];
+
+export const CAPACITY_RESERVATION_STATES = [
+  "held",
+  "released",
+  "transferred",
+  "expired",
+] as const;
+export type CapacityReservationState = (typeof CAPACITY_RESERVATION_STATES)[number];
+
+export interface CapacityPoolScope {
+  readonly network_ref: string;
+  readonly capability: string;
+  readonly community_ref?: string;
+}
+
+export interface CapacityPoolRecord {
+  readonly pool_id: string;
+  readonly ledger_kind: CapacityLedgerKind;
+  readonly network_ref: string;
+  readonly capability: string;
+  readonly community_ref?: string;
+  readonly limit_units: number;
+  readonly consumed_units: number;
+  readonly version: number;
+  readonly updated_at_unix_ms: number;
+}
+
+export interface CapacityReservationRecord {
+  readonly reservation_id: string;
+  readonly order_id: string;
+  readonly pool_id: string;
+  readonly ledger_kind: CapacityLedgerKind;
+  readonly quantity: number;
+  readonly reservation_version: number;
+  readonly state: CapacityReservationState;
+  readonly identity_digest: string;
+  readonly work_key_digest?: string;
+  readonly lease_until_unix_ms?: number;
+  readonly created_at_unix_ms: number;
+  readonly released_at_unix_ms?: number;
+}
+
+export interface CapacityTransferEvent {
+  readonly event_id: string;
+  readonly reservation_id: string;
+  readonly from_state: CapacityReservationState;
+  readonly to_state: CapacityReservationState;
+  readonly reason: string;
+  readonly event_version: number;
+  readonly created_at_unix_ms: number;
+}
+
+export interface OrderAdmissionIdempotencyRecord {
+  readonly requester_subject: string;
+  readonly client_request_id: string;
+  readonly body_digest: string;
+  readonly order_id: string;
+  readonly reservation_ids: readonly string[];
+  readonly stored_at_unix_ms: number;
+}
+
+/**
+ * Immutable recipe expansion certificate. Full compiler lands in CR-202;
+ * CR-201C admits only pre-validated certificates into the capacity transaction.
+ */
+export interface RecipeExpansionCertificate {
+  readonly schema_version: 1;
+  readonly compiler_version: string;
+  readonly root_count: number;
+  readonly worst_case_total_nodes: number;
+  readonly capacity_weight: number;
+  readonly certificate_digest: string;
+}
+
+export type CapacityUnavailableReason =
+  | "insufficient_admission_rate"
+  | "insufficient_queued_work"
+  | "insufficient_active_execution"
+  | "lock_timeout"
+  | "advisory_shed"
+  | "certificate_too_large";
+
+export class CapacityUnavailableError extends Error {
+  readonly code = "capacity_unavailable" as const;
+  constructor(
+    readonly reason: CapacityUnavailableReason,
+    message?: string,
+  ) {
+    super(message ?? `capacity_unavailable:${reason}`);
+    this.name = "CapacityUnavailableError";
+  }
+}
+
+export class AdmissionIdempotencyConflictError extends Error {
+  readonly code = "idempotency_conflict" as const;
+  constructor(message = "idempotency_conflict") {
+    super(message);
+    this.name = "AdmissionIdempotencyConflictError";
+  }
+}

--- a/packages/services/ordering/src/index.ts
+++ b/packages/services/ordering/src/index.ts
@@ -262,3 +262,38 @@ export {
   createSharedPreparationService,
   type SharedPreparationService,
 } from './shared-preparation-service.js';
+
+export {
+  CAPACITY_LEDGER_KINDS,
+  CAPACITY_RESERVATION_STATES,
+  CapacityUnavailableError,
+  AdmissionIdempotencyConflictError,
+  type CapacityLedgerKind,
+  type CapacityPoolRecord,
+  type CapacityReservationRecord,
+  type RecipeExpansionCertificate,
+  type CapacityUnavailableReason,
+} from './admission-capacity-types.js';
+export {
+  V1_MAX_RECIPE_NODES,
+  DEFAULT_ADMISSION_RATE_LIMIT,
+  DEFAULT_QUEUED_WORK_LIMIT,
+  DEFAULT_ACTIVE_EXECUTION_LIMIT,
+  ACTIVE_EXECUTION_LEASE_MS,
+} from './admission-capacity-constants.js';
+export {
+  buildRecipeExpansionCertificate,
+  fixtureGateLeakCertificate,
+  assertCertificateAdmissible,
+} from './recipe-expansion-certificate.js';
+export {
+  InMemoryAdmissionCapacityStore,
+  type AdmissionCapacityStore,
+  type AdmitOrderInput,
+  type AdmitOrderResult,
+} from './admission-capacity-store.js';
+export { PostgresAdmissionCapacityStore } from './admission-capacity-store-postgres.js';
+export {
+  createAdmissionCapacityService,
+  type AdmissionCapacityService,
+} from './admission-capacity-service.js';

--- a/packages/services/ordering/src/recipe-expansion-certificate.ts
+++ b/packages/services/ordering/src/recipe-expansion-certificate.ts
@@ -1,0 +1,75 @@
+/**
+ * CR-201C fixture/stub recipe expansion certificate.
+ * CR-202 replaces this with the deterministic recipe compiler.
+ */
+
+import { createHash } from "node:crypto";
+import { V1_MAX_RECIPE_NODES, V1_MAX_ROOT_REFERENCES } from "./admission-capacity-constants.js";
+import type { RecipeExpansionCertificate } from "./admission-capacity-types.js";
+import { CapacityUnavailableError } from "./admission-capacity-types.js";
+
+export function digestRecipeCertificate(material: {
+  compiler_version: string;
+  root_count: number;
+  worst_case_total_nodes: number;
+  capacity_weight: number;
+}): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        schema_version: 1,
+        compiler_version: material.compiler_version,
+        root_count: material.root_count,
+        worst_case_total_nodes: material.worst_case_total_nodes,
+        capacity_weight: material.capacity_weight,
+      }),
+    )
+    .digest("hex");
+}
+
+export function buildRecipeExpansionCertificate(input: {
+  compiler_version?: string;
+  root_count: number;
+  worst_case_total_nodes: number;
+  capacity_weight?: number;
+}): RecipeExpansionCertificate {
+  const compiler_version = input.compiler_version ?? "fixture-compiler.v1";
+  const capacity_weight = input.capacity_weight ?? input.worst_case_total_nodes;
+  const certificate_digest = digestRecipeCertificate({
+    compiler_version,
+    root_count: input.root_count,
+    worst_case_total_nodes: input.worst_case_total_nodes,
+    capacity_weight,
+  });
+  return {
+    schema_version: 1,
+    compiler_version,
+    root_count: input.root_count,
+    worst_case_total_nodes: input.worst_case_total_nodes,
+    capacity_weight,
+    certificate_digest,
+  };
+}
+
+/** Gate Leak public fixture: 16 deployments × 2 public nodes = 32 root refs. */
+export function fixtureGateLeakCertificate(deploymentCount = 2): RecipeExpansionCertificate {
+  const root_count = deploymentCount * 2;
+  return buildRecipeExpansionCertificate({
+    root_count,
+    worst_case_total_nodes: root_count,
+    capacity_weight: 1,
+  });
+}
+
+export function assertCertificateAdmissible(cert: RecipeExpansionCertificate): void {
+  if (
+    cert.worst_case_total_nodes > V1_MAX_RECIPE_NODES ||
+    cert.root_count > V1_MAX_ROOT_REFERENCES ||
+    cert.capacity_weight <= 0
+  ) {
+    throw new CapacityUnavailableError(
+      "certificate_too_large",
+      `recipe certificate exceeds V1 ceilings (nodes=${cert.worst_case_total_nodes}, roots=${cert.root_count})`,
+    );
+  }
+}

--- a/packages/services/ordering/src/shared-preparation-store-postgres.ts
+++ b/packages/services/ordering/src/shared-preparation-store-postgres.ts
@@ -197,120 +197,130 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
     throw new SharedPreparationStateError(`cannot ${context} from ${current.state}`);
   }
 
-  async joinPublicWork(input: JoinPublicWorkInput): Promise<JoinPublicWorkResult> {
+  /**
+   * CR-201C seam: join/create/link inside an already-open serializable transaction.
+   * Caller owns BEGIN/COMMIT/ROLLBACK and must hold capacity locks first.
+   */
+  async joinPublicWorkInTransaction(
+    client: pg.PoolClient,
+    input: JoinPublicWorkInput,
+  ): Promise<JoinPublicWorkResult> {
     const workKeyDigest = digestPublicWorkKey(input.work_key);
-    const client = await this.pool.connect();
-    try {
-      await client.query("BEGIN");
-      await this.advisoryLock(client, workKeyDigest);
+    await this.advisoryLock(client, workKeyDigest);
 
-      const readyResult = await client.query(
-        `SELECT * FROM shared_preparation_work
-         WHERE work_key_digest = $1
-           AND state = 'ready'
-           AND readiness_policy_version = $2
-           AND readiness_evidence IS NOT NULL
-           AND (readiness_evidence->'freshness'->>'qualified')::boolean = true
-         ORDER BY generation DESC
-         LIMIT 1`,
-        [workKeyDigest, input.work_key.readiness_policy_version],
-      );
-      if (readyResult.rows.length > 0) {
-        const work = rowToWork(readyResult.rows[0]);
-        await this.insertLink(client, input, work.work_id, work.generation);
-        const links = await this.fetchActiveLinks(client, work.work_id);
-        await client.query("COMMIT");
-        return {
-          kind: "joined",
-          work,
-          links,
-          created: false,
-          reused_ready: true,
-        };
-      }
+    const readyResult = await client.query(
+      `SELECT * FROM shared_preparation_work
+       WHERE work_key_digest = $1
+         AND state = 'ready'
+         AND readiness_policy_version = $2
+         AND readiness_evidence IS NOT NULL
+         AND (readiness_evidence->'freshness'->>'qualified')::boolean = true
+       ORDER BY generation DESC
+       LIMIT 1`,
+      [workKeyDigest, input.work_key.readiness_policy_version],
+    );
+    if (readyResult.rows.length > 0) {
+      const work = rowToWork(readyResult.rows[0]);
+      await this.insertLink(client, input, work.work_id, work.generation);
+      const links = await this.fetchActiveLinks(client, work.work_id);
+      return {
+        kind: "joined",
+        work,
+        links,
+        created: false,
+        reused_ready: true,
+      };
+    }
 
-      const activeResult = await client.query(
-        `SELECT * FROM shared_preparation_work
-         WHERE work_key_digest = $1 AND state IN ('queued', 'preparing', 'retry_wait')
-         LIMIT 1`,
-        [workKeyDigest],
-      );
-      if (activeResult.rows.length > 0) {
-        const work = rowToWork(activeResult.rows[0]);
-        await this.insertLink(client, input, work.work_id, work.generation);
-        const links = await this.fetchActiveLinks(client, work.work_id);
-        await client.query("COMMIT");
-        return {
-          kind: "joined",
-          work,
-          links,
-          created: false,
-          reused_ready: false,
-        };
-      }
+    const activeResult = await client.query(
+      `SELECT * FROM shared_preparation_work
+       WHERE work_key_digest = $1 AND state IN ('queued', 'preparing', 'retry_wait')
+       LIMIT 1`,
+      [workKeyDigest],
+    );
+    if (activeResult.rows.length > 0) {
+      const work = rowToWork(activeResult.rows[0]);
+      await this.insertLink(client, input, work.work_id, work.generation);
+      const links = await this.fetchActiveLinks(client, work.work_id);
+      return {
+        kind: "joined",
+        work,
+        links,
+        created: false,
+        reused_ready: false,
+      };
+    }
 
-      const maxGen = await client.query(
-        "SELECT COALESCE(MAX(generation), 0) AS max_generation FROM shared_preparation_work WHERE work_key_digest = $1",
-        [workKeyDigest],
-      );
-      const generation = Number(maxGen.rows[0].max_generation) + 1;
-      const workId = `spw_${randomUUID()}`;
-      const nowIso = msToIso(input.now_ms);
+    const maxGen = await client.query(
+      "SELECT COALESCE(MAX(generation), 0) AS max_generation FROM shared_preparation_work WHERE work_key_digest = $1",
+      [workKeyDigest],
+    );
+    const generation = Number(maxGen.rows[0].max_generation) + 1;
+    const workId = `spw_${randomUUID()}`;
+    const nowIso = msToIso(input.now_ms);
+    await client.query(
+      `INSERT INTO shared_preparation_work (
+        work_id, work_key_digest, deployment_set_digest, capability, capability_version,
+        scope_digest, source_identity, readiness_policy_version, evidence_boundary_kind,
+        evidence_boundary_digest, adapter_version, finality_policy_version, state, generation,
+        attempt, lease_epoch, created_at, updated_at
+      ) VALUES (
+        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'queued',$13,0,0,$14,$14
+      )`,
+      [
+        workId,
+        workKeyDigest,
+        deploymentSetDigest(input.work_key.deployment_ids),
+        input.work_key.capability,
+        input.work_key.capability_version,
+        input.work_key.scope_digest,
+        JSON.stringify(input.work_key.source_identity),
+        input.work_key.readiness_policy_version,
+        input.work_key.evidence_boundary_kind,
+        input.work_key.evidence_boundary_digest ?? null,
+        input.work_key.adapter_version,
+        finalityPolicyVersion(input.work_key.finality_policies),
+        generation,
+        nowIso,
+      ],
+    );
+    for (const deploymentId of input.work_key.deployment_ids) {
       await client.query(
-        `INSERT INTO shared_preparation_work (
-          work_id, work_key_digest, deployment_set_digest, capability, capability_version,
-          scope_digest, source_identity, readiness_policy_version, evidence_boundary_kind,
-          evidence_boundary_digest, adapter_version, finality_policy_version, state, generation,
-          attempt, lease_epoch, created_at, updated_at
-        ) VALUES (
-          $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'queued',$13,0,0,$14,$14
-        )`,
+        `INSERT INTO preparation_work_items (
+          work_item_id, work_id, deployment_id, capability, adapter_version, state, attempt, lease_epoch, created_at, updated_at
+        ) VALUES ($1,$2,$3,$4,$5,'queued',0,0,$6,$6)`,
         [
+          `pwi_${randomUUID()}`,
           workId,
-          workKeyDigest,
-          deploymentSetDigest(input.work_key.deployment_ids),
+          JSON.stringify(deploymentId),
           input.work_key.capability,
-          input.work_key.capability_version,
-          input.work_key.scope_digest,
-          JSON.stringify(input.work_key.source_identity),
-          input.work_key.readiness_policy_version,
-          input.work_key.evidence_boundary_kind,
-          input.work_key.evidence_boundary_digest ?? null,
           input.work_key.adapter_version,
-          finalityPolicyVersion(input.work_key.finality_policies),
-          generation,
           nowIso,
         ],
       );
-      for (const deploymentId of input.work_key.deployment_ids) {
-        await client.query(
-          `INSERT INTO preparation_work_items (
-            work_item_id, work_id, deployment_id, capability, adapter_version, state, attempt, lease_epoch, created_at, updated_at
-          ) VALUES ($1,$2,$3,$4,$5,'queued',0,0,$6,$6)`,
-          [
-            `pwi_${randomUUID()}`,
-            workId,
-            JSON.stringify(deploymentId),
-            input.work_key.capability,
-            input.work_key.adapter_version,
-            nowIso,
-          ],
-        );
-      }
-      await this.insertLink(client, input, workId, generation);
-      const workRow = await client.query(
-        "SELECT * FROM shared_preparation_work WHERE work_id = $1",
-        [workId],
-      );
-      const links = await this.fetchActiveLinks(client, workId);
+    }
+    await this.insertLink(client, input, workId, generation);
+    const workRow = await client.query(
+      "SELECT * FROM shared_preparation_work WHERE work_id = $1",
+      [workId],
+    );
+    const links = await this.fetchActiveLinks(client, workId);
+    return {
+      kind: "joined",
+      work: rowToWork(workRow.rows[0]),
+      links,
+      created: true,
+      reused_ready: false,
+    };
+  }
+
+  async joinPublicWork(input: JoinPublicWorkInput): Promise<JoinPublicWorkResult> {
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      const result = await this.joinPublicWorkInTransaction(client, input);
       await client.query("COMMIT");
-      return {
-        kind: "joined",
-        work: rowToWork(workRow.rows[0]),
-        links,
-        created: true,
-        reused_ready: false,
-      };
+      return result;
     } catch (err) {
       await client.query("ROLLBACK");
       if (isUniqueActiveKeyViolation(err)) {

--- a/packages/services/ordering/src/store-postgres.ts
+++ b/packages/services/ordering/src/store-postgres.ts
@@ -75,6 +75,7 @@ export class PostgresOrderStore implements OrderStore {
       '005_collection_report_list.sql',
       '006_report_attention_receipts.sql',
       '007_shared_preparation_work.sql',
+      '008_admission_capacity.sql',
     ]) {
       const sql = readFileSync(join(__dirname, '../migrations', file), 'utf8');
       await this.pool.query(sql);

--- a/packages/services/ordering/src/store.ts
+++ b/packages/services/ordering/src/store.ts
@@ -187,6 +187,21 @@ export class InMemoryOrderStore implements OrderStore {
     return { created: true, record };
   }
 
+  /**
+   * CR-201C admission txn rollback: remove a just-placed order + its outbox rows.
+   * Not part of OrderStore — only the in-memory backend exposes this for
+   * compensating a failed join/capacity txn.
+   */
+  removePlacedOrder(orderId: string): boolean {
+    const existed = this.orders.delete(orderId);
+    for (let i = this.outbox.length - 1; i >= 0; i -= 1) {
+      if (this.outbox[i]!.order_id === orderId) {
+        this.outbox.splice(i, 1);
+      }
+    }
+    return existed;
+  }
+
   async get(orderId: string): Promise<OrderRecord | undefined> {
     return this.orders.get(orderId);
   }


### PR DESCRIPTION
## Summary

- Adds expand-only migration `008_admission_capacity.sql` for three non-interchangeable capacity ledgers (`admission_rate`, `queued_work`, `active_execution`), versioned reservations, transfer log, and order-admission idempotency.
- Implements serializable admission transaction (in-memory + Postgres) that atomically locks counters, checks a recipe expansion certificate, and writes capacity consumption, idempotency, order, root work/links, and outbox — no separate pre-admission reservation state.
- Fan-in consumes per-order admission capacity but never duplicates the shared-work queued envelope; active-execution leases are acquired only at dispatch and reconcile on expiry.
- Exposes `joinPublicWorkInTransaction` on the CR-201A Postgres prep store so capacity + work join share one transaction.

**Stacks on #501 (CR-201A).** Base tip includes repaired CR-201A (`9a978aaf`). GitHub may show the full CR-201A+CR-201C diff against `main` until #501 merges — that is expected.

## Test plan

- [x] `pnpm exec vitest run src/__tests__/admission-capacity-migration.test.ts src/__tests__/admission-capacity-store.test.ts src/__tests__/admission-capacity-linearizability.test.ts` (18 tests)
- [x] Shared prep suite still green (CR-201A regression)
- [x] Linearizability: 100 / 500 / 1,000 concurrent equivalent + distinct requests (in-memory)
- [x] Capacity ceiling, fan-in accounting, idempotency replay/conflict, advisory shed, lease expiry, exact-once release

## Honest gaps

- Not wired into collection-report HTTP intake yet (CR-202 owns preset + `client_request_id` HTTP path).
- Recipe expansion certificate is a typed fixture/stub; full deterministic compiler is CR-202.
- Postgres linearizability / live SERIALIZABLE soak not in CI (adapter present; in-memory proves acceptance matrix).
- Active-execution lease acquisition at Sonar dispatch remains CR-204A wiring.


Made with [Cursor](https://cursor.com)