### PR TITLE
chore(security): scrub AWS account ID + state-bucket name from the public tree

### DIFF
--- a/.github/workflows/dns-drift-check.yml
+++ b/.github/workflows/dns-drift-check.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Terraform Init
         working-directory: infrastructure/terraform/dns
-        run: terraform init -backend-config=environments/production/backend.tfvars
+        run: terraform init -backend-config=environments/production/backend.tfvars -backend-config="bucket=${{ secrets.TFSTATE_BUCKET }}"
 
       - name: Terraform Plan (drift detection)
         working-directory: infrastructure/terraform/dns

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -269,9 +269,9 @@ After merge to main:
 - **`staging` tag**: Current staging
 
 ```bash
-891376933289.dkr.ecr.us-east-1.amazonaws.com/arrakis-production-api:abc1234
-891376933289.dkr.ecr.us-east-1.amazonaws.com/arrakis-production-api:latest
-891376933289.dkr.ecr.us-east-1.amazonaws.com/arrakis-staging-api:staging
+<AWS_ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/arrakis-production-api:abc1234
+<AWS_ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/arrakis-production-api:latest
+<AWS_ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/arrakis-staging-api:staging
 ```
 
 ---
@@ -289,7 +289,7 @@ After merge to main:
 ### Infrastructure Separation
 
 ```
-AWS Account: 891376933289
+AWS Account: <AWS_ACCOUNT_ID>
 ├── arrakis-staging-*     # Staging resources
 │   ├── ECS Cluster
 │   ├── RDS (separate instance)

--- a/grimoires/loa/a2a/gpt-review/sdd-findings-1.json
+++ b/grimoires/loa/a2a/gpt-review/sdd-findings-1.json
@@ -25,8 +25,8 @@
       "file": "infrastructure/terraform/dns/main.tf",
       "line": 6,
       "description": "Provider version constraint is malformed; `aws = \"~> 5.0\"` must be nested under `required_providers.aws.source/version`, otherwise Terraform init will fail.",
-      "current_code": "terraform {\n  required_version = \">= 1.6.0\"\n\n  required_providers {\n    aws = \"~> 5.0\"\n  }\n\n  backend \"s3\" {\n    bucket         = \"arrakis-tfstate-891376933289\"\n    region         = \"us-east-1\"\n    encrypt        = true\n    dynamodb_table = \"arrakis-terraform-locks\"\n  }\n}\n",
-      "fixed_code": "terraform {\n  required_version = \">= 1.6.0\"\n\n  required_providers {\n    aws = {\n      source  = \"hashicorp/aws\"\n      version = \"~> 5.0\"\n    }\n  }\n\n  backend \"s3\" {\n    bucket         = \"arrakis-tfstate-891376933289\"\n    region         = \"us-east-1\"\n    encrypt        = true\n    dynamodb_table = \"arrakis-terraform-locks\"\n  }\n}\n",
+      "current_code": "terraform {\n  required_version = \">= 1.6.0\"\n\n  required_providers {\n    aws = \"~> 5.0\"\n  }\n\n  backend \"s3\" {\n    bucket         = \"arrakis-tfstate-<AWS_ACCOUNT_ID>\"\n    region         = \"us-east-1\"\n    encrypt        = true\n    dynamodb_table = \"arrakis-terraform-locks\"\n  }\n}\n",
+      "fixed_code": "terraform {\n  required_version = \">= 1.6.0\"\n\n  required_providers {\n    aws = {\n      source  = \"hashicorp/aws\"\n      version = \"~> 5.0\"\n    }\n  }\n\n  backend \"s3\" {\n    bucket         = \"arrakis-tfstate-<AWS_ACCOUNT_ID>\"\n    region         = \"us-east-1\"\n    encrypt        = true\n    dynamodb_table = \"arrakis-terraform-locks\"\n  }\n}\n",
       "explanation": "Terraform requires `required_providers` entries to be objects with `source` and `version` (or at least `version`), not a bare string."
     },
     {
@@ -34,8 +34,8 @@
       "file": "infrastructure/terraform/dns/main.tf",
       "line": 13,
       "description": "Backend key cannot be set via `*.tfvars` as stated; `backend \"s3\"` does not read `var.*` or tfvars. Without `-backend-config=key=...` (or a backend config file), both environments will collide on the same state key or fail expectations.",
-      "current_code": "backend \"s3\" {\n  bucket         = \"arrakis-tfstate-891376933289\"\n  region         = \"us-east-1\"\n  encrypt        = true\n  dynamodb_table = \"arrakis-terraform-locks\"\n  # key set in environments/*.tfvars: \"dns/staging.tfstate\" or \"dns/production.tfstate\"\n}\n",
-      "fixed_code": "backend \"s3\" {\n  bucket         = \"arrakis-tfstate-891376933289\"\n  region         = \"us-east-1\"\n  encrypt        = true\n  dynamodb_table = \"arrakis-terraform-locks\"\n  # key is set via -backend-config, e.g.:\n  # terraform init -backend-config=environments/staging/backend.tfvars\n}\n",
+      "current_code": "backend \"s3\" {\n  bucket         = \"arrakis-tfstate-<AWS_ACCOUNT_ID>\"\n  region         = \"us-east-1\"\n  encrypt        = true\n  dynamodb_table = \"arrakis-terraform-locks\"\n  # key set in environments/*.tfvars: \"dns/staging.tfstate\" or \"dns/production.tfstate\"\n}\n",
+      "fixed_code": "backend \"s3\" {\n  bucket         = \"arrakis-tfstate-<AWS_ACCOUNT_ID>\"\n  region         = \"us-east-1\"\n  encrypt        = true\n  dynamodb_table = \"arrakis-terraform-locks\"\n  # key is set via -backend-config, e.g.:\n  # terraform init -backend-config=environments/staging/backend.tfvars\n}\n",
       "explanation": "Terraform backend configuration is loaded only at init time via `-backend-config` (or hardcoded in the backend block). Using tfvars for backend keys is not supported."
     },
     {

--- a/grimoires/loa/archive/2026-01-19-arrakis-genesis-v2/a2a/sprint-94/auditor-sprint-feedback.md
+++ b/grimoires/loa/archive/2026-01-19-arrakis-genesis-v2/a2a/sprint-94/auditor-sprint-feedback.md
@@ -773,7 +773,7 @@ Lateral Movement Prevention: ✅ EXCELLENT
    aws kms enable-key-rotation --key-id <key-id>
 
 4. Backup current state:
-   aws s3 cp s3://arrakis-tfstate-891376933289/staging/terraform.tfstate \
+   aws s3 cp s3://arrakis-tfstate-<AWS_ACCOUNT_ID>/staging/terraform.tfstate \
      ./terraform.tfstate.backup
 
 5. Uncomment kms_key_id in backend.tfvars
@@ -783,7 +783,7 @@ Lateral Movement Prevention: ✅ EXCELLENT
 
 7. Verify encryption:
    aws s3api head-object \
-     --bucket arrakis-tfstate-891376933289 \
+     --bucket arrakis-tfstate-<AWS_ACCOUNT_ID> \
      --key staging/terraform.tfstate \
      --query 'ServerSideEncryption,SSEKMSKeyId'
 ```

--- a/grimoires/loa/archive/2026-01/security-audits/SECURITY-AUDIT-REPORT-2026-01-18-full-codebase.md
+++ b/grimoires/loa/archive/2026-01/security-audits/SECURITY-AUDIT-REPORT-2026-01-18-full-codebase.md
@@ -94,7 +94,7 @@ secret_string = jsonencode({
 
 **Impact:**
 - Full database access if state file is leaked
-- State file stored in S3 (`arrakis-tfstate-891376933289`) - potential exposure
+- State file stored in S3 (`arrakis-tfstate-<AWS_ACCOUNT_ID>`) - potential exposure
 - No encryption of state file at rest beyond S3 SSE
 
 **Recommendation:**

--- a/grimoires/loa/archive/2026-01/security-audits/sprint-95-kms-activation.md
+++ b/grimoires/loa/archive/2026-01/security-audits/sprint-95-kms-activation.md
@@ -136,11 +136,11 @@ aws kms describe-key --key-id alias/arrakis-terraform-state
 **Step 2: Backup Current State**
 ```bash
 # Backup staging state
-aws s3 cp s3://arrakis-tfstate-891376933289/staging/terraform.tfstate \
+aws s3 cp s3://arrakis-tfstate-<AWS_ACCOUNT_ID>/staging/terraform.tfstate \
   ./terraform-state-backup-staging-$(date +%Y%m%d).tfstate
 
 # Backup production state
-aws s3 cp s3://arrakis-tfstate-891376933289/production/terraform.tfstate \
+aws s3 cp s3://arrakis-tfstate-<AWS_ACCOUNT_ID>/production/terraform.tfstate \
   ./terraform-state-backup-production-$(date +%Y%m%d).tfstate
 ```
 
@@ -159,7 +159,7 @@ terraform init -backend-config=environments/staging/backend.tfvars -reconfigure
 **Step 5: Verify Encryption**
 ```bash
 aws s3api head-object \
-  --bucket arrakis-tfstate-891376933289 \
+  --bucket arrakis-tfstate-<AWS_ACCOUNT_ID> \
   --key staging/terraform.tfstate \
   --query '[ServerSideEncryption, SSEKMSKeyId]'
 # Expected: ["aws:kms", "arn:aws:kms:us-east-1:...:key/..."]
@@ -299,7 +299,7 @@ After completing all tasks, verify:
 
 ### KMS Encryption
 - [ ] `aws secretsmanager describe-secret --secret-id arrakis-staging/database --query 'KmsKeyId'` returns customer KMS key ARN
-- [ ] `aws s3api head-object --bucket arrakis-tfstate-891376933289 --key staging/terraform.tfstate --query 'SSEKMSKeyId'` returns KMS key ARN
+- [ ] `aws s3api head-object --bucket arrakis-tfstate-<AWS_ACCOUNT_ID> --key staging/terraform.tfstate --query 'SSEKMSKeyId'` returns KMS key ARN
 
 ### Service Access
 - [ ] Gateway can connect to Discord (read app_config)

--- a/grimoires/loa/archive/2026-01/sprints/sprint-95/auditor-sprint-feedback.md
+++ b/grimoires/loa/archive/2026-01/sprints/sprint-95/auditor-sprint-feedback.md
@@ -279,7 +279,7 @@ aws iam get-role-policy \
 
 # Verify Terraform state KMS (after terraform init -reconfigure)
 aws s3api head-object \
-  --bucket arrakis-tfstate-891376933289 \
+  --bucket arrakis-tfstate-<AWS_ACCOUNT_ID> \
   --key staging/terraform.tfstate \
   --query '[ServerSideEncryption, SSEKMSKeyId]'
 # Expected: ["aws:kms", "arn:aws:kms:..."]

--- a/grimoires/loa/archive/2026-01/sprints/sprint-95/engineer-feedback.md
+++ b/grimoires/loa/archive/2026-01/sprints/sprint-95/engineer-feedback.md
@@ -145,7 +145,7 @@ Before deployment, ensure:
 
 2. **Backup state before migration**:
    ```bash
-   aws s3 cp s3://arrakis-tfstate-891376933289/staging/terraform.tfstate ./backup/
+   aws s3 cp s3://arrakis-tfstate-<AWS_ACCOUNT_ID>/staging/terraform.tfstate ./backup/
    ```
 
 3. **After terraform apply**:

--- a/grimoires/loa/archive/2026-01/sprints/sprint-95/reviewer.md
+++ b/grimoires/loa/archive/2026-01/sprints/sprint-95/reviewer.md
@@ -81,7 +81,7 @@ Uncommented and activated `kms_key_id` in both backend configuration files.
 **Key Changes**:
 ```hcl
 # environments/staging/backend.tfvars:
-bucket         = "arrakis-tfstate-891376933289"
+bucket         = "arrakis-tfstate-<AWS_ACCOUNT_ID>"
 key            = "staging/terraform.tfstate"
 region         = "us-east-1"
 encrypt        = true
@@ -225,7 +225,7 @@ aws secretsmanager describe-secret \
 
 # Verify Terraform state uses KMS (after terraform init -reconfigure)
 aws s3api head-object \
-  --bucket arrakis-tfstate-891376933289 \
+  --bucket arrakis-tfstate-<AWS_ACCOUNT_ID> \
   --key staging/terraform.tfstate \
   --query '[ServerSideEncryption, SSEKMSKeyId]'
 # Expected: ["aws:kms", "arn:aws:kms:us-east-1:...:key/..."]
@@ -261,7 +261,7 @@ aws iam get-role-policy \
 
 2. **Backup Current State**:
    ```bash
-   aws s3 cp s3://arrakis-tfstate-891376933289/staging/terraform.tfstate \
+   aws s3 cp s3://arrakis-tfstate-<AWS_ACCOUNT_ID>/staging/terraform.tfstate \
      ./terraform-state-backup-staging-$(date +%Y%m%d).tfstate
    ```
 

--- a/grimoires/loa/archive/cycle-046-armitage-platform/sdd.md
+++ b/grimoires/loa/archive/cycle-046-armitage-platform/sdd.md
@@ -24,7 +24,7 @@ The design prioritizes safety: stateful resources (S3 Object Lock, KMS, DynamoDB
 
 ```
 infrastructure/terraform/           ← COMPUTE ROOT (existing, extended)
-├── main.tf                         ← Backend: s3://arrakis-tfstate-891376933289
+├── main.tf                         ← Backend: s3://arrakis-tfstate-<AWS_ACCOUNT_ID>
 ├── environments/
 │   ├── staging/
 │   │   ├── terraform.tfvars
@@ -44,7 +44,7 @@ infrastructure/terraform/           ← COMPUTE ROOT (existing, extended)
 └── autoscaling-dixie.tf            ← NEW: AppAutoScaling target + CPU policy
 
 infrastructure/terraform/dns/       ← DNS ROOT (new, separate state)
-├── main.tf                         ← Backend: s3://arrakis-tfstate-891376933289
+├── main.tf                         ← Backend: s3://arrakis-tfstate-<AWS_ACCOUNT_ID>
 │                                      key via -backend-config
 ├── variables.tf
 ├── outputs.tf
@@ -79,7 +79,7 @@ Both roots share the same S3 bucket but use different key prefixes:
 - DynamoDB lock table: point-in-time recovery enabled
 - IAM: only CI service role (`github-actions-terraform`) and designated operators may read/write state
 - Prohibition of local state files in CI — all runs must use remote backend
-- State bucket access logging enabled (existing `arrakis-tfstate-891376933289` already has versioning)
+- State bucket access logging enabled (existing `arrakis-tfstate-<AWS_ACCOUNT_ID>` already has versioning)
 
 ### 2.3 Cross-Root References
 
@@ -1247,7 +1247,7 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "arrakis-tfstate-891376933289"
+    bucket         = "arrakis-tfstate-<AWS_ACCOUNT_ID>"
     region         = "us-east-1"
     encrypt        = true
     dynamodb_table = "arrakis-terraform-locks"
@@ -1846,7 +1846,7 @@ Dixie SG:   ingress from ALB SG (3001) + Finn SG (3001)
 - S3 bucket policy: deny `s3:PutObject` without `aws:kms` encryption
 - DynamoDB lock table: `arrakis-terraform-locks` with PITR enabled
 - IAM policy for CI: `arn:aws:iam::<account>:role/github-actions-terraform`
-- No wildcard permissions on `s3://arrakis-tfstate-891376933289/*`
+- No wildcard permissions on `s3://arrakis-tfstate-<AWS_ACCOUNT_ID>/*`
 - Access logging on state bucket
 
 ### 9.3 DNS Security (Post-Migration)

--- a/grimoires/loa/archive/cycle-046-armitage-platform/sprint.md
+++ b/grimoires/loa/archive/cycle-046-armitage-platform/sprint.md
@@ -50,7 +50,7 @@ All Terraform code, deploy scripts, wiring tests, and DNS modules were implement
 **Acceptance Criteria**:
 - [ ] `terraform plan` shows only creates (no destroys/replaces)
 - [ ] `terraform apply` succeeds without errors
-- [ ] `finn_ci_deploy_role_arn` output has value `arn:aws:iam::891376933289:role/arrakis-staging-finn-ci-deploy`
+- [ ] `finn_ci_deploy_role_arn` output has value `arn:aws:iam::<AWS_ACCOUNT_ID>:role/arrakis-staging-finn-ci-deploy`
 
 ### Task 1.2: Configure Finn Repo Secret → **[G-3]**
 
@@ -163,13 +163,13 @@ grep -c '^module ' infrastructure/terraform/*finn*.tf 2>/dev/null || echo "Confi
 # State backup
 terraform state pull > backup-$(date +%Y%m%d-%H%M%S).tfstate
 sha256sum backup-*.tfstate > backup-checksums.txt
-aws s3 cp backup-*.tfstate s3://arrakis-tfstate-891376933289/backups/ --sse aws:kms
-aws s3 cp backup-checksums.txt s3://arrakis-tfstate-891376933289/backups/ --sse aws:kms
+aws s3 cp backup-*.tfstate s3://arrakis-tfstate-<AWS_ACCOUNT_ID>/backups/ --sse aws:kms
+aws s3 cp backup-checksums.txt s3://arrakis-tfstate-<AWS_ACCOUNT_ID>/backups/ --sse aws:kms
 ```
 
 Restore drill:
 ```bash
-aws s3 cp s3://arrakis-tfstate-891376933289/backups/backup-*.tfstate /tmp/restore-test.tfstate
+aws s3 cp s3://arrakis-tfstate-<AWS_ACCOUNT_ID>/backups/backup-*.tfstate /tmp/restore-test.tfstate
 # Verify: file size > 0 and valid JSON
 jq '.version' /tmp/restore-test.tfstate
 ```
@@ -475,7 +475,7 @@ aws ecs wait services-stable --cluster arrakis-staging-cluster \
 # 5. Verify task roles have ssmmessages permissions
 for role in arrakis-staging-finn-task arrakis-staging-dixie-task arrakis-staging-freeside-task; do
   echo "=== $role ==="
-  aws iam simulate-principal-policy --policy-source-arn arn:aws:iam::891376933289:role/$role \
+  aws iam simulate-principal-policy --policy-source-arn arn:aws:iam::<AWS_ACCOUNT_ID>:role/$role \
     --action-names ssmmessages:CreateControlChannel ssmmessages:CreateDataChannel \
     ssmmessages:OpenControlChannel ssmmessages:OpenDataChannel \
     --query 'EvaluationResults[].{Action:EvalActionName,Decision:EvalDecision}'
@@ -606,7 +606,7 @@ done
 **Scope**: MEDIUM (5 tasks) | **Priority**: P1
 **Sprint Goal**: Remove all legacy `loa-finn-armitage` and remaining `dixie-armitage` AWS resources that are now superseded by the canonical Freeside infrastructure.
 
-> From loa-finn #114 (final comment): "Old loa-finn-armitage resources need deletion from 891376933289 account" — ECS service, ALB listener rule, Route53, task defs, ECR, CloudWatch, IAM, ElastiCache.
+> From loa-finn #114 (final comment): "Old loa-finn-armitage resources need deletion from <AWS_ACCOUNT_ID> account" — ECS service, ALB listener rule, Route53, task defs, ECR, CloudWatch, IAM, ElastiCache.
 
 ### Deliverables
 

--- a/grimoires/loa/deployment/README.md
+++ b/grimoires/loa/deployment/README.md
@@ -42,11 +42,11 @@ This directory contains infrastructure and deployment documentation for the Arra
 
 | Resource | Value |
 |----------|-------|
-| AWS Account | 891376933289 |
+| AWS Account | <AWS_ACCOUNT_ID> |
 | Region | us-east-1 |
 | VPC | vpc-08ccffcf89b8ec20d |
 | ECS Cluster | arrakis-production-cluster |
-| ECR Repository | 891376933289.dkr.ecr.us-east-1.amazonaws.com/arrakis-production-api |
+| ECR Repository | <AWS_ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/arrakis-production-api |
 | ALB DNS | arrakis-production-alb-427042206.us-east-1.elb.amazonaws.com |
 
 ## Terraform

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -95,7 +95,7 @@ This directory contains the Infrastructure as Code (IaC) for Freeside, using Ter
 
 - AWS CLI v2 configured
 - Terraform >= 1.5.0
-- Access to AWS account 891376933289
+- Access to AWS account <AWS_ACCOUNT_ID>
 
 ## State Management
 
@@ -103,7 +103,7 @@ Terraform state is stored in S3 with DynamoDB locking:
 
 ```hcl
 backend "s3" {
-  bucket         = "arrakis-tfstate-891376933289"
+  bucket         = "arrakis-tfstate-<AWS_ACCOUNT_ID>"
   key            = "production/terraform.tfstate"
   region         = "us-east-1"
   encrypt        = true

--- a/infrastructure/STAGING-SETUP.md
+++ b/infrastructure/STAGING-SETUP.md
@@ -6,7 +6,7 @@ This guide walks through setting up the staging environment for Arrakis.
 
 - AWS CLI v2 configured with appropriate permissions
 - Terraform >= 1.6.0
-- Access to AWS account 891376933289
+- Access to AWS account <AWS_ACCOUNT_ID>
 - ACM certificate for `staging.api.arrakis.community` (or wildcard `*.api.arrakis.community`)
 
 ## Step 1: Create Staging Secrets

--- a/infrastructure/terraform/DEPLOYMENT.md
+++ b/infrastructure/terraform/DEPLOYMENT.md
@@ -38,11 +38,11 @@ Record the physical IDs in the table below before proceeding.
 # Secure backup: encrypted S3 upload with sha256 checksum
 terraform state pull > backup-$(date +%Y%m%d-%H%M%S).tfstate
 sha256sum backup-*.tfstate > backup-checksums.txt
-aws s3 cp backup-*.tfstate s3://arrakis-tfstate-891376933289/backups/ --sse aws:kms
-aws s3 cp backup-checksums.txt s3://arrakis-tfstate-891376933289/backups/ --sse aws:kms
+aws s3 cp backup-*.tfstate s3://arrakis-tfstate-<AWS_ACCOUNT_ID>/backups/ --sse aws:kms
+aws s3 cp backup-checksums.txt s3://arrakis-tfstate-<AWS_ACCOUNT_ID>/backups/ --sse aws:kms
 
 # Restore drill: verify restore works before first import
-aws s3 cp s3://arrakis-tfstate-891376933289/backups/backup-*.tfstate /tmp/restore-test.tfstate
+aws s3 cp s3://arrakis-tfstate-<AWS_ACCOUNT_ID>/backups/backup-*.tfstate /tmp/restore-test.tfstate
 # In a scratch workspace: terraform state push /tmp/restore-test.tfstate
 ```
 
@@ -146,7 +146,7 @@ terraform state rm <resource_address>
 # Re-import after fix
 
 # Full state reset (emergency only):
-aws s3 cp s3://arrakis-tfstate-891376933289/backups/backup-YYYYMMDD-HHMMSS.tfstate ./
+aws s3 cp s3://arrakis-tfstate-<AWS_ACCOUNT_ID>/backups/backup-YYYYMMDD-HHMMSS.tfstate ./
 terraform state push backup-YYYYMMDD-HHMMSS.tfstate
 ```
 
@@ -257,7 +257,7 @@ terraform state rm <resource_address>
 ```bash
 # Trigger: multiple import failures, state corruption
 # Time limit: 15 minutes
-aws s3 cp s3://arrakis-tfstate-891376933289/backups/backup-YYYYMMDD-HHMMSS.tfstate ./
+aws s3 cp s3://arrakis-tfstate-<AWS_ACCOUNT_ID>/backups/backup-YYYYMMDD-HHMMSS.tfstate ./
 terraform state push backup-YYYYMMDD-HHMMSS.tfstate
 terraform plan -var-file=environments/staging/terraform.tfvars
 # Verify: plan shows expected state

--- a/infrastructure/terraform/ci-finn.tf
+++ b/infrastructure/terraform/ci-finn.tf
@@ -14,7 +14,7 @@
 # =============================================================================
 
 # GitHub OIDC provider (account-level singleton)
-# Created as a resource since no pre-existing provider was found in account 891376933289.
+# Created as a resource since no pre-existing provider was found in account <AWS_ACCOUNT_ID>.
 resource "aws_iam_openid_connect_provider" "github" {
   url             = "https://token.actions.githubusercontent.com"
   client_id_list  = ["sts.amazonaws.com"]

--- a/infrastructure/terraform/dns/environments/production/backend.tfvars
+++ b/infrastructure/terraform/dns/environments/production/backend.tfvars
@@ -3,7 +3,7 @@
 # =============================================================================
 # Use with: terraform init -backend-config=environments/production/backend.tfvars
 
-bucket         = "arrakis-tfstate-891376933289"
+bucket         = "REPLACE-WITH-YOUR-TFSTATE-BUCKET" # real value: private deploy fork / TFSTATE_BUCKET repo secret (CI)
 key            = "dns/production.tfstate"
 region         = "us-east-1"
 encrypt        = true

--- a/infrastructure/terraform/dns/environments/staging/backend.tfvars
+++ b/infrastructure/terraform/dns/environments/staging/backend.tfvars
@@ -3,7 +3,7 @@
 # =============================================================================
 # Use with: terraform init -backend-config=environments/staging/backend.tfvars
 
-bucket         = "arrakis-tfstate-891376933289"
+bucket         = "REPLACE-WITH-YOUR-TFSTATE-BUCKET" # real value: private deploy fork / TFSTATE_BUCKET repo secret (CI)
 key            = "dns/staging.tfstate"
 region         = "us-east-1"
 encrypt        = true

--- a/infrastructure/terraform/dns/main.tf
+++ b/infrastructure/terraform/dns/main.tf
@@ -18,7 +18,8 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "arrakis-tfstate-891376933289"
+    # bucket is supplied at init time: -backend-config flag or environments/*/backend.tfvars
+    # (kept out of the public tree deliberately - 2026-08-19 identifier scrub)
     region         = "us-east-1"
     encrypt        = true
     dynamodb_table = "arrakis-terraform-locks"

--- a/infrastructure/terraform/environments/production/backend.tfvars
+++ b/infrastructure/terraform/environments/production/backend.tfvars
@@ -7,7 +7,7 @@
 # The KMS key must be created before terraform init. See kms.tf for bootstrap steps.
 # =============================================================================
 
-bucket         = "arrakis-tfstate-891376933289"
+bucket         = "REPLACE-WITH-YOUR-TFSTATE-BUCKET" # real value: private deploy fork / TFSTATE_BUCKET repo secret (CI)
 key            = "production/terraform.tfstate"
 region         = "us-east-1"
 encrypt        = true

--- a/infrastructure/terraform/environments/staging/backend.tfvars
+++ b/infrastructure/terraform/environments/staging/backend.tfvars
@@ -7,7 +7,7 @@
 # The KMS key must be created before terraform init. See kms.tf for bootstrap steps.
 # =============================================================================
 
-bucket         = "arrakis-tfstate-891376933289"
+bucket         = "REPLACE-WITH-YOUR-TFSTATE-BUCKET" # real value: private deploy fork / TFSTATE_BUCKET repo secret (CI)
 key            = "staging/terraform.tfstate"
 region         = "us-east-1"
 encrypt        = true

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -26,7 +26,8 @@ terraform {
   # See environments/*/backend.tfvars for environment-specific configs
   backend "s3" {
     # These values are overridden by backend.tfvars
-    bucket         = "arrakis-tfstate-891376933289"
+    # bucket is supplied at init time: -backend-config flag or environments/*/backend.tfvars
+    # (kept out of the public tree deliberately - 2026-08-19 identifier scrub)
     region         = "us-east-1"
     encrypt        = true
     dynamodb_table = "arrakis-terraform-locks"

--- a/scripts/deploy-to-ecr.sh
+++ b/scripts/deploy-to-ecr.sh
@@ -18,7 +18,7 @@ set -e
 
 # Configuration
 AWS_REGION="us-east-1"
-AWS_ACCOUNT_ID="891376933289"
+AWS_ACCOUNT_ID="${AWS_ACCOUNT_ID:-$(aws sts get-caller-identity --query Account --output text)}"  # derived; overridable
 ECR_REPO="arrakis-production-api"
 ECS_CLUSTER="arrakis-production-cluster"
 ECS_SERVICE_API="arrakis-production-api"

--- a/scripts/load-honeyroad-secrets.sh
+++ b/scripts/load-honeyroad-secrets.sh
@@ -59,7 +59,7 @@ if [[ ! -f "$ENV_FILE" ]]; then
 fi
 
 # Preflight: confirm AWS identity before writing anything
-EXPECTED_ACCOUNT="${EXPECTED_ACCOUNT:-891376933289}"
+EXPECTED_ACCOUNT="${EXPECTED_ACCOUNT:?set EXPECTED_ACCOUNT to your AWS account id (guard against wrong-account runs)}"
 ACTUAL_ACCOUNT=$(aws sts get-caller-identity --profile "$AWS_PROFILE" --query Account --output text)
 if [[ "$ACTUAL_ACCOUNT" != "$EXPECTED_ACCOUNT" ]]; then
   echo "ERROR: Wrong AWS account. Expected $EXPECTED_ACCOUNT, got $ACTUAL_ACCOUNT" >&2


### PR DESCRIPTION
Operator-directed follow-up to #514. The account ID appeared in **24 active-tree files** — docs stating it outright, ECR URLs, both backend blocks, all four committed `backend.tfvars`, two scripts, and archived records.

**Mechanisms, not just find-replace**: scripts now *derive* the account (`sts get-caller-identity`) or *require* it explicitly (the wrong-account guard had a public default — which defeated its purpose); backend blocks go partial; CI keeps working via a `TFSTATE_BUCKET` repo secret appended after the tfvars flag (later `-backend-config` wins).

**For the private deploy fork (hosaka-fm/freeside)**: on your next upstream merge these placeholders will conflict with your real tfvars — resolve by keeping yours; that's now the intended home for real values.

**Stated limits**: git history still contains the ID (public-repo rewrite not attempted, deliberately); `.beads/*.jsonl` still contains it (machine-parsed DB — flagged for a deliberate decision, not edited). The bucket itself has all four public-access blocks ON, verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)