### PR TITLE
fix(network/freeside-cli): enforce workspace build order so the shipped CLI can't crash on stale deps (#449)

### DIFF
--- a/packages/freeside-cli/tests/cli-smoke.test.ts
+++ b/packages/freeside-cli/tests/cli-smoke.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Real-binary smoke · freeside-cli (bug #449)
+ *
+ * Guards the shipped binary against module-load crashes caused by a stale/unbuilt
+ * workspace dependency `dist/` (e.g. `@freeside/beacon-schema` missing a newer
+ * export like `BEACON_EXIT`). `bin/freeside-cli.ts` imports every verb at the top
+ * of the file, so a missing export aborts module load before any verb runs — the
+ * whole CLI is unrunnable as shipped.
+ *
+ * This asserts `--help` exits 0 AND prints usage on stdout. It is immune to the
+ * false-green in the existing `doctor --registry <bad> → exit 1` smoke: a
+ * module-load crash also exits non-zero, so an exit-1 assertion cannot tell
+ * "correctly rejected" from "crashed before running". Exit-0-with-usage can.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = join(__dirname, "..", "dist", "bin", "freeside-cli.js");
+
+for (const flag of ["--help", "-h"]) {
+  test(`CLI · ${flag} → exit 0 with usage on stdout (module-load smoke, #449)`, () => {
+    if (!existsSync(CLI)) throw new Error(`CLI not built at ${CLI} — run \`npm run build\` first`);
+    // execFileSync throws on non-zero exit → a module-load crash fails this test.
+    const stdout = execFileSync("node", [CLI, flag], { encoding: "utf-8" });
+    assert.match(stdout, /freeside-cli/, "usage banner must be printed on stdout");
+  });
+}

--- a/packages/freeside-cli/tsconfig.json
+++ b/packages/freeside-cli/tsconfig.json
@@ -15,5 +15,9 @@
     "resolveJsonModule": true
   },
   "include": ["src/**/*", "bin/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "exclude": ["node_modules", "dist", "tests"],
+  "references": [
+    { "path": "../beacon-schema" },
+    { "path": "../freeside-registry" }
+  ]
 }

--- a/packages/freeside-registry/tsconfig.json
+++ b/packages/freeside-registry/tsconfig.json
@@ -13,8 +13,13 @@
     "declarationMap": true,
     "sourceMap": true,
     "resolveJsonModule": true,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "composite": true,
+    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "exclude": ["node_modules", "dist", "tests"],
+  "references": [
+    { "path": "../beacon-schema" }
+  ]
 }


### PR DESCRIPTION
Fixes #449.

## Reproduction
Every verb of the compiled `@freeside/freeside-cli` binary crashed at module load:

```
$ node packages/freeside-cli/dist/bin/freeside-cli.js --help ; echo $?
SyntaxError: The requested module '@freeside/beacon-schema' does not provide an export named 'BEACON_EXIT'
exit=1
```

`bin/freeside-cli.ts` imports every verb at the top of the file, so a missing
export in a top-imported verb aborts module load before any verb runs — the CLI
is unrunnable as shipped. Reproduced locally in this worktree: building the CLI
in isolation (deps not built in order) yields the same class of failure
(`ERR_MODULE_NOT_FOUND` for `@freeside/freeside-registry`), `--help` exit 1.

## Root cause
`packages/freeside-cli/tsconfig.json` declared **no TypeScript project
references**. Its build script is `tsc -b`, which — without references — builds
only freeside-cli, never its `file:` workspace deps
(`@freeside/beacon-schema`, `@freeside/freeside-registry`). Those deps are
**symlinked** (`node_modules/@freeside/beacon-schema -> ../../../beacon-schema`),
so the compiled binary resolves each dep's `dist/` at runtime; a stale (missing a
newer export like `BEACON_EXIT`) or unbuilt dep `dist/` throws at module load.
Correct build ordering was enforced only externally (CI workflow step order), so
any other build path — a standalone package build, a local rebuild, or the
globally-linked `loa-cli` — could ship a broken binary.

## Fix
- **`packages/freeside-cli/tsconfig.json`**: add `references` → `../beacon-schema`
  + `../freeside-registry`, so `tsc -b` builds the dep chain in dependency order
  regardless of invocation path (compiler-enforced build order).
- **`packages/freeside-registry/tsconfig.json`**: add `composite: true` (required
  to be a reference target) + `references` → `../beacon-schema` (registry imports
  it — `src/beacon-loader.ts`). Also pin `tsBuildInfoFile` into `dist/` so
  `npm run clean` (`rm -rf dist`) removes build state uniformly — otherwise the
  root-level `.tsbuildinfo` survives a clean and makes `clean && build` skip a
  dependency rebuild, re-shipping a broken binary.
- **`packages/freeside-cli/tests/cli-smoke.test.ts`** (new): real-binary smoke —
  `--help`/`-h` must exit 0 with usage on stdout. Immune to the exit-1
  false-green in the existing `doctor --registry <bad> → exit 1` smoke, because a
  module-load crash also exits 1 (see the companion false-green issue #449 calls out).

`@freeside/beacon-schema` is already `composite: true` — unchanged. Build artifacts
(`dist/`, `**/tsconfig.tsbuildinfo`) are gitignored; none are committed.

## Tests / verification
Run from a fresh state (mirrors `registry-cli-tests.yml`):
```
cd packages/beacon-schema  && npm ci && npm run build          # exit 0
cd packages/freeside-registry && npm ci && npm run typecheck && npm test && npm run build   # 47 pass / 0 fail
cd packages/freeside-cli   && npm ci && npm run build && npm test                            # 112 pass / 0 fail (+2 new smoke, 1 pre-existing skip)
node packages/freeside-cli/dist/bin/freeside-cli.js --help   # usage + exit 0
```
Shipped binary now runs every verb: `--help`/`list`/`doctor` all exit 0 (no
module-load crash). Building **only** the CLI now rebuilds beacon-schema →
freeside-registry → freeside-cli in order via references; the `clean && build`
path is also verified to regenerate the dep dist.

## Review & audit
- **Review** (senior + adversarial): APPROVED. Cross-model dissent (`codex-headless`)
  ran on the final diff — `degraded: false`, verdict APPROVED. One BLOCKING finding
  (DISS-001: `composite` without pinned `rootDir` could shift emit to
  `dist/src/index.js`) was **empirically refuted** — `rootDir: ./src` is
  pre-existing (not in this diff), the actual emit is `dist/index.js` (matches
  `package.json main`, no `dist/src/` shift), and the CLI `list` consumer resolves
  the registry at runtime.
- **Security/quality audit**: APPROVED — no CRITICAL/HIGH/MEDIUM/LOW. Change surface
  is build config + one test: no app logic, no auth, no secrets, no network, no
  injection sinks (`execFileSync` uses a fixed argv, no shell, no user input). No
  dependency cycle (`beacon-schema` is a leaf). Blast radius bounded: the only
  consumers of these two packages are the three in this reference graph.

Scope: fixes only #449; no scope broadening, no weakened tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
