### PR TITLE
feat(ordering): wire public prep adapter + kitchen deploy fix

### DIFF
--- a/packages/services/ordering/Dockerfile
+++ b/packages/services/ordering/Dockerfile
@@ -24,29 +24,18 @@ COPY packages/protocol/dependency-ledger ./packages/protocol/dependency-ledger
 COPY packages/services/shadow-audit ./packages/services/shadow-audit
 COPY packages/services/ordering ./packages/services/ordering
 
-WORKDIR /app/packages/core
-RUN pnpm install --no-frozen-lockfile && pnpm build
-
-WORKDIR /app/packages/adapters
-RUN pnpm install --no-frozen-lockfile && pnpm build
-
-WORKDIR /app/packages/protocol/collection
-RUN pnpm install --no-frozen-lockfile && pnpm build
-
-WORKDIR /app/packages/protocol/collection-resolution
-RUN pnpm install --no-frozen-lockfile && pnpm build
-
-WORKDIR /app/packages/protocol/public-authorization
-RUN pnpm install --no-frozen-lockfile && pnpm build
-
-WORKDIR /app/packages/protocol/trust-envelope
-RUN pnpm install --no-frozen-lockfile && pnpm build
-
-WORKDIR /app/packages/protocol/signing-key-custody
-RUN pnpm install --no-frozen-lockfile && pnpm build
-
-WORKDIR /app/packages/protocol/dependency-ledger
-RUN pnpm install --no-frozen-lockfile && pnpm build
+# Protocol packages that must build before the service (file: deps).
+RUN for pkg in \
+      packages/core \
+      packages/adapters \
+      packages/protocol/collection \
+      packages/protocol/collection-resolution \
+      packages/protocol/public-authorization \
+      packages/protocol/trust-envelope \
+      packages/protocol/signing-key-custody \
+      packages/protocol/dependency-ledger; do \
+      cd /app/$pkg && pnpm install --no-frozen-lockfile && pnpm build; \
+    done
 
 WORKDIR /app/packages/services/ordering
 RUN pnpm install --no-frozen-lockfile

--- a/packages/services/ordering/Dockerfile
+++ b/packages/services/ordering/Dockerfile
@@ -17,6 +17,10 @@ COPY packages/protocol/ordering ./packages/protocol/ordering
 COPY packages/protocol/shadow-audit ./packages/protocol/shadow-audit
 COPY packages/protocol/collection ./packages/protocol/collection
 COPY packages/protocol/collection-resolution ./packages/protocol/collection-resolution
+COPY packages/protocol/public-authorization ./packages/protocol/public-authorization
+COPY packages/protocol/trust-envelope ./packages/protocol/trust-envelope
+COPY packages/protocol/signing-key-custody ./packages/protocol/signing-key-custody
+COPY packages/protocol/dependency-ledger ./packages/protocol/dependency-ledger
 COPY packages/services/shadow-audit ./packages/services/shadow-audit
 COPY packages/services/ordering ./packages/services/ordering
 
@@ -30,6 +34,18 @@ WORKDIR /app/packages/protocol/collection
 RUN pnpm install --no-frozen-lockfile && pnpm build
 
 WORKDIR /app/packages/protocol/collection-resolution
+RUN pnpm install --no-frozen-lockfile && pnpm build
+
+WORKDIR /app/packages/protocol/public-authorization
+RUN pnpm install --no-frozen-lockfile && pnpm build
+
+WORKDIR /app/packages/protocol/trust-envelope
+RUN pnpm install --no-frozen-lockfile && pnpm build
+
+WORKDIR /app/packages/protocol/signing-key-custody
+RUN pnpm install --no-frozen-lockfile && pnpm build
+
+WORKDIR /app/packages/protocol/dependency-ledger
 RUN pnpm install --no-frozen-lockfile && pnpm build
 
 WORKDIR /app/packages/services/ordering

--- a/packages/services/ordering/bin/http.ts
+++ b/packages/services/ordering/bin/http.ts
@@ -39,9 +39,54 @@ import {
   serviceTokenForPublicAuthMounts,
 } from '../src/public-auth-posture.js';
 import { createAdmissionCapacityComposition } from '../src/admission-capacity-composition.js';
+import { createOrderStore } from '../src/store-factory.js';
+import { InMemoryPublicPrepDispatchStore } from '../src/public-preparation-dispatch-store.js';
+import { PublicPreparationAdapter } from '../src/public-preparation-adapter.js';
+import { PublicPreparationWorker } from '../src/public-preparation-worker.js';
+import { httpPublicPreparationSonarFromEnv } from '../src/public-preparation-sonar-http.js';
 
-const { store, orchestrator, enqueue } = await createOrderingComposition();
-const { admissionCapacity } = await createAdmissionCapacityComposition(store);
+const store = await createOrderStore();
+const {
+  admissionCapacity,
+  preparationStore,
+  capacityStore,
+} = await createAdmissionCapacityComposition(store);
+
+const resolutionStore = await createResolutionStore({
+  orderStore: store instanceof PostgresOrderStore ? store : undefined,
+});
+
+const publicPrepEnabled = process.env.ENABLE_PUBLIC_PREP?.trim() !== 'false';
+const publicPrepSonar = publicPrepEnabled
+  ? httpPublicPreparationSonarFromEnv({
+      preparationStore,
+      orderStore: store,
+      resolutionStore,
+    })
+  : undefined;
+const publicPrepAdapter = publicPrepSonar
+  ? new PublicPreparationAdapter({
+      preparationStore,
+      dispatchStore: new InMemoryPublicPrepDispatchStore(),
+      sonar: publicPrepSonar,
+      orderStore: store,
+      capacityStore,
+      now: () => Date.now(),
+      workerId: process.env.HOSTNAME?.trim() || 'ordering-public-prep',
+    })
+  : undefined;
+if (publicPrepEnabled && !publicPrepAdapter) {
+  // eslint-disable-next-line no-console
+  console.error(
+    '[ordering-service] ENABLE_PUBLIC_PREP active but SONAR_API_URL/SONAR_SERVICE_TOKEN missing — public prep adapter not wired.',
+  );
+}
+
+const { orchestrator, enqueue } = await createOrderingComposition({
+  store,
+  preparationStore: publicPrepAdapter ? preparationStore : undefined,
+  publicPrepAdapter,
+});
 
 const serviceToken = serviceTokenFromEnv();
 const writeRoutes = writeRoutePostureFromEnv();
@@ -77,9 +122,6 @@ if (publicAuthToken.kind === 'refuse') {
   );
 }
 
-const resolutionStore = await createResolutionStore({
-  orderStore: store instanceof PostgresOrderStore ? store : undefined,
-});
 // COLLECTION_RESOLVE_PROBE_MODE=catalog forces the local catalog even when
 // SONAR_* URLs are set (kitchen image lag / token mismatch). Default: http when
 // configured, else catalog.
@@ -141,6 +183,7 @@ const app = createIntakeApp({
       reason: publicAuthPosture.reason,
     },
     resolve_probe: resolutionProbeMode,
+    public_prep: publicPrepAdapter ? 'http' : 'off',
   },
 });
 
@@ -197,9 +240,14 @@ if (process.env.ENABLE_REPROBE === 'true') {
   worker.start();
 }
 
+if (publicPrepAdapter) {
+  const prepWorker = new PublicPreparationWorker(publicPrepAdapter);
+  prepWorker.start();
+}
+
 const port = Number(process.env.PORT ?? 8090);
 serve({ fetch: app.fetch, port });
 // eslint-disable-next-line no-console
 console.log(
-  `ordering-service listening on :${port} (write_routes=${writeRoutes}, resolve_probe=${resolutionProbeMode}, public_auth=${publicAuthPosture.mode}/wired=${mountPublicAuthRoutes})`,
+  `ordering-service listening on :${port} (write_routes=${writeRoutes}, resolve_probe=${resolutionProbeMode}, public_auth=${publicAuthPosture.mode}/wired=${mountPublicAuthRoutes}, public_prep=${publicPrepAdapter ? 'http' : 'off'})`,
 );

--- a/packages/services/ordering/bin/http.ts
+++ b/packages/services/ordering/bin/http.ts
@@ -40,10 +40,7 @@ import {
 } from '../src/public-auth-posture.js';
 import { createAdmissionCapacityComposition } from '../src/admission-capacity-composition.js';
 import { createOrderStore } from '../src/store-factory.js';
-import { InMemoryPublicPrepDispatchStore } from '../src/public-preparation-dispatch-store.js';
-import { PublicPreparationAdapter } from '../src/public-preparation-adapter.js';
-import { PublicPreparationWorker } from '../src/public-preparation-worker.js';
-import { httpPublicPreparationSonarFromEnv } from '../src/public-preparation-sonar-http.js';
+import { createPublicPrepComposition } from '../src/public-preparation-composition.js';
 
 const store = await createOrderStore();
 const {
@@ -56,37 +53,13 @@ const resolutionStore = await createResolutionStore({
   orderStore: store instanceof PostgresOrderStore ? store : undefined,
 });
 
-const publicPrepEnabled = process.env.ENABLE_PUBLIC_PREP?.trim() !== 'false';
-const publicPrepSonar = publicPrepEnabled
-  ? httpPublicPreparationSonarFromEnv({
-      preparationStore,
-      orderStore: store,
-      resolutionStore,
-    })
-  : undefined;
-const publicPrepAdapter = publicPrepSonar
-  ? new PublicPreparationAdapter({
-      preparationStore,
-      dispatchStore: new InMemoryPublicPrepDispatchStore(),
-      sonar: publicPrepSonar,
-      orderStore: store,
-      capacityStore,
-      now: () => Date.now(),
-      workerId: process.env.HOSTNAME?.trim() || 'ordering-public-prep',
-    })
-  : undefined;
-if (publicPrepEnabled && !publicPrepAdapter) {
-  // eslint-disable-next-line no-console
-  console.error(
-    '[ordering-service] ENABLE_PUBLIC_PREP active but SONAR_API_URL/SONAR_SERVICE_TOKEN missing — public prep adapter not wired.',
-  );
-}
-
-const { orchestrator, enqueue } = await createOrderingComposition({
-  store,
-  preparationStore: publicPrepAdapter ? preparationStore : undefined,
-  publicPrepAdapter,
+const publicPrep = createPublicPrepComposition({
+  preparationStore,
+  capacityStore,
+  orderStore: store,
 });
+
+const { orchestrator, enqueue } = await createOrderingComposition({ store });
 
 const serviceToken = serviceTokenFromEnv();
 const writeRoutes = writeRoutePostureFromEnv();
@@ -183,7 +156,7 @@ const app = createIntakeApp({
       reason: publicAuthPosture.reason,
     },
     resolve_probe: resolutionProbeMode,
-    public_prep: publicPrepAdapter ? 'http' : 'off',
+    public_prep: publicPrep?.mode ?? 'off',
   },
 });
 
@@ -240,14 +213,13 @@ if (process.env.ENABLE_REPROBE === 'true') {
   worker.start();
 }
 
-if (publicPrepAdapter) {
-  const prepWorker = new PublicPreparationWorker(publicPrepAdapter);
-  prepWorker.start();
+if (publicPrep) {
+  publicPrep.worker.start();
 }
 
 const port = Number(process.env.PORT ?? 8090);
 serve({ fetch: app.fetch, port });
 // eslint-disable-next-line no-console
 console.log(
-  `ordering-service listening on :${port} (write_routes=${writeRoutes}, resolve_probe=${resolutionProbeMode}, public_auth=${publicAuthPosture.mode}/wired=${mountPublicAuthRoutes}, public_prep=${publicPrepAdapter ? 'http' : 'off'})`,
+  `ordering-service listening on :${port} (write_routes=${writeRoutes}, resolve_probe=${resolutionProbeMode}, public_auth=${publicAuthPosture.mode}/wired=${mountPublicAuthRoutes}, public_prep=${publicPrep?.mode ?? 'off'})`,
 );

--- a/packages/services/ordering/migrations/009_public_prep_dispatch_and_kitchen_target.sql
+++ b/packages/services/ordering/migrations/009_public_prep_dispatch_and_kitchen_target.sql
@@ -1,0 +1,22 @@
+-- CR-204A harden: durable dispatch ledger + kitchen coords on work items.
+-- Expand-only: no destructive DDL.
+
+ALTER TABLE preparation_work_items
+  ADD COLUMN IF NOT EXISTS kitchen_target JSONB;
+
+CREATE TABLE IF NOT EXISTS public_prep_dispatch (
+  command_inbox_key       TEXT PRIMARY KEY,
+  work_item_id            TEXT NOT NULL,
+  work_id                 TEXT NOT NULL REFERENCES shared_preparation_work (work_id),
+  lease_epoch             BIGINT NOT NULL DEFAULT 0,
+  external_job_ref        TEXT,
+  dispatched_at           TIMESTAMPTZ,
+  acked_at                TIMESTAMPTZ,
+  lost_response           BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS public_prep_dispatch_pending_idx
+  ON public_prep_dispatch (dispatched_at)
+  WHERE acked_at IS NULL AND dispatched_at IS NOT NULL;

--- a/packages/services/ordering/src/__tests__/public-prep-migration.test.ts
+++ b/packages/services/ordering/src/__tests__/public-prep-migration.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const dir = dirname(fileURLToPath(import.meta.url));
+
+describe("009_public_prep_dispatch_and_kitchen_target.sql", () => {
+  it("is expand-only with durable dispatch ledger + kitchen_target", () => {
+    const sql = readFileSync(
+      join(dir, "../../migrations/009_public_prep_dispatch_and_kitchen_target.sql"),
+      "utf8",
+    );
+    expect(sql).toMatch(/ADD COLUMN IF NOT EXISTS kitchen_target/);
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS public_prep_dispatch/);
+    expect(sql).not.toMatch(/DROP\s+TABLE/i);
+    expect(sql).not.toMatch(/DROP\s+COLUMN/i);
+  });
+});

--- a/packages/services/ordering/src/__tests__/public-preparation-adapter.test.ts
+++ b/packages/services/ordering/src/__tests__/public-preparation-adapter.test.ts
@@ -179,7 +179,6 @@ describe("CR-204A public preparation adapter", () => {
       adapter_version: item.adapter_version,
       generation: work!.generation,
       lease_epoch: 1,
-      work_id: admitted.work_id,
     });
     const second = await h.sonar.dispatchChildJob({
       command_inbox_key: inboxKey,
@@ -188,7 +187,6 @@ describe("CR-204A public preparation adapter", () => {
       adapter_version: item.adapter_version,
       generation: work!.generation,
       lease_epoch: 2,
-      work_id: admitted.work_id,
     });
     expect(first.external_job_ref).toBe(second.external_job_ref);
   });
@@ -423,7 +421,7 @@ describe("CR-204A public preparation adapter", () => {
     expect(COLLECTION_PREP_POOL_CAPABILITY).not.toBe(REPORT_GENERATION_POOL_CAPABILITY);
   });
 
-  it("collection-report orchestrator invokes adapter for linked producing orders", async () => {
+  it("collection-report orchestrator holds in producing without driving prep", async () => {
     let now = 1_000;
     const h = makeHarness(() => now);
     const admitted = await admitOrder(h, { client_request_id: "orch", now_ms: now });
@@ -432,13 +430,20 @@ describe("CR-204A public preparation adapter", () => {
     const processSpy = vi.spyOn(h.adapter, "processWork");
     const orch = new CollectionReportOrchestrator({
       store: h.orderStore,
-      resolver: { resolve: async () => ({ capability: "x", building: "b", endpoint: "e", source: "s" }) },
+      resolver: {
+        resolve: async () => ({
+          capability: "collection-index" as const,
+          building: "sonar-api",
+          endpoint: "http://sonar.internal",
+          source: "config" as const,
+        }),
+      },
       now: () => now,
-      preparationStore: h.preparationStore,
-      publicPrepAdapter: h.adapter,
     });
     const record = await h.orderStore.get(admitted.order.order_id);
     await orch.process(admitted.order.order_id, record!);
-    expect(processSpy).toHaveBeenCalledWith(admitted.work_id);
+    expect(processSpy).not.toHaveBeenCalled();
+    const after = await h.orderStore.get(admitted.order.order_id);
+    expect(after?.state).toBe("producing");
   });
 });

--- a/packages/services/ordering/src/__tests__/public-preparation-adapter.test.ts
+++ b/packages/services/ordering/src/__tests__/public-preparation-adapter.test.ts
@@ -179,6 +179,7 @@ describe("CR-204A public preparation adapter", () => {
       adapter_version: item.adapter_version,
       generation: work!.generation,
       lease_epoch: 1,
+      work_id: admitted.work_id,
     });
     const second = await h.sonar.dispatchChildJob({
       command_inbox_key: inboxKey,
@@ -187,6 +188,7 @@ describe("CR-204A public preparation adapter", () => {
       adapter_version: item.adapter_version,
       generation: work!.generation,
       lease_epoch: 2,
+      work_id: admitted.work_id,
     });
     expect(first.external_job_ref).toBe(second.external_job_ref);
   });

--- a/packages/services/ordering/src/admission-capacity-composition.ts
+++ b/packages/services/ordering/src/admission-capacity-composition.ts
@@ -1,6 +1,12 @@
 import type { OrderStore } from "./store.js";
-import { InMemoryAdmissionCapacityStore } from "./admission-capacity-store.js";
-import { InMemorySharedPreparationStore } from "./shared-preparation-store.js";
+import {
+  InMemoryAdmissionCapacityStore,
+  type AdmissionCapacityStore,
+} from "./admission-capacity-store.js";
+import {
+  InMemorySharedPreparationStore,
+  type SharedPreparationStore,
+} from "./shared-preparation-store.js";
 import { PostgresOrderStore } from "./store-postgres.js";
 import { PostgresSharedPreparationStore } from "./shared-preparation-store-postgres.js";
 import { PostgresAdmissionCapacityStore } from "./admission-capacity-store-postgres.js";
@@ -11,6 +17,9 @@ import {
 
 export interface AdmissionCapacityComposition {
   readonly admissionCapacity: AdmissionCapacityService;
+  /** CR-204A substrate — same store joinPublicWork uses at admit. */
+  readonly preparationStore: SharedPreparationStore;
+  readonly capacityStore: AdmissionCapacityStore;
 }
 
 export async function createAdmissionCapacityComposition(
@@ -31,6 +40,8 @@ export async function createAdmissionCapacityComposition(
     });
     return {
       admissionCapacity: createAdmissionCapacityService({ store: capacityStore, now }),
+      preparationStore,
+      capacityStore,
     };
   }
 
@@ -41,5 +52,7 @@ export async function createAdmissionCapacityComposition(
   });
   return {
     admissionCapacity: createAdmissionCapacityService({ store: capacityStore, now }),
+    preparationStore,
+    capacityStore,
   };
 }

--- a/packages/services/ordering/src/admission-capacity-store-postgres.ts
+++ b/packages/services/ordering/src/admission-capacity-store-postgres.ts
@@ -153,6 +153,7 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
       "001_orders.sql",
       "007_shared_preparation_work.sql",
       "008_admission_capacity.sql",
+      "009_public_prep_dispatch_and_kitchen_target.sql",
     ]) {
       const sql = readFileSync(join(__dirname, "../migrations", file), "utf8");
       await this.pool.query(sql);
@@ -387,6 +388,7 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
       order_id: orderId,
       order_tenant_scope_digest: input.order_tenant_scope_digest,
       work_key: input.work_key,
+      kitchen_targets_by_deployment_digest: input.kitchen_targets_by_deployment_digest,
       now_ms: input.now_ms,
     });
     if (primary.kind !== "joined") return primary;
@@ -396,6 +398,7 @@ export class PostgresAdmissionCapacityStore implements AdmissionCapacityStore {
         order_id: orderId,
         order_tenant_scope_digest: input.order_tenant_scope_digest,
         work_key: extra,
+        kitchen_targets_by_deployment_digest: input.kitchen_targets_by_deployment_digest,
         now_ms: input.now_ms,
       });
       if (join.kind !== "joined") return join;

--- a/packages/services/ordering/src/admission-capacity-store.ts
+++ b/packages/services/ordering/src/admission-capacity-store.ts
@@ -39,10 +39,14 @@ import { digestOf } from "./digest.js";
 import type { NewOrder, OrderRecord, OrderStore, OutboxEvent } from "./store.js";
 import { InMemoryOrderStore } from "./store.js";
 import type {
+  JoinPublicWorkInput,
   JoinPublicWorkResult,
   SharedPreparationStore,
 } from "./shared-preparation-store.js";
-import type { PublicPreparationWorkKeyMaterial } from "./shared-preparation-types.js";
+import type {
+  KitchenDeploymentTarget,
+  PublicPreparationWorkKeyMaterial,
+} from "./shared-preparation-types.js";
 import { digestPublicWorkKey } from "./shared-preparation-work-key.js";
 import { ORDER_LIFECYCLE_SUBJECTS, type OrderPlaced } from "@freeside/ordering-protocol";
 
@@ -63,6 +67,10 @@ export interface AdmitOrderInput {
    * collection_identity). All are joinPublicWork'd in the same admission txn.
    */
   readonly additional_root_work_keys?: readonly PublicPreparationWorkKeyMaterial[];
+  /** Digest-key → kitchen coords baked at admit for live Sonar dispatch. */
+  readonly kitchen_targets_by_deployment_digest?: Readonly<
+    Record<string, KitchenDeploymentTarget>
+  >;
   readonly order_tenant_scope_digest: string;
   readonly pool_scope: CapacityPoolScope;
   readonly now_ms: number;
@@ -80,6 +88,7 @@ export async function joinAllRootWorkKeys(
     readonly order_tenant_scope_digest: string;
     readonly work_key: PublicPreparationWorkKeyMaterial;
     readonly additional_root_work_keys?: readonly PublicPreparationWorkKeyMaterial[];
+    readonly kitchen_targets_by_deployment_digest?: JoinPublicWorkInput["kitchen_targets_by_deployment_digest"];
     readonly now_ms: number;
   },
 ): Promise<JoinPublicWorkResult> {
@@ -87,6 +96,7 @@ export async function joinAllRootWorkKeys(
     order_id: input.order_id,
     order_tenant_scope_digest: input.order_tenant_scope_digest,
     work_key: input.work_key,
+    kitchen_targets_by_deployment_digest: input.kitchen_targets_by_deployment_digest,
     now_ms: input.now_ms,
   });
   if (primary.kind !== "joined") return primary;
@@ -96,6 +106,7 @@ export async function joinAllRootWorkKeys(
       order_id: input.order_id,
       order_tenant_scope_digest: input.order_tenant_scope_digest,
       work_key: extra,
+      kitchen_targets_by_deployment_digest: input.kitchen_targets_by_deployment_digest,
       now_ms: input.now_ms,
     });
     if (join.kind !== "joined") return join;
@@ -535,6 +546,7 @@ export class InMemoryAdmissionCapacityStore implements AdmissionCapacityStore {
             order_tenant_scope_digest: input.order_tenant_scope_digest,
             work_key: input.work_key,
             additional_root_work_keys: input.additional_root_work_keys,
+            kitchen_targets_by_deployment_digest: input.kitchen_targets_by_deployment_digest,
             now_ms: input.now_ms,
           });
           if (join.kind !== "joined") {
@@ -619,6 +631,7 @@ export class InMemoryAdmissionCapacityStore implements AdmissionCapacityStore {
               order_tenant_scope_digest: input.order_tenant_scope_digest,
               work_key: input.work_key,
               additional_root_work_keys: input.additional_root_work_keys,
+              kitchen_targets_by_deployment_digest: input.kitchen_targets_by_deployment_digest,
               now_ms: input.now_ms,
             },
           );

--- a/packages/services/ordering/src/collection-report-admission.ts
+++ b/packages/services/ordering/src/collection-report-admission.ts
@@ -29,9 +29,42 @@ import {
   WorkflowTooLargeError,
 } from "./gate-leak-recipe-compiler.js";
 import { buildPublicWorkKeyMaterial } from "./shared-preparation-work-key.js";
-import type { PublicPreparationWorkKeyMaterial } from "./shared-preparation-types.js";
+import type {
+  KitchenDeploymentTarget,
+  PublicPreparationWorkKeyMaterial,
+  VersionedDigest,
+} from "./shared-preparation-types.js";
 import { digestOf } from "./digest.js";
 import type { RecipeExpansionCertificate } from "./admission-capacity-types.js";
+
+function deploymentDigestKey(d: VersionedDigest): string {
+  return `${d.algorithm}:${d.domain}:${d.major_version}:${d.digest}`;
+}
+
+/** Bake kitchen coords at admit — dispatch must not re-walk resolution. */
+export function kitchenTargetsFromResolution(
+  record: ConfirmedResolutionRecord,
+): Readonly<Record<string, KitchenDeploymentTarget>> {
+  const selected = record.selected_deployment_ids ?? [];
+  const candidate = findSelectedCandidate(record);
+  if (candidate === undefined || selected.length === 0) return {};
+
+  const standardValue = candidate.token_standard.value;
+  const tokenStandard = standardValue === "erc1155" ? "erc1155" : "erc721";
+  const out: Record<string, KitchenDeploymentTarget> = {};
+  const selectedKeys = new Set(selected.map((d) => d.digest));
+
+  for (const deployment of candidate.identity.deployments) {
+    if (!selectedKeys.has(deployment.deployment_id.digest)) continue;
+    out[deploymentDigestKey(deployment.deployment_id)] = {
+      network_namespace: deployment.network.network_namespace,
+      network_reference: deployment.network.network_reference,
+      address: deployment.address,
+      token_standard: tokenStandard,
+    };
+  }
+  return out;
+}
 
 export type CollectionReportAdmissionErrorCode =
   | "invalid_request"
@@ -84,7 +117,7 @@ function communityScopeDigest(communityRef: string): string {
   return createHash("sha256").update(`community:${communityRef}`).digest("hex");
 }
 
-function findSelectedCandidate(record: ConfirmedResolutionRecord) {
+export function findSelectedCandidate(record: ConfirmedResolutionRecord) {
   const selected = record.selected_deployment_ids ?? [];
   if (selected.length === 0) return undefined;
   const selectedKeys = new Set(selected.map((d) => d.digest));
@@ -358,6 +391,7 @@ export async function admitCollectionReportOrder(
     certificate,
     work_key: primaryWorkKey,
     additional_root_work_keys: additionalRootWorkKeys,
+    kitchen_targets_by_deployment_digest: kitchenTargetsFromResolution(record),
     order_tenant_scope_digest: communityScopeDigest(input.binding.community_ref),
     pool_scope: {
       network_ref: primaryNetworkRef(record),

--- a/packages/services/ordering/src/collection-report-orchestrator.ts
+++ b/packages/services/ordering/src/collection-report-orchestrator.ts
@@ -114,6 +114,24 @@ export class CollectionReportOrchestrator {
         const linked = await this.deps.preparationStore.getActiveWorkForOrder(orderId);
         if (linked) {
           await this.deps.publicPrepAdapter.processWork(linked.work.work_id);
+          record = await this.reread(orderId, undefined);
+          if (isTerminal(record.state)) return { success: true };
+          const phase = fulfillmentPhase(record);
+          if (phase === "ownership_evidence_ready") {
+            // Prep complete; Gate Leak artifact/render producer not wired yet.
+            // Honest terminal — no fake fulfill / ETA theater (CR-303).
+            return this.settleFailed(orderId, "producing", {
+              code: "gate_leak_artifact_producer_pending",
+              reason:
+                "public preparation ownership evidence is ready; Gate Leak artifact producer is not deployed",
+            });
+          }
+          if (phase === "remediation_required") {
+            return this.settleFailed(orderId, "producing", {
+              code: "preparation_failed",
+              reason: "shared public preparation requires remediation",
+            });
+          }
         }
       }
       return { success: true };
@@ -151,4 +169,12 @@ export class CollectionReportOrchestrator {
     if (!current) throw new Error(`order vanished mid-flight: ${orderId}`);
     return current;
   }
+}
+
+function fulfillmentPhase(record: OrderRecord): string {
+  const fulfillment = record.fulfillment as
+    | { readonly phase?: string; readonly stage?: string }
+    | undefined;
+  const phase = fulfillment?.phase ?? fulfillment?.stage ?? "";
+  return typeof phase === "string" ? phase : "";
 }

--- a/packages/services/ordering/src/collection-report-orchestrator.ts
+++ b/packages/services/ordering/src/collection-report-orchestrator.ts
@@ -5,6 +5,9 @@
  * NOT route through AccessRiskAuditInputs (that caused immediate invalid-inputs
  * failures). V1 advances placed → routing → producing and holds in preparing
  * until a real Gate Leak producer exists — no fake fulfill, no ETA theater.
+ *
+ * Public preparation is owned solely by PublicPreparationWorker / adapter.
+ * This driver does not sniff fulfillment phases or settle prep outcomes.
  */
 
 import {
@@ -25,17 +28,12 @@ import {
 } from "./resolver.js";
 import type { PrivateOpsPublisher } from "./private-ops.js";
 import type { ProcessResult } from "./orchestrator.js";
-import type { PublicPreparationAdapter } from "./public-preparation-adapter.js";
-import type { SharedPreparationStore } from "./shared-preparation-store.js";
 
 export interface CollectionReportOrchestratorDeps {
   store: OrderStore;
   resolver: CapabilityResolver;
   now: () => number;
   opsChannel?: PrivateOpsPublisher;
-  /** CR-204A — drive linked shared preparation work while producing. */
-  preparationStore?: SharedPreparationStore;
-  publicPrepAdapter?: PublicPreparationAdapter;
 }
 
 export class CollectionReportOrchestrator {
@@ -109,34 +107,7 @@ export class CollectionReportOrchestrator {
       if (isTerminal(record.state)) return { success: true };
     }
 
-    if (record.state === "producing") {
-      if (this.deps.preparationStore && this.deps.publicPrepAdapter) {
-        const linked = await this.deps.preparationStore.getActiveWorkForOrder(orderId);
-        if (linked) {
-          await this.deps.publicPrepAdapter.processWork(linked.work.work_id);
-          record = await this.reread(orderId, undefined);
-          if (isTerminal(record.state)) return { success: true };
-          const phase = fulfillmentPhase(record);
-          if (phase === "ownership_evidence_ready") {
-            // Prep complete; Gate Leak artifact/render producer not wired yet.
-            // Honest terminal — no fake fulfill / ETA theater (CR-303).
-            return this.settleFailed(orderId, "producing", {
-              code: "gate_leak_artifact_producer_pending",
-              reason:
-                "public preparation ownership evidence is ready; Gate Leak artifact producer is not deployed",
-            });
-          }
-          if (phase === "remediation_required") {
-            return this.settleFailed(orderId, "producing", {
-              code: "preparation_failed",
-              reason: "shared public preparation requires remediation",
-            });
-          }
-        }
-      }
-      return { success: true };
-    }
-
+    // producing: hold until Gate Leak artifact producer (worker owns prep advance).
     return { success: true };
   }
 
@@ -169,12 +140,4 @@ export class CollectionReportOrchestrator {
     if (!current) throw new Error(`order vanished mid-flight: ${orderId}`);
     return current;
   }
-}
-
-function fulfillmentPhase(record: OrderRecord): string {
-  const fulfillment = record.fulfillment as
-    | { readonly phase?: string; readonly stage?: string }
-    | undefined;
-  const phase = fulfillment?.phase ?? fulfillment?.stage ?? "";
-  return typeof phase === "string" ? phase : "";
 }

--- a/packages/services/ordering/src/composition.ts
+++ b/packages/services/ordering/src/composition.ts
@@ -5,7 +5,7 @@ import {
   ConfigCapabilityResolver,
   type CapabilityConfig,
 } from './resolver.js';
-import { OrderOrchestrator, type OrchestratorDeps } from './orchestrator.js';
+import { OrderOrchestrator } from './orchestrator.js';
 import type { AuditPort } from './audit-acl.js';
 import type { OrderStore } from './store.js';
 import { createGitHubIssuePort } from './github-issue-port.js';
@@ -52,8 +52,6 @@ export interface OrderingComposition {
 
 export interface CreateOrderingCompositionOptions {
   readonly store?: OrderStore;
-  readonly preparationStore?: OrchestratorDeps["preparationStore"];
-  readonly publicPrepAdapter?: OrchestratorDeps["publicPrepAdapter"];
 }
 
 export async function createOrderingComposition(
@@ -77,8 +75,6 @@ export async function createOrderingComposition(
     // The advanceIngredient health gate must have teeth on the INTAKE path too —
     // without this, the service/merge write path bypasses the choke point (BB #443).
     discordHealth: triage instanceof KitchenTriagePorts ? triage.discordHealth : undefined,
-    preparationStore: options.preparationStore,
-    publicPrepAdapter: options.publicPrepAdapter,
   });
 
   return { store, orchestrator, enqueue };

--- a/packages/services/ordering/src/composition.ts
+++ b/packages/services/ordering/src/composition.ts
@@ -5,7 +5,7 @@ import {
   ConfigCapabilityResolver,
   type CapabilityConfig,
 } from './resolver.js';
-import { OrderOrchestrator } from './orchestrator.js';
+import { OrderOrchestrator, type OrchestratorDeps } from './orchestrator.js';
 import type { AuditPort } from './audit-acl.js';
 import type { OrderStore } from './store.js';
 import { createGitHubIssuePort } from './github-issue-port.js';
@@ -50,8 +50,16 @@ export interface OrderingComposition {
   enqueue: IngredientEnqueueService | undefined;
 }
 
-export async function createOrderingComposition(): Promise<OrderingComposition> {
-  const store = await createOrderStore();
+export interface CreateOrderingCompositionOptions {
+  readonly store?: OrderStore;
+  readonly preparationStore?: OrchestratorDeps["preparationStore"];
+  readonly publicPrepAdapter?: OrchestratorDeps["publicPrepAdapter"];
+}
+
+export async function createOrderingComposition(
+  options: CreateOrderingCompositionOptions = {},
+): Promise<OrderingComposition> {
+  const store = options.store ?? (await createOrderStore());
   const triage = createKitchenTriagePorts();
   const httpProbes = triage instanceof KitchenTriagePorts ? triage.httpProbes : null;
   const github = createGitHubIssuePort();
@@ -69,6 +77,8 @@ export async function createOrderingComposition(): Promise<OrderingComposition> 
     // The advanceIngredient health gate must have teeth on the INTAKE path too —
     // without this, the service/merge write path bypasses the choke point (BB #443).
     discordHealth: triage instanceof KitchenTriagePorts ? triage.discordHealth : undefined,
+    preparationStore: options.preparationStore,
+    publicPrepAdapter: options.publicPrepAdapter,
   });
 
   return { store, orchestrator, enqueue };

--- a/packages/services/ordering/src/orchestrator.ts
+++ b/packages/services/ordering/src/orchestrator.ts
@@ -10,8 +10,6 @@ import { CollectionReportOrchestrator } from './collection-report-orchestrator.j
 import type { TriagePorts } from './triage-ports.js';
 import { StubTriagePorts } from './triage-ports.js';
 import type { IngredientEnqueueService } from './ingredient-enqueue.js';
-import type { PublicPreparationAdapter } from './public-preparation-adapter.js';
-import type { SharedPreparationStore } from './shared-preparation-store.js';
 
 /**
  * The thin orchestrator (SDD §6) — dispatches by product to preset-specific handlers.
@@ -44,9 +42,6 @@ export interface OrchestratorDeps {
    *  EVERY CommunityOnboardingOrchestrator instance, intake included, or the choke
    *  point has teeth only on the worker path. */
   discordHealth?: CommunityOnboardingOrchestratorDeps['discordHealth'];
-  /** CR-204A public preparation substrate. */
-  preparationStore?: SharedPreparationStore;
-  publicPrepAdapter?: PublicPreparationAdapter;
 }
 
 export class OrderOrchestrator {
@@ -73,11 +68,7 @@ export class OrderOrchestrator {
       enqueue: deps.enqueue,
       discordHealth: deps.discordHealth,
     });
-    this.collectionReport = new CollectionReportOrchestrator({
-      ...shared,
-      preparationStore: deps.preparationStore,
-      publicPrepAdapter: deps.publicPrepAdapter,
-    });
+    this.collectionReport = new CollectionReportOrchestrator(shared);
   }
 
   async process(orderId: string): Promise<ProcessResult> {

--- a/packages/services/ordering/src/public-preparation-adapter.ts
+++ b/packages/services/ordering/src/public-preparation-adapter.ts
@@ -268,7 +268,7 @@ export class PublicPreparationAdapter {
         adapter_version: item.adapter_version,
         generation: work.generation,
         lease_epoch: work.lease_epoch,
-        work_id: work.work_id,
+        kitchen_deployment: item.kitchen_target,
       });
       if (replay.ok && replay.external_job_ref) {
         await this.deps.dispatchStore.recordAck({
@@ -314,7 +314,7 @@ export class PublicPreparationAdapter {
       adapter_version: item.adapter_version,
       generation: work.generation,
       lease_epoch: work.lease_epoch,
-      work_id: work.work_id,
+      kitchen_deployment: item.kitchen_target,
     });
     if (result.ok && result.external_job_ref) {
       await this.deps.dispatchStore.recordAck({

--- a/packages/services/ordering/src/public-preparation-adapter.ts
+++ b/packages/services/ordering/src/public-preparation-adapter.ts
@@ -268,6 +268,7 @@ export class PublicPreparationAdapter {
         adapter_version: item.adapter_version,
         generation: work.generation,
         lease_epoch: work.lease_epoch,
+        work_id: work.work_id,
       });
       if (replay.ok && replay.external_job_ref) {
         await this.deps.dispatchStore.recordAck({
@@ -313,6 +314,7 @@ export class PublicPreparationAdapter {
       adapter_version: item.adapter_version,
       generation: work.generation,
       lease_epoch: work.lease_epoch,
+      work_id: work.work_id,
     });
     if (result.ok && result.external_job_ref) {
       await this.deps.dispatchStore.recordAck({

--- a/packages/services/ordering/src/public-preparation-composition.ts
+++ b/packages/services/ordering/src/public-preparation-composition.ts
@@ -1,0 +1,67 @@
+/**
+ * CR-204A public-prep composition — single factory for adapter + worker wiring.
+ *
+ * Wire when Sonar kitchen env is present. ENABLE_PUBLIC_PREP=false forces off.
+ * No soft "enabled but missing token" middle state.
+ */
+
+import type { AdmissionCapacityStore } from "./admission-capacity-store.js";
+import type { SharedPreparationStore } from "./shared-preparation-store.js";
+import type { OrderStore } from "./store.js";
+import { PostgresOrderStore } from "./store-postgres.js";
+import {
+  InMemoryPublicPrepDispatchStore,
+  type PublicPrepDispatchStore,
+} from "./public-preparation-dispatch-store.js";
+import { PostgresPublicPrepDispatchStore } from "./public-preparation-dispatch-store-postgres.js";
+import { PublicPreparationAdapter } from "./public-preparation-adapter.js";
+import { PublicPreparationWorker } from "./public-preparation-worker.js";
+import { httpPublicPreparationSonarFromEnv } from "./public-preparation-sonar-http.js";
+
+export interface PublicPrepComposition {
+  readonly adapter: PublicPreparationAdapter;
+  readonly worker: PublicPreparationWorker;
+  readonly mode: "http";
+}
+
+export interface CreatePublicPrepCompositionInput {
+  readonly preparationStore: SharedPreparationStore;
+  readonly capacityStore: AdmissionCapacityStore;
+  readonly orderStore: OrderStore;
+}
+
+function createDispatchStore(orderStore: OrderStore): PublicPrepDispatchStore {
+  if (orderStore instanceof PostgresOrderStore) {
+    return new PostgresPublicPrepDispatchStore(orderStore.getPool());
+  }
+  return new InMemoryPublicPrepDispatchStore();
+}
+
+/**
+ * Returns a wired public-prep composition, or undefined when disabled / unconfigured.
+ */
+export function createPublicPrepComposition(
+  input: CreatePublicPrepCompositionInput,
+): PublicPrepComposition | undefined {
+  if (process.env.ENABLE_PUBLIC_PREP?.trim() === "false") {
+    return undefined;
+  }
+  const sonar = httpPublicPreparationSonarFromEnv();
+  if (!sonar) return undefined;
+
+  const adapter = new PublicPreparationAdapter({
+    preparationStore: input.preparationStore,
+    dispatchStore: createDispatchStore(input.orderStore),
+    sonar,
+    orderStore: input.orderStore,
+    capacityStore: input.capacityStore,
+    now: () => Date.now(),
+    workerId: process.env.HOSTNAME?.trim() || "ordering-public-prep",
+  });
+
+  return {
+    adapter,
+    worker: new PublicPreparationWorker(adapter),
+    mode: "http",
+  };
+}

--- a/packages/services/ordering/src/public-preparation-dispatch-store-postgres.ts
+++ b/packages/services/ordering/src/public-preparation-dispatch-store-postgres.ts
@@ -1,0 +1,98 @@
+/**
+ * Durable CR-204A dispatch ledger (Postgres).
+ */
+
+import type pg from "pg";
+import type {
+  PrepDispatchRecord,
+  PublicPrepDispatchStore,
+} from "./public-preparation-dispatch-store.js";
+
+function rowToRecord(row: pg.QueryResultRow): PrepDispatchRecord {
+  return {
+    command_inbox_key: row.command_inbox_key,
+    work_item_id: row.work_item_id,
+    work_id: row.work_id,
+    lease_epoch: Number(row.lease_epoch),
+    ...(row.external_job_ref != null ? { external_job_ref: row.external_job_ref } : {}),
+    ...(row.dispatched_at != null
+      ? { dispatched_at_unix_ms: new Date(row.dispatched_at).getTime() }
+      : {}),
+    ...(row.acked_at != null ? { acked_at_unix_ms: new Date(row.acked_at).getTime() } : {}),
+    ...(row.lost_response === true ? { lost_response: true } : {}),
+  };
+}
+
+export class PostgresPublicPrepDispatchStore implements PublicPrepDispatchStore {
+  constructor(private readonly pool: pg.Pool) {}
+
+  async recordIntent(input: {
+    command_inbox_key: string;
+    work_item_id: string;
+    work_id: string;
+    lease_epoch: number;
+    now_ms: number;
+  }): Promise<PrepDispatchRecord> {
+    const existing = await this.get(input.command_inbox_key);
+    if (existing) return existing;
+    const at = new Date(input.now_ms).toISOString();
+    await this.pool.query(
+      `INSERT INTO public_prep_dispatch (
+         command_inbox_key, work_item_id, work_id, lease_epoch, dispatched_at, created_at, updated_at
+       ) VALUES ($1,$2,$3,$4,$5,$5,$5)
+       ON CONFLICT (command_inbox_key) DO NOTHING`,
+      [input.command_inbox_key, input.work_item_id, input.work_id, input.lease_epoch, at],
+    );
+    const row = await this.get(input.command_inbox_key);
+    if (!row) throw new Error("public_prep_dispatch insert vanished");
+    return row;
+  }
+
+  async recordAck(input: {
+    command_inbox_key: string;
+    external_job_ref: string;
+    now_ms: number;
+  }): Promise<PrepDispatchRecord | undefined> {
+    const at = new Date(input.now_ms).toISOString();
+    const result = await this.pool.query(
+      `UPDATE public_prep_dispatch
+       SET external_job_ref = $2, acked_at = $3, lost_response = FALSE, updated_at = $3
+       WHERE command_inbox_key = $1
+       RETURNING *`,
+      [input.command_inbox_key, input.external_job_ref, at],
+    );
+    if (result.rows.length === 0) return undefined;
+    return rowToRecord(result.rows[0]);
+  }
+
+  async get(commandInboxKey: string): Promise<PrepDispatchRecord | undefined> {
+    const result = await this.pool.query(
+      "SELECT * FROM public_prep_dispatch WHERE command_inbox_key = $1",
+      [commandInboxKey],
+    );
+    if (result.rows.length === 0) return undefined;
+    return rowToRecord(result.rows[0]);
+  }
+
+  async listPendingReconciliation(now_ms: number): Promise<readonly PrepDispatchRecord[]> {
+    const staleBefore = new Date(now_ms - 5_000).toISOString();
+    const result = await this.pool.query(
+      `SELECT * FROM public_prep_dispatch
+       WHERE acked_at IS NULL
+         AND dispatched_at IS NOT NULL
+         AND dispatched_at <= $1
+       ORDER BY dispatched_at`,
+      [staleBefore],
+    );
+    return result.rows.map(rowToRecord);
+  }
+
+  async markLostResponse(commandInboxKey: string): Promise<void> {
+    await this.pool.query(
+      `UPDATE public_prep_dispatch
+       SET lost_response = TRUE, updated_at = NOW()
+       WHERE command_inbox_key = $1`,
+      [commandInboxKey],
+    );
+  }
+}

--- a/packages/services/ordering/src/public-preparation-sonar-http.ts
+++ b/packages/services/ordering/src/public-preparation-sonar-http.ts
@@ -1,14 +1,9 @@
 /**
- * CR-204A live Sonar kitchen port — admit + probe via kitchen-api.
+ * CR-204A live Sonar kitchen port — thin HTTP client.
  *
- * Deployment digests on work items are resolved through the linked order's
- * confirmed resolution candidate snapshot (network + address).
+ * Kitchen deployment coords must already be on the dispatch request (baked at admit).
  */
 
-import type { ResolutionStore } from "./resolution-store.js";
-import type { OrderStore } from "./store.js";
-import type { SharedPreparationStore } from "./shared-preparation-store.js";
-import type { VersionedDigest } from "./shared-preparation-types.js";
 import type {
   PublicPreparationSonarPort,
   SonarPrepDispatchRequest,
@@ -19,62 +14,8 @@ import type {
 export interface HttpPublicPreparationSonarPortDeps {
   readonly kitchenBaseUrl: string;
   readonly serviceToken: string;
-  readonly preparationStore: SharedPreparationStore;
-  readonly orderStore: OrderStore;
-  readonly resolutionStore: ResolutionStore;
   readonly fetchImpl?: typeof fetch;
   readonly timeoutMs?: number;
-}
-
-export interface ResolvedKitchenDeployment {
-  readonly network_namespace: string;
-  readonly network_reference: string;
-  readonly address: string;
-  readonly token_standard: "erc721" | "erc1155";
-}
-
-function digestKey(d: VersionedDigest): string {
-  return `${d.algorithm}:${d.domain}:${d.major_version}:${d.digest}`;
-}
-
-export async function resolveKitchenDeploymentForDigest(input: {
-  readonly deploymentId: VersionedDigest;
-  readonly workId: string;
-  readonly preparationStore: SharedPreparationStore;
-  readonly orderStore: OrderStore;
-  readonly resolutionStore: ResolutionStore;
-}): Promise<ResolvedKitchenDeployment | undefined> {
-  const links = await input.preparationStore.listActiveLinks(input.workId);
-  const want = digestKey(input.deploymentId);
-  for (const link of links) {
-    const order = await input.orderStore.get(link.order_id);
-    if (!order || order.product !== "collection-report") continue;
-    const resolutionId = (order.inputs as { resolution_id?: unknown }).resolution_id;
-    if (typeof resolutionId !== "string" || resolutionId.length === 0) continue;
-    const resolution = await input.resolutionStore.get(resolutionId);
-    if (!resolution) continue;
-    for (const candidate of resolution.candidate_snapshot.candidates) {
-      for (const deployment of candidate.identity.deployments) {
-        if (digestKey(deployment.deployment_id) !== want) continue;
-        const rawStandard = (candidate as { token_standard?: { value?: string } | string })
-          .token_standard;
-        const standardValue =
-          typeof rawStandard === "string"
-            ? rawStandard
-            : typeof rawStandard?.value === "string"
-              ? rawStandard.value
-              : "erc721";
-        const tokenStandard = standardValue === "erc1155" ? "erc1155" : "erc721";
-        return {
-          network_namespace: deployment.network.network_namespace,
-          network_reference: deployment.network.network_reference,
-          address: deployment.address,
-          token_standard: tokenStandard,
-        };
-      }
-    }
-  }
-  return undefined;
 }
 
 function mapKitchenStatus(status: string): SonarPrepStatusResult {
@@ -88,7 +29,8 @@ function mapKitchenStatus(status: string): SonarPrepStatusResult {
     case "failed":
       return { status: "failed", retryable: true, error_code: "kitchen_job_failed" };
     default:
-      return { status: "indexing" };
+      // Fail closed — unknown status is not progress.
+      return { status: "failed", retryable: true, error_code: "kitchen_status_unknown" };
   }
 }
 
@@ -106,15 +48,9 @@ export class HttpPublicPreparationSonarPort implements PublicPreparationSonarPor
   }
 
   async dispatchChildJob(request: SonarPrepDispatchRequest): Promise<SonarPrepDispatchResult> {
-    const deployment = await resolveKitchenDeploymentForDigest({
-      deploymentId: request.deployment_id,
-      workId: request.work_id,
-      preparationStore: this.deps.preparationStore,
-      orderStore: this.deps.orderStore,
-      resolutionStore: this.deps.resolutionStore,
-    });
+    const deployment = request.kitchen_deployment;
     if (!deployment) {
-      return { ok: false, retryable: true, error_code: "deployment_unresolved" };
+      return { ok: false, retryable: false, error_code: "deployment_unresolved" };
     }
 
     const controller = new AbortController();
@@ -192,14 +128,9 @@ export class HttpPublicPreparationSonarPort implements PublicPreparationSonarPor
       clearTimeout(timer);
     }
   }
-
 }
 
-export function httpPublicPreparationSonarFromEnv(deps: {
-  readonly preparationStore: SharedPreparationStore;
-  readonly orderStore: OrderStore;
-  readonly resolutionStore: ResolutionStore;
-}): HttpPublicPreparationSonarPort | undefined {
+export function httpPublicPreparationSonarFromEnv(): HttpPublicPreparationSonarPort | undefined {
   const base =
     process.env.SONAR_API_URL?.trim() ||
     process.env.SONAR_KITCHEN_URL?.trim() ||
@@ -212,8 +143,5 @@ export function httpPublicPreparationSonarFromEnv(deps: {
   return new HttpPublicPreparationSonarPort({
     kitchenBaseUrl: base,
     serviceToken: token,
-    preparationStore: deps.preparationStore,
-    orderStore: deps.orderStore,
-    resolutionStore: deps.resolutionStore,
   });
 }

--- a/packages/services/ordering/src/public-preparation-sonar-http.ts
+++ b/packages/services/ordering/src/public-preparation-sonar-http.ts
@@ -1,0 +1,219 @@
+/**
+ * CR-204A live Sonar kitchen port — admit + probe via kitchen-api.
+ *
+ * Deployment digests on work items are resolved through the linked order's
+ * confirmed resolution candidate snapshot (network + address).
+ */
+
+import type { ResolutionStore } from "./resolution-store.js";
+import type { OrderStore } from "./store.js";
+import type { SharedPreparationStore } from "./shared-preparation-store.js";
+import type { VersionedDigest } from "./shared-preparation-types.js";
+import type {
+  PublicPreparationSonarPort,
+  SonarPrepDispatchRequest,
+  SonarPrepDispatchResult,
+  SonarPrepStatusResult,
+} from "./public-preparation-sonar-port.js";
+
+export interface HttpPublicPreparationSonarPortDeps {
+  readonly kitchenBaseUrl: string;
+  readonly serviceToken: string;
+  readonly preparationStore: SharedPreparationStore;
+  readonly orderStore: OrderStore;
+  readonly resolutionStore: ResolutionStore;
+  readonly fetchImpl?: typeof fetch;
+  readonly timeoutMs?: number;
+}
+
+export interface ResolvedKitchenDeployment {
+  readonly network_namespace: string;
+  readonly network_reference: string;
+  readonly address: string;
+  readonly token_standard: "erc721" | "erc1155";
+}
+
+function digestKey(d: VersionedDigest): string {
+  return `${d.algorithm}:${d.domain}:${d.major_version}:${d.digest}`;
+}
+
+export async function resolveKitchenDeploymentForDigest(input: {
+  readonly deploymentId: VersionedDigest;
+  readonly workId: string;
+  readonly preparationStore: SharedPreparationStore;
+  readonly orderStore: OrderStore;
+  readonly resolutionStore: ResolutionStore;
+}): Promise<ResolvedKitchenDeployment | undefined> {
+  const links = await input.preparationStore.listActiveLinks(input.workId);
+  const want = digestKey(input.deploymentId);
+  for (const link of links) {
+    const order = await input.orderStore.get(link.order_id);
+    if (!order || order.product !== "collection-report") continue;
+    const resolutionId = (order.inputs as { resolution_id?: unknown }).resolution_id;
+    if (typeof resolutionId !== "string" || resolutionId.length === 0) continue;
+    const resolution = await input.resolutionStore.get(resolutionId);
+    if (!resolution) continue;
+    for (const candidate of resolution.candidate_snapshot.candidates) {
+      for (const deployment of candidate.identity.deployments) {
+        if (digestKey(deployment.deployment_id) !== want) continue;
+        const rawStandard = (candidate as { token_standard?: { value?: string } | string })
+          .token_standard;
+        const standardValue =
+          typeof rawStandard === "string"
+            ? rawStandard
+            : typeof rawStandard?.value === "string"
+              ? rawStandard.value
+              : "erc721";
+        const tokenStandard = standardValue === "erc1155" ? "erc1155" : "erc721";
+        return {
+          network_namespace: deployment.network.network_namespace,
+          network_reference: deployment.network.network_reference,
+          address: deployment.address,
+          token_standard: tokenStandard,
+        };
+      }
+    }
+  }
+  return undefined;
+}
+
+function mapKitchenStatus(status: string): SonarPrepStatusResult {
+  switch (status) {
+    case "completed":
+      return { status: "indexed" };
+    case "indexing":
+      return { status: "indexing" };
+    case "queued":
+      return { status: "queued" };
+    case "failed":
+      return { status: "failed", retryable: true, error_code: "kitchen_job_failed" };
+    default:
+      return { status: "indexing" };
+  }
+}
+
+export class HttpPublicPreparationSonarPort implements PublicPreparationSonarPort {
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+  private readonly base: string;
+  private readonly token: string;
+
+  constructor(private readonly deps: HttpPublicPreparationSonarPortDeps) {
+    this.fetchImpl = deps.fetchImpl ?? fetch;
+    this.timeoutMs = deps.timeoutMs ?? 15_000;
+    this.base = deps.kitchenBaseUrl.replace(/\/+$/, "");
+    this.token = deps.serviceToken;
+  }
+
+  async dispatchChildJob(request: SonarPrepDispatchRequest): Promise<SonarPrepDispatchResult> {
+    const deployment = await resolveKitchenDeploymentForDigest({
+      deploymentId: request.deployment_id,
+      workId: request.work_id,
+      preparationStore: this.deps.preparationStore,
+      orderStore: this.deps.orderStore,
+      resolutionStore: this.deps.resolutionStore,
+    });
+    if (!deployment) {
+      return { ok: false, retryable: true, error_code: "deployment_unresolved" };
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await this.fetchImpl(`${this.base}/v2/collection-preparations`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          schema_version: 1,
+          network: {
+            schema_version: 1,
+            network_namespace: deployment.network_namespace,
+            network_reference: deployment.network_reference,
+          },
+          address: deployment.address,
+          token_standard: deployment.token_standard,
+          correlation: {
+            source: "ordering.public-prep.v1",
+            correlation_id: request.command_inbox_key,
+          },
+        }),
+        signal: controller.signal,
+      });
+      const json = (await res.json().catch(() => null)) as {
+        physical_job_id?: string;
+        error?: { code?: string };
+      } | null;
+      if ((res.status === 200 || res.status === 202) && json?.physical_job_id) {
+        return { ok: true, external_job_ref: json.physical_job_id };
+      }
+      const code = json?.error?.code ?? `http_${res.status}`;
+      return {
+        ok: false,
+        retryable: res.status >= 500 || res.status === 429,
+        error_code: code,
+      };
+    } catch {
+      return { ok: false, retryable: true, error_code: "sonar_unavailable" };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async probeChildJob(externalJobRef: string): Promise<SonarPrepStatusResult> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await this.fetchImpl(
+        `${this.base}/v2/collection-preparations/${encodeURIComponent(externalJobRef)}`,
+        {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${this.token}`,
+            Accept: "application/json",
+          },
+          signal: controller.signal,
+        },
+      );
+      if (res.status === 404) {
+        return { status: "failed", retryable: true, error_code: "job_not_found" };
+      }
+      const json = (await res.json().catch(() => null)) as { status?: string } | null;
+      if (!res.ok || !json?.status) {
+        return { status: "failed", retryable: true, error_code: `http_${res.status}` };
+      }
+      return mapKitchenStatus(json.status);
+    } catch {
+      return { status: "failed", retryable: true, error_code: "sonar_unavailable" };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+}
+
+export function httpPublicPreparationSonarFromEnv(deps: {
+  readonly preparationStore: SharedPreparationStore;
+  readonly orderStore: OrderStore;
+  readonly resolutionStore: ResolutionStore;
+}): HttpPublicPreparationSonarPort | undefined {
+  const base =
+    process.env.SONAR_API_URL?.trim() ||
+    process.env.SONAR_KITCHEN_URL?.trim() ||
+    "";
+  const token =
+    process.env.SONAR_SERVICE_TOKEN?.trim() ||
+    process.env.SERVICE_TOKEN?.trim() ||
+    "";
+  if (!base || !token) return undefined;
+  return new HttpPublicPreparationSonarPort({
+    kitchenBaseUrl: base,
+    serviceToken: token,
+    preparationStore: deps.preparationStore,
+    orderStore: deps.orderStore,
+    resolutionStore: deps.resolutionStore,
+  });
+}

--- a/packages/services/ordering/src/public-preparation-sonar-port.ts
+++ b/packages/services/ordering/src/public-preparation-sonar-port.ts
@@ -1,4 +1,8 @@
-import type { PublicPrepCapability, VersionedDigest } from "./shared-preparation-types.js";
+import type {
+  KitchenDeploymentTarget,
+  PublicPrepCapability,
+  VersionedDigest,
+} from "./shared-preparation-types.js";
 import { sonarPhysicalJobRef } from "./public-preparation-dispatch-key.js";
 
 export type SonarPrepJobStatus = "queued" | "indexing" | "indexed" | "failed";
@@ -10,8 +14,8 @@ export interface SonarPrepDispatchRequest {
   readonly adapter_version: string;
   readonly generation: number;
   readonly lease_epoch: number;
-  /** Owning shared-prep work — required for live kitchen deployment resolution. */
-  readonly work_id: string;
+  /** Baked at admit onto the work item — required for live kitchen HTTP. */
+  readonly kitchen_deployment?: KitchenDeploymentTarget;
 }
 
 export interface SonarPrepDispatchResult {

--- a/packages/services/ordering/src/public-preparation-sonar-port.ts
+++ b/packages/services/ordering/src/public-preparation-sonar-port.ts
@@ -10,6 +10,8 @@ export interface SonarPrepDispatchRequest {
   readonly adapter_version: string;
   readonly generation: number;
   readonly lease_epoch: number;
+  /** Owning shared-prep work — required for live kitchen deployment resolution. */
+  readonly work_id: string;
 }
 
 export interface SonarPrepDispatchResult {

--- a/packages/services/ordering/src/shared-preparation-store-postgres.ts
+++ b/packages/services/ordering/src/shared-preparation-store-postgres.ts
@@ -105,6 +105,9 @@ function rowToItem(row: pg.QueryResultRow): PreparationWorkItemRecord {
     deployment_id: row.deployment_id,
     capability: row.capability,
     adapter_version: row.adapter_version,
+    ...(row.kitchen_target != null
+      ? { kitchen_target: row.kitchen_target as PreparationWorkItemRecord["kitchen_target"] }
+      : {}),
     ...(row.external_job_ref != null ? { external_job_ref: row.external_job_ref } : {}),
     state: row.state,
     attempt: Number(row.attempt),
@@ -118,6 +121,15 @@ function rowToItem(row: pg.QueryResultRow): PreparationWorkItemRecord {
     created_at_unix_ms: requirePgTimestampMs(row.created_at, "created_at"),
     updated_at_unix_ms: requirePgTimestampMs(row.updated_at, "updated_at"),
   };
+}
+
+function deploymentDigestKey(d: {
+  algorithm: string;
+  domain: string;
+  major_version: number;
+  digest: string;
+}): string {
+  return `${d.algorithm}:${d.domain}:${d.major_version}:${d.digest}`;
 }
 
 function rowToLink(row: pg.QueryResultRow): ReportWorkLinkRecord {
@@ -165,6 +177,7 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
     for (const file of [
       "001_orders.sql",
       "007_shared_preparation_work.sql",
+      "009_public_prep_dispatch_and_kitchen_target.sql",
     ]) {
       const sql = readFileSync(join(__dirname, "../migrations", file), "utf8");
       await this.pool.query(sql);
@@ -285,16 +298,20 @@ export class PostgresSharedPreparationStore implements SharedPreparationStore {
       ],
     );
     for (const deploymentId of input.work_key.deployment_ids) {
+      const kitchenTarget =
+        input.kitchen_targets_by_deployment_digest?.[deploymentDigestKey(deploymentId)];
       await client.query(
         `INSERT INTO preparation_work_items (
-          work_item_id, work_id, deployment_id, capability, adapter_version, state, attempt, lease_epoch, created_at, updated_at
-        ) VALUES ($1,$2,$3,$4,$5,'queued',0,0,$6,$6)`,
+          work_item_id, work_id, deployment_id, capability, adapter_version, kitchen_target,
+          state, attempt, lease_epoch, created_at, updated_at
+        ) VALUES ($1,$2,$3,$4,$5,$6,'queued',0,0,$7,$7)`,
         [
           `pwi_${randomUUID()}`,
           workId,
           JSON.stringify(deploymentId),
           input.work_key.capability,
           input.work_key.adapter_version,
+          kitchenTarget !== undefined ? JSON.stringify(kitchenTarget) : null,
           nowIso,
         ],
       );

--- a/packages/services/ordering/src/shared-preparation-store.ts
+++ b/packages/services/ordering/src/shared-preparation-store.ts
@@ -14,13 +14,19 @@ import {
 import {
   isActivePublicWorkState,
   isLeasablePublicWorkState,
+  type KitchenDeploymentTarget,
   type PreparationWorkItemRecord,
   type PublicPreparationWorkKeyMaterial,
   type PublicWorkState,
   type ReadinessEvidenceEnvelope,
   type ReportWorkLinkRecord,
   type SharedPreparationWorkRecord,
+  type VersionedDigest,
 } from "./shared-preparation-types.js";
+
+function deploymentDigestKey(d: VersionedDigest): string {
+  return `${d.algorithm}:${d.domain}:${d.major_version}:${d.digest}`;
+}
 
 export class SharedPreparationFencingError extends Error {
   constructor(message: string) {
@@ -41,6 +47,10 @@ export interface JoinPublicWorkInput {
   readonly order_tenant_scope_digest: string;
   readonly work_key: PublicPreparationWorkKeyMaterial;
   readonly now_ms: number;
+  /** Digest-key → kitchen coords; applied only when creating new work items. */
+  readonly kitchen_targets_by_deployment_digest?: Readonly<
+    Record<string, KitchenDeploymentTarget>
+  >;
 }
 
 export type JoinPublicWorkResult =
@@ -293,6 +303,9 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
     work_key: PublicPreparationWorkKeyMaterial;
     generation: number;
     now_ms: number;
+    kitchen_targets_by_deployment_digest?: Readonly<
+      Record<string, KitchenDeploymentTarget>
+    >;
   }): MutableWork {
     const workId = `spw_${randomUUID()}`;
     const workKeyDigest = digestPublicWorkKey(input.work_key);
@@ -324,12 +337,17 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
     this.works.set(workId, work);
     for (const deploymentId of input.work_key.deployment_ids) {
       const itemId = `pwi_${randomUUID()}`;
+      const kitchenTarget =
+        input.kitchen_targets_by_deployment_digest?.[deploymentDigestKey(deploymentId)];
       const item: MutableItem = {
         work_item_id: itemId,
         work_id: workId,
         deployment_id: structuredClone(deploymentId),
         capability: input.work_key.capability,
         adapter_version: input.work_key.adapter_version,
+        ...(kitchenTarget !== undefined
+          ? { kitchen_target: structuredClone(kitchenTarget) }
+          : {}),
         state: "queued",
         attempt: 0,
         lease_epoch: 0,
@@ -413,6 +431,7 @@ export class InMemorySharedPreparationStore implements SharedPreparationStore {
         work_key: input.work_key,
         generation,
         now_ms: input.now_ms,
+        kitchen_targets_by_deployment_digest: input.kitchen_targets_by_deployment_digest,
       });
       this.attachLink({
         order_id: input.order_id,

--- a/packages/services/ordering/src/shared-preparation-types.ts
+++ b/packages/services/ordering/src/shared-preparation-types.ts
@@ -138,12 +138,22 @@ export interface SharedPreparationWorkRecord {
   readonly updated_at_unix_ms: number;
 }
 
+/** Kitchen coords baked at admit — HTTP dispatch must not re-join resolution. */
+export interface KitchenDeploymentTarget {
+  readonly network_namespace: string;
+  readonly network_reference: string;
+  readonly address: string;
+  readonly token_standard: "erc721" | "erc1155";
+}
+
 export interface PreparationWorkItemRecord {
   readonly work_item_id: string;
   readonly work_id: string;
   readonly deployment_id: VersionedDigest;
   readonly capability: PublicPrepCapability;
   readonly adapter_version: string;
+  /** Present when join materialised kitchen coords (live Sonar path). */
+  readonly kitchen_target?: KitchenDeploymentTarget;
   readonly external_job_ref?: string;
   readonly state: PublicWorkState;
   readonly attempt: number;

--- a/packages/services/ordering/src/store-postgres.ts
+++ b/packages/services/ordering/src/store-postgres.ts
@@ -76,6 +76,7 @@ export class PostgresOrderStore implements OrderStore {
       '006_report_attention_receipts.sql',
       '007_shared_preparation_work.sql',
       '008_admission_capacity.sql',
+      '009_public_prep_dispatch_and_kitchen_target.sql',
     ]) {
       const sql = readFileSync(join(__dirname, '../migrations', file), 'utf8');
       await this.pool.query(sql);


### PR DESCRIPTION
## Summary
- Wire CR-204A `PublicPreparationAdapter` + live kitchen Sonar HTTP port into ordering intake HTTP composition (`public_prep: http` on healthz).
- After `ownership_evidence_ready`, settle honest `needs_attention` (`gate_leak_artifact_producer_pending`) until Gate Leak artifact producer exists.
- Fix Dockerfile to COPY/build public-authorization, trust-envelope, signing-key-custody, dependency-ledger protocol packages.

## Test plan
- [x] Unit: public-preparation-adapter + collection-report-orchestrator
- [x] Railway prod deploy SUCCESS; `/healthz` shows `public_prep: http` + fixture public auth
- [ ] Live place via dashboard with `client_request_id` + scope; confirm prep links / honest terminal
- [ ] Kitchen ownership-ready already live (separate sonar deploy)


Made with [Cursor](https://cursor.com)