### PR TITLE
ci(railway): bootstrap trusted plan gate

### DIFF
--- a/.github/workflows/railway-plan-gate.yml
+++ b/.github/workflows/railway-plan-gate.yml
@@ -1,0 +1,196 @@
+# S2-T2 (SDD §8, IMP-013, G-6) — operator-approved org-as-code gate.
+#
+# Runs `railway config plan` (READ-ONLY) against .railway/railway.ts and fails the PR on:
+#   1. ANY destructive change (baseline-independent) — Railway IaC is declarative and will DELETE
+#      resources it does not declare. A plan against a wrongly-linked project once read
+#      "1 to add, 3 to DESTROY" (would have deleted ordering-service + its Postgres).
+#   2. Drift from the committed .railway/plan-baseline.json — an intended IaC change must refresh the
+#      baseline in the same PR, which makes it explicit and reviewable.
+#
+# This workflow NEVER applies. `railway config apply` stays human-gated (NFR-2).
+# Secrets never reach the logs: the gate prints only change kind/severity/summary (variable NAMES, not
+# values — Railway redacts values as «hidden»).
+#
+# ── SECRET-HANDLING (FAGAN + Bridgebuilder review, 2026-07-18) ─────────────────────────────────────────
+# RAILWAY_TOKEN is apply-capable, and `railway config plan` evaluates .railway/railway.ts. Therefore this
+# workflow MUST NOT run automatically on pull_request: a trusted workflow cannot sandbox PR-controlled
+# TypeScript that it later evaluates with a deployment credential.
+#
+# The credentialed plan is manual-only and protected by the `railway-plan` GitHub Environment:
+#   · The operator dispatches an EXACT reviewed commit SHA (not a moving branch).
+#   · Required environment reviewers approve that SHA before the job starts or receives the token.
+#   · RAILWAY_TOKEN lives in the environment, NOT as an automatically exposed repository secret.
+#   · The GATE SCRIPT is fetched from the DEFAULT branch, never the reviewed ref — otherwise a ref could edit
+#     plan-gate.mjs to exfiltrate the token after approval.
+#   · The Railway CLI + SDK are PINNED — `npm install -g @railway/cli` (unpinned) is arbitrary code
+#     running with the secret in env.
+#
+# Enforcement identity: a trusted `pull_request_target` job marks the exact PR head's
+# `railway-plan-gate` commit status PENDING without checking out PR code. The protected
+# manual run publishes SUCCESS or FAILURE to that same exact SHA. A new head gets a new
+# pending status, so stale success cannot travel forward.
+#
+# SETUP (operator, one-time): create a protected `railway-plan` environment with required reviewers; add
+# RAILWAY_TOKEN there (Railway project token scoped to shadow-audit-api/production); remove any repo-level
+# copy; require the `railway-plan-gate` commit-status context in main's branch protection. If Railway ships a
+# read-only/plan-scoped token, replace it.
+
+name: railway-plan-gate
+
+on:
+  # Safe sentinel: pull_request_target executes this workflow from the trusted
+  # base branch. It never checks out or executes PR-controlled code.
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'Exact 40-character reviewed commit SHA to plan'
+        required: true
+        type: string
+
+jobs:
+  require-plan:
+    name: require exact-head Railway plan
+    if: github.event_name == 'pull_request_target'
+    permissions:
+      contents: read
+      statuses: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish exact PR-head requirement
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          state=success
+          description='Railway plan not required for this change'
+          while IFS= read -r filename; do
+            case "$filename" in
+              .railway/*|packages/services/shadow-audit/Dockerfile)
+                state=pending
+                description='Awaiting protected Railway plan for this exact commit'
+                break
+                ;;
+            esac
+          done < <(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')
+          gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            -f state="$state" \
+            -f context=railway-plan-gate \
+            -f description="$description"
+
+  plan-gate:
+    name: railway config plan (operator-approved)
+    # Job-level guard is evaluated before the protected environment is
+    # requested. Only the workflow definition selected from the trusted default
+    # branch can reach approval or receive credentials.
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    environment: railway-plan
+    permissions:
+      contents: read
+      statuses: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit_sha }}
+          fetch-depth: 0
+
+      - name: Verify immutable reviewed ref
+        run: |
+          set -euo pipefail
+          case "${{ inputs.commit_sha }}" in
+            [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+            *) echo "::error::commit_sha must be an exact lowercase 40-character commit SHA"; exit 1 ;;
+          esac
+          test "$(git rev-parse HEAD)" = "${{ inputs.commit_sha }}"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Prepare trusted gate and locked Railway toolchain
+        run: |
+          set -euo pipefail
+          trusted_dir="$RUNNER_TEMP/railway-gate-trusted"
+          rm -rf "$trusted_dir"
+          mkdir -p "$trusted_dir"
+          default_branch="${{ github.event.repository.default_branch }}"
+          git fetch --no-tags origin "$default_branch"
+          for path in \
+            .railway/plan-gate.mjs \
+            .railway/trusted-tools/package.json \
+            .railway/trusted-tools/package-lock.json \
+            .railway/trusted-tools/railway-cli.sha256
+          do
+            if ! git cat-file -e "origin/$default_branch:$path" 2>/dev/null; then
+              echo "::error::Trusted default branch has no $path; refusing credentialed bootstrap."
+              exit 1
+            fi
+          done
+          git show "origin/$default_branch:.railway/plan-gate.mjs" > "$trusted_dir/plan-gate.mjs"
+          git show "origin/$default_branch:.railway/trusted-tools/package.json" > "$trusted_dir/package.json"
+          git show "origin/$default_branch:.railway/trusted-tools/package-lock.json" > "$trusted_dir/package-lock.json"
+          git show "origin/$default_branch:.railway/trusted-tools/railway-cli.sha256" > "$trusted_dir/railway-cli.sha256"
+          (
+            cd "$trusted_dir"
+            NPM_CONFIG_USERCONFIG=/dev/null npm ci \
+              --ignore-scripts \
+              --registry=https://registry.npmjs.org
+            curl --fail --location --proto '=https' \
+              https://github.com/railwayapp/cli/releases/download/v4.10.0/railway-v4.10.0-x86_64-unknown-linux-gnu.tar.gz \
+              --output railway-v4.10.0-x86_64-unknown-linux-gnu.tar.gz
+            sha256sum --check railway-cli.sha256
+            mkdir -p bin
+            tar -xzf railway-v4.10.0-x86_64-unknown-linux-gnu.tar.gz -C bin
+          )
+          # The reviewed IaC imports `railway`. Resolve only the default-branch
+          # lockfile installation; do not let PR .npmrc or lifecycle scripts
+          # acquire code in the credentialed job.
+          mkdir -p "$GITHUB_WORKSPACE/node_modules"
+          rm -rf "$GITHUB_WORKSPACE/node_modules/railway"
+          ln -s "$trusted_dir/node_modules/railway" "$GITHUB_WORKSPACE/node_modules/railway"
+
+      - name: Plan gate (READ-ONLY — never applies)
+        id: plan
+        continue-on-error: true
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RAILWAY_TOKEN:-}" ]; then
+            echo "::error title=railway-plan-gate NOT CONFIGURED::RAILWAY_TOKEN is missing from the protected railway-plan environment."
+            exit 1
+          fi
+          # Keep cwd at the reviewed workspace so the trusted CLI evaluates
+          # .railway/railway.ts while its SDK resolves through the trusted link.
+          PATH="$RUNNER_TEMP/railway-gate-trusted/bin:$PATH" \
+            node "$RUNNER_TEMP/railway-gate-trusted/plan-gate.mjs"
+
+      - name: Publish exact-commit plan status
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMIT_SHA: ${{ inputs.commit_sha }}
+          PLAN_OUTCOME: ${{ steps.plan.outcome }}
+        run: |
+          set -euo pipefail
+          state=failure
+          description='Protected Railway plan failed for this exact commit'
+          if [ "$PLAN_OUTCOME" = success ]; then
+            state=success
+            description='Protected Railway plan passed for this exact commit'
+          fi
+          gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$COMMIT_SHA" \
+            -f state="$state" \
+            -f context=railway-plan-gate \
+            -f description="$description" \
+            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
+      - name: Enforce plan result
+        if: steps.plan.outcome != 'success'
+        run: exit 1

--- a/.github/workflows/railway-plan-gate.yml
+++ b/.github/workflows/railway-plan-gate.yml
@@ -73,17 +73,23 @@ jobs:
           set -euo pipefail
           state=success
           description='Railway plan not required for this change'
-          while IFS= read -r filename; do
-            case "$filename" in
-              .railway/railway.ts|\
-              .railway/plan-baseline.json|\
-              packages/services/shadow-audit/Dockerfile)
-                state=pending
-                description='Awaiting protected Railway plan for this exact commit'
-                break
-                ;;
-            esac
-          done < <(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')
+          changed_count=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.changed_files')
+          if ! [[ "$changed_count" =~ ^[0-9]+$ ]] || [ "$changed_count" -ge 3000 ]; then
+            state=failure
+            description='PR diff exceeds complete changed-file enumeration'
+          else
+            while IFS= read -r filename; do
+              case "$filename" in
+                .railway/railway.ts|\
+                .railway/plan-baseline.json|\
+                packages/services/shadow-audit/Dockerfile)
+                  state=pending
+                  description='Awaiting protected Railway plan for this exact commit'
+                  break
+                  ;;
+              esac
+            done < <(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')
+          fi
           gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
             -f state="$state" \
             -f context=railway-plan-gate \
@@ -110,6 +116,8 @@ jobs:
 
       - name: Verify immutable reviewed ref
         env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
           REQUESTED_SHA: ${{ inputs.commit_sha }}
         run: |
           set -euo pipefail
@@ -118,6 +126,23 @@ jobs:
             *) echo "::error::commit_sha must be an exact lowercase 40-character commit SHA"; exit 1 ;;
           esac
           test "$(git rev-parse HEAD)" = "$REQUESTED_SHA"
+          pulls="$RUNNER_TEMP/railway-plan-associated-pulls.json"
+          gh api "repos/$GITHUB_REPOSITORY/commits/$REQUESTED_SHA/pulls" > "$pulls"
+          pr_number=$(
+            jq -r --arg sha "$REQUESTED_SHA" --arg base "$DEFAULT_BRANCH" \
+              '[.[] | select(.state == "open" and .head.sha == $sha and .base.ref == $base)] |
+               if length == 1 then .[0].number else empty end' \
+              "$pulls"
+          )
+          if [ -z "$pr_number" ]; then
+            echo "::error::commit_sha must identify exactly one open PR head into the default branch."
+            exit 1
+          fi
+          changed_count=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$pr_number" --jq '.changed_files')
+          if ! [[ "$changed_count" =~ ^[0-9]+$ ]] || [ "$changed_count" -ge 3000 ]; then
+            echo "::error::PR diff exceeds GitHub's complete changed-file enumeration limit."
+            exit 1
+          fi
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/.github/workflows/railway-plan-gate.yml
+++ b/.github/workflows/railway-plan-gate.yml
@@ -20,8 +20,9 @@
 #   · The operator dispatches an EXACT reviewed commit SHA (not a moving branch).
 #   · Required environment reviewers approve that SHA before the job starts or receives the token.
 #   · RAILWAY_TOKEN lives in the environment, NOT as an automatically exposed repository secret.
-#   · The GATE SCRIPT is fetched from the DEFAULT branch, never the reviewed ref — otherwise a ref could edit
-#     plan-gate.mjs to exfiltrate the token after approval.
+#   · The GATE SCRIPT AND EXECUTABLE CONFIG are fetched from the DEFAULT branch, never the reviewed ref.
+#     The reviewed `.railway/railway.ts` must be byte-identical to that trusted config, but is never executed
+#     in the credentialed job. This makes the executable input closure exact instead of path-heuristic.
 #   · The Railway CLI + SDK are PINNED — `npm install -g @railway/cli` (unpinned) is arbitrary code
 #     running with the secret in env.
 #
@@ -40,7 +41,10 @@ name: railway-plan-gate
 
 on:
   # Safe sentinel: pull_request_target executes this workflow from the trusted
-  # base branch. It never checks out or executes PR-controlled code.
+  # base branch. It never checks out or executes PR-controlled code. The later
+  # credentialed job also executes only the byte-identical default-branch IaC
+  # copy, so unrelated repository files are outside the evaluator's input
+  # closure and do not need to trigger a plan.
   pull_request_target:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
@@ -128,7 +132,8 @@ jobs:
             .railway/plan-gate.mjs \
             .railway/trusted-tools/package.json \
             .railway/trusted-tools/package-lock.json \
-            .railway/trusted-tools/railway-cli.sha256
+            .railway/trusted-tools/railway-cli.sha256 \
+            .railway/trusted-tools/railway.ts
           do
             if ! git cat-file -e "origin/$default_branch:$path" 2>/dev/null; then
               echo "::error::Trusted default branch has no $path; refusing credentialed bootstrap."
@@ -139,6 +144,7 @@ jobs:
           git show "origin/$default_branch:.railway/trusted-tools/package.json" > "$trusted_dir/package.json"
           git show "origin/$default_branch:.railway/trusted-tools/package-lock.json" > "$trusted_dir/package-lock.json"
           git show "origin/$default_branch:.railway/trusted-tools/railway-cli.sha256" > "$trusted_dir/railway-cli.sha256"
+          git show "origin/$default_branch:.railway/trusted-tools/railway.ts" > "$trusted_dir/railway.ts"
           (
             cd "$trusted_dir"
             NPM_CONFIG_USERCONFIG=/dev/null npm ci \
@@ -151,13 +157,6 @@ jobs:
             mkdir -p bin
             tar -xzf railway-v4.10.0-x86_64-unknown-linux-gnu.tar.gz -C bin
           )
-          # The reviewed IaC imports `railway`. Resolve only the default-branch
-          # lockfile installation; do not let PR .npmrc or lifecycle scripts
-          # acquire code in the credentialed job.
-          mkdir -p "$GITHUB_WORKSPACE/node_modules"
-          rm -rf "$GITHUB_WORKSPACE/node_modules/railway"
-          ln -s "$trusted_dir/node_modules/railway" "$GITHUB_WORKSPACE/node_modules/railway"
-
       - name: Re-attest reviewed workspace before credentials
         env:
           REQUESTED_SHA: ${{ inputs.commit_sha }}
@@ -170,12 +169,17 @@ jobs:
             .railway/railway.ts \
             .railway/plan-baseline.json \
             >/dev/null
+          # The reviewed ref cannot extend the TypeScript dependency closure:
+          # credentialed evaluation uses this default-branch copy, and the
+          # reviewed declaration must be byte-identical to it.
+          cmp --silent .railway/railway.ts "$RUNNER_TEMP/railway-gate-trusted/railway.ts"
 
       - name: Plan gate (READ-ONLY — never applies)
         id: plan
         continue-on-error: true
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          TRUSTED_RAILWAY_CONFIG: ${{ runner.temp }}/railway-gate-trusted/railway.ts
         run: |
           set -euo pipefail
           if [ -z "${RAILWAY_TOKEN:-}" ]; then

--- a/.github/workflows/railway-plan-gate.yml
+++ b/.github/workflows/railway-plan-gate.yml
@@ -21,8 +21,9 @@
 #   · Required environment reviewers approve that SHA before the job starts or receives the token.
 #   · RAILWAY_TOKEN lives in the environment, NOT as an automatically exposed repository secret.
 #   · The GATE SCRIPT AND EXECUTABLE CONFIG are fetched from the DEFAULT branch, never the reviewed ref.
-#     The reviewed `.railway/railway.ts` must be byte-identical to that trusted config, but is never executed
-#     in the credentialed job. This makes the executable input closure exact instead of path-heuristic.
+#     Normally the reviewed `.railway/railway.ts` must be byte-identical to that config. A rotation may use
+#     a candidate only after the separate credential-free trust-root status attests the exact SHA and its
+#     active/trusted copies are byte-identical. This makes the executable input closure explicit.
 #   · The Railway CLI + SDK are PINNED — `npm install -g @railway/cli` (unpinned) is arbitrary code
 #     running with the secret in env.
 #
@@ -161,6 +162,7 @@ jobs:
           )
       - name: Re-attest reviewed workspace before credentials
         env:
+          GH_TOKEN: ${{ github.token }}
           REQUESTED_SHA: ${{ inputs.commit_sha }}
         run: |
           set -euo pipefail
@@ -171,10 +173,28 @@ jobs:
             .railway/railway.ts \
             .railway/plan-baseline.json \
             >/dev/null
-          # The reviewed ref cannot extend the TypeScript dependency closure:
-          # credentialed evaluation uses this default-branch copy, and the
-          # reviewed declaration must be byte-identical to it.
-          cmp --silent .railway/railway.ts "$RUNNER_TEMP/railway-gate-trusted/railway.ts"
+          trusted_config="$RUNNER_TEMP/railway-gate-trusted/railway.ts"
+          if ! cmp --silent .railway/railway.ts "$trusted_config"; then
+            # Rotation protocol: the old/default evaluator and toolchain remain
+            # authoritative, but may plan an exact candidate config after the
+            # independent credential-free trust-root workflow attests this SHA.
+            trust_state=$(
+              gh api "repos/$GITHUB_REPOSITORY/commits/$REQUESTED_SHA/status" \
+                --jq '[.statuses[] | select(.context == "railway-trust-root-review")][0].state // "missing"'
+            )
+            if [ "$trust_state" != success ]; then
+              echo "::error::Candidate Railway config lacks a successful exact-head trust-root attestation."
+              exit 1
+            fi
+            git ls-files --error-unmatch .railway/trusted-tools/railway.ts >/dev/null
+            candidate="$RUNNER_TEMP/railway-gate-trusted/candidate-railway.ts"
+            git show "$REQUESTED_SHA:.railway/trusted-tools/railway.ts" > "$candidate"
+            if ! cmp --silent .railway/railway.ts "$candidate"; then
+              echo "::error::Active and independently attested candidate Railway configs differ."
+              exit 1
+            fi
+            mv "$candidate" "$trusted_config"
+          fi
 
       - name: Plan gate (READ-ONLY — never applies)
         id: plan
@@ -188,8 +208,8 @@ jobs:
             echo "::error title=railway-plan-gate NOT CONFIGURED::RAILWAY_TOKEN is missing from the protected railway-plan environment."
             exit 1
           fi
-          # Keep cwd at the reviewed workspace so the trusted CLI evaluates
-          # .railway/railway.ts while its SDK resolves through the trusted link.
+          # Keep cwd at the reviewed workspace for the baseline, but evaluate
+          # only the default or independently attested config in RUNNER_TEMP.
           PATH="$RUNNER_TEMP/railway-gate-trusted/bin:$PATH" \
             node "$RUNNER_TEMP/railway-gate-trusted/plan-gate.mjs"
 

--- a/.github/workflows/railway-plan-gate.yml
+++ b/.github/workflows/railway-plan-gate.yml
@@ -63,6 +63,7 @@ jobs:
       contents: read
       statuses: write
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Publish exact PR-head requirement
         env:

--- a/.github/workflows/railway-plan-gate.yml
+++ b/.github/workflows/railway-plan-gate.yml
@@ -8,8 +8,8 @@
 #      baseline in the same PR, which makes it explicit and reviewable.
 #
 # This workflow NEVER applies. `railway config apply` stays human-gated (NFR-2).
-# Secrets never reach the logs: the gate prints only change kind/severity/summary (variable NAMES, not
-# values — Railway redacts values as «hidden»).
+# Secrets never reach the logs: the gate rejects unknown plan shapes and converts recognized changes to
+# strict, value-free identities. Upstream summaries/details/diffs are never logged or persisted.
 #
 # ── SECRET-HANDLING (FAGAN + Bridgebuilder review, 2026-07-18) ─────────────────────────────────────────
 # RAILWAY_TOKEN is apply-capable, and `railway config plan` evaluates .railway/railway.ts. Therefore this
@@ -31,9 +31,10 @@
 # pending status, so stale success cannot travel forward.
 #
 # SETUP (operator, one-time): create a protected `railway-plan` environment with required reviewers; add
-# RAILWAY_TOKEN there (Railway project token scoped to shadow-audit-api/production); remove any repo-level
-# copy; require the `railway-plan-gate` commit-status context in main's branch protection. If Railway ships a
-# read-only/plan-scoped token, replace it.
+# RAILWAY_TOKEN there (Railway project token scoped to shadow-audit-api/production, project
+# 0bf95b1c-b8f2-4e60-a4a6-50089b521eb0, environment 2068efa5-0ed4-4cf3-9ae2-89120c4b18d5); remove any
+# repo-level copy; require the `railway-plan-gate` commit-status context in main's branch protection. If
+# Railway ships a read-only/plan-scoped token, replace it.
 
 name: railway-plan-gate
 
@@ -101,13 +102,15 @@ jobs:
           fetch-depth: 0
 
       - name: Verify immutable reviewed ref
+        env:
+          REQUESTED_SHA: ${{ inputs.commit_sha }}
         run: |
           set -euo pipefail
-          case "${{ inputs.commit_sha }}" in
+          case "$REQUESTED_SHA" in
             [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
             *) echo "::error::commit_sha must be an exact lowercase 40-character commit SHA"; exit 1 ;;
           esac
-          test "$(git rev-parse HEAD)" = "${{ inputs.commit_sha }}"
+          test "$(git rev-parse HEAD)" = "$REQUESTED_SHA"
 
       - uses: actions/setup-node@v4
         with:
@@ -154,6 +157,19 @@ jobs:
           mkdir -p "$GITHUB_WORKSPACE/node_modules"
           rm -rf "$GITHUB_WORKSPACE/node_modules/railway"
           ln -s "$trusted_dir/node_modules/railway" "$GITHUB_WORKSPACE/node_modules/railway"
+
+      - name: Re-attest reviewed workspace before credentials
+        env:
+          REQUESTED_SHA: ${{ inputs.commit_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$REQUESTED_SHA"
+          git diff-index --quiet "$REQUESTED_SHA" --
+          test -z "$(git status --porcelain --untracked-files=all)"
+          git ls-files --error-unmatch \
+            .railway/railway.ts \
+            .railway/plan-baseline.json \
+            >/dev/null
 
       - name: Plan gate (READ-ONLY — never applies)
         id: plan

--- a/.github/workflows/railway-plan-gate.yml
+++ b/.github/workflows/railway-plan-gate.yml
@@ -102,7 +102,7 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.commit_sha }}
           fetch-depth: 0
@@ -118,7 +118,7 @@ jobs:
           esac
           test "$(git rev-parse HEAD)" = "$REQUESTED_SHA"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
 

--- a/.github/workflows/railway-plan-gate.yml
+++ b/.github/workflows/railway-plan-gate.yml
@@ -1,6 +1,7 @@
 # S2-T2 (SDD §8, IMP-013, G-6) — operator-approved org-as-code gate.
 #
-# Runs `railway config plan` (READ-ONLY) against .railway/railway.ts and fails the PR on:
+# Runs `railway config plan` (READ-ONLY) against the default-branch executable config (after requiring the
+# reviewed `.railway/railway.ts` to be byte-identical) and fails the PR on:
 #   1. ANY destructive change (baseline-independent) — Railway IaC is declarative and will DELETE
 #      resources it does not declare. A plan against a wrongly-linked project once read
 #      "1 to add, 3 to DESTROY" (would have deleted ordering-service + its Postgres).
@@ -12,9 +13,8 @@
 # strict, value-free identities. Upstream summaries/details/diffs are never logged or persisted.
 #
 # ── SECRET-HANDLING (FAGAN + Bridgebuilder review, 2026-07-18) ─────────────────────────────────────────
-# RAILWAY_TOKEN is apply-capable, and `railway config plan` evaluates .railway/railway.ts. Therefore this
-# workflow MUST NOT run automatically on pull_request: a trusted workflow cannot sandbox PR-controlled
-# TypeScript that it later evaluates with a deployment credential.
+# RAILWAY_TOKEN is apply-capable. Therefore the credentialed runner evaluates only default-branch code;
+# reviewed TypeScript is compared byte-for-byte and never executed with the deployment credential.
 #
 # The credentialed plan is manual-only and protected by the `railway-plan` GitHub Environment:
 #   · The operator dispatches an EXACT reviewed commit SHA (not a moving branch).
@@ -34,8 +34,8 @@
 # SETUP (operator, one-time): create a protected `railway-plan` environment with required reviewers; add
 # RAILWAY_TOKEN there (Railway project token scoped to shadow-audit-api/production, project
 # 0bf95b1c-b8f2-4e60-a4a6-50089b521eb0, environment 2068efa5-0ed4-4cf3-9ae2-89120c4b18d5); remove any
-# repo-level copy; require the `railway-plan-gate` commit-status context in main's branch protection. If
-# Railway ships a read-only/plan-scoped token, replace it.
+# repo-level copy; require both `railway-plan-gate` and `railway-trust-root-review` commit-status contexts
+# in main's branch protection. If Railway ships a read-only/plan-scoped token, replace it.
 
 name: railway-plan-gate
 
@@ -74,7 +74,9 @@ jobs:
           description='Railway plan not required for this change'
           while IFS= read -r filename; do
             case "$filename" in
-              .railway/*|packages/services/shadow-audit/Dockerfile)
+              .railway/railway.ts|\
+              .railway/plan-baseline.json|\
+              packages/services/shadow-audit/Dockerfile)
                 state=pending
                 description='Awaiting protected Railway plan for this exact commit'
                 break

--- a/.github/workflows/railway-trust-root-review.yml
+++ b/.github/workflows/railway-trust-root-review.yml
@@ -18,97 +18,13 @@ on:
     types: [opened, synchronize, reopened]
   pull_request_review:
     types: [submitted, edited, dismissed]
+  workflow_run:
+    workflows: [railway-trust-root-tests]
+    types: [completed]
 
 jobs:
-  trust-tests:
-    name: credential-free exact-head trust-root tests
-    permissions:
-      contents: read
-      pull-requests: read
-    runs-on: ubuntu-latest
-    outputs:
-      required: ${{ steps.prepare_tests.outputs.required }}
-    steps:
-      - name: Prepare exact-head trust-root tests
-        id: prepare_tests
-        env:
-          GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        run: |
-          set -euo pipefail
-          changed_count=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.changed_files')
-          if ! [[ "$changed_count" =~ ^[0-9]+$ ]] || [ "$changed_count" -ge 3000 ]; then
-            echo "required=false" >> "$GITHUB_OUTPUT"
-            exit 1
-          fi
-
-          required=false
-          while IFS= read -r filename; do
-            case "$filename" in
-              .github/workflows/railway-plan-gate.yml|\
-              .github/workflows/railway-trust-root-review.yml|\
-              .railway/BOOTSTRAP.md|\
-              .railway/plan-gate.mjs|\
-              .railway/plan-gate.test.mjs|\
-              .railway/railway.ts|\
-              .railway/trusted-tools/*)
-                required=true
-                break
-                ;;
-            esac
-          done < <(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')
-          echo "required=$required" >> "$GITHUB_OUTPUT"
-          if [ "$required" != true ]; then
-            exit 0
-          fi
-
-          root="$RUNNER_TEMP/railway-trust-tests"
-          for suite in regression candidate; do
-            mkdir -p "$root/$suite/.railway/trusted-tools"
-          done
-          fetch_raw() {
-            gh api -H 'Accept: application/vnd.github.raw+json' \
-              "repos/$GITHUB_REPOSITORY/contents/$2?ref=$1" > "$3"
-          }
-
-          # Candidate verifier code is the subject. The old/default tests are
-          # independently trusted regression policy; the candidate tests prove
-          # new intentional behavior without replacing those old assertions.
-          fetch_raw "$HEAD_SHA" .railway/plan-gate.mjs \
-            "$root/regression/.railway/plan-gate.mjs"
-          fetch_raw "$HEAD_SHA" .railway/trusted-tools/bridge-review-attestation.mjs \
-            "$root/regression/.railway/trusted-tools/bridge-review-attestation.mjs"
-          fetch_raw "$DEFAULT_BRANCH" .railway/plan-gate.test.mjs \
-            "$root/regression/.railway/plan-gate.test.mjs"
-          fetch_raw "$DEFAULT_BRANCH" .railway/trusted-tools/bridge-review-attestation.test.mjs \
-            "$root/regression/.railway/trusted-tools/bridge-review-attestation.test.mjs"
-
-          fetch_raw "$HEAD_SHA" .railway/plan-gate.mjs \
-            "$root/candidate/.railway/plan-gate.mjs"
-          fetch_raw "$HEAD_SHA" .railway/plan-gate.test.mjs \
-            "$root/candidate/.railway/plan-gate.test.mjs"
-          fetch_raw "$HEAD_SHA" .railway/trusted-tools/bridge-review-attestation.mjs \
-            "$root/candidate/.railway/trusted-tools/bridge-review-attestation.mjs"
-          fetch_raw "$HEAD_SHA" .railway/trusted-tools/bridge-review-attestation.test.mjs \
-            "$root/candidate/.railway/trusted-tools/bridge-review-attestation.test.mjs"
-
-      - name: Run trusted regression and candidate suites without credentials
-        if: steps.prepare_tests.outputs.required == 'true'
-        run: |
-          set -euo pipefail
-          root="$RUNNER_TEMP/railway-trust-tests"
-          timeout 60s node --test \
-            "$root/regression/.railway/plan-gate.test.mjs" \
-            "$root/regression/.railway/trusted-tools/bridge-review-attestation.test.mjs" \
-            "$root/candidate/.railway/plan-gate.test.mjs" \
-            "$root/candidate/.railway/trusted-tools/bridge-review-attestation.test.mjs"
-
   attest:
     name: independent Railway trust-root review
-    needs: trust-tests
-    if: always()
     permissions:
       contents: read
       pull-requests: read
@@ -117,50 +33,101 @@ jobs:
     steps:
       - name: Publish exact-head trust-root status
         env:
-          TEST_JOB_RESULT: ${{ needs.trust-tests.result }}
-          TEST_REQUIRED: ${{ needs.trust-tests.outputs.required }}
+          EVENT_NAME: ${{ github.event_name }}
           GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id || '' }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
+          case "$HEAD_SHA" in
+            [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+            *) echo "::error::No exact pull-request head was available."; exit 1 ;;
+          esac
+          case "$PR_NUMBER" in
+            ''|*[!0-9]*) echo "::error::No pull-request number was available."; exit 1 ;;
+          esac
+          pr="$RUNNER_TEMP/railway-trust-root-pr.json"
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > "$pr"
+          if [ "$(jq -r '.head.sha' "$pr")" != "$HEAD_SHA" ] ||
+            [ "$(jq -r '.state' "$pr")" != open ]
+          then
+            echo "::error::Workflow metadata does not identify the current open PR head."
+            exit 1
+          fi
+          PR_AUTHOR=$(jq -r '.user.login' "$pr")
+
           state=success
           description='Railway trust root unchanged'
           changed=false
           active_config_changed=false
           trusted_config_changed=false
-          if [ "$TEST_JOB_RESULT" != success ]; then
+          changed_count=$(jq -r '.changed_files' "$pr")
+          if ! [[ "$changed_count" =~ ^[0-9]+$ ]] || [ "$changed_count" -ge 3000 ]; then
             state=failure
-            description='Exact-head Railway trust-root tests failed'
-          else
-            files="$RUNNER_TEMP/railway-trust-root-files.txt"
-            gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
-              --paginate --jq '.[].filename' > "$files"
-            while IFS= read -r filename; do
-              case "$filename" in
-                .railway/railway.ts)
-                  changed=true
-                  active_config_changed=true
-                  ;;
-                .railway/trusted-tools/railway.ts)
-                  changed=true
-                  trusted_config_changed=true
-                  ;;
-                .github/workflows/railway-plan-gate.yml|\
-                .github/workflows/railway-trust-root-review.yml|\
-                .railway/BOOTSTRAP.md|\
-                .railway/plan-gate.mjs|\
-                .railway/plan-gate.test.mjs|\
-                .railway/trusted-tools/*)
-                  changed=true
-                  ;;
+            description='PR diff exceeds complete changed-file enumeration'
+          fi
+          files="$RUNNER_TEMP/railway-trust-root-files.txt"
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
+            --paginate --jq '.[].filename' > "$files"
+          while IFS= read -r filename; do
+            case "$filename" in
+              .railway/railway.ts)
+                changed=true
+                active_config_changed=true
+                ;;
+              .railway/trusted-tools/railway.ts)
+                changed=true
+                trusted_config_changed=true
+                ;;
+              .github/workflows/railway-plan-gate.yml|\
+              .github/workflows/railway-trust-root-review.yml|\
+              .github/workflows/railway-trust-root-tests.yml|\
+              .railway/BOOTSTRAP.md|\
+              .railway/plan-gate.mjs|\
+              .railway/plan-gate.test.mjs|\
+              .railway/trusted-tools/*)
+                changed=true
+                ;;
+            esac
+          done < "$files"
+
+          if [ "$state" != failure ] && [ "$changed" = true ]; then
+            test_run="$RUNNER_TEMP/railway-trust-root-test-run.json"
+            if [ "$EVENT_NAME" = workflow_run ]; then
+              case "$WORKFLOW_RUN_ID" in
+                ''|*[!0-9]*) state=failure ;;
+                *) gh api "repos/$GITHUB_REPOSITORY/actions/runs/$WORKFLOW_RUN_ID" > "$test_run" ;;
               esac
-            done < "$files"
+            else
+              runs="$RUNNER_TEMP/railway-trust-root-test-runs.json"
+              gh api \
+                "repos/$GITHUB_REPOSITORY/actions/workflows/railway-trust-root-tests.yml/runs?event=pull_request&head_sha=$HEAD_SHA&per_page=10" \
+                > "$runs" 2>/dev/null || echo '{"workflow_runs":[]}' > "$runs"
+              jq --arg sha "$HEAD_SHA" \
+                '[.workflow_runs[] | select(.head_sha == $sha)] |
+                 sort_by(.created_at) | last // {}' \
+                "$runs" > "$test_run"
+            fi
+            test_state=$(
+              jq -r --arg sha "$HEAD_SHA" --arg repo "$GITHUB_REPOSITORY" \
+                'if .name == "railway-trust-root-tests" and
+                    .path == ".github/workflows/railway-trust-root-tests.yml" and
+                    .event == "pull_request" and
+                    .head_sha == $sha and
+                    .head_repository.full_name == $repo and
+                    .conclusion == "success"
+                 then "success" else "pending" end' \
+                "$test_run" 2>/dev/null || echo pending
+            )
+            if [ "$test_state" != success ]; then
+              state=pending
+              description='Awaiting credential-free exact-head trust-root tests'
+            fi
           fi
 
-          if [ "$state" != failure ]; then
+          if [ "$state" = success ]; then
             if [ "$active_config_changed" = true ] || [ "$trusted_config_changed" = true ]; then
               if [ "$active_config_changed" != true ] || [ "$trusted_config_changed" != true ]; then
                 state=failure
@@ -183,7 +150,7 @@ jobs:
             fi
           fi
 
-          if [ "$state" != failure ] && [ "$changed" = true ]; then
+          if [ "$state" = success ] && [ "$changed" = true ]; then
             reviews="$RUNNER_TEMP/railway-trust-root-reviews.json"
             permissions="$RUNNER_TEMP/railway-trust-root-permissions.json"
             attestor="$RUNNER_TEMP/bridge-review-attestation.mjs"

--- a/.github/workflows/railway-trust-root-review.yml
+++ b/.github/workflows/railway-trust-root-review.yml
@@ -20,17 +20,17 @@ on:
     types: [submitted, edited, dismissed]
 
 jobs:
-  attest:
-    name: independent Railway trust-root review
+  trust-tests:
+    name: credential-free exact-head trust-root tests
     permissions:
       contents: read
       pull-requests: read
-      statuses: write
     runs-on: ubuntu-latest
+    outputs:
+      required: ${{ steps.prepare_tests.outputs.required }}
     steps:
       - name: Prepare exact-head trust-root tests
         id: prepare_tests
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -95,9 +95,7 @@ jobs:
             "$root/candidate/.railway/trusted-tools/bridge-review-attestation.test.mjs"
 
       - name: Run trusted regression and candidate suites without credentials
-        id: trust_tests
-        if: steps.prepare_tests.outputs.required == 'true' && steps.prepare_tests.outcome == 'success'
-        continue-on-error: true
+        if: steps.prepare_tests.outputs.required == 'true'
         run: |
           set -euo pipefail
           root="$RUNNER_TEMP/railway-trust-tests"
@@ -107,12 +105,20 @@ jobs:
             "$root/candidate/.railway/plan-gate.test.mjs" \
             "$root/candidate/.railway/trusted-tools/bridge-review-attestation.test.mjs"
 
+  attest:
+    name: independent Railway trust-root review
+    needs: trust-tests
+    if: always()
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    runs-on: ubuntu-latest
+    steps:
       - name: Publish exact-head trust-root status
-        if: always()
         env:
-          PREP_OUTCOME: ${{ steps.prepare_tests.outcome }}
-          TEST_OUTCOME: ${{ steps.trust_tests.outcome }}
-          TEST_REQUIRED: ${{ steps.prepare_tests.outputs.required }}
+          TEST_JOB_RESULT: ${{ needs.trust-tests.result }}
+          TEST_REQUIRED: ${{ needs.trust-tests.outputs.required }}
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -125,10 +131,7 @@ jobs:
           changed=false
           active_config_changed=false
           trusted_config_changed=false
-          if [ "$PREP_OUTCOME" != success ]; then
-            state=failure
-            description='Trust-root test preparation or diff inventory failed'
-          elif [ "$TEST_REQUIRED" = true ] && [ "$TEST_OUTCOME" != success ]; then
+          if [ "$TEST_JOB_RESULT" != success ]; then
             state=failure
             description='Exact-head Railway trust-root tests failed'
           else

--- a/.github/workflows/railway-trust-root-review.yml
+++ b/.github/workflows/railway-trust-root-review.yml
@@ -94,6 +94,25 @@ jobs:
           done < "$files"
 
           if [ "$state" != failure ] && [ "$changed" = true ]; then
+            default_runner="$RUNNER_TEMP/railway-trust-root-tests.default.yml"
+            candidate_runner="$RUNNER_TEMP/railway-trust-root-tests.candidate.yml"
+            if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/$GITHUB_REPOSITORY/contents/.github/workflows/railway-trust-root-tests.yml?ref=$DEFAULT_BRANCH" \
+              > "$default_runner"
+            then
+              state=pending
+              description='Bootstrap requires explicit exact-head review'
+            elif ! gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/$GITHUB_REPOSITORY/contents/.github/workflows/railway-trust-root-tests.yml?ref=$HEAD_SHA" \
+              > "$candidate_runner" ||
+              ! cmp --silent "$default_runner" "$candidate_runner"
+            then
+              state=failure
+              description='Independent trust-test runner differs from default branch'
+            fi
+          fi
+
+          if [ "$state" = success ] && [ "$changed" = true ]; then
             test_run="$RUNNER_TEMP/railway-trust-root-test-run.json"
             if [ "$EVENT_NAME" = workflow_run ]; then
               case "$WORKFLOW_RUN_ID" in

--- a/.github/workflows/railway-trust-root-review.yml
+++ b/.github/workflows/railway-trust-root-review.yml
@@ -1,0 +1,117 @@
+# Independent admission path for changes to the Railway gate itself.
+#
+# Ordinary `railway-plan-gate` attests an active, byte-pinned IaC declaration.
+# It MUST NOT authorize replacement of its own workflow, evaluator, executable
+# config, tests, or toolchain. Trust-root rotation is instead admitted by an
+# exact-head Bridgebuilder review from a repository member with no blocking
+# structured findings. No Railway credential is available to this workflow.
+#
+# Bootstrap: the first merge installing this workflow has no predecessor that
+# can emit the status. Its one-time ceremony is documented in
+# `.railway/BOOTSTRAP.md`; every later rotation is evaluated by the version on
+# the default branch.
+
+name: railway-trust-root-review
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted, edited]
+
+jobs:
+  attest:
+    name: independent Railway trust-root review
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish exact-head trust-root status
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          changed=false
+          while IFS= read -r filename; do
+            case "$filename" in
+              .github/workflows/railway-plan-gate.yml|\
+              .github/workflows/railway-trust-root-review.yml|\
+              .railway/BOOTSTRAP.md|\
+              .railway/plan-gate.mjs|\
+              .railway/plan-gate.test.mjs|\
+              .railway/trusted-tools/*)
+                changed=true
+                break
+                ;;
+            esac
+          done < <(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')
+
+          state=success
+          description='Railway trust root unchanged'
+          if [ "$changed" = true ]; then
+            reviews="$RUNNER_TEMP/railway-trust-root-reviews.json"
+            result="$RUNNER_TEMP/railway-trust-root-result.json"
+            gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" --paginate --slurp > "$reviews"
+            REVIEWS_FILE="$reviews" RESULT_FILE="$result" node <<'NODE'
+          const { readFileSync, writeFileSync } = require('node:fs');
+
+          const head = process.env.HEAD_SHA;
+          const reviews = JSON.parse(readFileSync(process.env.REVIEWS_FILE, 'utf8')).flat();
+          const marker = `<!-- bridgebuilder-review: ${head} -->`;
+          const trustedAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+          const eligible = reviews
+            .filter(
+              (review) =>
+                review.commit_id === head &&
+                trustedAssociations.has(review.author_association) &&
+                typeof review.body === 'string' &&
+                review.body.includes(marker),
+            )
+            .sort((a, b) => String(b.submitted_at).localeCompare(String(a.submitted_at)));
+
+          let result = {
+            state: 'pending',
+            description: 'Awaiting exact-head member Bridgebuilder review',
+          };
+          const review = eligible[0];
+          if (review) {
+            const match = review.body.match(
+              /<!-- bridge-findings-start -->\s*```json\s*([\s\S]*?)\s*```\s*<!-- bridge-findings-end -->/,
+            );
+            if (match) {
+              try {
+                const document = JSON.parse(match[1]);
+                const findings = Array.isArray(document.findings) ? document.findings : [];
+                const blocking = findings.filter((finding) =>
+                  ['CRITICAL', 'HIGH', 'MEDIUM'].includes(finding?.severity),
+                );
+                result =
+                  blocking.length === 0
+                    ? {
+                        state: 'success',
+                        description: 'Exact-head Bridgebuilder trust-root review passed',
+                      }
+                    : {
+                        state: 'failure',
+                        description: `Bridgebuilder found ${blocking.length} blocking trust-root issue(s)`,
+                      };
+              } catch {
+                // A malformed review is not an attestation.
+              }
+            }
+          }
+          writeFileSync(process.env.RESULT_FILE, JSON.stringify(result));
+          NODE
+            state=$(jq -r '.state' "$result")
+            description=$(jq -r '.description' "$result")
+          fi
+
+          gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            -f state="$state" \
+            -f context=railway-trust-root-review \
+            -f description="$description" \
+            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/pull/$PR_NUMBER"

--- a/.github/workflows/railway-trust-root-review.yml
+++ b/.github/workflows/railway-trust-root-review.yml
@@ -3,8 +3,8 @@
 # Ordinary `railway-plan-gate` attests an active, byte-pinned IaC declaration.
 # It MUST NOT authorize replacement of its own workflow, evaluator, executable
 # config, tests, or toolchain. Trust-root rotation is instead admitted by an
-# exact-head Bridgebuilder review from a repository member with no blocking
-# structured findings. No Railway credential is available to this workflow.
+# exact-head Bridgebuilder review from a non-author maintainer/admin with no
+# blocking structured findings. No Railway credential is available here.
 #
 # Bootstrap: the first merge installing this workflow has no predecessor that
 # can emit the status. Its one-time ceremony is documented in
@@ -17,7 +17,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
   pull_request_review:
-    types: [submitted, edited]
+    types: [submitted, edited, dismissed]
 
 jobs:
   attest:
@@ -33,6 +33,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           changed=false
@@ -54,58 +56,34 @@ jobs:
           description='Railway trust root unchanged'
           if [ "$changed" = true ]; then
             reviews="$RUNNER_TEMP/railway-trust-root-reviews.json"
+            permissions="$RUNNER_TEMP/railway-trust-root-permissions.json"
+            attestor="$RUNNER_TEMP/bridge-review-attestation.mjs"
             result="$RUNNER_TEMP/railway-trust-root-result.json"
             gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" --paginate --slurp > "$reviews"
-            REVIEWS_FILE="$reviews" RESULT_FILE="$result" node <<'NODE'
-          const { readFileSync, writeFileSync } = require('node:fs');
+            gh api \
+              -H 'Accept: application/vnd.github.raw+json' \
+              "repos/$GITHUB_REPOSITORY/contents/.railway/trusted-tools/bridge-review-attestation.mjs?ref=$DEFAULT_BRANCH" \
+              > "$attestor"
 
-          const head = process.env.HEAD_SHA;
-          const reviews = JSON.parse(readFileSync(process.env.REVIEWS_FILE, 'utf8')).flat();
-          const marker = `<!-- bridgebuilder-review: ${head} -->`;
-          const trustedAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
-          const eligible = reviews
-            .filter(
-              (review) =>
-                review.commit_id === head &&
-                trustedAssociations.has(review.author_association) &&
-                typeof review.body === 'string' &&
-                review.body.includes(marker),
-            )
-            .sort((a, b) => String(b.submitted_at).localeCompare(String(a.submitted_at)));
+            echo '{}' > "$permissions"
+            while IFS= read -r reviewer; do
+              case "$reviewer" in
+                ''|*[!A-Za-z0-9-]*) continue ;;
+              esac
+              permission=$(
+                gh api "repos/$GITHUB_REPOSITORY/collaborators/$reviewer/permission" \
+                  --jq '.permission' 2>/dev/null || echo none
+              )
+              jq --arg reviewer "$reviewer" --arg permission "$permission" \
+                '. + {($reviewer): $permission}' "$permissions" > "$permissions.next"
+              mv "$permissions.next" "$permissions"
+            done < <(jq -r '[.[][] | .user.login // empty] | unique[]' "$reviews")
 
-          let result = {
-            state: 'pending',
-            description: 'Awaiting exact-head member Bridgebuilder review',
-          };
-          const review = eligible[0];
-          if (review) {
-            const match = review.body.match(
-              /<!-- bridge-findings-start -->\s*```json\s*([\s\S]*?)\s*```\s*<!-- bridge-findings-end -->/,
-            );
-            if (match) {
-              try {
-                const document = JSON.parse(match[1]);
-                const findings = Array.isArray(document.findings) ? document.findings : [];
-                const blocking = findings.filter((finding) =>
-                  ['CRITICAL', 'HIGH', 'MEDIUM'].includes(finding?.severity),
-                );
-                result =
-                  blocking.length === 0
-                    ? {
-                        state: 'success',
-                        description: 'Exact-head Bridgebuilder trust-root review passed',
-                      }
-                    : {
-                        state: 'failure',
-                        description: `Bridgebuilder found ${blocking.length} blocking trust-root issue(s)`,
-                      };
-              } catch {
-                // A malformed review is not an attestation.
-              }
-            }
-          }
-          writeFileSync(process.env.RESULT_FILE, JSON.stringify(result));
-          NODE
+            REVIEWS_FILE="$reviews" \
+              PERMISSIONS_FILE="$permissions" \
+              HEAD_SHA="$HEAD_SHA" \
+              PR_AUTHOR="$PR_AUTHOR" \
+              node "$attestor" > "$result"
             state=$(jq -r '.state' "$result")
             description=$(jq -r '.description' "$result")
           fi

--- a/.github/workflows/railway-trust-root-review.yml
+++ b/.github/workflows/railway-trust-root-review.yml
@@ -37,24 +37,65 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
-          changed=false
-          while IFS= read -r filename; do
-            case "$filename" in
-              .github/workflows/railway-plan-gate.yml|\
-              .github/workflows/railway-trust-root-review.yml|\
-              .railway/BOOTSTRAP.md|\
-              .railway/plan-gate.mjs|\
-              .railway/plan-gate.test.mjs|\
-              .railway/trusted-tools/*)
-                changed=true
-                break
-                ;;
-            esac
-          done < <(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')
-
           state=success
           description='Railway trust root unchanged'
-          if [ "$changed" = true ]; then
+          changed=false
+          active_config_changed=false
+          trusted_config_changed=false
+          changed_count=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.changed_files')
+          if ! [[ "$changed_count" =~ ^[0-9]+$ ]] || [ "$changed_count" -ge 3000 ]; then
+            state=failure
+            description='PR diff exceeds complete changed-file enumeration'
+          else
+            files="$RUNNER_TEMP/railway-trust-root-files.txt"
+            gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
+              --paginate --jq '.[].filename' > "$files"
+            while IFS= read -r filename; do
+              case "$filename" in
+                .railway/railway.ts)
+                  changed=true
+                  active_config_changed=true
+                  ;;
+                .railway/trusted-tools/railway.ts)
+                  changed=true
+                  trusted_config_changed=true
+                  ;;
+                .github/workflows/railway-plan-gate.yml|\
+                .github/workflows/railway-trust-root-review.yml|\
+                .railway/BOOTSTRAP.md|\
+                .railway/plan-gate.mjs|\
+                .railway/plan-gate.test.mjs|\
+                .railway/trusted-tools/*)
+                  changed=true
+                  ;;
+              esac
+            done < "$files"
+          fi
+
+          if [ "$state" != failure ]; then
+            if [ "$active_config_changed" = true ] || [ "$trusted_config_changed" = true ]; then
+              if [ "$active_config_changed" != true ] || [ "$trusted_config_changed" != true ]; then
+                state=failure
+                description='Active and trusted Railway configs must rotate together'
+              else
+                active_config="$RUNNER_TEMP/active-railway.ts"
+                trusted_config="$RUNNER_TEMP/trusted-railway.ts"
+                if ! gh api -H 'Accept: application/vnd.github.raw+json' \
+                  "repos/$GITHUB_REPOSITORY/contents/.railway/railway.ts?ref=$HEAD_SHA" \
+                  > "$active_config" ||
+                  ! gh api -H 'Accept: application/vnd.github.raw+json' \
+                  "repos/$GITHUB_REPOSITORY/contents/.railway/trusted-tools/railway.ts?ref=$HEAD_SHA" \
+                  > "$trusted_config" ||
+                  ! cmp --silent "$active_config" "$trusted_config"
+                then
+                  state=failure
+                  description='Active and trusted Railway configs differ at exact head'
+                fi
+              fi
+            fi
+          fi
+
+          if [ "$state" != failure ] && [ "$changed" = true ]; then
             reviews="$RUNNER_TEMP/railway-trust-root-reviews.json"
             permissions="$RUNNER_TEMP/railway-trust-root-permissions.json"
             attestor="$RUNNER_TEMP/bridge-review-attestation.mjs"

--- a/.github/workflows/railway-trust-root-review.yml
+++ b/.github/workflows/railway-trust-root-review.yml
@@ -28,8 +28,91 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     steps:
-      - name: Publish exact-head trust-root status
+      - name: Prepare exact-head trust-root tests
+        id: prepare_tests
+        continue-on-error: true
         env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          changed_count=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.changed_files')
+          if ! [[ "$changed_count" =~ ^[0-9]+$ ]] || [ "$changed_count" -ge 3000 ]; then
+            echo "required=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          required=false
+          while IFS= read -r filename; do
+            case "$filename" in
+              .github/workflows/railway-plan-gate.yml|\
+              .github/workflows/railway-trust-root-review.yml|\
+              .railway/BOOTSTRAP.md|\
+              .railway/plan-gate.mjs|\
+              .railway/plan-gate.test.mjs|\
+              .railway/railway.ts|\
+              .railway/trusted-tools/*)
+                required=true
+                break
+                ;;
+            esac
+          done < <(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')
+          echo "required=$required" >> "$GITHUB_OUTPUT"
+          if [ "$required" != true ]; then
+            exit 0
+          fi
+
+          root="$RUNNER_TEMP/railway-trust-tests"
+          for suite in regression candidate; do
+            mkdir -p "$root/$suite/.railway/trusted-tools"
+          done
+          fetch_raw() {
+            gh api -H 'Accept: application/vnd.github.raw+json' \
+              "repos/$GITHUB_REPOSITORY/contents/$2?ref=$1" > "$3"
+          }
+
+          # Candidate verifier code is the subject. The old/default tests are
+          # independently trusted regression policy; the candidate tests prove
+          # new intentional behavior without replacing those old assertions.
+          fetch_raw "$HEAD_SHA" .railway/plan-gate.mjs \
+            "$root/regression/.railway/plan-gate.mjs"
+          fetch_raw "$HEAD_SHA" .railway/trusted-tools/bridge-review-attestation.mjs \
+            "$root/regression/.railway/trusted-tools/bridge-review-attestation.mjs"
+          fetch_raw "$DEFAULT_BRANCH" .railway/plan-gate.test.mjs \
+            "$root/regression/.railway/plan-gate.test.mjs"
+          fetch_raw "$DEFAULT_BRANCH" .railway/trusted-tools/bridge-review-attestation.test.mjs \
+            "$root/regression/.railway/trusted-tools/bridge-review-attestation.test.mjs"
+
+          fetch_raw "$HEAD_SHA" .railway/plan-gate.mjs \
+            "$root/candidate/.railway/plan-gate.mjs"
+          fetch_raw "$HEAD_SHA" .railway/plan-gate.test.mjs \
+            "$root/candidate/.railway/plan-gate.test.mjs"
+          fetch_raw "$HEAD_SHA" .railway/trusted-tools/bridge-review-attestation.mjs \
+            "$root/candidate/.railway/trusted-tools/bridge-review-attestation.mjs"
+          fetch_raw "$HEAD_SHA" .railway/trusted-tools/bridge-review-attestation.test.mjs \
+            "$root/candidate/.railway/trusted-tools/bridge-review-attestation.test.mjs"
+
+      - name: Run trusted regression and candidate suites without credentials
+        id: trust_tests
+        if: steps.prepare_tests.outputs.required == 'true' && steps.prepare_tests.outcome == 'success'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/railway-trust-tests"
+          timeout 60s node --test \
+            "$root/regression/.railway/plan-gate.test.mjs" \
+            "$root/regression/.railway/trusted-tools/bridge-review-attestation.test.mjs" \
+            "$root/candidate/.railway/plan-gate.test.mjs" \
+            "$root/candidate/.railway/trusted-tools/bridge-review-attestation.test.mjs"
+
+      - name: Publish exact-head trust-root status
+        if: always()
+        env:
+          PREP_OUTCOME: ${{ steps.prepare_tests.outcome }}
+          TEST_OUTCOME: ${{ steps.trust_tests.outcome }}
+          TEST_REQUIRED: ${{ steps.prepare_tests.outputs.required }}
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -42,10 +125,12 @@ jobs:
           changed=false
           active_config_changed=false
           trusted_config_changed=false
-          changed_count=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.changed_files')
-          if ! [[ "$changed_count" =~ ^[0-9]+$ ]] || [ "$changed_count" -ge 3000 ]; then
+          if [ "$PREP_OUTCOME" != success ]; then
             state=failure
-            description='PR diff exceeds complete changed-file enumeration'
+            description='Trust-root test preparation or diff inventory failed'
+          elif [ "$TEST_REQUIRED" = true ] && [ "$TEST_OUTCOME" != success ]; then
+            state=failure
+            description='Exact-head Railway trust-root tests failed'
           else
             files="$RUNNER_TEMP/railway-trust-root-files.txt"
             gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \

--- a/.github/workflows/railway-trust-root-review.yml
+++ b/.github/workflows/railway-trust-root-review.yml
@@ -21,10 +21,13 @@ on:
   workflow_run:
     workflows: [railway-trust-root-tests]
     types: [completed]
+  schedule:
+    - cron: '*/5 * * * *'
 
 jobs:
   attest:
     name: independent Railway trust-root review
+    if: github.event_name != 'schedule'
     permissions:
       contents: read
       pull-requests: read
@@ -208,3 +211,77 @@ jobs:
             -f context=railway-trust-root-review \
             -f description="$description" \
             -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/pull/$PR_NUMBER"
+
+  refresh-authorizations:
+    name: refresh Railway reviewer authorization
+    if: github.event_name == 'schedule'
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Revoke stale successful attestations
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          attestor="$RUNNER_TEMP/bridge-review-attestation.mjs"
+          gh api -H 'Accept: application/vnd.github.raw+json' \
+            "repos/$GITHUB_REPOSITORY/contents/.railway/trusted-tools/bridge-review-attestation.mjs?ref=$DEFAULT_BRANCH" \
+            > "$attestor"
+
+          while IFS= read -r pr_number; do
+            pr="$RUNNER_TEMP/pr-$pr_number.json"
+            gh api "repos/$GITHUB_REPOSITORY/pulls/$pr_number" > "$pr"
+            head_sha=$(jq -r '.head.sha' "$pr")
+            pr_author=$(jq -r '.user.login' "$pr")
+            current_state=$(
+              gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/status" \
+                --jq '[.statuses[] | select(.context == "railway-trust-root-review")] |
+                      sort_by(.created_at) | last | .state // "missing"'
+            )
+            if [ "$current_state" != success ]; then
+              continue
+            fi
+
+            reviews="$RUNNER_TEMP/reviews-$pr_number.json"
+            permissions="$RUNNER_TEMP/permissions-$pr_number.json"
+            result="$RUNNER_TEMP/result-$pr_number.json"
+            gh api "repos/$GITHUB_REPOSITORY/pulls/$pr_number/reviews" \
+              --paginate --slurp > "$reviews"
+            echo '{}' > "$permissions"
+            while IFS= read -r reviewer; do
+              case "$reviewer" in
+                ''|*[!A-Za-z0-9-]*) continue ;;
+              esac
+              permission=$(
+                gh api "repos/$GITHUB_REPOSITORY/collaborators/$reviewer/permission" \
+                  --jq '.permission' 2>/dev/null || echo none
+              )
+              jq --arg reviewer "$reviewer" --arg permission "$permission" \
+                '. + {($reviewer): $permission}' "$permissions" > "$permissions.next"
+              mv "$permissions.next" "$permissions"
+            done < <(jq -r '[.[][] | .user.login // empty] | unique[]' "$reviews")
+
+            REVIEWS_FILE="$reviews" \
+              PERMISSIONS_FILE="$permissions" \
+              HEAD_SHA="$head_sha" \
+              PR_AUTHOR="$pr_author" \
+              node "$attestor" > "$result"
+            state=$(jq -r '.state' "$result")
+            if [ "$state" = success ]; then
+              continue
+            fi
+            description=$(jq -r '.description' "$result")
+            gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$head_sha" \
+              -f state="$state" \
+              -f context=railway-trust-root-review \
+              -f description="$description" \
+              -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/pull/$pr_number"
+          done < <(
+            gh api "repos/$GITHUB_REPOSITORY/pulls?state=open&per_page=100" \
+              --paginate --jq '.[].number'
+          )

--- a/.github/workflows/railway-trust-root-tests.yml
+++ b/.github/workflows/railway-trust-root-tests.yml
@@ -49,14 +49,32 @@ jobs:
           done
 
           git fetch --no-tags origin "$DEFAULT_BRANCH"
-          git show "origin/$DEFAULT_BRANCH:.railway/plan-gate.test.mjs" \
-            > "$root/regression/.railway/plan-gate.test.mjs"
-          git show "origin/$DEFAULT_BRANCH:.railway/trusted-tools/bridge-review-attestation.test.mjs" \
-            > "$root/regression/.railway/trusted-tools/bridge-review-attestation.test.mjs"
-          cp .railway/plan-gate.mjs \
-            "$root/regression/.railway/plan-gate.mjs"
-          cp .railway/trusted-tools/bridge-review-attestation.mjs \
-            "$root/regression/.railway/trusted-tools/bridge-review-attestation.mjs"
+          suites=()
+          has_plan_regression=false
+          has_review_regression=false
+          git cat-file -e "origin/$DEFAULT_BRANCH:.railway/plan-gate.test.mjs" &&
+            has_plan_regression=true
+          git cat-file -e "origin/$DEFAULT_BRANCH:.railway/trusted-tools/bridge-review-attestation.test.mjs" &&
+            has_review_regression=true
+          if [ "$has_plan_regression" = true ] && [ "$has_review_regression" = true ]; then
+            git show "origin/$DEFAULT_BRANCH:.railway/plan-gate.test.mjs" \
+              > "$root/regression/.railway/plan-gate.test.mjs"
+            git show "origin/$DEFAULT_BRANCH:.railway/trusted-tools/bridge-review-attestation.test.mjs" \
+              > "$root/regression/.railway/trusted-tools/bridge-review-attestation.test.mjs"
+            cp .railway/plan-gate.mjs \
+              "$root/regression/.railway/plan-gate.mjs"
+            cp .railway/trusted-tools/bridge-review-attestation.mjs \
+              "$root/regression/.railway/trusted-tools/bridge-review-attestation.mjs"
+            suites+=(
+              "$root/regression/.railway/plan-gate.test.mjs"
+              "$root/regression/.railway/trusted-tools/bridge-review-attestation.test.mjs"
+            )
+          elif [ "$has_plan_regression" = true ] || [ "$has_review_regression" = true ]; then
+            echo "::error::Default branch has an incomplete Railway trust-root regression suite."
+            exit 1
+          else
+            echo "Bootstrap: default branch has no predecessor trust-root tests; candidate suites only."
+          fi
 
           cp .railway/plan-gate.mjs \
             "$root/candidate/.railway/plan-gate.mjs"
@@ -66,9 +84,9 @@ jobs:
             "$root/candidate/.railway/trusted-tools/bridge-review-attestation.mjs"
           cp .railway/trusted-tools/bridge-review-attestation.test.mjs \
             "$root/candidate/.railway/trusted-tools/bridge-review-attestation.test.mjs"
-
-          timeout 60s node --test \
-            "$root/regression/.railway/plan-gate.test.mjs" \
-            "$root/regression/.railway/trusted-tools/bridge-review-attestation.test.mjs" \
-            "$root/candidate/.railway/plan-gate.test.mjs" \
+          suites+=(
+            "$root/candidate/.railway/plan-gate.test.mjs"
             "$root/candidate/.railway/trusted-tools/bridge-review-attestation.test.mjs"
+          )
+
+          timeout 60s node --test "${suites[@]}"

--- a/.github/workflows/railway-trust-root-tests.yml
+++ b/.github/workflows/railway-trust-root-tests.yml
@@ -1,0 +1,74 @@
+# Unprivileged producer for Railway trust-root test evidence.
+#
+# Candidate code executes only under the ordinary pull_request event, with no
+# Railway credential and a read-only repository token. The separate trusted
+# pull_request_target/workflow_run attester consumes only this run's immutable
+# identity, repository, exact head SHA, and conclusion; it never imports an
+# artifact, output, environment value, or script from this workflow.
+
+name: railway-trust-root-tests
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/railway-plan-gate.yml'
+      - '.github/workflows/railway-trust-root-review.yml'
+      - '.github/workflows/railway-trust-root-tests.yml'
+      - '.railway/BOOTSTRAP.md'
+      - '.railway/plan-gate.mjs'
+      - '.railway/plan-gate.test.mjs'
+      - '.railway/railway.ts'
+      - '.railway/trusted-tools/**'
+
+permissions:
+  contents: read
+
+jobs:
+  trust-tests:
+    name: credential-free exact-head trust-root tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+
+      - name: Run default regression and exact-head candidate suites
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/railway-trust-tests"
+          for suite in regression candidate; do
+            mkdir -p "$root/$suite/.railway/trusted-tools"
+          done
+
+          git fetch --no-tags origin "$DEFAULT_BRANCH"
+          git show "origin/$DEFAULT_BRANCH:.railway/plan-gate.test.mjs" \
+            > "$root/regression/.railway/plan-gate.test.mjs"
+          git show "origin/$DEFAULT_BRANCH:.railway/trusted-tools/bridge-review-attestation.test.mjs" \
+            > "$root/regression/.railway/trusted-tools/bridge-review-attestation.test.mjs"
+          cp .railway/plan-gate.mjs \
+            "$root/regression/.railway/plan-gate.mjs"
+          cp .railway/trusted-tools/bridge-review-attestation.mjs \
+            "$root/regression/.railway/trusted-tools/bridge-review-attestation.mjs"
+
+          cp .railway/plan-gate.mjs \
+            "$root/candidate/.railway/plan-gate.mjs"
+          cp .railway/plan-gate.test.mjs \
+            "$root/candidate/.railway/plan-gate.test.mjs"
+          cp .railway/trusted-tools/bridge-review-attestation.mjs \
+            "$root/candidate/.railway/trusted-tools/bridge-review-attestation.mjs"
+          cp .railway/trusted-tools/bridge-review-attestation.test.mjs \
+            "$root/candidate/.railway/trusted-tools/bridge-review-attestation.test.mjs"
+
+          timeout 60s node --test \
+            "$root/regression/.railway/plan-gate.test.mjs" \
+            "$root/regression/.railway/trusted-tools/bridge-review-attestation.test.mjs" \
+            "$root/candidate/.railway/plan-gate.test.mjs" \
+            "$root/candidate/.railway/trusted-tools/bridge-review-attestation.test.mjs"

--- a/.railway/BOOTSTRAP.md
+++ b/.railway/BOOTSTRAP.md
@@ -34,3 +34,20 @@ executable config, or tool-lock file. A later Railway PR's active
 `.railway/railway.ts` must be byte-identical to the default-branch trust-root
 copy, but the credentialed job executes only the trusted copy. Unrelated
 repository files are therefore outside the executable input closure.
+
+## Trust-root rotation sequence
+
+An intentional config rotation changes both `.railway/railway.ts` and
+`.railway/trusted-tools/railway.ts` to identical bytes in one PR:
+
+1. Both exact-head statuses begin pending.
+2. A non-author maintainer/admin runs Bridgebuilder. The default-branch
+   `railway-trust-root-review` validates that review without Railway credentials
+   and attests the candidate SHA.
+3. Only after that success may the protected plan run. It retains the old
+   default-branch evaluator, SDK lock, and CLI checksum; it extracts the
+   candidate config from the attested SHA, verifies it is byte-identical to the
+   active config, then evaluates that exact candidate.
+4. The PR merges only when both contexts succeed. If review is dismissed, the
+   candidate changes again, or the plan fails, no trust-root state advances;
+   `main` remains the rollback root.

--- a/.railway/BOOTSTRAP.md
+++ b/.railway/BOOTSTRAP.md
@@ -52,12 +52,14 @@ An intentional config rotation changes both `.railway/railway.ts` and
    `railway-trust-root-review` validates that review without Railway credentials
    and attests the candidate SHA. That workflow also requires both config copies
    to change together and fetches them from the exact head to prove byte identity.
-   Before attestation, a credential-free job runs the old/default regression
-   suites against candidate verifier code, then runs the candidate suites too.
-   That job receives no write permission or Railway token. The status publisher
-   runs afterward on a fresh runner and consumes only GitHub's recorded job
-   result and the boolean indicating whether trust-root files changed; it never
-   receives candidate-produced files, environment values, or command outputs.
+   Before attestation, the separate `railway-trust-root-tests` workflow runs
+   under the ordinary unprivileged `pull_request` event. It executes the
+   old/default regression suites against candidate verifier code, then runs the
+   candidate suites too, with no write permission or Railway token. The trusted
+   `pull_request_target`/`workflow_run` status publisher consumes only the
+   canonical workflow-run identity, repository, exact head SHA, and conclusion;
+   it never receives candidate-produced files, environment values, or command
+   outputs, and it never executes PR-head code.
 3. Only after that success may the protected plan run. It retains the old
    default-branch evaluator, SDK lock, and CLI checksum; it extracts the
    candidate config from the attested SHA, verifies it is byte-identical to the

--- a/.railway/BOOTSTRAP.md
+++ b/.railway/BOOTSTRAP.md
@@ -45,6 +45,9 @@ An intentional config rotation changes both `.railway/railway.ts` and
    `railway-trust-root-review` validates that review without Railway credentials
    and attests the candidate SHA. That workflow also requires both config copies
    to change together and fetches them from the exact head to prove byte identity.
+   Before attestation, a credential-free step runs the old/default regression
+   suites against candidate verifier code, then runs the candidate suites too;
+   neither test process receives a GitHub or Railway token.
 3. Only after that success may the protected plan run. It retains the old
    default-branch evaluator, SDK lock, and CLI checksum; it extracts the
    candidate config from the attested SHA, verifies it is byte-identical to the

--- a/.railway/BOOTSTRAP.md
+++ b/.railway/BOOTSTRAP.md
@@ -32,6 +32,9 @@ Captured Railway v4.10.0 plans identify safe service and Postgres creation as
 `resource.create` with `Create service <name>` and `Create database <name>`
 summaries. The evaluator converts only those two strict shapes into value-free
 baseline identities; other creation types fail closed until separately grounded.
+Subprocess stderr, malformed JSON, and exception messages are never reflected
+into CI logs; the public diagnostic surface is limited to fixed local codes such
+as `PLAN_EXEC_FAILED`, `PLAN_JSON_INVALID`, and `PLAN_SCHEMA_REJECTED`.
 
 The workflow fails closed when the default branch lacks any trusted evaluator,
 executable config, or tool-lock file. A later Railway PR's active

--- a/.railway/BOOTSTRAP.md
+++ b/.railway/BOOTSTRAP.md
@@ -60,6 +60,10 @@ An intentional config rotation changes both `.railway/railway.ts` and
    canonical workflow-run identity, repository, exact head SHA, and conclusion;
    it never receives candidate-produced files, environment values, or command
    outputs, and it never executes PR-head code.
+   For this first bootstrap only, no default-branch regression suite exists, so
+   the unprivileged workflow runs all candidate tests and the exact-head
+   Bridgebuilder review is the independent substitute. Once merged, absence of
+   either default regression file is a hard test failure.
 3. Only after that success may the protected plan run. It retains the old
    default-branch evaluator, SDK lock, and CLI checksum; it extracts the
    candidate config from the attested SHA, verifies it is byte-identical to the

--- a/.railway/BOOTSTRAP.md
+++ b/.railway/BOOTSTRAP.md
@@ -28,6 +28,10 @@ The trusted evaluator is bound to Railway project
 `0bf95b1c-b8f2-4e60-a4a6-50089b521eb0` and production environment
 `2068efa5-0ed4-4cf3-9ae2-89120c4b18d5`. A token or checkout resolving to any
 other target fails before changes are compared or logged.
+Captured Railway v4.10.0 plans identify safe service and Postgres creation as
+`resource.create` with `Create service <name>` and `Create database <name>`
+summaries. The evaluator converts only those two strict shapes into value-free
+baseline identities; other creation types fail closed until separately grounded.
 
 The workflow fails closed when the default branch lacks any trusted evaluator,
 executable config, or tool-lock file. A later Railway PR's active

--- a/.railway/BOOTSTRAP.md
+++ b/.railway/BOOTSTRAP.md
@@ -43,7 +43,8 @@ An intentional config rotation changes both `.railway/railway.ts` and
 1. Both exact-head statuses begin pending.
 2. A non-author maintainer/admin runs Bridgebuilder. The default-branch
    `railway-trust-root-review` validates that review without Railway credentials
-   and attests the candidate SHA.
+   and attests the candidate SHA. That workflow also requires both config copies
+   to change together and fetches them from the exact head to prove byte identity.
 3. Only after that success may the protected plan run. It retains the old
    default-branch evaluator, SDK lock, and CLI checksum; it extracts the
    candidate config from the attested SHA, verifies it is byte-identical to the
@@ -51,3 +52,8 @@ An intentional config rotation changes both `.railway/railway.ts` and
 4. The PR merges only when both contexts succeed. If review is dismissed, the
    candidate changes again, or the plan fails, no trust-root state advances;
    `main` remains the rollback root.
+
+Both status workflows reject PRs at GitHub's 3,000-file pull-files API ceiling,
+where complete changed-path enumeration cannot be proven. The manual plan entry
+rechecks the associated open PR and the same ceiling before credentials are
+requested, so a dispatch cannot overwrite that inventory failure with success.

--- a/.railway/BOOTSTRAP.md
+++ b/.railway/BOOTSTRAP.md
@@ -8,14 +8,20 @@ under `.railway/trusted-tools/railway.ts` is a dormant trust-root copy: the CLI
 does not discover it automatically, and the bootstrap never executes it:
 
 1. Review the exact PR head with Bridgebuilder.
-2. Confirm the workflow contains no apply path and the bootstrap diff contains
-   no Railway resource declaration.
-3. Merge the bootstrap only after its exact-head review passes.
+2. Confirm there is no auto-discovered active config or apply path. Review the
+   dormant resource declaration in full because it becomes the executable
+   default-branch trust root after merge.
+3. Merge the bootstrap only after its exact-head Bridgebuilder review contains
+   no critical, high, or medium findings. This is the one-time substitute for
+   the not-yet-installed `railway-trust-root-review` status.
 4. On `main`, create the protected `railway-plan` environment with required
    reviewers, move `RAILWAY_TOKEN` into that environment, and require the
-   `railway-plan-gate` commit status for branch protection.
+   `railway-plan-gate` and `railway-trust-root-review` commit-status contexts
+   for branch protection.
 5. Every later Railway change is marked pending on its exact PR head and must
-   receive a protected manual plan status for that same SHA.
+   receive the applicable exact-head status. Active IaC uses the protected
+   manual plan; verifier/workflow/toolchain rotations use the independent
+   member-authored Bridgebuilder attestation with no Railway credential.
 
 The trusted evaluator is bound to Railway project
 `0bf95b1c-b8f2-4e60-a4a6-50089b521eb0` and production environment

--- a/.railway/BOOTSTRAP.md
+++ b/.railway/BOOTSTRAP.md
@@ -1,0 +1,21 @@
+# Railway plan-gate bootstrap
+
+The credentialed gate cannot attest to the same change that creates its trust
+root. The first merge that adds `.github/workflows/railway-plan-gate.yml`,
+`.railway/plan-gate.mjs`, and `.railway/trusted-tools/` is therefore bootstrap
+only:
+
+1. Review the exact PR head with Bridgebuilder.
+2. From a trusted operator checkout, run `railway config plan --json` and the
+   gate without applying. Record only the pass/fail receipt; never copy plan
+   values or credentials into the PR.
+3. Merge the bootstrap only when the read-only plan has no destructive change
+   and the committed baseline matches.
+4. On `main`, create the protected `railway-plan` environment with required
+   reviewers, move `RAILWAY_TOKEN` into that environment, and require the
+   `railway-plan-gate` commit status for branch protection.
+5. Every later Railway change is marked pending on its exact PR head and must
+   receive a protected manual plan status for that same SHA.
+
+The workflow fails closed when the default branch lacks any trusted evaluator
+or tool-lock file. It never falls back to code from the reviewed PR.

--- a/.railway/BOOTSTRAP.md
+++ b/.railway/BOOTSTRAP.md
@@ -3,19 +3,23 @@
 The credentialed gate cannot attest to the same change that creates its trust
 root. The first merge that adds `.github/workflows/railway-plan-gate.yml`,
 `.railway/plan-gate.mjs`, and `.railway/trusted-tools/` is therefore bootstrap
-only:
+only. It contains no `.railway/railway.ts`, so there is no reviewed resource
+declaration to execute during this bootstrap:
 
 1. Review the exact PR head with Bridgebuilder.
-2. From a trusted operator checkout, run `railway config plan --json` and the
-   gate without applying. Record only the pass/fail receipt; never copy plan
-   values or credentials into the PR.
-3. Merge the bootstrap only when the read-only plan has no destructive change
-   and the committed baseline matches.
+2. Confirm the workflow contains no apply path and the bootstrap diff contains
+   no Railway resource declaration.
+3. Merge the bootstrap only after its exact-head review passes.
 4. On `main`, create the protected `railway-plan` environment with required
    reviewers, move `RAILWAY_TOKEN` into that environment, and require the
    `railway-plan-gate` commit status for branch protection.
 5. Every later Railway change is marked pending on its exact PR head and must
    receive a protected manual plan status for that same SHA.
+
+The trusted evaluator is bound to Railway project
+`0bf95b1c-b8f2-4e60-a4a6-50089b521eb0` and production environment
+`2068efa5-0ed4-4cf3-9ae2-89120c4b18d5`. A token or checkout resolving to any
+other target fails before changes are compared or logged.
 
 The workflow fails closed when the default branch lacks any trusted evaluator
 or tool-lock file. It never falls back to code from the reviewed PR.

--- a/.railway/BOOTSTRAP.md
+++ b/.railway/BOOTSTRAP.md
@@ -59,11 +59,17 @@ An intentional config rotation changes both `.railway/railway.ts` and
    `pull_request_target`/`workflow_run` status publisher consumes only the
    canonical workflow-run identity, repository, exact head SHA, and conclusion;
    it never receives candidate-produced files, environment values, or command
-   outputs, and it never executes PR-head code.
+   outputs, and it never executes PR-head code. Before accepting that
+   conclusion, it also proves the candidate's
+   `railway-trust-root-tests.yml` is byte-identical to the default-branch
+   runner, so a candidate cannot replace the test command with a no-op.
    For this first bootstrap only, no default-branch regression suite exists, so
    the unprivileged workflow runs all candidate tests and the exact-head
    Bridgebuilder review is the independent substitute. Once merged, absence of
    either default regression file is a hard test failure.
+   The independent runner is deliberately outside ordinary trust-root rotation:
+   changing it requires a separate bootstrap ceremony and may not be combined
+   with verifier/config/toolchain changes that rely on its conclusion.
 3. Only after that success may the protected plan run. It retains the old
    default-branch evaluator, SDK lock, and CLI checksum; it extracts the
    candidate config from the attested SHA, verifies it is byte-identical to the

--- a/.railway/BOOTSTRAP.md
+++ b/.railway/BOOTSTRAP.md
@@ -3,8 +3,9 @@
 The credentialed gate cannot attest to the same change that creates its trust
 root. The first merge that adds `.github/workflows/railway-plan-gate.yml`,
 `.railway/plan-gate.mjs`, and `.railway/trusted-tools/` is therefore bootstrap
-only. It contains no `.railway/railway.ts`, so there is no reviewed resource
-declaration to execute during this bootstrap:
+only. It contains no active `.railway/railway.ts`. The resource declaration
+under `.railway/trusted-tools/railway.ts` is a dormant trust-root copy: the CLI
+does not discover it automatically, and the bootstrap never executes it:
 
 1. Review the exact PR head with Bridgebuilder.
 2. Confirm the workflow contains no apply path and the bootstrap diff contains
@@ -21,5 +22,8 @@ The trusted evaluator is bound to Railway project
 `2068efa5-0ed4-4cf3-9ae2-89120c4b18d5`. A token or checkout resolving to any
 other target fails before changes are compared or logged.
 
-The workflow fails closed when the default branch lacks any trusted evaluator
-or tool-lock file. It never falls back to code from the reviewed PR.
+The workflow fails closed when the default branch lacks any trusted evaluator,
+executable config, or tool-lock file. A later Railway PR's active
+`.railway/railway.ts` must be byte-identical to the default-branch trust-root
+copy, but the credentialed job executes only the trusted copy. Unrelated
+repository files are therefore outside the executable input closure.

--- a/.railway/BOOTSTRAP.md
+++ b/.railway/BOOTSTRAP.md
@@ -70,6 +70,13 @@ An intentional config rotation changes both `.railway/railway.ts` and
    The independent runner is deliberately outside ordinary trust-root rotation:
    changing it requires a separate bootstrap ceremony and may not be combined
    with verifier/config/toolchain changes that rely on its conclusion.
+   Eligible exact-head reviews use union-of-blockers semantics: one clean review
+   cannot conceal another current maintainer's critical, high, or medium finding.
+   GitHub emits no event when collaborator permission changes, so the trusted
+   default-branch workflow re-evaluates every successful open-PR attestation on
+   a five-minute schedule and republishes pending/failure if authorization was
+   revoked. This bounds—but cannot eliminate—the residual stale-authorization
+   window; merge policy must not bypass that required status.
 3. Only after that success may the protected plan run. It retains the old
    default-branch evaluator, SDK lock, and CLI checksum; it extracts the
    candidate config from the attested SHA, verifies it is byte-identical to the

--- a/.railway/BOOTSTRAP.md
+++ b/.railway/BOOTSTRAP.md
@@ -45,9 +45,12 @@ An intentional config rotation changes both `.railway/railway.ts` and
    `railway-trust-root-review` validates that review without Railway credentials
    and attests the candidate SHA. That workflow also requires both config copies
    to change together and fetches them from the exact head to prove byte identity.
-   Before attestation, a credential-free step runs the old/default regression
-   suites against candidate verifier code, then runs the candidate suites too;
-   neither test process receives a GitHub or Railway token.
+   Before attestation, a credential-free job runs the old/default regression
+   suites against candidate verifier code, then runs the candidate suites too.
+   That job receives no write permission or Railway token. The status publisher
+   runs afterward on a fresh runner and consumes only GitHub's recorded job
+   result and the boolean indicating whether trust-root files changed; it never
+   receives candidate-produced files, environment values, or command outputs.
 3. Only after that success may the protected plan run. It retains the old
    default-branch evaluator, SDK lock, and CLI checksum; it extracts the
    candidate config from the attested SHA, verifies it is byte-identical to the

--- a/.railway/BOOTSTRAP.md
+++ b/.railway/BOOTSTRAP.md
@@ -21,7 +21,8 @@ does not discover it automatically, and the bootstrap never executes it:
 5. Every later Railway change is marked pending on its exact PR head and must
    receive the applicable exact-head status. Active IaC uses the protected
    manual plan; verifier/workflow/toolchain rotations use the independent
-   member-authored Bridgebuilder attestation with no Railway credential.
+   Bridgebuilder attestation from a non-author maintainer/admin with no Railway
+   credential. A dismissed or superseded review revokes the attestation.
 
 The trusted evaluator is bound to Railway project
 `0bf95b1c-b8f2-4e60-a4a6-50089b521eb0` and production environment

--- a/.railway/plan-gate.mjs
+++ b/.railway/plan-gate.mjs
@@ -94,6 +94,11 @@ function failSchema(message) {
   throw new Error(`unrecognized Railway plan schema: ${message}`);
 }
 
+function assertAllowedKeys(record, allowed, label) {
+  const unknown = Object.keys(record).filter((key) => !allowed.has(key));
+  if (unknown.length > 0) failSchema(`${label} contains unknown fields`);
+}
+
 /**
  * Convert a validated upstream change to a value-free identifier.
  *
@@ -103,6 +108,11 @@ function failSchema(message) {
  */
 function safeChangeIdentity(change, index) {
   if (!isRecord(change)) failSchema(`change ${index} is not an object`);
+  assertAllowedKeys(
+    change,
+    new Set(['kind', 'severity', 'summary', 'details']),
+    `change ${index}`,
+  );
   const { kind, severity, summary } = change;
   if (typeof kind !== 'string' || !KNOWN_KINDS.has(kind)) {
     failSchema(`change ${index} has an unknown kind`);
@@ -139,9 +149,34 @@ function safeChangeIdentity(change, index) {
 
 function validatePlan(value) {
   if (!isRecord(value)) failSchema('top-level result is not an object');
+  assertAllowedKeys(
+    value,
+    new Set([
+      'ok',
+      'command',
+      'file',
+      'currentEnvironment',
+      'changeSet',
+      'diff',
+      'diagnostics',
+      'currentGraph',
+      'desiredGraph',
+      'stagedPatch',
+      'applyResult',
+      'deploymentId',
+      'stagedPatchId',
+    ]),
+    'top-level result',
+  );
   if (value.ok !== true) failSchema('top-level ok is not true');
   if (!isRecord(value.currentEnvironment)) failSchema('currentEnvironment is missing');
   if (!isRecord(value.changeSet)) failSchema('changeSet is missing');
+  assertAllowedKeys(
+    value.currentEnvironment,
+    new Set(['projectId', 'projectName', 'environmentId', 'environmentName']),
+    'currentEnvironment',
+  );
+  assertAllowedKeys(value.changeSet, new Set(['changes']), 'changeSet');
   if (!Array.isArray(value.changeSet.changes)) failSchema('changeSet.changes is not an array');
 
   const env = value.currentEnvironment;
@@ -249,6 +284,9 @@ try {
 }
 if (
   !isRecord(baseline) ||
+  Object.keys(baseline).some(
+    (key) => !new Set(['_comment', 'fingerprint', 'changeCount', 'changes']).has(key),
+  ) ||
   !/^[0-9a-f]{64}$/.test(baseline.fingerprint) ||
   !Number.isSafeInteger(baseline.changeCount) ||
   baseline.changeCount < 0 ||

--- a/.railway/plan-gate.mjs
+++ b/.railway/plan-gate.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * S2-T2 (SDD §8, IMP-013, G-6) — org-as-code agent gate for `.railway/railway.ts`.
+ *
+ * Runs `railway config plan --json` (READ-ONLY) and gates it. Two independent checks, in priority order:
+ *
+ *   1. DESTRUCTIVE GUARD (unconditional, baseline-independent) — any change that is not `severity: safe`,
+ *      or whose `kind` deletes/destroys a resource or variable, FAILS. This exists because Railway IaC is
+ *      DECLARATIVE: a `.railway/railway.ts` applied against the WRONG project plans to DELETE every
+ *      resource it does not declare. On 2026-07-10 a plan run against the (wrongly-linked)
+ *      `ordering-service` project read "1 to add, 3 to DESTROY" — it would have deleted ordering-service,
+ *      its Postgres, and fulfillment-orchestrator. A destroy must NEVER pass this gate silently.
+ *
+ *   2. DRIFT GUARD — fingerprint the normalized changeSet, compare to `.railway/plan-baseline.json`.
+ *      A mismatch means either someone edited `.railway/railway.ts` (INTENDED → refresh the baseline in
+ *      the same PR, which makes the change explicit and reviewable) or Railway drifted out-of-band
+ *      (UNINTENDED → investigate before applying).
+ *
+ * SECRETS: the fingerprint and ALL output use only `kind | severity | summary`. Summaries carry variable
+ * NAMES, never values (Railway redacts values as «hidden»). `details` is deliberately EXCLUDED from both
+ * the fingerprint and the logs — nothing secret can reach CI logs through this gate.
+ *
+ * WHY A BASELINE AND NOT "ZERO CHANGES": Railway redacts variable values, so `plan` cannot compare them —
+ * it re-plans every `variable.set` on every run even when the value is identical. A "plan must be empty"
+ * gate is therefore impossible; the baseline is the honest form.
+ *
+ * KNOWN LIMIT (honest): this detects STRUCTURAL drift (a variable/build/deploy setting added, removed, or
+ * renamed; anything destructive) but NOT a value-only change made in the Railway dashboard — the plan
+ * cannot see values. Closing that needs a separate value-attestation; out of scope.
+ *
+ * This gate NEVER applies. `railway config apply` stays human-gated (NFR-2).
+ *
+ * Usage:
+ *   node .railway/plan-gate.mjs                     # gate (CI)
+ *   node .railway/plan-gate.mjs --update-baseline   # regenerate baseline (in the PR that changes the IaC)
+ *   node .railway/plan-gate.mjs --plan-file p.json  # gate a captured plan (offline / tests)
+ */
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+
+const BASELINE = '.railway/plan-baseline.json';
+
+const args = process.argv.slice(2);
+const updateBaseline = args.includes('--update-baseline');
+const planFileIdx = args.indexOf('--plan-file');
+let planFile = null;
+if (planFileIdx !== -1) {
+  // A bare `--plan-file` (value missing, or the next token is another flag) must NOT silently fall through
+  // to `railway config plan` against the LIVE project — that turns an offline check into a live API call.
+  const value = args[planFileIdx + 1];
+  if (!value || value.startsWith('-')) {
+    console.error('FAIL: --plan-file requires a path.  usage: node .railway/plan-gate.mjs --plan-file <plan.json>');
+    process.exit(1);
+  }
+  planFile = value;
+}
+
+/** Destructive unless explicitly `safe` AND the kind is not a delete/destroy/remove. */
+function isDestructive(change) {
+  if (String(change.severity ?? '') !== 'safe') return true;
+  return /delete|destroy|remove/i.test(String(change.kind ?? ''));
+}
+
+/** Names + shape only — never values. Sorted so the fingerprint is order-independent. */
+function normalize(changes) {
+  return changes.map((c) => `${c.kind ?? '?'}|${c.severity ?? '?'}|${c.summary ?? '?'}`).sort();
+}
+
+const fingerprint = (normalized) => createHash('sha256').update(JSON.stringify(normalized)).digest('hex');
+
+function getPlan() {
+  if (planFile) return JSON.parse(readFileSync(planFile, 'utf8'));
+  const out = execFileSync('railway', ['config', 'plan', '--json'], {
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return JSON.parse(out);
+}
+
+let plan;
+try {
+  plan = getPlan();
+} catch (err) {
+  console.error('FAIL: could not run `railway config plan --json`.');
+  console.error('      CI needs RAILWAY_TOKEN (repo secret) + a linked project/environment.');
+  console.error(`      ${String(err.message ?? err).split('\n')[0]}`);
+  process.exit(1);
+}
+
+const changes = plan?.changeSet?.changes ?? [];
+const normalized = normalize(changes);
+const fp = fingerprint(normalized);
+const env = plan?.currentEnvironment ?? {};
+
+console.log(`railway plan gate — project=${env.projectName ?? '?'} env=${env.environmentName ?? '?'}`);
+console.log(`changes: ${changes.length}  fingerprint: ${fp.slice(0, 16)}…`);
+
+// ---- 1. DESTRUCTIVE GUARD (unconditional) --------------------------------
+const destructive = changes.filter(isDestructive);
+if (destructive.length > 0) {
+  console.error(`\nFAIL: ${destructive.length} DESTRUCTIVE change(s) — refusing regardless of baseline.`);
+  for (const c of destructive) console.error(`  ✗ ${c.kind} | ${c.severity} | ${c.summary}`);
+  console.error('\nRailway IaC is DECLARATIVE — it deletes anything not declared in .railway/railway.ts.');
+  console.error('Verify the LINKED PROJECT is correct before anything is applied.');
+  process.exit(1);
+}
+
+// ---- 2. BASELINE / DRIFT GUARD -------------------------------------------
+if (updateBaseline) {
+  const doc = {
+    _comment:
+      'S2-T2 org-as-code baseline. Names/shape only — no secret values (Railway redacts them). Regenerate ' +
+      'with `node .railway/plan-gate.mjs --update-baseline` in the same PR that changes .railway/railway.ts.',
+    fingerprint: fp,
+    changeCount: changes.length,
+    changes: normalized,
+  };
+  writeFileSync(BASELINE, JSON.stringify(doc, null, 2) + '\n');
+  console.log(`\n✓ baseline written → ${BASELINE} (${changes.length} changes)`);
+  process.exit(0);
+}
+
+if (!existsSync(BASELINE)) {
+  console.error(`\nFAIL: no baseline at ${BASELINE}. Create it: node .railway/plan-gate.mjs --update-baseline`);
+  process.exit(1);
+}
+
+const baseline = JSON.parse(readFileSync(BASELINE, 'utf8'));
+if (baseline.fingerprint === fp) {
+  console.log('\n✓ plan matches baseline — no unexpected drift.');
+  process.exit(0);
+}
+
+console.error('\nFAIL: plan does NOT match the committed baseline (unexpected drift).');
+const base = new Set(baseline.changes ?? []);
+const cur = new Set(normalized);
+for (const c of normalized) if (!base.has(c)) console.error(`  + in plan, not in baseline: ${c}`);
+for (const c of baseline.changes ?? []) if (!cur.has(c)) console.error(`  - in baseline, not in plan: ${c}`);
+console.error('\nINTENDED (you edited .railway/railway.ts)? Refresh the baseline in this PR:');
+console.error('  node .railway/plan-gate.mjs --update-baseline');
+console.error('NOT intended? Railway drifted out-of-band — investigate before applying.');
+process.exit(1);

--- a/.railway/plan-gate.mjs
+++ b/.railway/plan-gate.mjs
@@ -16,9 +16,10 @@
  *      the same PR, which makes the change explicit and reviewable) or Railway drifted out-of-band
  *      (UNINTENDED → investigate before applying).
  *
- * SECRETS: the fingerprint and ALL output use only `kind | severity | summary`. Summaries carry variable
- * NAMES, never values (Railway redacts values as «hidden»). `details` is deliberately EXCLUDED from both
- * the fingerprint and the logs — nothing secret can reach CI logs through this gate.
+ * SECRETS: upstream `summary`, `details`, and `diff` are NEVER logged or persisted. Each recognized change
+ * kind is converted to a small canonical identity only after its summary matches a strict, kind-specific
+ * grammar containing resource/field NAMES and no values. Unknown kinds, severities, fields, or shapes fail
+ * closed before normalization.
  *
  * WHY A BASELINE AND NOT "ZERO CHANGES": Railway redacts variable values, so `plan` cannot compare them —
  * it re-plans every `variable.set` on every run even when the value is identical. A "plan must be empty"
@@ -40,6 +41,28 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 
 const BASELINE = '.railway/plan-baseline.json';
+const EXPECTED_TARGET = Object.freeze({
+  projectId: '0bf95b1c-b8f2-4e60-a4a6-50089b521eb0',
+  environmentId: '2068efa5-0ed4-4cf3-9ae2-89120c4b18d5',
+});
+
+const KNOWN_SEVERITIES = new Set(['safe', 'destructive']);
+const KNOWN_KINDS = new Set([
+  'resource.update',
+  'resource.delete',
+  'variable.set',
+  'variable.delete',
+]);
+const SAFE_RESOURCE_FIELDS = new Set([
+  'source.branch',
+  'build.builder',
+  'build.dockerfilePath',
+  'healthcheck',
+  'healthcheckTimeout',
+  'rootDirectory',
+]);
+const SAFE_NAME = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$/;
+const SAFE_VARIABLE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}\.[A-Z][A-Z0-9_]{0,127}$/;
 
 const args = process.argv.slice(2);
 const updateBaseline = args.includes('--update-baseline');
@@ -56,15 +79,94 @@ if (planFileIdx !== -1) {
   planFile = value;
 }
 
-/** Destructive unless explicitly `safe` AND the kind is not a delete/destroy/remove. */
-function isDestructive(change) {
-  if (String(change.severity ?? '') !== 'safe') return true;
-  return /delete|destroy|remove/i.test(String(change.kind ?? ''));
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-/** Names + shape only — never values. Sorted so the fingerprint is order-independent. */
-function normalize(changes) {
-  return changes.map((c) => `${c.kind ?? '?'}|${c.severity ?? '?'}|${c.summary ?? '?'}`).sort();
+function failSchema(message) {
+  throw new Error(`unrecognized Railway plan schema: ${message}`);
+}
+
+/**
+ * Convert a validated upstream change to a value-free identifier.
+ *
+ * The summary itself is never returned or logged. The accepted grammars are
+ * intentionally narrower than Railway's possible output: a new shape stops the
+ * gate until this trusted file is reviewed and extended on the default branch.
+ */
+function safeChangeIdentity(change, index) {
+  if (!isRecord(change)) failSchema(`change ${index} is not an object`);
+  const { kind, severity, summary } = change;
+  if (typeof kind !== 'string' || !KNOWN_KINDS.has(kind)) {
+    failSchema(`change ${index} has an unknown kind`);
+  }
+  if (typeof severity !== 'string' || !KNOWN_SEVERITIES.has(severity)) {
+    failSchema(`change ${index} has an unknown severity`);
+  }
+  if (typeof summary !== 'string') failSchema(`change ${index} has no string summary`);
+
+  if (kind === 'resource.delete' || kind === 'variable.delete') {
+    // Destructive changes never reach the baseline. Do not parse or repeat
+    // producer-controlled prose merely to explain a rejection.
+    return `${kind}|${severity}`;
+  }
+
+  if (kind === 'resource.update') {
+    const match = /^Update ([A-Za-z0-9][A-Za-z0-9._/-]{0,127}) ([A-Za-z][A-Za-z0-9_.-]{0,127})$/.exec(
+      summary,
+    );
+    if (!match || !SAFE_NAME.test(match[1]) || !SAFE_RESOURCE_FIELDS.has(match[2])) {
+      failSchema(`change ${index} has an unknown resource-update summary`);
+    }
+    return `${kind}|${severity}|resource:${match[1]}|field:${match[2]}`;
+  }
+
+  const match = /^Update variable ([A-Za-z0-9][A-Za-z0-9._-]{0,127}\.[A-Z][A-Z0-9_]{0,127})$/.exec(
+    summary,
+  );
+  if (!match || !SAFE_VARIABLE.test(match[1])) {
+    failSchema(`change ${index} has an unknown variable-set summary`);
+  }
+  return `${kind}|${severity}|variable:${match[1]}`;
+}
+
+function validatePlan(value) {
+  if (!isRecord(value)) failSchema('top-level result is not an object');
+  if (value.ok !== true) failSchema('top-level ok is not true');
+  if (!isRecord(value.currentEnvironment)) failSchema('currentEnvironment is missing');
+  if (!isRecord(value.changeSet)) failSchema('changeSet is missing');
+  if (!Array.isArray(value.changeSet.changes)) failSchema('changeSet.changes is not an array');
+
+  const env = value.currentEnvironment;
+  if (
+    env.projectId !== EXPECTED_TARGET.projectId ||
+    env.environmentId !== EXPECTED_TARGET.environmentId
+  ) {
+    throw new Error('Railway plan target does not match the trusted project/environment IDs');
+  }
+
+  return value.changeSet.changes.map(safeChangeIdentity).sort();
+}
+
+/** Destructive unless explicitly `safe` and a recognized non-delete kind. */
+function isDestructiveIdentity(identity) {
+  const [kind, severity] = identity.split('|');
+  return severity !== 'safe' || kind.endsWith('.delete');
+}
+
+function isCanonicalBaselineIdentity(identity) {
+  if (typeof identity !== 'string') return false;
+  const parts = identity.split('|');
+  if (parts[0] === 'resource.update' && parts[1] === 'safe' && parts.length === 4) {
+    const resource = parts[2].startsWith('resource:') ? parts[2].slice('resource:'.length) : '';
+    const field = parts[3].startsWith('field:') ? parts[3].slice('field:'.length) : '';
+    return SAFE_NAME.test(resource) && SAFE_RESOURCE_FIELDS.has(field);
+  }
+  if (parts[0] === 'variable.set' && parts[1] === 'safe' && parts.length === 3) {
+    const variable = parts[2].startsWith('variable:') ? parts[2].slice('variable:'.length) : '';
+    return SAFE_VARIABLE.test(variable);
+  }
+  return false;
 }
 
 const fingerprint = (normalized) => createHash('sha256').update(JSON.stringify(normalized)).digest('hex');
@@ -79,30 +181,31 @@ function getPlan() {
 }
 
 let plan;
+let normalized;
 try {
   plan = getPlan();
+  normalized = validatePlan(plan);
 } catch (err) {
-  console.error('FAIL: could not run `railway config plan --json`.');
-  console.error('      CI needs RAILWAY_TOKEN (repo secret) + a linked project/environment.');
+  console.error('FAIL: Railway plan could not be evaluated safely.');
+  console.error('      CI needs its protected RAILWAY_TOKEN and the exact trusted target.');
   console.error(`      ${String(err.message ?? err).split('\n')[0]}`);
   process.exit(1);
 }
 
-const changes = plan?.changeSet?.changes ?? [];
-const normalized = normalize(changes);
 const fp = fingerprint(normalized);
-const env = plan?.currentEnvironment ?? {};
 
-console.log(`railway plan gate — project=${env.projectName ?? '?'} env=${env.environmentName ?? '?'}`);
-console.log(`changes: ${changes.length}  fingerprint: ${fp.slice(0, 16)}…`);
+console.log(
+  `railway plan gate — target=${EXPECTED_TARGET.projectId}/${EXPECTED_TARGET.environmentId}`,
+);
+console.log(`changes: ${normalized.length}  fingerprint: ${fp.slice(0, 16)}…`);
 
 // ---- 1. DESTRUCTIVE GUARD (unconditional) --------------------------------
-const destructive = changes.filter(isDestructive);
+const destructive = normalized.filter(isDestructiveIdentity);
 if (destructive.length > 0) {
   console.error(`\nFAIL: ${destructive.length} DESTRUCTIVE change(s) — refusing regardless of baseline.`);
-  for (const c of destructive) console.error(`  ✗ ${c.kind} | ${c.severity} | ${c.summary}`);
+  for (const identity of destructive) console.error(`  ✗ ${identity}`);
   console.error('\nRailway IaC is DECLARATIVE — it deletes anything not declared in .railway/railway.ts.');
-  console.error('Verify the LINKED PROJECT is correct before anything is applied.');
+  console.error('Verify the trusted project/environment target before anything is applied.');
   process.exit(1);
 }
 
@@ -110,14 +213,14 @@ if (destructive.length > 0) {
 if (updateBaseline) {
   const doc = {
     _comment:
-      'S2-T2 org-as-code baseline. Names/shape only — no secret values (Railway redacts them). Regenerate ' +
+      'S2-T2 org-as-code baseline. Trusted canonical identities only; no upstream summaries or values. Regenerate ' +
       'with `node .railway/plan-gate.mjs --update-baseline` in the same PR that changes .railway/railway.ts.',
     fingerprint: fp,
-    changeCount: changes.length,
+    changeCount: normalized.length,
     changes: normalized,
   };
   writeFileSync(BASELINE, JSON.stringify(doc, null, 2) + '\n');
-  console.log(`\n✓ baseline written → ${BASELINE} (${changes.length} changes)`);
+  console.log(`\n✓ baseline written → ${BASELINE} (${normalized.length} changes)`);
   process.exit(0);
 }
 
@@ -126,7 +229,26 @@ if (!existsSync(BASELINE)) {
   process.exit(1);
 }
 
-const baseline = JSON.parse(readFileSync(BASELINE, 'utf8'));
+let baseline;
+try {
+  baseline = JSON.parse(readFileSync(BASELINE, 'utf8'));
+} catch {
+  console.error(`\nFAIL: baseline at ${BASELINE} is not valid JSON.`);
+  process.exit(1);
+}
+if (
+  !isRecord(baseline) ||
+  !/^[0-9a-f]{64}$/.test(baseline.fingerprint) ||
+  !Number.isSafeInteger(baseline.changeCount) ||
+  baseline.changeCount < 0 ||
+  !Array.isArray(baseline.changes) ||
+  baseline.changes.some((entry) => !isCanonicalBaselineIdentity(entry)) ||
+  baseline.changeCount !== baseline.changes.length ||
+  fingerprint([...baseline.changes].sort()) !== baseline.fingerprint
+) {
+  console.error(`\nFAIL: baseline at ${BASELINE} has an invalid or internally inconsistent schema.`);
+  process.exit(1);
+}
 if (baseline.fingerprint === fp) {
   console.log('\n✓ plan matches baseline — no unexpected drift.');
   process.exit(0);

--- a/.railway/plan-gate.mjs
+++ b/.railway/plan-gate.mjs
@@ -91,8 +91,15 @@ function isRecord(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-function failSchema(message) {
-  throw new Error(`unrecognized Railway plan schema: ${message}`);
+class SafePlanError extends Error {
+  constructor(code) {
+    super(code);
+    this.code = code;
+  }
+}
+
+function failSchema() {
+  throw new SafePlanError('PLAN_SCHEMA_REJECTED');
 }
 
 function assertAllowedKeys(record, allowed, label) {
@@ -195,7 +202,7 @@ function validatePlan(value) {
     env.projectId !== EXPECTED_TARGET.projectId ||
     env.environmentId !== EXPECTED_TARGET.environmentId
   ) {
-    throw new Error('Railway plan target does not match the trusted project/environment IDs');
+    throw new SafePlanError('PLAN_TARGET_MISMATCH');
   }
 
   return value.changeSet.changes.map(safeChangeIdentity).sort();
@@ -230,16 +237,32 @@ function isCanonicalBaselineIdentity(identity) {
 const fingerprint = (normalized) => createHash('sha256').update(JSON.stringify(normalized)).digest('hex');
 
 function getPlan() {
-  if (planFile) return JSON.parse(readFileSync(planFile, 'utf8'));
-  const out = execFileSync(
-    'railway',
-    ['config', 'plan', '--json', '--file', TRUSTED_RAILWAY_CONFIG],
-    {
-    encoding: 'utf8',
-    maxBuffer: 32 * 1024 * 1024,
-    },
-  );
-  return JSON.parse(out);
+  if (planFile) {
+    try {
+      return JSON.parse(readFileSync(planFile, 'utf8'));
+    } catch {
+      throw new SafePlanError('PLAN_JSON_INVALID');
+    }
+  }
+  let out;
+  try {
+    out = execFileSync(
+      'railway',
+      ['config', 'plan', '--json', '--file', TRUSTED_RAILWAY_CONFIG],
+      {
+        encoding: 'utf8',
+        maxBuffer: 32 * 1024 * 1024,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+  } catch {
+    throw new SafePlanError('PLAN_EXEC_FAILED');
+  }
+  try {
+    return JSON.parse(out);
+  } catch {
+    throw new SafePlanError('PLAN_JSON_INVALID');
+  }
 }
 
 let plan;
@@ -250,7 +273,7 @@ try {
 } catch (err) {
   console.error('FAIL: Railway plan could not be evaluated safely.');
   console.error('      CI needs its protected RAILWAY_TOKEN and the exact trusted target.');
-  console.error(`      ${String(err.message ?? err).split('\n')[0]}`);
+  console.error(`      code=${err instanceof SafePlanError ? err.code : 'PLAN_EVALUATION_FAILED'}`);
   process.exit(1);
 }
 

--- a/.railway/plan-gate.mjs
+++ b/.railway/plan-gate.mjs
@@ -30,6 +30,9 @@
  * cannot see values. Closing that needs a separate value-attestation; out of scope.
  *
  * This gate NEVER applies. `railway config apply` stays human-gated (NFR-2).
+ * The credentialed plan evaluates only `TRUSTED_RAILWAY_CONFIG`, fetched from
+ * the default branch by CI. The reviewed `.railway/railway.ts` is required to
+ * be byte-identical but is never executed with credentials.
  *
  * Usage:
  *   node .railway/plan-gate.mjs                     # gate (CI)
@@ -39,8 +42,12 @@
 import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 const BASELINE = '.railway/plan-baseline.json';
+const TRUSTED_RAILWAY_CONFIG =
+  process.env.TRUSTED_RAILWAY_CONFIG ??
+  fileURLToPath(new URL('./trusted-tools/railway.ts', import.meta.url));
 const EXPECTED_TARGET = Object.freeze({
   projectId: '0bf95b1c-b8f2-4e60-a4a6-50089b521eb0',
   environmentId: '2068efa5-0ed4-4cf3-9ae2-89120c4b18d5',
@@ -173,10 +180,14 @@ const fingerprint = (normalized) => createHash('sha256').update(JSON.stringify(n
 
 function getPlan() {
   if (planFile) return JSON.parse(readFileSync(planFile, 'utf8'));
-  const out = execFileSync('railway', ['config', 'plan', '--json'], {
+  const out = execFileSync(
+    'railway',
+    ['config', 'plan', '--json', '--file', TRUSTED_RAILWAY_CONFIG],
+    {
     encoding: 'utf8',
     maxBuffer: 32 * 1024 * 1024,
-  });
+    },
+  );
   return JSON.parse(out);
 }
 

--- a/.railway/plan-gate.mjs
+++ b/.railway/plan-gate.mjs
@@ -55,6 +55,7 @@ const EXPECTED_TARGET = Object.freeze({
 
 const KNOWN_SEVERITIES = new Set(['safe', 'destructive']);
 const KNOWN_KINDS = new Set([
+  'resource.create',
   'resource.update',
   'resource.delete',
   'variable.set',
@@ -128,6 +129,16 @@ function safeChangeIdentity(change, index) {
     return `${kind}|${severity}`;
   }
 
+  if (kind === 'resource.create') {
+    const match = /^Create (service|database) ([A-Za-z0-9][A-Za-z0-9._/-]{0,127})$/.exec(
+      summary,
+    );
+    if (!match || !SAFE_NAME.test(match[2])) {
+      failSchema(`change ${index} has an unknown resource-create summary`);
+    }
+    return `${kind}|${severity}|type:${match[1]}|resource:${match[2]}`;
+  }
+
   if (kind === 'resource.update') {
     const match = /^Update ([A-Za-z0-9][A-Za-z0-9._/-]{0,127}) ([A-Za-z][A-Za-z0-9_.-]{0,127})$/.exec(
       summary,
@@ -199,6 +210,11 @@ function isDestructiveIdentity(identity) {
 function isCanonicalBaselineIdentity(identity) {
   if (typeof identity !== 'string') return false;
   const parts = identity.split('|');
+  if (parts[0] === 'resource.create' && parts[1] === 'safe' && parts.length === 4) {
+    const type = parts[2].startsWith('type:') ? parts[2].slice('type:'.length) : '';
+    const resource = parts[3].startsWith('resource:') ? parts[3].slice('resource:'.length) : '';
+    return (type === 'service' || type === 'database') && SAFE_NAME.test(resource);
+  }
   if (parts[0] === 'resource.update' && parts[1] === 'safe' && parts.length === 4) {
     const resource = parts[2].startsWith('resource:') ? parts[2].slice('resource:'.length) : '';
     const field = parts[3].startsWith('field:') ? parts[3].slice('field:'.length) : '';

--- a/.railway/plan-gate.mjs
+++ b/.railway/plan-gate.mjs
@@ -253,6 +253,8 @@ function getPlan() {
         encoding: 'utf8',
         maxBuffer: 32 * 1024 * 1024,
         stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 5 * 60 * 1000,
+        killSignal: 'SIGTERM',
       },
     );
   } catch {

--- a/.railway/plan-gate.test.mjs
+++ b/.railway/plan-gate.test.mjs
@@ -58,6 +58,18 @@ function runGate(plan, baselineChanges = [IDENTITY]) {
   });
 }
 
+function runGateWithRawPlan(rawPlan) {
+  const cwd = mkdtempSync(join(tmpdir(), 'railway-plan-gate-raw-'));
+  const railwayDir = join(cwd, '.railway');
+  mkdirSync(railwayDir);
+  const planPath = join(cwd, 'plan.json');
+  writeFileSync(planPath, rawPlan);
+  return spawnSync(process.execPath, [GATE, '--plan-file', planPath], {
+    cwd,
+    encoding: 'utf8',
+  });
+}
+
 test('accepts the trusted target and canonical value-free baseline', () => {
   const result = runGate(validPlan());
   assert.equal(result.status, 0, result.stderr);
@@ -92,7 +104,35 @@ test('rejects unknown resource creation types without echoing producer prose', (
   };
   const result = runGate(plan);
   assert.equal(result.status, 1);
-  assert.match(result.stderr, /unknown resource-create summary/);
+  assert.match(result.stderr, /PLAN_SCHEMA_REJECTED/);
+  assert.doesNotMatch(`${result.stdout}${result.stderr}`, new RegExp(marker));
+});
+
+test('does not reflect malformed plan JSON through exception diagnostics', () => {
+  const marker = 'SENSITIVE_MARKER_DO_NOT_PRINT';
+  const result = runGateWithRawPlan(`{"malformed":"${marker}"`);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /PLAN_JSON_INVALID/);
+  assert.doesNotMatch(`${result.stdout}${result.stderr}`, new RegExp(marker));
+});
+
+test('does not reflect Railway subprocess stderr through exception diagnostics', () => {
+  const marker = 'SENSITIVE_MARKER_DO_NOT_PRINT';
+  const cwd = mkdtempSync(join(tmpdir(), 'railway-plan-gate-exec-'));
+  const bin = join(cwd, 'bin');
+  mkdirSync(bin);
+  writeFileSync(
+    join(bin, 'railway'),
+    `#!/bin/sh\nprintf '%s\\n' '${marker}' >&2\nexit 1\n`,
+    { mode: 0o755 },
+  );
+  const result = spawnSync(process.execPath, [GATE], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ''}` },
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /PLAN_EXEC_FAILED/);
   assert.doesNotMatch(`${result.stdout}${result.stderr}`, new RegExp(marker));
 });
 
@@ -101,7 +141,7 @@ test('fails closed when the target IDs do not match', () => {
   plan.currentEnvironment.projectId = '00000000-0000-0000-0000-000000000000';
   const result = runGate(plan);
   assert.equal(result.status, 1);
-  assert.match(result.stderr, /target does not match/);
+  assert.match(result.stderr, /PLAN_TARGET_MISMATCH/);
 });
 
 test('fails closed when changeSet is missing', () => {
@@ -109,7 +149,7 @@ test('fails closed when changeSet is missing', () => {
   delete plan.changeSet;
   const result = runGate(plan);
   assert.equal(result.status, 1);
-  assert.match(result.stderr, /changeSet is missing/);
+  assert.match(result.stderr, /PLAN_SCHEMA_REJECTED/);
 });
 
 test('fails closed on unknown kinds', () => {
@@ -117,7 +157,7 @@ test('fails closed on unknown kinds', () => {
   plan.changeSet.changes[0].kind = 'future.magic';
   const result = runGate(plan);
   assert.equal(result.status, 1);
-  assert.match(result.stderr, /unknown kind/);
+  assert.match(result.stderr, /PLAN_SCHEMA_REJECTED/);
 });
 
 test('fails closed on unknown plan fields', () => {
@@ -125,7 +165,7 @@ test('fails closed on unknown plan fields', () => {
   plan.unexpected = { meaning: 'producer schema changed' };
   const result = runGate(plan);
   assert.equal(result.status, 1);
-  assert.match(result.stderr, /top-level result contains unknown fields/);
+  assert.match(result.stderr, /PLAN_SCHEMA_REJECTED/);
 });
 
 test('rejects and never echoes summaries that contain a value', () => {
@@ -134,7 +174,7 @@ test('rejects and never echoes summaries that contain a value', () => {
   plan.changeSet.changes[0].summary = `Update shadow-audit-api source.branch ${marker}`;
   const result = runGate(plan);
   assert.equal(result.status, 1);
-  assert.match(result.stderr, /unknown resource-update summary/);
+  assert.match(result.stderr, /PLAN_SCHEMA_REJECTED/);
   assert.doesNotMatch(`${result.stdout}${result.stderr}`, new RegExp(marker));
 });
 

--- a/.railway/plan-gate.test.mjs
+++ b/.railway/plan-gate.test.mjs
@@ -88,6 +88,14 @@ test('fails closed on unknown kinds', () => {
   assert.match(result.stderr, /unknown kind/);
 });
 
+test('fails closed on unknown plan fields', () => {
+  const plan = validPlan();
+  plan.unexpected = { meaning: 'producer schema changed' };
+  const result = runGate(plan);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /top-level result contains unknown fields/);
+});
+
 test('rejects and never echoes summaries that contain a value', () => {
   const plan = validPlan();
   const marker = 'SENSITIVE_MARKER_DO_NOT_PRINT';

--- a/.railway/plan-gate.test.mjs
+++ b/.railway/plan-gate.test.mjs
@@ -64,6 +64,38 @@ test('accepts the trusted target and canonical value-free baseline', () => {
   assert.match(result.stdout, /plan matches baseline/);
 });
 
+for (const [type, name] of [
+  ['service', 'shadow-audit-api'],
+  ['database', 'shadow-audit-postgres'],
+]) {
+  test(`accepts captured safe ${type} creation output`, () => {
+    const plan = validPlan();
+    plan.changeSet.changes[0] = {
+      kind: 'resource.create',
+      severity: 'safe',
+      summary: `Create ${type} ${name}`,
+    };
+    const identity = `resource.create|safe|type:${type}|resource:${name}`;
+    const result = runGate(plan, [identity]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /plan matches baseline/);
+  });
+}
+
+test('rejects unknown resource creation types without echoing producer prose', () => {
+  const plan = validPlan();
+  const marker = 'SENSITIVE_MARKER_DO_NOT_PRINT';
+  plan.changeSet.changes[0] = {
+    kind: 'resource.create',
+    severity: 'safe',
+    summary: `Create bucket ${marker}`,
+  };
+  const result = runGate(plan);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /unknown resource-create summary/);
+  assert.doesNotMatch(`${result.stdout}${result.stderr}`, new RegExp(marker));
+});
+
 test('fails closed when the target IDs do not match', () => {
   const plan = validPlan();
   plan.currentEnvironment.projectId = '00000000-0000-0000-0000-000000000000';

--- a/.railway/plan-gate.test.mjs
+++ b/.railway/plan-gate.test.mjs
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+const GATE = join(dirname(fileURLToPath(import.meta.url)), 'plan-gate.mjs');
+const PROJECT_ID = '0bf95b1c-b8f2-4e60-a4a6-50089b521eb0';
+const ENVIRONMENT_ID = '2068efa5-0ed4-4cf3-9ae2-89120c4b18d5';
+const IDENTITY =
+  'resource.update|safe|resource:shadow-audit-api|field:source.branch';
+
+const fingerprint = (changes) =>
+  createHash('sha256').update(JSON.stringify([...changes].sort())).digest('hex');
+
+function validPlan() {
+  return {
+    ok: true,
+    currentEnvironment: {
+      projectId: PROJECT_ID,
+      projectName: 'shadow-audit-api',
+      environmentId: ENVIRONMENT_ID,
+      environmentName: 'production',
+    },
+    changeSet: {
+      changes: [
+        {
+          kind: 'resource.update',
+          severity: 'safe',
+          summary: 'Update shadow-audit-api source.branch',
+          details: ['producer-controlled and intentionally ignored'],
+        },
+      ],
+    },
+  };
+}
+
+function runGate(plan, baselineChanges = [IDENTITY]) {
+  const cwd = mkdtempSync(join(tmpdir(), 'railway-plan-gate-'));
+  const railwayDir = join(cwd, '.railway');
+  mkdirSync(railwayDir);
+  const planPath = join(cwd, 'plan.json');
+  writeFileSync(planPath, JSON.stringify(plan));
+  writeFileSync(
+    join(railwayDir, 'plan-baseline.json'),
+    JSON.stringify({
+      fingerprint: fingerprint(baselineChanges),
+      changeCount: baselineChanges.length,
+      changes: baselineChanges,
+    }),
+  );
+  return spawnSync(process.execPath, [GATE, '--plan-file', planPath], {
+    cwd,
+    encoding: 'utf8',
+  });
+}
+
+test('accepts the trusted target and canonical value-free baseline', () => {
+  const result = runGate(validPlan());
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /plan matches baseline/);
+});
+
+test('fails closed when the target IDs do not match', () => {
+  const plan = validPlan();
+  plan.currentEnvironment.projectId = '00000000-0000-0000-0000-000000000000';
+  const result = runGate(plan);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /target does not match/);
+});
+
+test('fails closed when changeSet is missing', () => {
+  const plan = validPlan();
+  delete plan.changeSet;
+  const result = runGate(plan);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /changeSet is missing/);
+});
+
+test('fails closed on unknown kinds', () => {
+  const plan = validPlan();
+  plan.changeSet.changes[0].kind = 'future.magic';
+  const result = runGate(plan);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /unknown kind/);
+});
+
+test('rejects and never echoes summaries that contain a value', () => {
+  const plan = validPlan();
+  const marker = 'SENSITIVE_MARKER_DO_NOT_PRINT';
+  plan.changeSet.changes[0].summary = `Update shadow-audit-api source.branch ${marker}`;
+  const result = runGate(plan);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /unknown resource-update summary/);
+  assert.doesNotMatch(`${result.stdout}${result.stderr}`, new RegExp(marker));
+});
+
+test('rejects destructive changes without echoing producer prose', () => {
+  const plan = validPlan();
+  const marker = 'SENSITIVE_MARKER_DO_NOT_PRINT';
+  plan.changeSet.changes[0] = {
+    kind: 'resource.delete',
+    severity: 'destructive',
+    summary: marker,
+  };
+  const result = runGate(plan);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /DESTRUCTIVE/);
+  assert.doesNotMatch(`${result.stdout}${result.stderr}`, new RegExp(marker));
+});
+
+test('rejects and never echoes non-canonical baseline entries', () => {
+  const marker = 'SENSITIVE_MARKER_DO_NOT_PRINT';
+  const result = runGate(validPlan(), [marker]);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /invalid or internally inconsistent schema/);
+  assert.doesNotMatch(`${result.stdout}${result.stderr}`, new RegExp(marker));
+});

--- a/.railway/trusted-tools/bridge-review-attestation.mjs
+++ b/.railway/trusted-tools/bridge-review-attestation.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const TRUSTED_PERMISSIONS = new Set(['admin', 'maintain']);
+const ACCEPTED_REVIEW_STATES = new Set(['APPROVED', 'COMMENTED']);
+const SEVERITIES = new Set(['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'PRAISE']);
+const BLOCKING = new Set(['CRITICAL', 'HIGH', 'MEDIUM']);
+const DOCUMENT_KEYS = new Set(['schema_version', 'findings']);
+const FINDING_KEYS = new Set([
+  'id',
+  'title',
+  'severity',
+  'category',
+  'file',
+  'description',
+  'suggestion',
+  'confidence',
+  'faang_parallel',
+  'metaphor',
+  'teachable_moment',
+  'connection',
+  'decision_trail',
+]);
+const REQUIRED_STRING_FIELDS = [
+  'id',
+  'title',
+  'severity',
+  'category',
+  'file',
+  'description',
+  'suggestion',
+  'faang_parallel',
+  'metaphor',
+  'teachable_moment',
+  'connection',
+];
+
+const pending = (description) => ({ state: 'pending', description });
+const failure = (description) => ({ state: 'failure', description });
+const success = (description) => ({ state: 'success', description });
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function hasOnlyKeys(value, allowed) {
+  return Object.keys(value).every((key) => allowed.has(key));
+}
+
+function reviewOrder(review) {
+  const timestamp = Date.parse(review?.submitted_at ?? '');
+  const id = Number(review?.id);
+  return [
+    Number.isFinite(timestamp) ? timestamp : Number.NEGATIVE_INFINITY,
+    Number.isSafeInteger(id) ? id : Number.NEGATIVE_INFINITY,
+  ];
+}
+
+function isLaterReview(candidate, previous) {
+  const [candidateTime, candidateId] = reviewOrder(candidate);
+  const [previousTime, previousId] = reviewOrder(previous);
+  return candidateTime > previousTime || (candidateTime === previousTime && candidateId > previousId);
+}
+
+function parseFindings(body) {
+  const match = body.match(
+    /<!-- bridge-findings-start -->\s*```json\s*([\s\S]*?)\s*```\s*<!-- bridge-findings-end -->/,
+  );
+  if (!match) return null;
+
+  let document;
+  try {
+    document = JSON.parse(match[1]);
+  } catch {
+    return null;
+  }
+  if (
+    !isRecord(document) ||
+    !hasOnlyKeys(document, DOCUMENT_KEYS) ||
+    document.schema_version !== 1 ||
+    !Array.isArray(document.findings) ||
+    document.findings.length === 0
+  ) {
+    return null;
+  }
+
+  const ids = new Set();
+  for (const finding of document.findings) {
+    if (
+      !isRecord(finding) ||
+      !hasOnlyKeys(finding, FINDING_KEYS) ||
+      REQUIRED_STRING_FIELDS.some(
+        (field) => typeof finding[field] !== 'string' || finding[field].length === 0,
+      ) ||
+      !SEVERITIES.has(finding.severity) ||
+      typeof finding.confidence !== 'number' ||
+      !Number.isFinite(finding.confidence) ||
+      finding.confidence < 0 ||
+      finding.confidence > 1 ||
+      (finding.decision_trail !== undefined &&
+        (typeof finding.decision_trail !== 'string' || finding.decision_trail.length === 0)) ||
+      ids.has(finding.id)
+    ) {
+      return null;
+    }
+    ids.add(finding.id);
+  }
+  return document.findings;
+}
+
+/**
+ * Resolve current authorization state for an exact PR head.
+ *
+ * The latest review from each reviewer supersedes their earlier history. A
+ * candidate must be independent of the PR author, currently APPROVED or
+ * COMMENTED (never DISMISSED), carry the exact Bridgebuilder marker, and hold
+ * effective maintain/admin permission.
+ */
+export function evaluateBridgeAttestation({
+  reviews,
+  headSha,
+  prAuthor,
+  permissions,
+}) {
+  if (
+    !Array.isArray(reviews) ||
+    typeof headSha !== 'string' ||
+    typeof prAuthor !== 'string' ||
+    !isRecord(permissions)
+  ) {
+    return failure('Bridgebuilder attestation inputs are malformed');
+  }
+
+  const latestByReviewer = new Map();
+  for (const review of reviews) {
+    const login = review?.user?.login;
+    if (review?.commit_id !== headSha || typeof login !== 'string') continue;
+    const previous = latestByReviewer.get(login);
+    if (!previous || isLaterReview(review, previous)) latestByReviewer.set(login, review);
+  }
+
+  const marker = `<!-- bridgebuilder-review: ${headSha} -->`;
+  const candidates = [...latestByReviewer.values()]
+    .filter((review) => {
+      const login = review.user.login;
+      return (
+        login.toLowerCase() !== prAuthor.toLowerCase() &&
+        ACCEPTED_REVIEW_STATES.has(review.state) &&
+        TRUSTED_PERMISSIONS.has(permissions[login]) &&
+        typeof review.body === 'string' &&
+        review.body.includes(marker)
+      );
+    })
+    .sort((a, b) => (isLaterReview(a, b) ? -1 : isLaterReview(b, a) ? 1 : 0));
+
+  const review = candidates[0];
+  if (!review) {
+    return pending('Awaiting exact-head independent maintainer Bridgebuilder review');
+  }
+
+  const findings = parseFindings(review.body);
+  if (!findings) return failure('Bridgebuilder findings document is invalid');
+  const blocking = findings.filter((finding) => BLOCKING.has(finding.severity));
+  if (blocking.length > 0) {
+    return failure(`Bridgebuilder found ${blocking.length} blocking trust-root issue(s)`);
+  }
+  return success('Independent exact-head Bridgebuilder trust-root review passed');
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(process.argv[1]).href : '';
+if (import.meta.url === invokedPath) {
+  const reviews = JSON.parse(readFileSync(process.env.REVIEWS_FILE, 'utf8')).flat();
+  const permissions = JSON.parse(readFileSync(process.env.PERMISSIONS_FILE, 'utf8'));
+  const result = evaluateBridgeAttestation({
+    reviews,
+    headSha: process.env.HEAD_SHA,
+    prAuthor: process.env.PR_AUTHOR,
+    permissions,
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}

--- a/.railway/trusted-tools/bridge-review-attestation.mjs
+++ b/.railway/trusted-tools/bridge-review-attestation.mjs
@@ -4,7 +4,15 @@ import { pathToFileURL } from 'node:url';
 
 const TRUSTED_PERMISSIONS = new Set(['admin', 'maintain']);
 const ACCEPTED_REVIEW_STATES = new Set(['APPROVED', 'COMMENTED']);
-const SEVERITIES = new Set(['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'PRAISE']);
+const SEVERITIES = new Set([
+  'CRITICAL',
+  'HIGH',
+  'MEDIUM',
+  'LOW',
+  'PRAISE',
+  'SPECULATION',
+  'REFRAME',
+]);
 const BLOCKING = new Set(['CRITICAL', 'HIGH', 'MEDIUM']);
 const DOCUMENT_KEYS = new Set(['schema_version', 'findings']);
 const FINDING_KEYS = new Set([
@@ -30,10 +38,13 @@ const REQUIRED_STRING_FIELDS = [
   'file',
   'description',
   'suggestion',
+];
+const OPTIONAL_STRING_FIELDS = [
   'faang_parallel',
   'metaphor',
   'teachable_moment',
   'connection',
+  'decision_trail',
 ];
 
 const pending = (description) => ({ state: 'pending', description });
@@ -94,12 +105,16 @@ function parseFindings(body) {
         (field) => typeof finding[field] !== 'string' || finding[field].length === 0,
       ) ||
       !SEVERITIES.has(finding.severity) ||
-      typeof finding.confidence !== 'number' ||
-      !Number.isFinite(finding.confidence) ||
-      finding.confidence < 0 ||
-      finding.confidence > 1 ||
-      (finding.decision_trail !== undefined &&
-        (typeof finding.decision_trail !== 'string' || finding.decision_trail.length === 0)) ||
+      (finding.confidence !== undefined &&
+        (typeof finding.confidence !== 'number' ||
+          !Number.isFinite(finding.confidence) ||
+          finding.confidence < 0 ||
+          finding.confidence > 1)) ||
+      OPTIONAL_STRING_FIELDS.some(
+        (field) =>
+          finding[field] !== undefined &&
+          (typeof finding[field] !== 'string' || finding[field].length === 0),
+      ) ||
       ids.has(finding.id)
     ) {
       return null;

--- a/.railway/trusted-tools/bridge-review-attestation.mjs
+++ b/.railway/trusted-tools/bridge-review-attestation.mjs
@@ -169,13 +169,16 @@ export function evaluateBridgeAttestation({
     })
     .sort((a, b) => (isLaterReview(a, b) ? -1 : isLaterReview(b, a) ? 1 : 0));
 
-  const review = candidates[0];
-  if (!review) {
+  if (candidates.length === 0) {
     return pending('Awaiting exact-head independent maintainer Bridgebuilder review');
   }
 
-  const findings = parseFindings(review.body);
-  if (!findings) return failure('Bridgebuilder findings document is invalid');
+  const findings = [];
+  for (const review of candidates) {
+    const reviewFindings = parseFindings(review.body);
+    if (!reviewFindings) return failure('Bridgebuilder findings document is invalid');
+    findings.push(...reviewFindings);
+  }
   const blocking = findings.filter((finding) => BLOCKING.has(finding.severity));
   if (blocking.length > 0) {
     return failure(`Bridgebuilder found ${blocking.length} blocking trust-root issue(s)`);

--- a/.railway/trusted-tools/bridge-review-attestation.test.mjs
+++ b/.railway/trusted-tools/bridge-review-attestation.test.mjs
@@ -49,7 +49,11 @@ function evaluate(reviews, overrides = {}) {
     reviews,
     headSha: HEAD,
     prAuthor: 'author',
-    permissions: { maintainer: 'maintain', author: 'admin' },
+    permissions: {
+      maintainer: 'maintain',
+      'second-maintainer': 'admin',
+      author: 'admin',
+    },
     ...overrides,
   });
 }
@@ -120,6 +124,18 @@ test('fails closed on an unknown severity', () => {
 
 test('fails when a valid exact-head review contains a medium finding', () => {
   const result = evaluate([review({ body: body([finding('MEDIUM')]) })]);
+  assert.equal(result.state, 'failure');
+  assert.match(result.description, /1 blocking/);
+});
+
+test('fails when any current eligible reviewer reports a blocking finding', () => {
+  const clean = review();
+  const blocking = review({
+    id: 2,
+    user: { login: 'second-maintainer' },
+    body: body([finding('HIGH')]),
+  });
+  const result = evaluate([clean, blocking]);
   assert.equal(result.state, 'failure');
   assert.match(result.description, /1 blocking/);
 });

--- a/.railway/trusted-tools/bridge-review-attestation.test.mjs
+++ b/.railway/trusted-tools/bridge-review-attestation.test.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { evaluateBridgeAttestation } from './bridge-review-attestation.mjs';
+
+const HEAD = 'a'.repeat(40);
+
+function finding(severity = 'PRAISE') {
+  return {
+    id: 'BB-001',
+    title: 'A grounded finding',
+    severity,
+    category: 'security',
+    file: 'example.ts:1',
+    description: 'Evidence-backed description.',
+    suggestion: 'Retain the invariant.',
+    confidence: 0.99,
+    faang_parallel: 'Comparable control.',
+    metaphor: 'A precise metaphor.',
+    teachable_moment: 'A useful lesson.',
+    connection: 'A relevant connection.',
+  };
+}
+
+function body(findings = [finding()]) {
+  return [
+    '<!-- bridge-findings-start -->',
+    '```json',
+    JSON.stringify({ schema_version: 1, findings }),
+    '```',
+    '<!-- bridge-findings-end -->',
+    `<!-- bridgebuilder-review: ${HEAD} -->`,
+  ].join('\n');
+}
+
+function review(overrides = {}) {
+  return {
+    id: 1,
+    commit_id: HEAD,
+    submitted_at: '2026-07-18T00:00:00Z',
+    state: 'COMMENTED',
+    body: body(),
+    user: { login: 'maintainer' },
+    ...overrides,
+  };
+}
+
+function evaluate(reviews, overrides = {}) {
+  return evaluateBridgeAttestation({
+    reviews,
+    headSha: HEAD,
+    prAuthor: 'author',
+    permissions: { maintainer: 'maintain', author: 'admin' },
+    ...overrides,
+  });
+}
+
+test('accepts a non-author maintainer exact-head review with no blocking findings', () => {
+  assert.equal(evaluate([review()]).state, 'success');
+});
+
+test('rejects a review from the pull-request author', () => {
+  const result = evaluate(
+    [review({ user: { login: 'author' } })],
+    { permissions: { author: 'admin' } },
+  );
+  assert.equal(result.state, 'pending');
+});
+
+test('rejects a reviewer below maintain permission', () => {
+  const result = evaluate([review()], { permissions: { maintainer: 'write' } });
+  assert.equal(result.state, 'pending');
+});
+
+test('a dismissed latest review revokes an earlier attestation', () => {
+  const earlier = review();
+  const dismissed = review({
+    id: 2,
+    submitted_at: '2026-07-18T00:01:00Z',
+    state: 'DISMISSED',
+  });
+  assert.equal(evaluate([earlier, dismissed]).state, 'pending');
+});
+
+test('a later non-Bridgebuilder review supersedes an earlier attestation', () => {
+  const earlier = review();
+  const replacement = review({
+    id: 2,
+    submitted_at: '2026-07-18T00:01:00Z',
+    body: 'review replaced without an attestation marker',
+  });
+  assert.equal(evaluate([earlier, replacement]).state, 'pending');
+});
+
+test('fails closed on an empty findings document', () => {
+  const result = evaluate([review({ body: body([]) })]);
+  assert.equal(result.state, 'failure');
+  assert.match(result.description, /invalid/);
+});
+
+test('fails closed on an unknown severity', () => {
+  const result = evaluate([review({ body: body([finding('IMPORTANT')]) })]);
+  assert.equal(result.state, 'failure');
+});
+
+test('fails when a valid exact-head review contains a medium finding', () => {
+  const result = evaluate([review({ body: body([finding('MEDIUM')]) })]);
+  assert.equal(result.state, 'failure');
+  assert.match(result.description, /1 blocking/);
+});

--- a/.railway/trusted-tools/bridge-review-attestation.test.mjs
+++ b/.railway/trusted-tools/bridge-review-attestation.test.mjs
@@ -58,6 +58,22 @@ test('accepts a non-author maintainer exact-head review with no blocking finding
   assert.equal(evaluate([review()]).state, 'success');
 });
 
+test('accepts the canonical unenriched Bridgebuilder finding fixture shape', () => {
+  const core = finding('LOW');
+  delete core.confidence;
+  delete core.faang_parallel;
+  delete core.metaphor;
+  delete core.teachable_moment;
+  delete core.connection;
+  assert.equal(evaluate([review({ body: body([core]) })]).state, 'success');
+});
+
+for (const severity of ['SPECULATION', 'REFRAME']) {
+  test(`accepts non-blocking ${severity} severity`, () => {
+    assert.equal(evaluate([review({ body: body([finding(severity)]) })]).state, 'success');
+  });
+}
+
 test('rejects a review from the pull-request author', () => {
   const result = evaluate(
     [review({ user: { login: 'author' } })],

--- a/.railway/trusted-tools/package-lock.json
+++ b/.railway/trusted-tools/package-lock.json
@@ -1,0 +1,539 @@
+{
+  "name": "shadow-audit-railway-gate-tools",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "shadow-audit-railway-gate-tools",
+      "version": "1.0.0",
+      "dependencies": {
+        "railway": "3.5.5"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/railway": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/railway/-/railway-3.5.5.tgz",
+      "integrity": "sha512-7P6/F9GQsZcuMxdy9OGSUkOkWkPbyVOUFAJxZNqZx4fV2ss2fCYJE/R/+8cP7/bysSGm2kGDzFhDk54ENhpN7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "graphql": "^16.10.0",
+        "tsx": "^4.20.0"
+      },
+      "bin": {
+        "railway-iac-ts": "dist/iac/bin.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    }
+  }
+}

--- a/.railway/trusted-tools/package.json
+++ b/.railway/trusted-tools/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "shadow-audit-railway-gate-tools",
+  "private": true,
+  "version": "1.0.0",
+  "dependencies": {
+    "railway": "3.5.5"
+  }
+}

--- a/.railway/trusted-tools/railway-cli.sha256
+++ b/.railway/trusted-tools/railway-cli.sha256
@@ -1,0 +1,1 @@
+62cdf035e664aad79a7c629c3437ba371b4dd5a9bb7af3df7837d3e3f77474d2  railway-v4.10.0-x86_64-unknown-linux-gnu.tar.gz

--- a/.railway/trusted-tools/railway.ts
+++ b/.railway/trusted-tools/railway.ts
@@ -1,0 +1,72 @@
+/**
+ * S2-T1 (SDD §8, G-1) — Railway Infrastructure-as-Code for `shadow-audit-api`.
+ *
+ * Grounded against docs.railway.com/infrastructure-as-code (the `railway/iac` TypeScript DSL:
+ * defineRailway / project / service / github / preserve). This file does what config-as-code CANNOT:
+ * declare the service, pin the GitHub source, and set the env. The Dockerfile BUILD + deploy settings
+ * (healthcheck, restart) live in `railway.json` at repo root — the split the shadow-audit Dockerfile
+ * comment itself endorses ("rely on railway.toml's dockerfilePath relative to repo root").
+ *
+ * Build context = repo ROOT (github source with NO rootDirectory), because the Dockerfile stages the
+ * transitive file: tree packages/core ← packages/adapters ← packages/services/shadow-audit (+ protocol).
+ *
+ * ⚠️ RAILWAY IaC IS DECLARATIVE — this file is the COMPLETE desired state of its LINKED project. Applying
+ * it to a project that holds OTHER services DELETES every resource not declared here. `railway config plan`
+ * on 2026-07-10 was linked to the `ordering-service` project and planned "1 to add, 3 to DESTROY" (would
+ * have deleted ordering-service + its Postgres + fulfillment-orchestrator). shadow-audit-api MUST get its
+ * OWN Railway project. Operator: create/link a dedicated project (`railway link` → new/empty project), then
+ * re-plan — a correct plan reads "1 to add, 0 to destroy".
+ *
+ * DEPLOY IS OPERATOR-GATED (SDD §8 / NFR-2):
+ *   railway config plan --json --detailed-exit-code   # read-only — validates against Railway's live schema
+ *   → operator reviews the EXACT plan (ZERO destroys) →
+ *   railway config apply                               # NEVER --yes / --confirm-destructive from the agent
+ *
+ * Secrets (SHADOW_AUDIT_API_KEY, ROLE_SNAPSHOT_INGEST_TOKEN, CTA_*) use preserve() — set once in the
+ * Railway dashboard/secret store, never written into source. `railway config plan` shows them as «hidden».
+ */
+import { defineRailway, project, service, github, postgres, preserve } from "railway/iac";
+
+export default defineRailway(() => {
+  const database = postgres("shadow-audit-postgres");
+  const audit = service("shadow-audit-api", {
+    // Build context = repo root (no rootDirectory) — the Dockerfile needs core+adapters+protocol siblings.
+    // Production IaC must outlive any feature branch. This PR carries the coherent shadow-audit lineage
+    // onto main, so future Railway builds follow the durable production branch.
+    source: github("0xHoneyJar/loa-freeside", { branch: "main" }),
+    // Dockerfile build. CONFIRMED against the SDK types (railway/dist: `build?: string | BuildConfig`;
+    // BuildConfig.builder ∈ "DOCKERFILE"|… ; BuildConfig.dockerfilePath) AND a successful `railway config
+    // plan`. dockerfilePath is relative to the repo-root build context.
+    build: { builder: "DOCKERFILE", dockerfilePath: "packages/services/shadow-audit/Dockerfile" },
+    // /healthz is the open liveness route (server.ts:134); everything else is X-API-Key gated.
+    healthcheck: "/healthz",
+    healthcheckTimeout: 30,
+    env: {
+      // arrakis-7mtwa is a persistence-only apply. Preserve the live public configuration so creating the
+      // database cannot also redeploy a registry/RPC/community change. Reconcile those literals separately
+      // after grounding their current live values; they are not part of this bug's mutation boundary.
+      OPERATED_COMMUNITIES: preserve(),
+      COLLECTION_REGISTRY: preserve(),
+      RPC_URL_1: preserve(),
+      RPC_URL_10: preserve(),
+      RPC_URL_8453: preserve(),
+      RPC_URL_42161: preserve(),
+      RPC_URL_80094: preserve(),
+      AUDIT_K: preserve(),
+      // arrakis-7mtwa: the container filesystem is ephemeral. Role snapshots live in the project-managed
+      // Postgres resource so a deploy replacement cannot silently erase the latest export.
+      ROLE_SNAPSHOT_STORE: "postgres",
+      DATABASE_URL: database.env.DATABASE_URL,
+      // Retain the old dashboard value during migration. The postgres backend ignores it, but preserving it
+      // keeps this bounded change non-destructive and leaves an operator-controlled rollback path.
+      ROLE_SNAPSHOT_DIR: preserve(),
+      // Secrets — set once in Railway, never in source. preserve() keeps the dashboard value.
+      SHADOW_AUDIT_API_KEY: preserve(),
+      ROLE_SNAPSHOT_INGEST_TOKEN: preserve(),
+      CTA_PRODUCT: preserve(),
+      CTA_CONVERSATION: preserve(),
+    },
+  });
+
+  return project("shadow-audit-api", { resources: [database, audit] });
+});


### PR DESCRIPTION
## Summary
- install the trusted Railway plan workflow on the default branch before IaC changes can invoke it
- pin the Railway SDK and official CLI archive checksum
- bind manual plans to an exact same-repository PR head SHA and publish a trusted pending sentinel for affected PRs

## Validation
- workflow YAML parsed locally
- trusted SDK lock installs with scripts disabled
- Railway CLI archive checksum matches the official v4.10.0 release

This bootstrap PR intentionally contains no Railway resource declaration and never applies infrastructure.