### PR TITLE
feat(ordering): CR-202 collection-report Ordering preset intake + recipe compiler

### DIFF
--- a/packages/services/ordering/bin/http.ts
+++ b/packages/services/ordering/bin/http.ts
@@ -38,8 +38,10 @@ import {
   publicAuthPostureFromEnv,
   serviceTokenForPublicAuthMounts,
 } from '../src/public-auth-posture.js';
+import { createAdmissionCapacityComposition } from '../src/admission-capacity-composition.js';
 
 const { store, orchestrator, enqueue } = await createOrderingComposition();
+const { admissionCapacity } = await createAdmissionCapacityComposition(store);
 
 const serviceToken = serviceTokenFromEnv();
 const writeRoutes = writeRoutePostureFromEnv();
@@ -114,6 +116,7 @@ const app = createIntakeApp({
   resolutionService,
   resolutionStore,
   publicAuth: mountPublicAuthRoutes ? publicAuth : undefined,
+  admissionCapacity,
   healthz: {
     store: process.env.DATABASE_URL ? 'postgres' : 'memory',
     kitchen_enqueue: Boolean(enqueue),

--- a/packages/services/ordering/src/__tests__/collection-report-intake.test.ts
+++ b/packages/services/ordering/src/__tests__/collection-report-intake.test.ts
@@ -12,10 +12,13 @@ import { createFixturePublicAuthorizationService } from "../public-authorization
 import { InMemoryAdmissionCapacityStore } from "../admission-capacity-store.js";
 import { InMemorySharedPreparationStore } from "../shared-preparation-store.js";
 import { createAdmissionCapacityService } from "../admission-capacity-service.js";
+import { buildPublicRootWorkKeysFromResolution } from "../collection-report-admission.js";
+import { createHash } from "node:crypto";
 import type {
   AuthorizationScope,
   ConfirmedResolutionRecord,
 } from "@freeside/collection-resolution-protocol";
+import { AuthorizationDeniedError } from "@freeside/public-authorization-protocol";
 
 const fixturesDir = join(
   dirname(fileURLToPath(import.meta.url)),
@@ -30,7 +33,10 @@ const scope = JSON.parse(
   readFileSync(join(fixturesDir, "authorization-scope.valid.json"), "utf8"),
 ) as AuthorizationScope;
 
-function harness(nowMs = Date.parse("2026-07-16T08:10:00Z")) {
+function harness(
+  nowMs = Date.parse("2026-07-16T08:10:00Z"),
+  opts?: { denyLease?: boolean },
+) {
   const store = new InMemoryOrderStore({ now: () => nowMs });
   const resolutionStore = new InMemoryResolutionStore();
   const resolutionService = new CollectionResolutionService({
@@ -53,6 +59,14 @@ function harness(nowMs = Date.parse("2026-07-16T08:10:00Z")) {
     ),
   );
   const publicAuth = createFixturePublicAuthorizationService(authFixture);
+  if (opts?.denyLease) {
+    publicAuth.acquireLease = () => {
+      throw new AuthorizationDeniedError({
+        reason: "permission_revoked",
+        safe_code: "forbidden",
+      });
+    };
+  }
 
   const app = createIntakeApp({
     store,
@@ -63,7 +77,7 @@ function harness(nowMs = Date.parse("2026-07-16T08:10:00Z")) {
     admissionCapacity,
   });
 
-  return { app, store, resolutionStore };
+  return { app, store, resolutionStore, preparationStore };
 }
 
 function seedResolution(store: InMemoryResolutionStore, record: ConfirmedResolutionRecord) {
@@ -194,5 +208,89 @@ describe("CR-202 collection-report intake", () => {
     expect(res.status).toBe(400);
     const parsed = (await res.json()) as { code: string };
     expect(parsed.code).toBe("client_request_id_required");
+  });
+
+  it("joins all certified root work keys including ownership_index (F1)", async () => {
+    const { app, resolutionStore, preparationStore } = harness();
+    await seedResolution(resolutionStore, confirmedFixture);
+
+    const res = await app.request("/v1/orders", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(orderBody("req-roots")),
+    });
+    expect(res.status).toBe(200);
+    const { order_id } = (await res.json()) as { order_id: string };
+
+    const rootKeys = buildPublicRootWorkKeysFromResolution(confirmedFixture);
+    expect(rootKeys.map((k) => k.capability).sort()).toEqual([
+      "collection_identity.v1",
+      "ownership_index.v1",
+    ]);
+
+    const scopeDigest = createHash("sha256")
+      .update("community:community-alpha")
+      .digest("hex");
+    for (const work_key of rootKeys) {
+      const join = await preparationStore.joinPublicWork({
+        order_id,
+        order_tenant_scope_digest: scopeDigest,
+        work_key,
+        now_ms: Date.parse("2026-07-16T08:10:00Z"),
+      });
+      expect(join.kind).toBe("joined");
+      if (join.kind === "joined") {
+        // Already created+linked at admission — not invented on re-join.
+        expect(join.created).toBe(false);
+        expect(join.work.capability).toBe(work_key.capability);
+      }
+    }
+  });
+
+  it("maps public-auth lease denial to authorization_denied (F2)", async () => {
+    const { app, resolutionStore } = harness(Date.parse("2026-07-16T08:10:00Z"), {
+      denyLease: true,
+    });
+    await seedResolution(resolutionStore, confirmedFixture);
+
+    const res = await app.request("/v1/orders", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(orderBody("req-auth-deny")),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code: string; reason?: string };
+    expect(body.code).toBe("authorization_denied");
+    expect(body.code).not.toBe("resolution_scope_mismatch");
+    expect(body.reason).toBe("permission_revoked");
+  });
+
+  it("replays idempotent order without live resolution row (F3)", async () => {
+    const { app, resolutionStore } = harness();
+    await seedResolution(resolutionStore, confirmedFixture);
+
+    const first = await app.request("/v1/orders", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(orderBody("req-gone-res")),
+    });
+    expect(first.status).toBe(200);
+    const firstBody = (await first.json()) as { order_id: string };
+
+    // Drop the resolution after successful admission.
+    const internal = resolutionStore as unknown as {
+      records: Map<string, ConfirmedResolutionRecord>;
+    };
+    internal.records.delete(confirmedFixture.resolution_id);
+
+    const replay = await app.request("/v1/orders", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(orderBody("req-gone-res")),
+    });
+    expect(replay.status).toBe(200);
+    const replayBody = (await replay.json()) as { order_id: string; replay?: boolean };
+    expect(replayBody.order_id).toBe(firstBody.order_id);
+    expect(replayBody.replay).toBe(true);
   });
 });

--- a/packages/services/ordering/src/__tests__/collection-report-intake.test.ts
+++ b/packages/services/ordering/src/__tests__/collection-report-intake.test.ts
@@ -1,0 +1,198 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { createIntakeApp } from "../intake.js";
+import { InMemoryOrderStore } from "../store.js";
+import { InMemoryResolutionStore } from "../resolution-store.js";
+import { CollectionResolutionService } from "../resolution-service.js";
+import { createCatalogResolveProbePort } from "../catalog-resolve-probe.js";
+import { createFixturePublicAuthorizationService } from "../public-authorization-service.js";
+import { InMemoryAdmissionCapacityStore } from "../admission-capacity-store.js";
+import { InMemorySharedPreparationStore } from "../shared-preparation-store.js";
+import { createAdmissionCapacityService } from "../admission-capacity-service.js";
+import type {
+  AuthorizationScope,
+  ConfirmedResolutionRecord,
+} from "@freeside/collection-resolution-protocol";
+
+const fixturesDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../protocol/collection-resolution/fixtures",
+);
+
+const confirmedFixture = JSON.parse(
+  readFileSync(join(fixturesDir, "confirmed-resolution.valid.json"), "utf8"),
+) as ConfirmedResolutionRecord;
+
+const scope = JSON.parse(
+  readFileSync(join(fixturesDir, "authorization-scope.valid.json"), "utf8"),
+) as AuthorizationScope;
+
+function harness(nowMs = Date.parse("2026-07-16T08:10:00Z")) {
+  const store = new InMemoryOrderStore({ now: () => nowMs });
+  const resolutionStore = new InMemoryResolutionStore();
+  const resolutionService = new CollectionResolutionService({
+    store: resolutionStore,
+    sonar: createCatalogResolveProbePort(),
+    clock: { nowMs: () => nowMs },
+  });
+  const preparationStore = new InMemorySharedPreparationStore();
+  const admissionCapacity = createAdmissionCapacityService({
+    store: new InMemoryAdmissionCapacityStore({ orderStore: store, preparationStore }),
+    now: () => nowMs,
+  });
+  const authFixture = JSON.parse(
+    readFileSync(
+      join(
+        dirname(fileURLToPath(import.meta.url)),
+        "../../../../protocol/public-authorization/fixtures/acl/projection-baseline.valid.json",
+      ),
+      "utf8",
+    ),
+  );
+  const publicAuth = createFixturePublicAuthorizationService(authFixture);
+
+  const app = createIntakeApp({
+    store,
+    now: () => nowMs,
+    resolutionService,
+    resolutionStore,
+    publicAuth,
+    admissionCapacity,
+  });
+
+  return { app, store, resolutionStore };
+}
+
+function seedResolution(store: InMemoryResolutionStore, record: ConfirmedResolutionRecord) {
+  const internal = store as unknown as {
+    records: Map<string, ConfirmedResolutionRecord>;
+  };
+  internal.records.set(record.resolution_id, structuredClone(record));
+}
+
+function orderBody(clientRequestId: string, digestOverride?: string) {
+  return {
+    product: "collection-report",
+    placed_by: "subject-alice",
+    client_request_id: clientRequestId,
+    authorization_scope: scope,
+    inputs: {
+      schema_version: 1,
+      resolution_id: confirmedFixture.resolution_id,
+      candidate_snapshot_digest: digestOverride
+        ? {
+            ...confirmedFixture.candidate_snapshot_digest,
+            digest: digestOverride,
+          }
+        : confirmedFixture.candidate_snapshot_digest,
+      community_ref: "community-alpha",
+    },
+  };
+}
+
+describe("CR-202 collection-report intake", () => {
+  it("admits via admitOrder with compiled recipe and idempotent replay", async () => {
+    const { app, store, resolutionStore } = harness();
+    await seedResolution(resolutionStore, confirmedFixture);
+
+    const first = await app.request("/v1/orders", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(orderBody("req-cr-202-a")),
+    });
+    expect(first.status).toBe(200);
+    const firstBody = (await first.json()) as { order_id: string; replay?: boolean };
+    expect(firstBody.replay).toBe(false);
+
+    const record = await store.get(firstBody.order_id);
+    expect(record?.product).toBe("collection-report");
+    expect(record?.state).toBe("placed");
+    const inputs = record?.inputs as {
+      recipe_expansion_certificate?: { compiler_version: string; worst_case_total_nodes: number };
+    };
+    expect(inputs.recipe_expansion_certificate?.compiler_version).toBe("gate-leak-public.v1");
+    expect(inputs.recipe_expansion_certificate?.worst_case_total_nodes).toBeLessThanOrEqual(160);
+
+    const replay = await app.request("/v1/orders", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(orderBody("req-cr-202-a")),
+    });
+    expect(replay.status).toBe(200);
+    const replayBody = (await replay.json()) as { order_id: string; replay?: boolean };
+    expect(replayBody.order_id).toBe(firstBody.order_id);
+    expect(replayBody.replay).toBe(true);
+  });
+
+  it("returns idempotency_conflict when client_request_id is reused with different body", async () => {
+    const { app, resolutionStore } = harness();
+    await seedResolution(resolutionStore, confirmedFixture);
+
+    const ok = await app.request("/v1/orders", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(orderBody("req-conflict")),
+    });
+    expect(ok.status).toBe(200);
+
+    const conflict = await app.request("/v1/orders", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(orderBody("req-conflict", "f".repeat(64))),
+    });
+    expect(conflict.status).toBe(409);
+    const body = (await conflict.json()) as { code: string };
+    expect(body.code).toBe("idempotency_conflict");
+  });
+
+  it("returns candidate_digest_mismatch before order create", async () => {
+    const { app, resolutionStore } = harness();
+    await seedResolution(resolutionStore, confirmedFixture);
+
+    const res = await app.request("/v1/orders", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(orderBody("req-digest", "dead".repeat(16))),
+    });
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("candidate_digest_mismatch");
+  });
+
+  it("returns resolution_expired before order create", async () => {
+    const expired: ConfirmedResolutionRecord = {
+      ...confirmedFixture,
+      expires_at: "2026-07-16T08:00:00Z",
+    };
+    const { app, resolutionStore } = harness(Date.parse("2026-07-16T08:20:00Z"));
+    await seedResolution(resolutionStore, expired);
+
+    const res = await app.request("/v1/orders", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(orderBody("req-expired")),
+    });
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("resolution_expired");
+  });
+
+  it("requires client_request_id", async () => {
+    const { app, resolutionStore } = harness();
+    await seedResolution(resolutionStore, confirmedFixture);
+    const body = orderBody("ignored");
+    const { client_request_id: _drop, ...without } = body;
+
+    const res = await app.request("/v1/orders", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(without),
+    });
+    expect(res.status).toBe(400);
+    const parsed = (await res.json()) as { code: string };
+    expect(parsed.code).toBe("client_request_id_required");
+  });
+});

--- a/packages/services/ordering/src/__tests__/gate-leak-recipe-compiler.test.ts
+++ b/packages/services/ordering/src/__tests__/gate-leak-recipe-compiler.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  GATE_LEAK_MAX_IDENTITY_LINK_PAGES,
+  GATE_LEAK_NODE_TYPES,
+  GATE_LEAK_PUBLIC_NODES_PER_DEPLOYMENT,
+  compileGateLeakRecipe,
+  SelectionTooLargeError,
+} from "../gate-leak-recipe-compiler.js";
+import { V1_MAX_DEPLOYMENTS, V1_MAX_RECIPE_NODES } from "../admission-capacity-constants.js";
+
+describe("CR-202 gate-leak recipe compiler", () => {
+  it("enumerates every node type in a fixed catalog", () => {
+    expect(GATE_LEAK_NODE_TYPES.length).toBeGreaterThanOrEqual(6);
+    expect(new Set(GATE_LEAK_NODE_TYPES).size).toBe(GATE_LEAK_NODE_TYPES.length);
+  });
+
+  it("proves worst-case bound <=160 for max deployments", () => {
+    const compiled = compileGateLeakRecipe({
+      deployment_count: V1_MAX_DEPLOYMENTS,
+      tier: "public",
+    });
+    expect(compiled.worst_case_total_nodes).toBeLessThanOrEqual(V1_MAX_RECIPE_NODES);
+    expect(compiled.root_reference_count).toBe(
+      V1_MAX_DEPLOYMENTS * GATE_LEAK_PUBLIC_NODES_PER_DEPLOYMENT,
+    );
+    expect(compiled.certificate.worst_case_total_nodes).toBe(compiled.worst_case_total_nodes);
+    expect(compiled.certificate.root_count).toBe(compiled.root_reference_count);
+  });
+
+  it("rejects deployment overflow before admission", () => {
+    expect(() =>
+      compileGateLeakRecipe({ deployment_count: V1_MAX_DEPLOYMENTS + 1 }),
+    ).toThrow(SelectionTooLargeError);
+  });
+
+  it("is deterministic for the same deployment count", () => {
+    const a = compileGateLeakRecipe({ deployment_count: 2, tier: "public" });
+    const b = compileGateLeakRecipe({ deployment_count: 2, tier: "public" });
+    expect(a.certificate).toEqual(b.certificate);
+    expect(a.public_root_work_key_count).toBe(GATE_LEAK_PUBLIC_NODES_PER_DEPLOYMENT);
+  });
+
+  it("accounts for restricted expansion branches in worst-case total", () => {
+    const one = compileGateLeakRecipe({ deployment_count: 1, tier: "public" });
+    expect(one.worst_case_total_nodes).toBe(
+      GATE_LEAK_PUBLIC_NODES_PER_DEPLOYMENT + 3 + 1 + GATE_LEAK_MAX_IDENTITY_LINK_PAGES,
+    );
+  });
+});

--- a/packages/services/ordering/src/admission-capacity-composition.ts
+++ b/packages/services/ordering/src/admission-capacity-composition.ts
@@ -1,0 +1,45 @@
+import type { OrderStore } from "./store.js";
+import { InMemoryAdmissionCapacityStore } from "./admission-capacity-store.js";
+import { InMemorySharedPreparationStore } from "./shared-preparation-store.js";
+import { PostgresOrderStore } from "./store-postgres.js";
+import { PostgresSharedPreparationStore } from "./shared-preparation-store-postgres.js";
+import { PostgresAdmissionCapacityStore } from "./admission-capacity-store-postgres.js";
+import {
+  createAdmissionCapacityService,
+  type AdmissionCapacityService,
+} from "./admission-capacity-service.js";
+
+export interface AdmissionCapacityComposition {
+  readonly admissionCapacity: AdmissionCapacityService;
+}
+
+export async function createAdmissionCapacityComposition(
+  store: OrderStore,
+): Promise<AdmissionCapacityComposition> {
+  const now = () => Date.now();
+
+  if (store instanceof PostgresOrderStore) {
+    const connectionString = process.env.DATABASE_URL!.trim();
+    const pool = store.getPool();
+    const preparationStore = await PostgresSharedPreparationStore.connect(connectionString, {
+      pool,
+      migrate: process.env.RUN_MIGRATIONS === "true",
+    });
+    const capacityStore = await PostgresAdmissionCapacityStore.connect(connectionString, {
+      migrate: process.env.RUN_MIGRATIONS === "true",
+      preparationStore,
+    });
+    return {
+      admissionCapacity: createAdmissionCapacityService({ store: capacityStore, now }),
+    };
+  }
+
+  const preparationStore = new InMemorySharedPreparationStore();
+  const capacityStore = new InMemoryAdmissionCapacityStore({
+    orderStore: store,
+    preparationStore,
+  });
+  return {
+    admissionCapacity: createAdmissionCapacityService({ store: capacityStore, now }),
+  };
+}

--- a/packages/services/ordering/src/admission-capacity-store-postgres.ts
+++ b/packages/services/ordering/src/admission-capacity-store-postgres.ts
@@ -40,6 +40,7 @@ import {
 import { assertCertificateAdmissible } from "./recipe-expansion-certificate.js";
 import { digestOf } from "./digest.js";
 import { PostgresSharedPreparationStore } from "./shared-preparation-store-postgres.js";
+import type { JoinPublicWorkResult } from "./shared-preparation-store.js";
 import { digestPublicWorkKey } from "./shared-preparation-work-key.js";
 import type { OrderRecord } from "./store.js";
 
@@ -376,6 +377,32 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
     return { kind: "capacity_unavailable", reason: "lock_timeout" };
   }
 
+  /** Join primary + every additional certified root work key inside the open txn. */
+  private async joinAllRootWorkKeysInTxn(
+    client: pg.PoolClient,
+    input: AdmitOrderInput,
+    orderId: string,
+  ): Promise<JoinPublicWorkResult> {
+    const primary = await this.preparationStore.joinPublicWorkInTransaction(client, {
+      order_id: orderId,
+      order_tenant_scope_digest: input.order_tenant_scope_digest,
+      work_key: input.work_key,
+      now_ms: input.now_ms,
+    });
+    if (primary.kind !== "joined") return primary;
+
+    for (const extra of input.additional_root_work_keys ?? []) {
+      const join = await this.preparationStore.joinPublicWorkInTransaction(client, {
+        order_id: orderId,
+        order_tenant_scope_digest: input.order_tenant_scope_digest,
+        work_key: extra,
+        now_ms: input.now_ms,
+      });
+      if (join.kind !== "joined") return join;
+    }
+    return primary;
+  }
+
   private async admitOrderAttempt(input: AdmitOrderInput): Promise<AdmitOrderResult> {
     const client = await this.pool.connect();
     /** Tracks whether COMMIT/ROLLBACK already ran — finally always cleans open txns. */
@@ -418,12 +445,7 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
         const orderRes = await client.query("SELECT * FROM orders WHERE order_id = $1", [
           row.order_id,
         ]);
-        const join = await this.preparationStore.joinPublicWorkInTransaction(client, {
-          order_id: row.order_id,
-          order_tenant_scope_digest: input.order_tenant_scope_digest,
-          work_key: input.work_key,
-          now_ms: input.now_ms,
-        });
+        const join = await this.joinAllRootWorkKeysInTxn(client, input, row.order_id);
         if (join.kind !== "joined") {
           // Route through outer admission retry loop (do not bypass as typed deny).
           await rollback();
@@ -563,12 +585,7 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
         ],
       );
 
-      const join = await this.preparationStore.joinPublicWorkInTransaction(client, {
-        order_id,
-        order_tenant_scope_digest: input.order_tenant_scope_digest,
-        work_key: input.work_key,
-        now_ms: input.now_ms,
-      });
+      const join = await this.joinAllRootWorkKeysInTxn(client, input, order_id);
       if (join.kind !== "joined") {
         throw new Error("serialization_retry");
       }

--- a/packages/services/ordering/src/admission-capacity-store.ts
+++ b/packages/services/ordering/src/admission-capacity-store.ts
@@ -58,6 +58,11 @@ export interface AdmitOrderInput {
   readonly body: Record<string, unknown>;
   readonly certificate: RecipeExpansionCertificate;
   readonly work_key: PublicPreparationWorkKeyMaterial;
+  /**
+   * Additional certified root work keys (e.g. ownership_index alongside
+   * collection_identity). All are joinPublicWork'd in the same admission txn.
+   */
+  readonly additional_root_work_keys?: readonly PublicPreparationWorkKeyMaterial[];
   readonly order_tenant_scope_digest: string;
   readonly pool_scope: CapacityPoolScope;
   readonly now_ms: number;
@@ -65,6 +70,37 @@ export interface AdmitOrderInput {
   readonly advisory_shed?: boolean;
   /** Simulated lock-wait ms for advisory shed tests. */
   readonly simulated_lock_wait_ms?: number;
+}
+
+/** Join primary + every additional certified root work key in one admission path. */
+export async function joinAllRootWorkKeys(
+  preparationStore: SharedPreparationStore,
+  input: {
+    readonly order_id: string;
+    readonly order_tenant_scope_digest: string;
+    readonly work_key: PublicPreparationWorkKeyMaterial;
+    readonly additional_root_work_keys?: readonly PublicPreparationWorkKeyMaterial[];
+    readonly now_ms: number;
+  },
+): Promise<JoinPublicWorkResult> {
+  const primary = await preparationStore.joinPublicWork({
+    order_id: input.order_id,
+    order_tenant_scope_digest: input.order_tenant_scope_digest,
+    work_key: input.work_key,
+    now_ms: input.now_ms,
+  });
+  if (primary.kind !== "joined") return primary;
+
+  for (const extra of input.additional_root_work_keys ?? []) {
+    const join = await preparationStore.joinPublicWork({
+      order_id: input.order_id,
+      order_tenant_scope_digest: input.order_tenant_scope_digest,
+      work_key: extra,
+      now_ms: input.now_ms,
+    });
+    if (join.kind !== "joined") return join;
+  }
+  return primary;
 }
 
 export type AdmitOrderResult =
@@ -494,10 +530,11 @@ export class InMemoryAdmissionCapacityStore implements AdmissionCapacityStore {
           if (!order) {
             throw new Error("serialization_retry");
           }
-          const join = await this.preparationStore.joinPublicWork({
+          const join = await joinAllRootWorkKeys(this.preparationStore, {
             order_id: prior.order_id,
             order_tenant_scope_digest: input.order_tenant_scope_digest,
             work_key: input.work_key,
+            additional_root_work_keys: input.additional_root_work_keys,
             now_ms: input.now_ms,
           });
           if (join.kind !== "joined") {
@@ -574,12 +611,17 @@ export class InMemoryAdmissionCapacityStore implements AdmissionCapacityStore {
           // Join before placeOrder so a failed join never leaves an orphan order.
           // (Postgres FK requires order-first inside one SERIALIZABLE txn; in-memory
           // has no FK — join-then-place keeps the logical txn atomic.)
-          const join: JoinPublicWorkResult = await this.preparationStore.joinPublicWork({
-            order_id,
-            order_tenant_scope_digest: input.order_tenant_scope_digest,
-            work_key: input.work_key,
-            now_ms: input.now_ms,
-          });
+          // Join every certified root work key (collection_identity + ownership_index).
+          const join: JoinPublicWorkResult = await joinAllRootWorkKeys(
+            this.preparationStore,
+            {
+              order_id,
+              order_tenant_scope_digest: input.order_tenant_scope_digest,
+              work_key: input.work_key,
+              additional_root_work_keys: input.additional_root_work_keys,
+              now_ms: input.now_ms,
+            },
+          );
           if (join.kind !== "joined") {
             throw new Error("serialization_retry");
           }

--- a/packages/services/ordering/src/collection-report-admission.ts
+++ b/packages/services/ordering/src/collection-report-admission.ts
@@ -1,0 +1,343 @@
+/**
+ * CR-202 collection-report order admission — resolution revalidation, recipe
+ * compilation, and CR-201C admitOrder in one path.
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+import type {
+  AuthorizationScope,
+  ConfirmedResolutionRecord,
+  LocalCapabilitySnapshot,
+} from "@freeside/collection-resolution-protocol";
+import {
+  AuthorizationScopeMismatchError,
+  OrderBindingRejectedError,
+  ResolutionExpiredError,
+  ResolutionNotFoundError,
+  SelectionStaleError,
+} from "@freeside/collection-resolution-protocol";
+import { digestsEqual } from "@freeside/collection-resolution-protocol";
+import type { CollectionReportInputs } from "@freeside/ordering-protocol";
+import type { CollectionResolutionService } from "./resolution-service.js";
+import type { ResolutionStore } from "./resolution-store.js";
+import type { PublicAuthorizationService } from "./public-authorization-service.js";
+import type { AdmissionCapacityService } from "./admission-capacity-service.js";
+import { buildLocalCapabilityFromRecord } from "./admission-local-capability.js";
+import {
+  compileGateLeakRecipe,
+  SelectionTooLargeError,
+  WorkflowTooLargeError,
+} from "./gate-leak-recipe-compiler.js";
+import { buildPublicWorkKeyMaterial } from "./shared-preparation-work-key.js";
+import type { PublicPreparationWorkKeyMaterial } from "./shared-preparation-types.js";
+import { digestOf } from "./digest.js";
+import type { RecipeExpansionCertificate } from "./admission-capacity-types.js";
+
+export type CollectionReportAdmissionErrorCode =
+  | "invalid_request"
+  | "authorization_scope_required"
+  | "invalid_authorization_scope"
+  | "permission_mismatch"
+  | "cross_subject"
+  | "scope_tamper"
+  | "collection_report_admission_unavailable"
+  | "public_authorization_unconfigured"
+  | "resolution_not_found"
+  | "resolution_expired"
+  | "selection_stale"
+  | "candidate_digest_mismatch"
+  | "resolution_scope_mismatch"
+  | "selection_too_large"
+  | "workflow_too_large"
+  | "idempotency_conflict"
+  | "capacity_unavailable"
+  | "missing_confirmation";
+
+export interface CollectionReportAdmissionDeny {
+  readonly status: 400 | 403 | 409 | 503;
+  readonly code: CollectionReportAdmissionErrorCode;
+  readonly reason?: string;
+}
+
+export interface CollectionReportAdmissionDeps {
+  readonly resolutionService: CollectionResolutionService;
+  readonly resolutionStore: ResolutionStore;
+  readonly publicAuth: PublicAuthorizationService;
+  readonly admissionCapacity: AdmissionCapacityService;
+  readonly now: () => number;
+}
+
+export interface AdmitCollectionReportInput {
+  readonly placed_by: string;
+  readonly client_request_id: string;
+  readonly binding: CollectionReportInputs;
+  readonly authorization_scope: unknown;
+}
+
+export type AdmitCollectionReportResult =
+  | { readonly kind: "admitted"; readonly order_id: string; readonly replay: boolean }
+  | { readonly kind: "deny"; readonly deny: CollectionReportAdmissionDeny };
+
+function communityScopeDigest(communityRef: string): string {
+  return createHash("sha256").update(`community:${communityRef}`).digest("hex");
+}
+
+function findSelectedCandidate(record: ConfirmedResolutionRecord) {
+  const selected = record.selected_deployment_ids ?? [];
+  if (selected.length === 0) return undefined;
+  const selectedKeys = new Set(selected.map((d) => d.digest));
+  for (const candidate of record.candidate_snapshot.candidates) {
+    if (
+      candidate.identity.deployments.some((d) => selectedKeys.has(d.deployment_id.digest))
+    ) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+export function buildPublicRootWorkKeysFromResolution(
+  record: ConfirmedResolutionRecord,
+): PublicPreparationWorkKeyMaterial[] {
+  const selected = record.selected_deployment_ids ?? [];
+  const candidate = findSelectedCandidate(record);
+  if (candidate === undefined || selected.length === 0) {
+    throw new Error("confirmed resolution missing selected deployments");
+  }
+
+  const collectionId =
+    record.selected_collection_id ?? candidate.identity.collection_id;
+  const shared = {
+    collection_id: collectionId,
+    deployment_ids: selected,
+    finality_policies: candidate.finality_policies,
+    source_identity: {
+      schema_version: 1 as const,
+      producer: "ordering.collection-report.v1",
+      upstream_evidence_source: "sonar.public-capability.v1",
+    },
+    readiness_policy_version: "gate-leak-public-prep.v1",
+    adapter_version: "sonar-kitchen.v1",
+  };
+
+  return [
+    buildPublicWorkKeyMaterial({
+      ...shared,
+      capability: "collection_identity.v1",
+      capability_version: "v1",
+    }),
+    buildPublicWorkKeyMaterial({
+      ...shared,
+      capability: "ownership_index.v1",
+      capability_version: "v1",
+    }),
+  ];
+}
+
+export function mapCollectionReportAdmissionError(
+  err: unknown,
+): CollectionReportAdmissionDeny | undefined {
+  if (err instanceof ResolutionNotFoundError) {
+    return { status: 409, code: "resolution_not_found" };
+  }
+  if (err instanceof ResolutionExpiredError) {
+    return { status: 409, code: "resolution_expired" };
+  }
+  if (err instanceof SelectionStaleError) {
+    return { status: 409, code: "selection_stale", reason: err.reason };
+  }
+  if (err instanceof OrderBindingRejectedError) {
+    if (err.reason === "digest_grafting") {
+      return { status: 409, code: "candidate_digest_mismatch", reason: err.detail };
+    }
+    if (err.reason === "missing_confirmation") {
+      return { status: 409, code: "missing_confirmation", reason: err.detail };
+    }
+    return { status: 409, code: "selection_stale", reason: err.reason };
+  }
+  if (err instanceof AuthorizationScopeMismatchError) {
+    return { status: 403, code: "resolution_scope_mismatch", reason: err.reason };
+  }
+  if (err instanceof SelectionTooLargeError) {
+    return { status: 409, code: "selection_too_large" };
+  }
+  if (err instanceof WorkflowTooLargeError) {
+    return { status: 409, code: "workflow_too_large" };
+  }
+  return undefined;
+}
+
+function primaryNetworkRef(record: ConfirmedResolutionRecord): string {
+  const candidate = findSelectedCandidate(record);
+  const deployment = candidate?.identity.deployments[0];
+  if (deployment === undefined) return "unknown";
+  return `${deployment.network.network_namespace}:${deployment.network.network_reference}`;
+}
+
+export async function admitCollectionReportOrder(
+  deps: CollectionReportAdmissionDeps,
+  input: AdmitCollectionReportInput,
+): Promise<AdmitCollectionReportResult> {
+  let scope: AuthorizationScope;
+  try {
+    scope = deps.publicAuth.decodeScope(input.authorization_scope);
+  } catch {
+    return {
+      kind: "deny",
+      deny: { status: 400, code: "invalid_authorization_scope" },
+    };
+  }
+
+  if (scope.permission !== "report:create") {
+    return {
+      kind: "deny",
+      deny: {
+        status: 403,
+        code: "permission_mismatch",
+        reason: "order placement requires report:create",
+      },
+    };
+  }
+  if (scope.subject_id !== input.placed_by) {
+    return {
+      kind: "deny",
+      deny: { status: 403, code: "cross_subject", reason: "placed_by must match authorization subject" },
+    };
+  }
+  if (input.binding.community_ref !== scope.community_ref) {
+    return {
+      kind: "deny",
+      deny: { status: 403, code: "scope_tamper", reason: "community_ref must match authorization scope" },
+    };
+  }
+
+  try {
+    deps.publicAuth.acquireLease({
+      operation: { resource: "report_order", action: "create" },
+      scope,
+      authoritativeCommunityRef: input.binding.community_ref,
+      authoritativeSubjectId: input.placed_by,
+    });
+  } catch (err) {
+    const mapped = deps.publicAuth.mapDenial(err);
+    return {
+      kind: "deny",
+      deny: {
+        status: mapped.status as 403,
+        code: "resolution_scope_mismatch",
+        reason: (mapped.body as { code?: string }).code,
+      },
+    };
+  }
+
+  const record = await deps.resolutionStore.get(input.binding.resolution_id);
+  if (record === undefined) {
+    return { kind: "deny", deny: { status: 409, code: "resolution_not_found" } };
+  }
+
+  const resolutionScope: AuthorizationScope = {
+    schema_version: 1,
+    subject_id: scope.subject_id,
+    community_ref: scope.community_ref,
+    permission: "report:create",
+  };
+
+  const priorIdem = await deps.admissionCapacity.store.getIdempotency(
+    input.placed_by,
+    input.client_request_id,
+  );
+
+  if (priorIdem === undefined) {
+    try {
+      const localCapability = buildLocalCapabilityFromRecord(record);
+      await deps.resolutionService.admit(input.binding, resolutionScope, localCapability);
+    } catch (err) {
+      const mapped = mapCollectionReportAdmissionError(err);
+      if (mapped) return { kind: "deny", deny: mapped };
+      return {
+        kind: "deny",
+        deny: { status: 409, code: "selection_stale", reason: "order_binding_rejected" },
+      };
+    }
+  }
+
+  const deploymentCount = record.selected_deployment_ids?.length ?? 0;
+  let compiled;
+  try {
+    compiled = compileGateLeakRecipe({ deployment_count: deploymentCount, tier: "public" });
+  } catch (err) {
+    const mapped = mapCollectionReportAdmissionError(err);
+    if (mapped) return { kind: "deny", deny: mapped };
+    throw err;
+  }
+
+  const rootWorkKeys = buildPublicRootWorkKeysFromResolution(record);
+  const [primaryWorkKey, ...additionalRootWorkKeys] = rootWorkKeys;
+  if (primaryWorkKey === undefined) {
+    return {
+      kind: "deny",
+      deny: { status: 409, code: "missing_confirmation" },
+    };
+  }
+
+  const certificate: RecipeExpansionCertificate = compiled.certificate;
+  const enrichedInputs: Record<string, unknown> = {
+    ...input.binding,
+    recipe_expansion_certificate: certificate,
+  };
+
+  const body = {
+    product: "collection-report" as const,
+    placed_by: input.placed_by,
+    client_request_id: input.client_request_id,
+    inputs: enrichedInputs,
+    authorization_scope: scope,
+  };
+
+  const placed_at_unix = Math.floor(deps.now() / 1000);
+  const admitResult = await deps.admissionCapacity.admitOrder({
+    requester_subject: input.placed_by,
+    client_request_id: input.client_request_id,
+    order: {
+      product: "collection-report",
+      placed_by: input.placed_by,
+      inputs: enrichedInputs,
+      placed_at_unix,
+      inputs_digest: digestOf(enrichedInputs),
+      order_id: randomUUID(),
+    },
+    body,
+    certificate,
+    work_key: primaryWorkKey,
+    additional_root_work_keys: additionalRootWorkKeys,
+    order_tenant_scope_digest: communityScopeDigest(input.binding.community_ref),
+    pool_scope: {
+      network_ref: primaryNetworkRef(record),
+      capability: "ownership_index.v1",
+    },
+  });
+
+  if (admitResult.kind === "idempotency_conflict") {
+    return { kind: "deny", deny: { status: 409, code: "idempotency_conflict" } };
+  }
+  if (admitResult.kind === "capacity_unavailable") {
+    return {
+      kind: "deny",
+      deny: { status: 503, code: "capacity_unavailable", reason: admitResult.reason },
+    };
+  }
+
+  return {
+    kind: "admitted",
+    order_id: admitResult.order.order_id,
+    replay: admitResult.replay,
+  };
+}
+
+/** Revalidate binding digest without persisting — used in tests and pre-flight checks. */
+export function bindingDigestMatchesRecord(
+  binding: CollectionReportInputs,
+  record: ConfirmedResolutionRecord,
+): boolean {
+  return digestsEqual(binding.candidate_snapshot_digest, record.candidate_snapshot_digest);
+}

--- a/packages/services/ordering/src/collection-report-admission.ts
+++ b/packages/services/ordering/src/collection-report-admission.ts
@@ -7,7 +7,6 @@ import { createHash, randomUUID } from "node:crypto";
 import type {
   AuthorizationScope,
   ConfirmedResolutionRecord,
-  LocalCapabilitySnapshot,
 } from "@freeside/collection-resolution-protocol";
 import {
   AuthorizationScopeMismatchError,
@@ -22,6 +21,7 @@ import type { CollectionResolutionService } from "./resolution-service.js";
 import type { ResolutionStore } from "./resolution-store.js";
 import type { PublicAuthorizationService } from "./public-authorization-service.js";
 import type { AdmissionCapacityService } from "./admission-capacity-service.js";
+import type { OrderStore } from "./store.js";
 import { buildLocalCapabilityFromRecord } from "./admission-local-capability.js";
 import {
   compileGateLeakRecipe,
@@ -42,6 +42,7 @@ export type CollectionReportAdmissionErrorCode =
   | "scope_tamper"
   | "collection_report_admission_unavailable"
   | "public_authorization_unconfigured"
+  | "authorization_denied"
   | "resolution_not_found"
   | "resolution_expired"
   | "selection_stale"
@@ -54,7 +55,7 @@ export type CollectionReportAdmissionErrorCode =
   | "missing_confirmation";
 
 export interface CollectionReportAdmissionDeny {
-  readonly status: 400 | 403 | 409 | 503;
+  readonly status: 400 | 401 | 403 | 409 | 503;
   readonly code: CollectionReportAdmissionErrorCode;
   readonly reason?: string;
 }
@@ -64,6 +65,7 @@ export interface CollectionReportAdmissionDeps {
   readonly resolutionStore: ResolutionStore;
   readonly publicAuth: PublicAuthorizationService;
   readonly admissionCapacity: AdmissionCapacityService;
+  readonly orderStore: OrderStore;
   readonly now: () => number;
 }
 
@@ -174,6 +176,29 @@ function primaryNetworkRef(record: ConfirmedResolutionRecord): string {
   return `${deployment.network.network_namespace}:${deployment.network.network_reference}`;
 }
 
+/**
+ * Reconstruct the admission body digest using the stored certificate so
+ * idempotent replay can detect content conflict without a live resolution row.
+ */
+function replayBodyDigest(input: {
+  readonly placed_by: string;
+  readonly client_request_id: string;
+  readonly binding: CollectionReportInputs;
+  readonly authorization_scope: AuthorizationScope;
+  readonly stored_certificate: unknown;
+}): string {
+  return digestOf({
+    product: "collection-report",
+    placed_by: input.placed_by,
+    client_request_id: input.client_request_id,
+    inputs: {
+      ...input.binding,
+      recipe_expansion_certificate: input.stored_certificate,
+    },
+    authorization_scope: input.authorization_scope,
+  });
+}
+
 export async function admitCollectionReportOrder(
   deps: CollectionReportAdmissionDeps,
   input: AdmitCollectionReportInput,
@@ -219,15 +244,45 @@ export async function admitCollectionReportOrder(
       authoritativeSubjectId: input.placed_by,
     });
   } catch (err) {
+    // F2: public-auth ACL/lease denials are distinct from resolution_scope_mismatch.
     const mapped = deps.publicAuth.mapDenial(err);
+    const body = mapped.body as { code?: string; reason?: string };
     return {
       kind: "deny",
       deny: {
-        status: mapped.status as 403,
-        code: "resolution_scope_mismatch",
-        reason: (mapped.body as { code?: string }).code,
+        status: mapped.status,
+        code: "authorization_denied",
+        reason: body.reason ?? body.code,
       },
     };
+  }
+
+  // F3: idempotent replay must not require a live resolution row.
+  const priorIdem = await deps.admissionCapacity.store.getIdempotency(
+    input.placed_by,
+    input.client_request_id,
+  );
+  if (priorIdem !== undefined) {
+    const order = await deps.orderStore.get(priorIdem.order_id);
+    if (order !== undefined) {
+      const storedCert = (order.inputs as { recipe_expansion_certificate?: unknown })
+        .recipe_expansion_certificate;
+      const candidateDigest = replayBodyDigest({
+        placed_by: input.placed_by,
+        client_request_id: input.client_request_id,
+        binding: input.binding,
+        authorization_scope: scope,
+        stored_certificate: storedCert,
+      });
+      if (candidateDigest !== priorIdem.body_digest) {
+        return { kind: "deny", deny: { status: 409, code: "idempotency_conflict" } };
+      }
+      return {
+        kind: "admitted",
+        order_id: priorIdem.order_id,
+        replay: true,
+      };
+    }
   }
 
   const record = await deps.resolutionStore.get(input.binding.resolution_id);
@@ -242,23 +297,16 @@ export async function admitCollectionReportOrder(
     permission: "report:create",
   };
 
-  const priorIdem = await deps.admissionCapacity.store.getIdempotency(
-    input.placed_by,
-    input.client_request_id,
-  );
-
-  if (priorIdem === undefined) {
-    try {
-      const localCapability = buildLocalCapabilityFromRecord(record);
-      await deps.resolutionService.admit(input.binding, resolutionScope, localCapability);
-    } catch (err) {
-      const mapped = mapCollectionReportAdmissionError(err);
-      if (mapped) return { kind: "deny", deny: mapped };
-      return {
-        kind: "deny",
-        deny: { status: 409, code: "selection_stale", reason: "order_binding_rejected" },
-      };
-    }
+  try {
+    const localCapability = buildLocalCapabilityFromRecord(record);
+    await deps.resolutionService.admit(input.binding, resolutionScope, localCapability);
+  } catch (err) {
+    const mapped = mapCollectionReportAdmissionError(err);
+    if (mapped) return { kind: "deny", deny: mapped };
+    return {
+      kind: "deny",
+      deny: { status: 409, code: "selection_stale", reason: "order_binding_rejected" },
+    };
   }
 
   const deploymentCount = record.selected_deployment_ids?.length ?? 0;

--- a/packages/services/ordering/src/gate-leak-recipe-compiler.ts
+++ b/packages/services/ordering/src/gate-leak-recipe-compiler.ts
@@ -1,0 +1,107 @@
+/**
+ * CR-202 deterministic Gate Leak recipe compiler (T1 public path).
+ *
+ * Enumerates every possible node type and proves a recipe-specific worst-case
+ * node/capacity bound <=160 before admission. Runtime evidence determines
+ * which certified branches materialize — never an unknown graph shape.
+ */
+
+import {
+  V1_MAX_DEPLOYMENTS,
+  V1_MAX_RECIPE_NODES,
+  V1_MAX_ROOT_REFERENCES,
+} from "./admission-capacity-constants.js";
+import type { RecipeExpansionCertificate } from "./admission-capacity-types.js";
+import { buildRecipeExpansionCertificate } from "./recipe-expansion-certificate.js";
+
+export const GATE_LEAK_COMPILER_VERSION = "gate-leak-public.v1" as const;
+
+/** Every node type the Gate Leak v1 recipe may expand — fixed catalog. */
+export const GATE_LEAK_NODE_TYPES = [
+  "public.collection_identity_per_deployment",
+  "public.ownership_index_per_deployment",
+  "restricted.gate_mapping",
+  "restricted.discord_role_snapshot",
+  "restricted.identity_link_snapshot",
+  "restricted.identity_link_page",
+  "order.gate_leak_compute",
+] as const;
+
+export type GateLeakNodeType = (typeof GATE_LEAK_NODE_TYPES)[number];
+
+export const GATE_LEAK_PUBLIC_NODES_PER_DEPLOYMENT = 2;
+export const GATE_LEAK_RESTRICTED_COMMUNITY_NODES = 3;
+export const GATE_LEAK_COMPUTE_NODES = 1;
+/** V1: 50_000 subjects / 500 per page. */
+export const GATE_LEAK_MAX_IDENTITY_LINK_PAGES = 100;
+
+export class SelectionTooLargeError extends Error {
+  readonly code = "selection_too_large" as const;
+  constructor(deploymentCount: number) {
+    super(`selection exceeds ${V1_MAX_DEPLOYMENTS} deployments (${deploymentCount})`);
+    this.name = "SelectionTooLargeError";
+  }
+}
+
+export class WorkflowTooLargeError extends Error {
+  readonly code = "workflow_too_large" as const;
+  constructor(worstCaseNodes: number) {
+    super(`compiled recipe worst-case ${worstCaseNodes} exceeds ${V1_MAX_RECIPE_NODES}`);
+    this.name = "WorkflowTooLargeError";
+  }
+}
+
+export interface CompileGateLeakRecipeInput {
+  readonly deployment_count: number;
+  /** T1 uses public-only materialization; full tier reserved for T2 restricted path. */
+  readonly tier?: "public" | "full";
+}
+
+export interface CompiledGateLeakRecipe {
+  readonly certificate: RecipeExpansionCertificate;
+  readonly node_type_catalog: readonly GateLeakNodeType[];
+  readonly public_root_work_key_count: number;
+  readonly root_reference_count: number;
+  readonly worst_case_total_nodes: number;
+}
+
+export function compileGateLeakRecipe(input: CompileGateLeakRecipeInput): CompiledGateLeakRecipe {
+  const deploymentCount = input.deployment_count;
+  if (deploymentCount <= 0) {
+    throw new Error("deployment_count must be positive");
+  }
+  if (deploymentCount > V1_MAX_DEPLOYMENTS) {
+    throw new SelectionTooLargeError(deploymentCount);
+  }
+
+  const root_reference_count = deploymentCount * GATE_LEAK_PUBLIC_NODES_PER_DEPLOYMENT;
+  if (root_reference_count > V1_MAX_ROOT_REFERENCES) {
+    throw new WorkflowTooLargeError(root_reference_count);
+  }
+
+  const worst_case_total_nodes =
+    root_reference_count +
+    GATE_LEAK_RESTRICTED_COMMUNITY_NODES +
+    GATE_LEAK_COMPUTE_NODES +
+    GATE_LEAK_MAX_IDENTITY_LINK_PAGES;
+
+  if (worst_case_total_nodes > V1_MAX_RECIPE_NODES) {
+    throw new WorkflowTooLargeError(worst_case_total_nodes);
+  }
+
+  const public_root_work_key_count = GATE_LEAK_PUBLIC_NODES_PER_DEPLOYMENT;
+  const certificate = buildRecipeExpansionCertificate({
+    compiler_version: GATE_LEAK_COMPILER_VERSION,
+    root_count: root_reference_count,
+    worst_case_total_nodes,
+    capacity_weight: public_root_work_key_count,
+  });
+
+  return {
+    certificate,
+    node_type_catalog: GATE_LEAK_NODE_TYPES,
+    public_root_work_key_count,
+    root_reference_count,
+    worst_case_total_nodes,
+  };
+}

--- a/packages/services/ordering/src/index.ts
+++ b/packages/services/ordering/src/index.ts
@@ -297,3 +297,32 @@ export {
   createAdmissionCapacityService,
   type AdmissionCapacityService,
 } from './admission-capacity-service.js';
+export {
+  createAdmissionCapacityComposition,
+  type AdmissionCapacityComposition,
+} from './admission-capacity-composition.js';
+export {
+  admitCollectionReportOrder,
+  buildPublicRootWorkKeysFromResolution,
+  mapCollectionReportAdmissionError,
+  bindingDigestMatchesRecord,
+  type CollectionReportAdmissionDeps,
+  type AdmitCollectionReportInput,
+  type AdmitCollectionReportResult,
+  type CollectionReportAdmissionDeny,
+  type CollectionReportAdmissionErrorCode,
+} from './collection-report-admission.js';
+export {
+  GATE_LEAK_COMPILER_VERSION,
+  GATE_LEAK_NODE_TYPES,
+  GATE_LEAK_PUBLIC_NODES_PER_DEPLOYMENT,
+  GATE_LEAK_RESTRICTED_COMMUNITY_NODES,
+  GATE_LEAK_COMPUTE_NODES,
+  GATE_LEAK_MAX_IDENTITY_LINK_PAGES,
+  compileGateLeakRecipe,
+  SelectionTooLargeError,
+  WorkflowTooLargeError,
+  type GateLeakNodeType,
+  type CompileGateLeakRecipeInput,
+  type CompiledGateLeakRecipe,
+} from './gate-leak-recipe-compiler.js';

--- a/packages/services/ordering/src/intake.ts
+++ b/packages/services/ordering/src/intake.ts
@@ -134,7 +134,7 @@ export function createIntakeApp(deps: IntakeDeps): Hono {
     if (body.data.product === 'collection-report') {
       // CR-007A/CR-202 denial envelope — schema_version/code/reason (BB #496).
       const deny = (
-        status: 400 | 403 | 409 | 503,
+        status: 400 | 401 | 403 | 409 | 503,
         code: string,
         reason?: string,
       ) =>
@@ -167,6 +167,7 @@ export function createIntakeApp(deps: IntakeDeps): Hono {
           resolutionStore: deps.resolutionStore,
           publicAuth: deps.publicAuth,
           admissionCapacity: deps.admissionCapacity,
+          orderStore: deps.store,
           now: deps.now,
         },
         {

--- a/packages/services/ordering/src/intake.ts
+++ b/packages/services/ordering/src/intake.ts
@@ -20,8 +20,9 @@ import {
 } from './order-ops-webhook.js';
 import type { CollectionResolutionService } from './resolution-service.js';
 import type { ResolutionStore } from './resolution-store.js';
-import { buildLocalCapabilityFromRecord } from './admission-local-capability.js';
 import type { PublicAuthorizationService } from './public-authorization-service.js';
+import type { AdmissionCapacityService } from './admission-capacity-service.js';
+import { admitCollectionReportOrder } from './collection-report-admission.js';
 import { noStoreHeaders, requireServiceBearer } from './public-authorization-http.js';
 
 /**
@@ -59,12 +60,16 @@ export interface IntakeDeps {
   resolutionStore?: ResolutionStore;
   /** CR-007A public authorization recheck for collection-report placement. */
   publicAuth?: PublicAuthorizationService;
+  /** CR-202 atomic admission capacity + recipe compiler for collection-report. */
+  admissionCapacity?: AdmissionCapacityService;
 }
 
 const PlaceOrderBodySchema = z
   .object({
     product: ProductId,
     placed_by: z.string().min(1),
+    /** CR-202 idempotency key — required for collection-report placement. */
+    client_request_id: z.string().min(1).optional(),
     inputs: z.record(z.string(), z.unknown()),
     authorization_scope: z.record(z.string(), z.unknown()).optional(),
   })
@@ -127,7 +132,7 @@ export function createIntakeApp(deps: IntakeDeps): Hono {
     }
 
     if (body.data.product === 'collection-report') {
-      // CR-007A denial envelope — schema_version/code/reason (BB #496).
+      // CR-007A/CR-202 denial envelope — schema_version/code/reason (BB #496).
       const deny = (
         status: 400 | 403 | 409 | 503,
         code: string,
@@ -143,7 +148,7 @@ export function createIntakeApp(deps: IntakeDeps): Hono {
           noStoreHeaders(),
         );
 
-      if (!deps.resolutionService || !deps.resolutionStore) {
+      if (!deps.resolutionService || !deps.resolutionStore || !deps.admissionCapacity) {
         return deny(503, 'collection_report_admission_unavailable');
       }
       if (!deps.publicAuth) {
@@ -152,60 +157,36 @@ export function createIntakeApp(deps: IntakeDeps): Hono {
       if (body.data.authorization_scope === undefined) {
         return deny(400, 'authorization_scope_required');
       }
-      let scope;
-      try {
-        scope = deps.publicAuth.decodeScope(body.data.authorization_scope);
-      } catch {
-        return deny(400, 'invalid_authorization_scope');
+      if (body.data.client_request_id === undefined) {
+        return deny(400, 'client_request_id_required');
       }
-      if (scope.permission !== 'report:create') {
-        return deny(403, 'permission_mismatch', 'order placement requires report:create');
+
+      const admitted = await admitCollectionReportOrder(
+        {
+          resolutionService: deps.resolutionService,
+          resolutionStore: deps.resolutionStore,
+          publicAuth: deps.publicAuth,
+          admissionCapacity: deps.admissionCapacity,
+          now: deps.now,
+        },
+        {
+          placed_by: body.data.placed_by,
+          client_request_id: body.data.client_request_id,
+          binding: inputsParsed.data,
+          authorization_scope: body.data.authorization_scope,
+        },
+      );
+
+      if (admitted.kind === 'deny') {
+        return deny(admitted.deny.status, admitted.deny.code, admitted.deny.reason);
       }
-      if (scope.subject_id !== body.data.placed_by) {
-        return deny(403, 'cross_subject', 'placed_by must match authorization subject');
-      }
-      const binding = inputsParsed.data as {
-        schema_version: 1;
-        resolution_id: string;
-        candidate_snapshot_digest: unknown;
-        community_ref: string;
-      };
-      if (binding.community_ref !== scope.community_ref) {
-        return deny(403, 'scope_tamper', 'community_ref must match authorization scope');
-      }
-      const record = await deps.resolutionStore.get(binding.resolution_id);
-      if (record === undefined) {
-        return deny(409, 'resolution_not_found');
-      }
-      try {
-        deps.publicAuth.acquireLease({
-          operation: { resource: 'report_order', action: 'create' },
-          scope,
-          authoritativeCommunityRef: binding.community_ref,
-          authoritativeSubjectId: body.data.placed_by,
-        });
-      } catch (err) {
-        const mapped = deps.publicAuth.mapDenial(err);
-        return c.json(mapped.body, mapped.status, noStoreHeaders());
-      }
-      const resolutionScope = {
-        schema_version: 1 as const,
-        subject_id: scope.subject_id,
-        community_ref: scope.community_ref,
-        permission: 'report:create' as const,
-      };
-      try {
-        const admitted = await deps.resolutionService.admit(
-          binding,
-          resolutionScope,
-          buildLocalCapabilityFromRecord(record),
-        );
-        if (admitted.decision !== 'admit') {
-          return deny(409, 'order_binding_rejected', admitted.decision);
-        }
-      } catch {
-        return deny(409, 'order_binding_rejected');
-      }
+
+      deps.onPlaced?.(admitted.order_id);
+      return c.json(
+        { order_id: admitted.order_id, replay: admitted.replay },
+        200,
+        noStoreHeaders(),
+      );
     }
 
     const order_id = randomUUID();


### PR DESCRIPTION
## Summary

- Add **collection-report admission path** (`admitCollectionReportOrder`) wiring resolution revalidation, gate-leak recipe compilation (worst-case ≤160 nodes), and CR-201C `admitOrder` in one intake flow.
- Extend intake envelope schema with **`client_request_id`**; idempotent replay returns the same order; reuse with different body returns **`idempotency_conflict`** before digest validation.
- Add deterministic **gate-leak recipe compiler** + composition helper; wire admission capacity in `bin/http.ts`.

## Test plan

- [x] `pnpm test src/__tests__/collection-report-intake.test.ts` — 5 pass (idempotency, conflict, digest mismatch, resolution expired, client_request_id required)
- [x] `pnpm test src/__tests__/gate-leak-recipe-compiler.test.ts` — 5 pass (catalog, ≤160 bound, overflow rejection, determinism)
- [ ] CI green on ordering-service package

## Gaps / follow-ups

- User-visible state mapping lives in existing `collection-report-projection.ts` (CR-206); no new projection tests in this PR.
- `invalid_recipe_expansion` quarantine path and upstream evidence DAG expansion are orchestrator/runtime concerns — not covered here.
- Public-preparation adapter/worker (CR-204A) intentionally excluded from this branch.


Made with [Cursor](https://cursor.com)