### PR TITLE
feat(ordering): CR-204A public Ordering-to-Sonar preparation adapter

### DIFF
--- a/packages/services/ordering/src/__tests__/public-preparation-adapter.test.ts
+++ b/packages/services/ordering/src/__tests__/public-preparation-adapter.test.ts
@@ -1,0 +1,430 @@
+import { describe, expect, it, vi } from "vitest";
+import { ORDER_LIFECYCLE_SUBJECTS } from "@freeside/ordering-protocol";
+
+import { InMemoryAdmissionCapacityStore } from "../admission-capacity-store.js";
+import {
+  COLLECTION_PREP_POOL_CAPABILITY,
+  REPORT_GENERATION_POOL_CAPABILITY,
+} from "../public-preparation-constants.js";
+import { sonarCommandInboxKey } from "../public-preparation-dispatch-key.js";
+import { InMemoryPublicPrepDispatchStore } from "../public-preparation-dispatch-store.js";
+import { PublicPreparationAdapter } from "../public-preparation-adapter.js";
+import { FixturePublicPreparationSonarPort } from "../public-preparation-sonar-port.js";
+import { PublicPreparationWorker } from "../public-preparation-worker.js";
+import { fixtureGateLeakCertificate } from "../recipe-expansion-certificate.js";
+import { InMemorySharedPreparationStore } from "../shared-preparation-store.js";
+import { buildPublicWorkKeyMaterial } from "../shared-preparation-work-key.js";
+import { InMemoryOrderStore } from "../store.js";
+import { CollectionReportOrchestrator } from "../collection-report-orchestrator.js";
+import type { VersionedDigest } from "../shared-preparation-types.js";
+import {
+  fixtureCommunityScopeDigest,
+  fixturePublicWorkKey,
+  loadEvmFixtureCandidate,
+} from "./shared-preparation-fixtures.js";
+
+function validCollectionReportInputs() {
+  return {
+    schema_version: 1 as const,
+    resolution_id: "res-fixture",
+    candidate_snapshot_digest: {
+      algorithm: "sha-256" as const,
+      domain: "collection-resolution.candidate-snapshot",
+      major_version: 1,
+      digest: "ab".repeat(32),
+    },
+    community_ref: "community-alpha",
+  };
+}
+
+function fixtureSecondDeployment(): VersionedDigest {
+  return {
+    algorithm: "sha-256",
+    domain: "collection.deployment",
+    major_version: 1,
+    digest: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  };
+}
+
+function multiDeploymentIds(deployments: readonly VersionedDigest[]): VersionedDigest[] {
+  if (deployments.length >= 2) return [...deployments.slice(0, 2)];
+  return [deployments[0]!, fixtureSecondDeployment()];
+}
+
+async function completePrepWork(
+  h: ReturnType<typeof makeHarness>,
+  workId: string,
+  advanceMs: (delta: number) => void,
+): Promise<void> {
+  await h.adapter.processWork(workId);
+  for (const item of await h.preparationStore.listWorkItems(workId)) {
+    const ref = item.external_job_ref;
+    if (ref) h.sonar.markIndexed(ref);
+  }
+  advanceMs(31_000);
+  await h.adapter.processWork(workId);
+}
+
+function makeHarness(nowMs?: number | (() => number)) {
+  const clock = { value: typeof nowMs === "number" ? nowMs : Date.now() };
+  const tick = typeof nowMs === "function" ? nowMs : () => clock.value;
+  const orderStore = new InMemoryOrderStore({ now: () => Math.floor(tick() / 1000) });
+  const preparationStore = new InMemorySharedPreparationStore();
+  const dispatchStore = new InMemoryPublicPrepDispatchStore();
+  const sonar = new FixturePublicPreparationSonarPort();
+  const capacity = new InMemoryAdmissionCapacityStore({ orderStore, preparationStore });
+  const adapter = new PublicPreparationAdapter({
+    preparationStore,
+    dispatchStore,
+    sonar,
+    orderStore,
+    capacityStore: capacity,
+    now: tick,
+    workerId: "test-worker",
+  });
+  return { orderStore, preparationStore, dispatchStore, sonar, capacity, adapter, nowMs: tick, clock };
+}
+
+async function admitOrder(
+  h: ReturnType<typeof makeHarness>,
+  input: {
+    order_id?: string;
+    client_request_id: string;
+    now_ms: number;
+    work_key?: ReturnType<typeof fixturePublicWorkKey>;
+    drive_producing?: boolean;
+  },
+) {
+  const work_key = input.work_key ?? fixturePublicWorkKey();
+  const inputs = validCollectionReportInputs();
+  const result = await h.capacity.admitOrder({
+    requester_subject: "subject-alice",
+    client_request_id: input.client_request_id,
+    order: {
+      order_id: input.order_id,
+      product: "collection-report",
+      placed_by: "subject-alice",
+      inputs,
+      placed_at_unix: Math.floor(input.now_ms / 1000),
+      inputs_digest: "digest",
+    },
+    body: inputs,
+    certificate: fixtureGateLeakCertificate(work_key.deployment_ids.length * 2),
+    work_key,
+    order_tenant_scope_digest: fixtureCommunityScopeDigest("community-alpha"),
+    pool_scope: { network_ref: "eip155:1", capability: "ownership_index.v1" },
+    now_ms: input.now_ms,
+  });
+  if (result.kind === "admitted" && input.drive_producing !== false) {
+    await h.orderStore.transition(result.order.order_id, "placed", "routing", {});
+    await h.orderStore.transition(result.order.order_id, "routing", "producing", {});
+  }
+  return result;
+}
+
+/** Advance past worker lease so a subsequent processWork can reclaim. */
+function expireLease(now: { value: number }): void {
+  now.value += 31_000;
+}
+
+describe("CR-204A public preparation adapter", () => {
+  it("creates/joins work at admission before Sonar dispatch", async () => {
+    const h = makeHarness();
+    const now = h.clock;
+    now.value = 1_000;
+    const admitted = await admitOrder(h, { client_request_id: "req-a", now_ms: now.value });
+    expect(admitted.kind).toBe("admitted");
+    if (admitted.kind !== "admitted") return;
+    expect(admitted.work_created).toBe(true);
+    expect(h.sonar.dispatchCalls).toHaveLength(0);
+
+    now.value = 2_000;
+    await h.adapter.processWork(admitted.work_id);
+    expect(h.sonar.dispatchCalls.length).toBeGreaterThan(0);
+  });
+
+  it("does not duplicate physical ingest on redelivered worker invocation", async () => {
+    let now = 1_000;
+    const h = makeHarness(() => now);
+    const admitted = await admitOrder(h, { client_request_id: "dup", now_ms: now });
+    if (admitted.kind !== "admitted") throw new Error("admit failed");
+
+    now = 2_000;
+    await h.adapter.processWork(admitted.work_id);
+    const firstCalls = h.sonar.dispatchCalls.length;
+    const firstKeys = new Set(h.sonar.dispatchCalls.map((c) => c.command_inbox_key));
+
+    expireLease({ value: now });
+    await h.adapter.processWork(admitted.work_id);
+    expect(h.sonar.dispatchCalls.length).toBe(firstCalls);
+    expect(new Set(h.sonar.dispatchCalls.map((c) => c.command_inbox_key))).toEqual(firstKeys);
+  });
+
+  it("returns the same child job on Sonar replay of inbox key", async () => {
+    let now = 1_000;
+    const h = makeHarness(() => now);
+    const admitted = await admitOrder(h, { client_request_id: "replay", now_ms: now });
+    if (admitted.kind !== "admitted") throw new Error("admit failed");
+    const work = await h.preparationStore.getWork(admitted.work_id);
+    const items = await h.preparationStore.listWorkItems(admitted.work_id);
+    const item = items[0]!;
+    const inboxKey = sonarCommandInboxKey({
+      generation: work!.generation,
+      deployment_id: item.deployment_id,
+      capability: item.capability,
+      adapter_version: item.adapter_version,
+    });
+
+    const first = await h.sonar.dispatchChildJob({
+      command_inbox_key: inboxKey,
+      deployment_id: item.deployment_id,
+      capability: item.capability,
+      adapter_version: item.adapter_version,
+      generation: work!.generation,
+      lease_epoch: 1,
+    });
+    const second = await h.sonar.dispatchChildJob({
+      command_inbox_key: inboxKey,
+      deployment_id: item.deployment_id,
+      capability: item.capability,
+      adapter_version: item.adapter_version,
+      generation: work!.generation,
+      lease_epoch: 2,
+    });
+    expect(first.external_job_ref).toBe(second.external_job_ref);
+  });
+
+  it("repairs lost dispatch via reconciliation", async () => {
+    let now = 1_000;
+    const h = makeHarness(() => now);
+    const admitted = await admitOrder(h, { client_request_id: "lost", now_ms: now });
+    if (admitted.kind !== "admitted") throw new Error("admit failed");
+    const items = await h.preparationStore.listWorkItems(admitted.work_id);
+    const work = (await h.preparationStore.getWork(admitted.work_id))!;
+    const item = items[0]!;
+    const inboxKey = sonarCommandInboxKey({
+      generation: work.generation,
+      deployment_id: item.deployment_id,
+      capability: item.capability,
+      adapter_version: item.adapter_version,
+    });
+    await h.dispatchStore.recordIntent({
+      command_inbox_key: inboxKey,
+      work_item_id: item.work_item_id,
+      work_id: work.work_id,
+      lease_epoch: 0,
+      now_ms: now,
+    });
+
+    now = 10_000;
+    await h.adapter.reconcileLostDispatches(now);
+    const refreshed = (await h.preparationStore.listWorkItems(admitted.work_id))[0]!;
+    expect(refreshed.external_job_ref).toBeDefined();
+  });
+
+  it("keeps orders durable and retryable through Sonar outage", async () => {
+    let now = 1_000;
+    const h = makeHarness(() => now);
+    const admitted = await admitOrder(h, { client_request_id: "outage", now_ms: now });
+    if (admitted.kind !== "admitted") throw new Error("admit failed");
+
+    h.sonar.setOutage(true);
+    now = 2_000;
+    const result = await h.adapter.processWork(admitted.work_id);
+    expect(result.kind).toBe("retry_scheduled");
+
+    const order = await h.orderStore.get(admitted.order.order_id);
+    expect(order?.state).toBe("producing");
+    const work = await h.preparationStore.getWork(admitted.work_id);
+    expect(work?.state).toBe("retry_wait");
+  });
+
+  it("wakes retry_wait and resumes after scheduled time", async () => {
+    let now = 1_000;
+    const h = makeHarness(() => now);
+    const admitted = await admitOrder(h, { client_request_id: "wake", now_ms: now });
+    if (admitted.kind !== "admitted") throw new Error("admit failed");
+
+    h.sonar.setOutage(true);
+    now = 2_000;
+    await h.adapter.processWork(admitted.work_id);
+    const failed = await h.preparationStore.getWork(admitted.work_id);
+    expect(failed?.state).toBe("retry_wait");
+
+    h.sonar.setOutage(false);
+    now = failed!.next_attempt_at_unix_ms! + 1;
+    await h.adapter.tick();
+    const woke = await h.preparationStore.getWork(admitted.work_id);
+    expect(woke?.state).not.toBe("retry_wait");
+  });
+
+  it("reclaims expired lease once under contested reclaim", async () => {
+    let now = 1_000;
+    const h = makeHarness(() => now);
+    const admitted = await admitOrder(h, { client_request_id: "lease", now_ms: now });
+    if (admitted.kind !== "admitted") throw new Error("admit failed");
+
+    now = 2_000;
+    await h.preparationStore.acquireLease({
+      work_id: admitted.work_id,
+      worker_id: "worker-a",
+      lease_duration_ms: 1_000,
+      now_ms: now,
+    });
+
+    now = 10_000;
+    const results = await Promise.all(
+      Array.from({ length: 20 }, (_, i) =>
+        h.preparationStore.acquireLease({
+          work_id: admitted.work_id,
+          worker_id: `worker-${i}`,
+          lease_duration_ms: 30_000,
+          now_ms: now,
+        }),
+      ),
+    );
+    const winners = results.filter((r) => r.kind === "reclaimed" || r.kind === "acquired");
+    expect(winners).toHaveLength(1);
+  });
+
+  it("requires every reject-policy child before parent ready (staged expansion)", async () => {
+    let now = 1_000;
+    const h = makeHarness(() => now);
+    const candidate = loadEvmFixtureCandidate();
+    const deployments = candidate.identity.deployments.map((d) => d.deployment_id);
+    const workKey = buildPublicWorkKeyMaterial({
+      capability: "ownership_index.v1",
+      capability_version: "v1",
+      collection_id: candidate.identity.collection_id,
+      deployment_ids: multiDeploymentIds(deployments),
+      finality_policies: candidate.finality_policies,
+      source_identity: {
+        schema_version: 1,
+        producer: "sonar-api.fixture",
+        upstream_evidence_source: "sonar.public-capability.v1",
+      },
+      readiness_policy_version: "gate-leak-public-prep.v1",
+      adapter_version: "sonar-kitchen.v1",
+    });
+    const admitted = await admitOrder(h, {
+      client_request_id: "multi",
+      now_ms: now,
+      work_key: workKey,
+    });
+    if (admitted.kind !== "admitted") throw new Error("admit failed");
+
+    now = 2_000;
+    await h.adapter.processWork(admitted.work_id);
+    const items = await h.preparationStore.listWorkItems(admitted.work_id);
+    expect(items.length).toBe(2);
+    for (const item of await h.preparationStore.listWorkItems(admitted.work_id)) {
+      if (item.external_job_ref) h.sonar.markIndexed(item.external_job_ref);
+    }
+
+    now += 31_000;
+    const result = await h.adapter.processWork(admitted.work_id);
+    expect(result.kind).toBe("advanced");
+    const work = await h.preparationStore.getWork(admitted.work_id);
+    expect(work?.state).toBe("ready");
+  });
+
+  it("advances every linked eligible order when work becomes ready", async () => {
+    let now = 1_000;
+    const h = makeHarness(() => now);
+    const workKey = fixturePublicWorkKey();
+    const a = await admitOrder(h, { client_request_id: "fan-a", now_ms: now, work_key: workKey });
+    now = 1_100;
+    const b = await admitOrder(h, { client_request_id: "fan-b", now_ms: now, work_key: workKey });
+    if (a.kind !== "admitted" || b.kind !== "admitted") throw new Error("admit failed");
+    expect(a.work_id).toBe(b.work_id);
+
+    now += 31_000;
+    await completePrepWork(h, a.work_id, (delta) => {
+      now += delta;
+    });
+
+    const orderA = await h.orderStore.get(a.order.order_id);
+    const orderB = await h.orderStore.get(b.order.order_id);
+    expect(orderA?.ingredient_jobs?.length).toBeGreaterThan(0);
+    expect(orderB?.ingredient_jobs?.length).toBeGreaterThan(0);
+    expect(orderA?.state).toBe("producing");
+    expect(orderB?.state).toBe("producing");
+  });
+
+  it("projects one terminal Needs attention outcome to all subscribers", async () => {
+    let now = 1_000;
+    const h = makeHarness(() => now);
+    const workKey = fixturePublicWorkKey();
+    const a = await admitOrder(h, { client_request_id: "fail-a", now_ms: now, work_key: workKey });
+    now = 1_100;
+    const b = await admitOrder(h, { client_request_id: "fail-b", now_ms: now, work_key: workKey });
+    if (a.kind !== "admitted" || b.kind !== "admitted") throw new Error("admit failed");
+
+    now = 2_000;
+    const lease = await h.preparationStore.acquireLease({
+      work_id: a.work_id,
+      worker_id: "w",
+      lease_duration_ms: 30_000,
+      now_ms: now,
+    });
+    if (lease.kind !== "acquired") throw new Error("lease failed");
+    await h.preparationStore.transitionToPreparing({
+      work_id: a.work_id,
+      expected_lease_epoch: lease.work.lease_epoch,
+      now_ms: now,
+    });
+    await h.preparationStore.recordTerminalFailure({
+      work_id: a.work_id,
+      expected_lease_epoch: lease.work.lease_epoch,
+      failure: { code: "preparation_failed", reason: "fixture terminal" },
+      now_ms: now + 1,
+    });
+    await h.adapter.processWork(a.work_id);
+
+    const orderA = await h.orderStore.get(a.order.order_id);
+    const orderB = await h.orderStore.get(b.order.order_id);
+    expect(orderA?.state).toBe("failed");
+    expect(orderB?.state).toBe("failed");
+    expect(orderA?.refusal?.code).toBe("preparation_failed");
+    expect(orderB?.refusal?.code).toBe("preparation_failed");
+  });
+
+  it("resumes after worker restart from durable state", async () => {
+    let now = 1_000;
+    const h = makeHarness(() => now);
+    const admitted = await admitOrder(h, { client_request_id: "restart", now_ms: now });
+    if (admitted.kind !== "admitted") throw new Error("admit failed");
+
+    await completePrepWork(h, admitted.work_id, (delta) => {
+      now += delta;
+    });
+
+    const work = await h.preparationStore.getWork(admitted.work_id);
+    expect(work?.state).toBe("ready");
+  });
+
+  it("uses separate collection_prep and report_generation pool capability constants", () => {
+    expect(COLLECTION_PREP_POOL_CAPABILITY).toBe("collection_prep");
+    expect(REPORT_GENERATION_POOL_CAPABILITY).toBe("report_generation");
+    expect(COLLECTION_PREP_POOL_CAPABILITY).not.toBe(REPORT_GENERATION_POOL_CAPABILITY);
+  });
+
+  it("collection-report orchestrator invokes adapter for linked producing orders", async () => {
+    let now = 1_000;
+    const h = makeHarness(() => now);
+    const admitted = await admitOrder(h, { client_request_id: "orch", now_ms: now });
+    if (admitted.kind !== "admitted") throw new Error("admit failed");
+
+    const processSpy = vi.spyOn(h.adapter, "processWork");
+    const orch = new CollectionReportOrchestrator({
+      store: h.orderStore,
+      resolver: { resolve: async () => ({ capability: "x", building: "b", endpoint: "e", source: "s" }) },
+      now: () => now,
+      preparationStore: h.preparationStore,
+      publicPrepAdapter: h.adapter,
+    });
+    const record = await h.orderStore.get(admitted.order.order_id);
+    await orch.process(admitted.order.order_id, record!);
+    expect(processSpy).toHaveBeenCalledWith(admitted.work_id);
+  });
+});

--- a/packages/services/ordering/src/__tests__/public-preparation-adapter.test.ts
+++ b/packages/services/ordering/src/__tests__/public-preparation-adapter.test.ts
@@ -122,11 +122,6 @@ async function admitOrder(
   return result;
 }
 
-/** Advance past worker lease so a subsequent processWork can reclaim. */
-function expireLease(now: { value: number }): void {
-  now.value += 31_000;
-}
-
 describe("CR-204A public preparation adapter", () => {
   it("creates/joins work at admission before Sonar dispatch", async () => {
     const h = makeHarness();
@@ -154,8 +149,10 @@ describe("CR-204A public preparation adapter", () => {
     const firstCalls = h.sonar.dispatchCalls.length;
     const firstKeys = new Set(h.sonar.dispatchCalls.map((c) => c.command_inbox_key));
 
-    expireLease({ value: now });
-    await h.adapter.processWork(admitted.work_id);
+    // Advance the live harness clock past PUBLIC_PREP_WORKER_LEASE_MS so reclaim runs.
+    now += 31_000;
+    const redelivered = await h.adapter.processWork(admitted.work_id);
+    expect(redelivered.kind).not.toBe("busy");
     expect(h.sonar.dispatchCalls.length).toBe(firstCalls);
     expect(new Set(h.sonar.dispatchCalls.map((c) => c.command_inbox_key))).toEqual(firstKeys);
   });
@@ -322,10 +319,25 @@ describe("CR-204A public preparation adapter", () => {
     }
 
     now += 31_000;
+    await h.capacity.reconcileExpiredActiveLeases({ now_ms: now });
+    const activeBefore = (await h.capacity.snapshotAccounting()).active_execution.consumed;
     const result = await h.adapter.processWork(admitted.work_id);
     expect(result.kind).toBe("advanced");
     const work = await h.preparationStore.getWork(admitted.work_id);
     expect(work?.state).toBe("ready");
+
+    const order = await h.orderStore.get(admitted.order.order_id);
+    const keys = (order?.ingredient_jobs ?? []).map((j) => j.idempotency_key);
+    expect(keys).toHaveLength(2);
+    expect(new Set(keys).size).toBe(2);
+    for (const key of keys) {
+      expect(key).toContain(admitted.order.order_id);
+      expect(key).toContain("sonar");
+    }
+
+    // Ready path must release the active execution lease acquired on this tick.
+    const activeAfter = (await h.capacity.snapshotAccounting()).active_execution.consumed;
+    expect(activeAfter).toBe(activeBefore);
   });
 
   it("advances every linked eligible order when work becomes ready", async () => {

--- a/packages/services/ordering/src/collection-report-orchestrator.ts
+++ b/packages/services/ordering/src/collection-report-orchestrator.ts
@@ -25,12 +25,17 @@ import {
 } from "./resolver.js";
 import type { PrivateOpsPublisher } from "./private-ops.js";
 import type { ProcessResult } from "./orchestrator.js";
+import type { PublicPreparationAdapter } from "./public-preparation-adapter.js";
+import type { SharedPreparationStore } from "./shared-preparation-store.js";
 
 export interface CollectionReportOrchestratorDeps {
   store: OrderStore;
   resolver: CapabilityResolver;
   now: () => number;
   opsChannel?: PrivateOpsPublisher;
+  /** CR-204A — drive linked shared preparation work while producing. */
+  preparationStore?: SharedPreparationStore;
+  publicPrepAdapter?: PublicPreparationAdapter;
 }
 
 export class CollectionReportOrchestrator {
@@ -104,9 +109,13 @@ export class CollectionReportOrchestrator {
       if (isTerminal(record.state)) return { success: true };
     }
 
-    // Hold in producing — Gate Leak artifact producer is not mounted yet.
-    // Honest UI maps this to "Preparing collection data" (not Needs attention).
     if (record.state === "producing") {
+      if (this.deps.preparationStore && this.deps.publicPrepAdapter) {
+        const linked = await this.deps.preparationStore.getActiveWorkForOrder(orderId);
+        if (linked) {
+          await this.deps.publicPrepAdapter.processWork(linked.work.work_id);
+        }
+      }
       return { success: true };
     }
 

--- a/packages/services/ordering/src/index.ts
+++ b/packages/services/ordering/src/index.ts
@@ -264,6 +264,36 @@ export {
 } from './shared-preparation-service.js';
 
 export {
+  COLLECTION_PREP_POOL_CAPABILITY,
+  REPORT_GENERATION_POOL_CAPABILITY,
+  PUBLIC_PREP_WORKER_LEASE_MS,
+  publicPrepWorkerEnabled,
+  publicPrepWorkerIntervalMs,
+} from './public-preparation-constants.js';
+export { sonarCommandInboxKey, sonarPhysicalJobRef } from './public-preparation-dispatch-key.js';
+export {
+  InMemoryPublicPrepDispatchStore,
+  type PublicPrepDispatchStore,
+  type PrepDispatchRecord,
+} from './public-preparation-dispatch-store.js';
+export {
+  FixturePublicPreparationSonarPort,
+  type PublicPreparationSonarPort,
+  type SonarPrepDispatchRequest,
+  type SonarPrepDispatchResult,
+} from './public-preparation-sonar-port.js';
+export {
+  PublicPreparationAdapter,
+  type PublicPreparationAdapterDeps,
+  type PublicPrepProcessResult,
+} from './public-preparation-adapter.js';
+export { PublicPreparationWorker } from './public-preparation-worker.js';
+export {
+  aggregateReadinessEvidence,
+  buildReadinessEvidenceFromDeployments,
+} from './public-preparation-evidence.js';
+
+export {
   CAPACITY_LEDGER_KINDS,
   CAPACITY_RESERVATION_STATES,
   CapacityUnavailableError,

--- a/packages/services/ordering/src/orchestrator.ts
+++ b/packages/services/ordering/src/orchestrator.ts
@@ -10,6 +10,8 @@ import { CollectionReportOrchestrator } from './collection-report-orchestrator.j
 import type { TriagePorts } from './triage-ports.js';
 import { StubTriagePorts } from './triage-ports.js';
 import type { IngredientEnqueueService } from './ingredient-enqueue.js';
+import type { PublicPreparationAdapter } from './public-preparation-adapter.js';
+import type { SharedPreparationStore } from './shared-preparation-store.js';
 
 /**
  * The thin orchestrator (SDD §6) — dispatches by product to preset-specific handlers.
@@ -42,6 +44,9 @@ export interface OrchestratorDeps {
    *  EVERY CommunityOnboardingOrchestrator instance, intake included, or the choke
    *  point has teeth only on the worker path. */
   discordHealth?: CommunityOnboardingOrchestratorDeps['discordHealth'];
+  /** CR-204A public preparation substrate. */
+  preparationStore?: SharedPreparationStore;
+  publicPrepAdapter?: PublicPreparationAdapter;
 }
 
 export class OrderOrchestrator {
@@ -68,7 +73,11 @@ export class OrderOrchestrator {
       enqueue: deps.enqueue,
       discordHealth: deps.discordHealth,
     });
-    this.collectionReport = new CollectionReportOrchestrator(shared);
+    this.collectionReport = new CollectionReportOrchestrator({
+      ...shared,
+      preparationStore: deps.preparationStore,
+      publicPrepAdapter: deps.publicPrepAdapter,
+    });
   }
 
   async process(orderId: string): Promise<ProcessResult> {

--- a/packages/services/ordering/src/public-preparation-adapter.ts
+++ b/packages/services/ordering/src/public-preparation-adapter.ts
@@ -1,0 +1,434 @@
+/**
+ * CR-204A — Public Ordering-to-Sonar preparation adapter.
+ *
+ * Worker leases shared preparation work, dispatches idempotent Sonar child jobs,
+ * reconciles lost responses, aggregates evidence, and fans outcomes to subscribers.
+ * T1 public-chain fixtures only — no restricted Discord/identity paths.
+ */
+
+import { ORDER_LIFECYCLE_SUBJECTS, type OrderFailed } from "@freeside/ordering-protocol";
+import type { IngredientJob } from "./kitchen-types.js";
+import { ingredientJobIdempotencyKey } from "./kitchen-types.js";
+import type { AdmissionCapacityStore } from "./admission-capacity-store.js";
+import { COLLECTION_PREP_POOL_CAPABILITY } from "./public-preparation-constants.js";
+import {
+  PUBLIC_PREP_MAX_ATTEMPTS,
+  PUBLIC_PREP_RETRY_DEADLINE_MS,
+  PUBLIC_PREP_WORKER_LEASE_MS,
+  publicPrepRetryAtMs,
+} from "./public-preparation-constants.js";
+import { sonarCommandInboxKey } from "./public-preparation-dispatch-key.js";
+import type { PublicPrepDispatchStore } from "./public-preparation-dispatch-store.js";
+import type { PublicPreparationSonarPort } from "./public-preparation-sonar-port.js";
+import {
+  SharedPreparationFencingError,
+  type SharedPreparationStore,
+} from "./shared-preparation-store.js";
+import type {
+  PreparationWorkItemRecord,
+  ReadinessEvidenceEnvelope,
+  SharedPreparationWorkRecord,
+} from "./shared-preparation-types.js";
+import { aggregateReadinessEvidence } from "./public-preparation-evidence.js";
+import type { OrderPatch, OrderStore } from "./store.js";
+import type { PrivateOpsPublisher } from "./private-ops.js";
+
+export interface PublicPreparationAdapterDeps {
+  readonly preparationStore: SharedPreparationStore;
+  readonly dispatchStore: PublicPrepDispatchStore;
+  readonly sonar: PublicPreparationSonarPort;
+  readonly orderStore: OrderStore;
+  readonly capacityStore?: AdmissionCapacityStore;
+  readonly opsChannel?: PrivateOpsPublisher;
+  readonly now: () => number;
+  readonly workerId?: string;
+  /** Test hook — when set, builds evidence from deployment ids instead of fixture helper. */
+  readonly buildEvidence?: (
+    work: SharedPreparationWorkRecord,
+    items: readonly PreparationWorkItemRecord[],
+  ) => ReadinessEvidenceEnvelope;
+}
+
+export type PublicPrepProcessResult =
+  | { readonly kind: "idle" }
+  | { readonly kind: "busy" }
+  | { readonly kind: "advanced"; readonly work_id: string }
+  | { readonly kind: "retry_scheduled"; readonly work_id: string }
+  | { readonly kind: "terminal"; readonly work_id: string; readonly code: string };
+
+function prepIngredientJobs(
+  orderId: string,
+  work: SharedPreparationWorkRecord,
+  items: readonly PreparationWorkItemRecord[],
+): IngredientJob[] {
+  return items.map((item) => ({
+    ingredient: "sonar" as const,
+    kind: "http_enqueue" as const,
+    external_ref: item.external_job_ref ?? item.work_item_id,
+    idempotency_key: ingredientJobIdempotencyKey(orderId, "sonar"),
+    enqueued_at_unix: Math.floor(work.updated_at_unix_ms / 1000),
+  }));
+}
+
+function prepFulfillmentPatch(
+  workId: string,
+  phase: string,
+  extra?: Record<string, unknown>,
+): OrderPatch {
+  return {
+    fulfillment: {
+      world_slug: workId,
+      contact_email: "prep@fixture.local",
+      chain_id: "fixture",
+      contract_address: workId,
+      ...extra,
+      phase,
+    } as OrderPatch["fulfillment"],
+  };
+}
+
+export class PublicPreparationAdapter {
+  constructor(private readonly deps: PublicPreparationAdapterDeps) {}
+
+  async tick(): Promise<void> {
+    const now = this.deps.now();
+    for (const work of await this.deps.preparationStore.listRetryWaitDue({ now_ms: now })) {
+      await this.deps.preparationStore.wakeRetryWait({
+        work_id: work.work_id,
+        expected_attempt: work.attempt,
+        now_ms: now,
+      });
+    }
+    await this.reconcileLostDispatches(now);
+    for (const work of await this.deps.preparationStore.listLeasableWork()) {
+      try {
+        await this.processWork(work.work_id);
+      } catch (err) {
+        if (err instanceof SharedPreparationFencingError) continue;
+        throw err;
+      }
+    }
+  }
+
+  async processWork(workId: string): Promise<PublicPrepProcessResult> {
+    const now = this.deps.now();
+    const workBefore = await this.deps.preparationStore.getWork(workId);
+    if (!workBefore) return { kind: "idle" };
+
+    if (workBefore.state === "ready") {
+      await this.advanceLinkedOrders(workBefore);
+      return { kind: "advanced", work_id: workId };
+    }
+    if (workBefore.state === "failed") {
+      await this.failLinkedOrders(workBefore);
+      return { kind: "terminal", work_id: workId, code: workBefore.failure_reason?.code ?? "preparation_failed" };
+    }
+
+    const lease = await this.deps.preparationStore.acquireLease({
+      work_id: workId,
+      worker_id: this.deps.workerId ?? "public-prep-worker",
+      lease_duration_ms: PUBLIC_PREP_WORKER_LEASE_MS,
+      now_ms: now,
+    });
+    if (lease.kind === "busy" || lease.kind === "not_active") {
+      return { kind: lease.kind === "busy" ? "busy" : "idle" };
+    }
+
+    let work = lease.work;
+    if (work.state === "queued") {
+      work = await this.deps.preparationStore.transitionToPreparing({
+        work_id: workId,
+        expected_lease_epoch: work.lease_epoch,
+        now_ms: now,
+      });
+    }
+
+    if (this.deps.capacityStore) {
+      const links = await this.deps.preparationStore.listActiveLinks(workId);
+      const firstOrder = links[0]?.order_id;
+      if (firstOrder) {
+        await this.deps.capacityStore.acquireActiveExecutionLease({
+          order_id: firstOrder,
+          pool_scope: {
+            network_ref: work.finality_policy_version.split(":")[0] ?? "public",
+            capability: COLLECTION_PREP_POOL_CAPABILITY,
+          },
+          now_ms: now,
+        });
+      }
+    }
+
+    const items = await this.deps.preparationStore.listWorkItems(workId);
+    for (const item of items) {
+      if (item.state === "ready") continue;
+      const dispatched = await this.dispatchChildIfNeeded(work, item);
+      if (!dispatched.ok && dispatched.retryable) {
+        return this.scheduleRetry(work, {
+          code: dispatched.error_code ?? "dependency_unavailable",
+          reason: "Sonar dispatch or probe unavailable",
+        });
+      }
+      if (!dispatched.ok && !dispatched.retryable) {
+        return this.terminalFailure(work, {
+          code: dispatched.error_code ?? "preparation_failed",
+          reason: "Sonar rejected preparation dispatch",
+        });
+      }
+      const current = await this.deps.preparationStore.listWorkItems(workId);
+      const refreshed = current.find((row) => row.work_item_id === item.work_item_id);
+      if (!refreshed?.external_job_ref) continue;
+      const probed = await this.deps.sonar.probeChildJob(refreshed.external_job_ref);
+      if (probed.status === "indexed") {
+        const evidence =
+          this.deps.buildEvidence?.(work, items) ??
+          aggregateReadinessEvidence(work, [item.deployment_id]);
+        await this.deps.preparationStore.publishChildEvidence({
+          work_item_id: item.work_item_id,
+          expected_lease_epoch: work.lease_epoch,
+          evidence,
+          now_ms: this.deps.now(),
+        });
+      } else if (probed.status === "failed" && !probed.retryable) {
+        return this.terminalFailure(work, {
+          code: probed.error_code ?? "preparation_failed",
+          reason: "Sonar child job failed terminally",
+        });
+      } else if (probed.status === "failed" && probed.retryable) {
+        return this.scheduleRetry(work, {
+          code: probed.error_code ?? "dependency_unavailable",
+          reason: "Sonar child job retryable failure",
+        });
+      }
+    }
+
+    const afterItems = await this.deps.preparationStore.listWorkItems(workId);
+    const allReady = afterItems.length > 0 && afterItems.every((item) => item.state === "ready");
+    if (!allReady) {
+      await this.syncOrderPrepProjection(workId, work, afterItems);
+      return { kind: "idle" };
+    }
+
+    const aggregateEvidence =
+      this.deps.buildEvidence?.(work, afterItems) ??
+      aggregateReadinessEvidence(
+        work,
+        afterItems.map((item) => item.deployment_id),
+      );
+    const finalized = await this.deps.preparationStore.finalizeReadyIfQualified({
+      work_id: workId,
+      expected_lease_epoch: work.lease_epoch,
+      readiness_evidence: aggregateEvidence,
+      now_ms: this.deps.now(),
+    });
+    if (finalized.kind === "ready") {
+      await this.advanceLinkedOrders(finalized.work);
+      return { kind: "advanced", work_id: workId };
+    }
+    await this.syncOrderPrepProjection(workId, work, afterItems);
+    return { kind: "idle" };
+  }
+
+  async reconcileLostDispatches(nowMs: number): Promise<void> {
+    const pending = await this.deps.dispatchStore.listPendingReconciliation(nowMs);
+    for (const row of pending) {
+      const existing = await this.deps.dispatchStore.get(row.command_inbox_key);
+      if (!existing) continue;
+      const work = await this.deps.preparationStore.getWork(row.work_id);
+      if (!work) continue;
+      const items = await this.deps.preparationStore.listWorkItems(row.work_id);
+      const item = items.find((i) => i.work_item_id === row.work_item_id);
+      if (!item || item.external_job_ref) continue;
+      const replay = await this.deps.sonar.dispatchChildJob({
+        command_inbox_key: row.command_inbox_key,
+        deployment_id: item.deployment_id,
+        capability: item.capability,
+        adapter_version: item.adapter_version,
+        generation: work.generation,
+        lease_epoch: work.lease_epoch,
+      });
+      if (replay.ok && replay.external_job_ref) {
+        await this.deps.dispatchStore.recordAck({
+          command_inbox_key: row.command_inbox_key,
+          external_job_ref: replay.external_job_ref,
+          now_ms: nowMs,
+        });
+        await this.deps.preparationStore.recordChildJobRef({
+          work_item_id: item.work_item_id,
+          expected_lease_epoch: work.lease_epoch,
+          external_job_ref: replay.external_job_ref,
+          now_ms: nowMs,
+        });
+      }
+    }
+  }
+
+  private async dispatchChildIfNeeded(
+    work: SharedPreparationWorkRecord,
+    item: PreparationWorkItemRecord,
+  ): Promise<{ ok: boolean; retryable?: boolean; error_code?: string }> {
+    if (item.external_job_ref) {
+      return { ok: true };
+    }
+    const inboxKey = sonarCommandInboxKey({
+      generation: work.generation,
+      deployment_id: item.deployment_id,
+      capability: item.capability,
+      adapter_version: item.adapter_version,
+    });
+    const now = this.deps.now();
+    await this.deps.dispatchStore.recordIntent({
+      command_inbox_key: inboxKey,
+      work_item_id: item.work_item_id,
+      work_id: work.work_id,
+      lease_epoch: work.lease_epoch,
+      now_ms: now,
+    });
+    const result = await this.deps.sonar.dispatchChildJob({
+      command_inbox_key: inboxKey,
+      deployment_id: item.deployment_id,
+      capability: item.capability,
+      adapter_version: item.adapter_version,
+      generation: work.generation,
+      lease_epoch: work.lease_epoch,
+    });
+    if (result.ok && result.external_job_ref) {
+      await this.deps.dispatchStore.recordAck({
+        command_inbox_key: inboxKey,
+        external_job_ref: result.external_job_ref,
+        now_ms: now,
+      });
+      await this.deps.preparationStore.recordChildJobRef({
+        work_item_id: item.work_item_id,
+        expected_lease_epoch: work.lease_epoch,
+        external_job_ref: result.external_job_ref,
+        now_ms: now,
+      });
+      return { ok: true };
+    }
+    if (!result.ok && result.external_job_ref === undefined) {
+      await this.deps.dispatchStore.markLostResponse(inboxKey);
+    }
+    return {
+      ok: result.ok,
+      retryable: result.retryable,
+      error_code: result.error_code,
+    };
+  }
+
+  private async scheduleRetry(
+    work: SharedPreparationWorkRecord,
+    failure: { code: string; reason: string },
+  ): Promise<PublicPrepProcessResult> {
+    const now = this.deps.now();
+    const nextAttempt = publicPrepRetryAtMs(work.attempt + 1, now);
+    const deadline = work.retry_deadline_unix_ms ?? now + PUBLIC_PREP_RETRY_DEADLINE_MS;
+    if (work.attempt + 1 >= PUBLIC_PREP_MAX_ATTEMPTS || nextAttempt > deadline) {
+      return this.terminalFailure(work, {
+        code: "retry_exhausted",
+        reason: failure.reason,
+      });
+    }
+    await this.deps.preparationStore.recordRetryableFailure({
+      work_id: work.work_id,
+      expected_lease_epoch: work.lease_epoch,
+      next_attempt_at_unix_ms: nextAttempt,
+      retry_deadline_unix_ms: deadline,
+      failure,
+      now_ms: now,
+    });
+    await this.syncSubscriberAttention(work, failure.code, false);
+    return { kind: "retry_scheduled", work_id: work.work_id };
+  }
+
+  private async terminalFailure(
+    work: SharedPreparationWorkRecord,
+    failure: { code: string; reason: string },
+  ): Promise<PublicPrepProcessResult> {
+    const failed = await this.deps.preparationStore.recordTerminalFailure({
+      work_id: work.work_id,
+      expected_lease_epoch: work.lease_epoch,
+      failure,
+      now_ms: this.deps.now(),
+    });
+    await this.failLinkedOrders(failed);
+    return { kind: "terminal", work_id: work.work_id, code: failure.code };
+  }
+
+  private async syncOrderPrepProjection(
+    workId: string,
+    work: SharedPreparationWorkRecord,
+    items: readonly PreparationWorkItemRecord[],
+  ): Promise<void> {
+    const links = await this.deps.preparationStore.listActiveLinks(workId);
+    for (const link of links) {
+      const jobs = prepIngredientJobs(link.order_id, work, items);
+      await this.deps.orderStore.patchRecord(link.order_id, {
+        ingredient_jobs: jobs,
+        ...prepFulfillmentPatch(workId, "preparing_collection_data"),
+      });
+    }
+  }
+
+  private async advanceLinkedOrders(work: SharedPreparationWorkRecord): Promise<void> {
+    const items = await this.deps.preparationStore.listWorkItems(work.work_id);
+    const links = await this.deps.preparationStore.listActiveLinks(work.work_id);
+    for (const link of links) {
+      const jobs = prepIngredientJobs(link.order_id, work, items);
+      await this.deps.orderStore.patchRecord(link.order_id, {
+        ingredient_jobs: jobs,
+        ...prepFulfillmentPatch(work.work_id, "ownership_evidence_ready", {
+          prep_generation: work.generation,
+        }),
+      });
+    }
+  }
+
+  private async failLinkedOrders(work: SharedPreparationWorkRecord): Promise<void> {
+    const code = work.failure_reason?.code ?? "preparation_failed";
+    const reason = work.failure_reason?.reason ?? "shared preparation failed";
+    await this.syncSubscriberAttention(work, code, true);
+    const links = await this.deps.preparationStore.listActiveLinks(work.work_id);
+    for (const link of links) {
+      const record = await this.deps.orderStore.get(link.order_id);
+      if (!record || record.state !== "producing") continue;
+      if (this.deps.opsChannel) {
+        await this.deps.opsChannel.emit({
+          order_id: link.order_id,
+          correlation_id: work.work_id,
+          cause: { code, reason },
+        });
+      }
+      const failed: OrderFailed = {
+        order_id: link.order_id,
+        refusal: { code, reason },
+      };
+      await this.deps.orderStore.transition(link.order_id, "producing", "failed", {
+        patch: { refusal: failed.refusal },
+        event: { subject: ORDER_LIFECYCLE_SUBJECTS.failed, payload: failed },
+      });
+      if (this.deps.capacityStore) {
+        await this.deps.capacityStore.releaseOrderCapacity({
+          order_id: link.order_id,
+          reason: "terminal_failure",
+          now_ms: this.deps.now(),
+        });
+      }
+    }
+  }
+
+  private async syncSubscriberAttention(
+    work: SharedPreparationWorkRecord,
+    code: string,
+    terminal: boolean,
+  ): Promise<void> {
+    const links = await this.deps.preparationStore.listActiveLinks(work.work_id);
+    for (const link of links) {
+      if (terminal) continue;
+      await this.deps.orderStore.patchRecord(link.order_id, {
+        ...prepFulfillmentPatch(work.work_id, "remediation_required", {
+          action_needed_code: code,
+        }),
+      });
+    }
+  }
+}

--- a/packages/services/ordering/src/public-preparation-adapter.ts
+++ b/packages/services/ordering/src/public-preparation-adapter.ts
@@ -65,7 +65,8 @@ function prepIngredientJobs(
     ingredient: "sonar" as const,
     kind: "http_enqueue" as const,
     external_ref: item.external_job_ref ?? item.work_item_id,
-    idempotency_key: ingredientJobIdempotencyKey(orderId, "sonar"),
+    // Distinct per child — multi-deployment must not collide on orderId:sonar.
+    idempotency_key: `${ingredientJobIdempotencyKey(orderId, "sonar")}:${item.work_item_id}`,
     enqueued_at_unix: Math.floor(work.updated_at_unix_ms / 1000),
   }));
 }
@@ -143,11 +144,14 @@ export class PublicPreparationAdapter {
       });
     }
 
+    let activeLease:
+      | { reservation_id: string; expected_version: number }
+      | undefined;
     if (this.deps.capacityStore) {
       const links = await this.deps.preparationStore.listActiveLinks(workId);
       const firstOrder = links[0]?.order_id;
       if (firstOrder) {
-        await this.deps.capacityStore.acquireActiveExecutionLease({
+        const acquired = await this.deps.capacityStore.acquireActiveExecutionLease({
           order_id: firstOrder,
           pool_scope: {
             network_ref: work.finality_policy_version.split(":")[0] ?? "public",
@@ -155,6 +159,12 @@ export class PublicPreparationAdapter {
           },
           now_ms: now,
         });
+        if (acquired.kind === "acquired") {
+          activeLease = {
+            reservation_id: acquired.reservation.reservation_id,
+            expected_version: acquired.reservation.reservation_version,
+          };
+        }
       }
     }
 
@@ -222,10 +232,23 @@ export class PublicPreparationAdapter {
     });
     if (finalized.kind === "ready") {
       await this.advanceLinkedOrders(finalized.work);
+      await this.releaseActiveExecutionLease(activeLease);
       return { kind: "advanced", work_id: workId };
     }
     await this.syncOrderPrepProjection(workId, work, afterItems);
     return { kind: "idle" };
+  }
+
+  private async releaseActiveExecutionLease(
+    lease: { reservation_id: string; expected_version: number } | undefined,
+  ): Promise<void> {
+    if (!lease || !this.deps.capacityStore) return;
+    await this.deps.capacityStore.releaseReservation({
+      reservation_id: lease.reservation_id,
+      expected_version: lease.expected_version,
+      reason: "prep_ready",
+      now_ms: this.deps.now(),
+    });
   }
 
   async reconcileLostDispatches(nowMs: number): Promise<void> {

--- a/packages/services/ordering/src/public-preparation-constants.ts
+++ b/packages/services/ordering/src/public-preparation-constants.ts
@@ -1,0 +1,39 @@
+/**
+ * CR-204A public preparation adapter constants (T1 fixtures only).
+ */
+
+/** Worker lease duration for shared preparation dispatch. */
+export const PUBLIC_PREP_WORKER_LEASE_MS = 30_000;
+
+/** V1 retry ceiling from SDD §6.3. */
+export const PUBLIC_PREP_MAX_ATTEMPTS = 12;
+export const PUBLIC_PREP_RETRY_DEADLINE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Default retry schedule: 1m, 5m, 15m, 1h, 6h, 12h, then 24h slots. */
+export const PUBLIC_PREP_RETRY_SCHEDULE_MS = [
+  60_000,
+  300_000,
+  900_000,
+  3_600_000,
+  21_600_000,
+  43_200_000,
+  86_400_000,
+] as const;
+
+/** Separate concurrency pool scopes (SDD §6.5). */
+export const COLLECTION_PREP_POOL_CAPABILITY = "collection_prep";
+export const REPORT_GENERATION_POOL_CAPABILITY = "report_generation";
+
+export function publicPrepRetryAtMs(attempt: number, nowMs: number): number {
+  const idx = Math.min(Math.max(attempt, 1) - 1, PUBLIC_PREP_RETRY_SCHEDULE_MS.length - 1);
+  return nowMs + PUBLIC_PREP_RETRY_SCHEDULE_MS[idx]!;
+}
+
+export function publicPrepWorkerEnabled(): boolean {
+  return process.env.PUBLIC_PREP_WORKER_ENABLED?.trim() !== "false";
+}
+
+export function publicPrepWorkerIntervalMs(): number {
+  const sec = Number(process.env.PUBLIC_PREP_WORKER_INTERVAL_SEC ?? 5);
+  return Number.isFinite(sec) && sec > 0 ? sec * 1000 : 5_000;
+}

--- a/packages/services/ordering/src/public-preparation-dispatch-key.ts
+++ b/packages/services/ordering/src/public-preparation-dispatch-key.ts
@@ -1,0 +1,31 @@
+import { createHash } from "node:crypto";
+
+import type { PublicPrepCapability, VersionedDigest } from "./shared-preparation-types.js";
+
+/**
+ * Sonar command inbox key — idempotent per generation × deployment × capability × adapter.
+ * SDD §6.4 / §12.1 remote command consumption.
+ */
+export function sonarCommandInboxKey(input: {
+  readonly generation: number;
+  readonly deployment_id: VersionedDigest;
+  readonly capability: PublicPrepCapability;
+  readonly adapter_version: string;
+}): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        schema_version: 1,
+        generation: input.generation,
+        deployment_id: input.deployment_id,
+        capability: input.capability,
+        adapter_version: input.adapter_version,
+      }),
+    )
+    .digest("hex");
+}
+
+/** Stable external job ref returned by Sonar on replay of the same inbox key. */
+export function sonarPhysicalJobRef(commandInboxKey: string): string {
+  return `sonar-job:${commandInboxKey.slice(0, 32)}`;
+}

--- a/packages/services/ordering/src/public-preparation-dispatch-store.ts
+++ b/packages/services/ordering/src/public-preparation-dispatch-store.ts
@@ -1,0 +1,97 @@
+/**
+ * CR-204A dispatch outbox/inbox ledger for Sonar command correlation and reconciliation.
+ */
+
+export interface PrepDispatchRecord {
+  readonly command_inbox_key: string;
+  readonly work_item_id: string;
+  readonly work_id: string;
+  readonly lease_epoch: number;
+  readonly external_job_ref?: string;
+  readonly dispatched_at_unix_ms?: number;
+  readonly acked_at_unix_ms?: number;
+  readonly lost_response?: boolean;
+}
+
+export interface PublicPrepDispatchStore {
+  recordIntent(input: {
+    command_inbox_key: string;
+    work_item_id: string;
+    work_id: string;
+    lease_epoch: number;
+    now_ms: number;
+  }): Promise<PrepDispatchRecord>;
+  recordAck(input: {
+    command_inbox_key: string;
+    external_job_ref: string;
+    now_ms: number;
+  }): Promise<PrepDispatchRecord | undefined>;
+  get(commandInboxKey: string): Promise<PrepDispatchRecord | undefined>;
+  listPendingReconciliation(now_ms: number): Promise<readonly PrepDispatchRecord[]>;
+  markLostResponse(commandInboxKey: string): Promise<void>;
+}
+
+type MutableDispatch = {
+  -readonly [K in keyof PrepDispatchRecord]: PrepDispatchRecord[K];
+};
+
+export class InMemoryPublicPrepDispatchStore implements PublicPrepDispatchStore {
+  private readonly rows = new Map<string, MutableDispatch>();
+
+  async recordIntent(input: {
+    command_inbox_key: string;
+    work_item_id: string;
+    work_id: string;
+    lease_epoch: number;
+    now_ms: number;
+  }): Promise<PrepDispatchRecord> {
+    const existing = this.rows.get(input.command_inbox_key);
+    if (existing) {
+      return structuredClone(existing);
+    }
+    const row: MutableDispatch = {
+      command_inbox_key: input.command_inbox_key,
+      work_item_id: input.work_item_id,
+      work_id: input.work_id,
+      lease_epoch: input.lease_epoch,
+      dispatched_at_unix_ms: input.now_ms,
+    };
+    this.rows.set(input.command_inbox_key, row);
+    return structuredClone(row);
+  }
+
+  async recordAck(input: {
+    command_inbox_key: string;
+    external_job_ref: string;
+    now_ms: number;
+  }): Promise<PrepDispatchRecord | undefined> {
+    const row = this.rows.get(input.command_inbox_key);
+    if (!row) return undefined;
+    row.external_job_ref = input.external_job_ref;
+    row.acked_at_unix_ms = input.now_ms;
+    row.lost_response = false;
+    return structuredClone(row);
+  }
+
+  async get(commandInboxKey: string): Promise<PrepDispatchRecord | undefined> {
+    const row = this.rows.get(commandInboxKey);
+    return row ? structuredClone(row) : undefined;
+  }
+
+  async listPendingReconciliation(now_ms: number): Promise<readonly PrepDispatchRecord[]> {
+    const staleMs = 5_000;
+    return [...this.rows.values()]
+      .filter(
+        (row) =>
+          row.dispatched_at_unix_ms !== undefined &&
+          row.acked_at_unix_ms === undefined &&
+          now_ms - row.dispatched_at_unix_ms >= staleMs,
+      )
+      .map((row) => structuredClone(row));
+  }
+
+  async markLostResponse(commandInboxKey: string): Promise<void> {
+    const row = this.rows.get(commandInboxKey);
+    if (row) row.lost_response = true;
+  }
+}

--- a/packages/services/ordering/src/public-preparation-evidence.ts
+++ b/packages/services/ordering/src/public-preparation-evidence.ts
@@ -1,0 +1,54 @@
+import { createHash } from "node:crypto";
+
+import type {
+  ReadinessEvidenceEnvelope,
+  SharedPreparationWorkRecord,
+  VersionedDigest,
+} from "./shared-preparation-types.js";
+
+export function buildReadinessEvidenceFromDeployments(input: {
+  deploymentIds: readonly VersionedDigest[];
+  readinessPolicyVersion: string;
+  adapterVersion: string;
+  producer?: string;
+  observedAt?: string;
+}): ReadinessEvidenceEnvelope {
+  const digest = (domain: string, seed: string): VersionedDigest => ({
+    algorithm: "sha-256",
+    domain,
+    major_version: 1,
+    digest: createHash("sha256").update(seed).digest("hex"),
+  });
+  const observedAt = input.observedAt ?? new Date().toISOString();
+  return {
+    schema_version: 1,
+    producer: input.producer ?? "sonar-api.fixture",
+    schema: "collection.public-evidence.v1",
+    adapter: input.adapterVersion,
+    readiness_policy_version: input.readinessPolicyVersion,
+    privacy_scope: "public_chain",
+    deployment_coverage: [...input.deploymentIds],
+    observation_window: {
+      observed_at: observedAt,
+      as_of: observedAt,
+    },
+    freshness: {
+      qualified: true,
+      max_age_ms: 60_000,
+    },
+    source_digest: digest("collection.evidence-source", "prep-source"),
+    evidence_digest: digest("collection.evidence", "prep-evidence"),
+  };
+}
+
+export function aggregateReadinessEvidence(
+  work: SharedPreparationWorkRecord,
+  deploymentIds: readonly VersionedDigest[],
+): ReadinessEvidenceEnvelope {
+  return buildReadinessEvidenceFromDeployments({
+    deploymentIds,
+    readinessPolicyVersion: work.readiness_policy_version,
+    adapterVersion: work.adapter_version,
+    producer: work.source_identity.producer,
+  });
+}

--- a/packages/services/ordering/src/public-preparation-sonar-port.ts
+++ b/packages/services/ordering/src/public-preparation-sonar-port.ts
@@ -1,0 +1,76 @@
+import type { PublicPrepCapability, VersionedDigest } from "./shared-preparation-types.js";
+import { sonarPhysicalJobRef } from "./public-preparation-dispatch-key.js";
+
+export type SonarPrepJobStatus = "queued" | "indexing" | "indexed" | "failed";
+
+export interface SonarPrepDispatchRequest {
+  readonly command_inbox_key: string;
+  readonly deployment_id: VersionedDigest;
+  readonly capability: PublicPrepCapability;
+  readonly adapter_version: string;
+  readonly generation: number;
+  readonly lease_epoch: number;
+}
+
+export interface SonarPrepDispatchResult {
+  readonly ok: boolean;
+  readonly external_job_ref?: string;
+  readonly retryable?: boolean;
+  readonly error_code?: string;
+}
+
+export interface SonarPrepStatusResult {
+  readonly status: SonarPrepJobStatus;
+  readonly retryable?: boolean;
+  readonly error_code?: string;
+}
+
+/** Idempotent Sonar Kitchen dispatch + status probe (CR-204A). */
+export interface PublicPreparationSonarPort {
+  dispatchChildJob(request: SonarPrepDispatchRequest): Promise<SonarPrepDispatchResult>;
+  probeChildJob(externalJobRef: string): Promise<SonarPrepStatusResult>;
+}
+
+/** Fixture Sonar — records inbox keys and returns stable job refs on replay. */
+export class FixturePublicPreparationSonarPort implements PublicPreparationSonarPort {
+  readonly dispatchCalls: SonarPrepDispatchRequest[] = [];
+  readonly probeCalls: string[] = [];
+  private readonly inbox = new Map<string, string>();
+  private outage = false;
+  private jobStatus = new Map<string, SonarPrepJobStatus>();
+
+  setOutage(active: boolean): void {
+    this.outage = active;
+  }
+
+  setJobStatus(externalJobRef: string, status: SonarPrepJobStatus): void {
+    this.jobStatus.set(externalJobRef, status);
+  }
+
+  async dispatchChildJob(request: SonarPrepDispatchRequest): Promise<SonarPrepDispatchResult> {
+    this.dispatchCalls.push(request);
+    if (this.outage) {
+      return { ok: false, retryable: true, error_code: "sonar_unavailable" };
+    }
+    const prior = this.inbox.get(request.command_inbox_key);
+    if (prior) {
+      return { ok: true, external_job_ref: prior };
+    }
+    const ref = sonarPhysicalJobRef(request.command_inbox_key);
+    this.inbox.set(request.command_inbox_key, ref);
+    this.jobStatus.set(ref, "queued");
+    return { ok: true, external_job_ref: ref };
+  }
+
+  async probeChildJob(externalJobRef: string): Promise<SonarPrepStatusResult> {
+    this.probeCalls.push(externalJobRef);
+    if (this.outage) {
+      return { status: "failed", retryable: true, error_code: "sonar_unavailable" };
+    }
+    return { status: this.jobStatus.get(externalJobRef) ?? "indexing", retryable: false };
+  }
+
+  markIndexed(externalJobRef: string): void {
+    this.jobStatus.set(externalJobRef, "indexed");
+  }
+}

--- a/packages/services/ordering/src/public-preparation-worker.ts
+++ b/packages/services/ordering/src/public-preparation-worker.ts
@@ -1,0 +1,28 @@
+import { PublicPreparationAdapter } from "./public-preparation-adapter.js";
+import { publicPrepWorkerIntervalMs } from "./public-preparation-constants.js";
+
+export class PublicPreparationWorker {
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private readonly adapter: PublicPreparationAdapter,
+    private readonly intervalMs: number = publicPrepWorkerIntervalMs(),
+  ) {}
+
+  start(): void {
+    if (this.timer) return;
+    void this.tick();
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, this.intervalMs);
+  }
+
+  stop(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  async tick(): Promise<void> {
+    await this.adapter.tick();
+  }
+}

--- a/packages/services/ordering/src/shared-preparation-store-postgres.ts
+++ b/packages/services/ordering/src/shared-preparation-store-postgres.ts
@@ -787,4 +787,123 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
       client.release();
     }
   }
+
+  async recordChildJobRef(input: {
+    work_item_id: string;
+    expected_lease_epoch: number;
+    external_job_ref: string;
+    now_ms: number;
+  }): Promise<PreparationWorkItemRecord> {
+    const result = await this.pool.query(
+      `UPDATE preparation_work_items AS i
+       SET external_job_ref = $3, updated_at = $4
+       FROM shared_preparation_work AS w
+       WHERE i.work_item_id = $1
+         AND i.work_id = w.work_id
+         AND i.lease_epoch = $2
+         AND w.state IN ('queued', 'preparing')
+       RETURNING i.*`,
+      [input.work_item_id, input.expected_lease_epoch, input.external_job_ref, msToIso(input.now_ms)],
+    );
+    if (result.rows.length === 0) {
+      throw new SharedPreparationFencingError("stale lease epoch for child job ref");
+    }
+    return rowToItem(result.rows[0]!);
+  }
+
+  async recordTerminalFailure(input: {
+    work_id: string;
+    expected_lease_epoch: number;
+    failure: { code: string; reason: string };
+    now_ms: number;
+  }): Promise<SharedPreparationWorkRecord> {
+    const client = await this.pool.connect();
+    const nowIso = msToIso(input.now_ms);
+    try {
+      await client.query("BEGIN");
+      const workResult = await client.query(
+        `UPDATE shared_preparation_work
+         SET state = 'failed',
+             failure_reason = $4::jsonb,
+             lease_until = NULL,
+             updated_at = $3
+         WHERE work_id = $1
+           AND lease_epoch = $2
+           AND state IN ('queued', 'preparing', 'retry_wait')
+         RETURNING *`,
+        [
+          input.work_id,
+          input.expected_lease_epoch,
+          nowIso,
+          JSON.stringify(input.failure),
+        ],
+      );
+      if (workResult.rows.length === 0) {
+        throw new SharedPreparationFencingError("stale lease epoch for terminal failure");
+      }
+      await client.query(
+        `UPDATE preparation_work_items
+         SET state = 'failed',
+             failure_reason = $3::jsonb,
+             updated_at = $2
+         WHERE work_id = $1 AND state NOT IN ('ready', 'failed')`,
+        [input.work_id, nowIso, JSON.stringify(input.failure)],
+      );
+      await client.query("COMMIT");
+      return rowToWork(workResult.rows[0]!);
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async listLeasableWork(limit = 64): Promise<readonly SharedPreparationWorkRecord[]> {
+    const result = await this.pool.query(
+      `SELECT * FROM shared_preparation_work
+       WHERE state IN ('queued', 'preparing')
+       ORDER BY created_at ASC
+       LIMIT $1`,
+      [limit],
+    );
+    return result.rows.map(rowToWork);
+  }
+
+  async listRetryWaitDue(input: {
+    now_ms: number;
+    limit?: number;
+  }): Promise<readonly SharedPreparationWorkRecord[]> {
+    const result = await this.pool.query(
+      `SELECT * FROM shared_preparation_work
+       WHERE state = 'retry_wait'
+         AND next_attempt_at IS NOT NULL
+         AND next_attempt_at <= $1
+       ORDER BY next_attempt_at ASC
+       LIMIT $2`,
+      [msToIso(input.now_ms), input.limit ?? 64],
+    );
+    return result.rows.map(rowToWork);
+  }
+
+  async getActiveWorkForOrder(order_id: string): Promise<
+    | { readonly work: SharedPreparationWorkRecord; readonly link: ReportWorkLinkRecord }
+    | undefined
+  > {
+    const linkResult = await this.pool.query(
+      `SELECT * FROM report_work_links
+       WHERE order_id = $1 AND detached_at IS NULL
+       ORDER BY joined_at DESC
+       LIMIT 1`,
+      [order_id],
+    );
+    if (linkResult.rows.length === 0) return undefined;
+    const link = rowToLink(linkResult.rows[0]!);
+    const workResult = await this.pool.query(
+      "SELECT * FROM shared_preparation_work WHERE work_id = $1",
+      [link.work_id],
+    );
+    if (workResult.rows.length === 0) return undefined;
+    return { work: rowToWork(workResult.rows[0]!), link };
+  }
 }

--- a/packages/services/ordering/src/shared-preparation-store.ts
+++ b/packages/services/ordering/src/shared-preparation-store.ts
@@ -119,6 +119,26 @@ export interface SharedPreparationStore {
     work_key_digest: string;
     now_ms: number;
   }): Promise<SharedPreparationWorkRecord | undefined>;
+  recordChildJobRef(input: {
+    work_item_id: string;
+    expected_lease_epoch: number;
+    external_job_ref: string;
+    now_ms: number;
+  }): Promise<PreparationWorkItemRecord>;
+  recordTerminalFailure(input: {
+    work_id: string;
+    expected_lease_epoch: number;
+    failure: { code: string; reason: string };
+    now_ms: number;
+  }): Promise<SharedPreparationWorkRecord>;
+  listLeasableWork(limit?: number): Promise<readonly SharedPreparationWorkRecord[]>;
+  listRetryWaitDue(input: { now_ms: number; limit?: number }): Promise<
+    readonly SharedPreparationWorkRecord[]
+  >;
+  getActiveWorkForOrder(order_id: string): Promise<
+    | { readonly work: SharedPreparationWorkRecord; readonly link: ReportWorkLinkRecord }
+    | undefined
+  >;
 }
 
 type MutableWork = {
@@ -696,6 +716,109 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
       return { kind: "serialization_retry" };
     }
     return locked as DetachResult;
+  }
+
+  async recordChildJobRef(input: {
+    work_item_id: string;
+    expected_lease_epoch: number;
+    external_job_ref: string;
+    now_ms: number;
+  }): Promise<PreparationWorkItemRecord> {
+    const itemLookup = this.items.get(input.work_item_id);
+    if (!itemLookup) throw new SharedPreparationStateError("work item not found");
+    const locked = await this.withWorkIdLock(itemLookup.work_id, async () => {
+      const item = this.items.get(input.work_item_id);
+      if (!item) throw new SharedPreparationStateError("work item not found");
+      const parent = this.works.get(item.work_id);
+      if (!parent) throw new SharedPreparationStateError("work not found");
+      if (parent.state !== "preparing" && parent.state !== "queued") {
+        throw new SharedPreparationStateError(
+          `child job ref requires parent active, got ${parent.state}`,
+        );
+      }
+      if (item.lease_epoch !== input.expected_lease_epoch) {
+        throw new SharedPreparationFencingError("stale lease epoch for child job ref");
+      }
+      item.external_job_ref = input.external_job_ref;
+      item.updated_at_unix_ms = input.now_ms;
+      return cloneItem(item);
+    });
+    return this.unwrapLocked(locked, () => {
+      throw new SharedPreparationStateError("work item not found");
+    });
+  }
+
+  async recordTerminalFailure(input: {
+    work_id: string;
+    expected_lease_epoch: number;
+    failure: { code: string; reason: string };
+    now_ms: number;
+  }): Promise<SharedPreparationWorkRecord> {
+    const locked = await this.withWorkIdLock(input.work_id, async () => {
+      const work = this.works.get(input.work_id);
+      if (!work) throw new SharedPreparationStateError("work not found");
+      if (work.lease_epoch !== input.expected_lease_epoch) {
+        throw new SharedPreparationFencingError("stale lease epoch for terminal failure");
+      }
+      if (!isActivePublicWorkState(work.state) && work.state !== "preparing") {
+        throw new SharedPreparationStateError(
+          `terminal failure requires active work, got ${work.state}`,
+        );
+      }
+      work.state = "failed";
+      work.failure_reason = { ...input.failure };
+      work.lease_until_unix_ms = undefined;
+      work.updated_at_unix_ms = input.now_ms;
+      for (const item of this.itemsForWork(work.work_id)) {
+        if (item.state !== "ready" && item.state !== "failed") {
+          item.state = "failed";
+          item.failure_reason = { ...input.failure };
+          item.updated_at_unix_ms = input.now_ms;
+        }
+      }
+      return cloneWork(work);
+    });
+    return this.unwrapLocked(locked, () => {
+      throw new SharedPreparationStateError("work not found");
+    });
+  }
+
+  async listLeasableWork(limit = 64): Promise<readonly SharedPreparationWorkRecord[]> {
+    return [...this.works.values()]
+      .filter((row) => isLeasablePublicWorkState(row.state))
+      .sort((a, b) => a.created_at_unix_ms - b.created_at_unix_ms)
+      .slice(0, limit)
+      .map(cloneWork);
+  }
+
+  async listRetryWaitDue(input: {
+    now_ms: number;
+    limit?: number;
+  }): Promise<readonly SharedPreparationWorkRecord[]> {
+    const limit = input.limit ?? 64;
+    return [...this.works.values()]
+      .filter(
+        (row) =>
+          row.state === "retry_wait" &&
+          row.next_attempt_at_unix_ms !== undefined &&
+          input.now_ms >= row.next_attempt_at_unix_ms,
+      )
+      .sort((a, b) => (a.next_attempt_at_unix_ms ?? 0) - (b.next_attempt_at_unix_ms ?? 0))
+      .slice(0, limit)
+      .map(cloneWork);
+  }
+
+  async getActiveWorkForOrder(order_id: string): Promise<
+    | { readonly work: SharedPreparationWorkRecord; readonly link: ReportWorkLinkRecord }
+    | undefined
+  > {
+    for (const link of this.links.values()) {
+      if (link.order_id !== order_id || link.detached_at_unix_ms !== undefined) continue;
+      const work = this.works.get(link.work_id);
+      if (!work) continue;
+      return { work: cloneWork(work), link: cloneLink(link) };
+    }
+    return undefined;
   }
 
   async supersedeActiveGeneration(input: {


### PR DESCRIPTION
## Summary
- Add the CR-204A public preparation adapter: idempotent Sonar child dispatch via inbox keys, dispatch outbox/inbox reconciliation, worker leases, child evidence aggregation, retry/terminal fan-out, and linked-order advancement.
- Extend shared preparation store (memory + Postgres) with child job refs, terminal failure, order lookup, and retry-wait wake helpers used by the adapter.
- Wire `CollectionReportOrchestrator` / `OrderOrchestrator` to drive linked shared preparation work while collection-report orders are producing.

## Test plan
- [x] `pnpm exec vitest run src/__tests__/public-preparation-adapter.test.ts` (13/13)
- [x] `pnpm exec vitest run src/__tests__/shared-preparation-store.test.ts` (16/16)
- [ ] Production Sonar port wiring + HTTP worker bootstrap (follow-up; fixture port only in this PR)
- [ ] Postgres integration run against migrated schema

## Coordinator
- Bead: `collection-report-coordinator-f09.30`
- Sprint: CR-204A acceptance in `grimoires/loa/sprint.md`

Made with [Cursor](https://cursor.com)