### PR TITLE
chore(oidc): migrate deploy workflows to GitHub OIDC — no long-lived keys in the public repo

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -43,6 +43,10 @@ env:
   AWS_REGION: us-east-1
   ECR_REPOSITORY: arrakis-base
 
+permissions:
+  id-token: write   # REQUIRED for OIDC role assumption
+  contents: read
+
 jobs:
   build-base:
     name: Build Base Image
@@ -55,8 +59,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN_STAGING }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR

--- a/.github/workflows/deploy-gp-worker.yml
+++ b/.github/workflows/deploy-gp-worker.yml
@@ -47,6 +47,10 @@ on:
 env:
   AWS_REGION: us-east-1
 
+permissions:
+  id-token: write   # REQUIRED for OIDC role assumption
+  contents: read
+
 jobs:
   # ===========================================================================
   # Build and Push GP Worker
@@ -88,8 +92,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN_STAGING }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
@@ -155,8 +158,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN_STAGING }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
@@ -243,8 +245,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN_STAGING }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Wait for service to be ready

--- a/.github/workflows/deploy-ingestor.yml
+++ b/.github/workflows/deploy-ingestor.yml
@@ -45,6 +45,10 @@ on:
 env:
   AWS_REGION: us-east-1
 
+permissions:
+  id-token: write   # REQUIRED for OIDC role assumption
+  contents: read
+
 jobs:
   # ===========================================================================
   # Build and Push Ingestor
@@ -86,8 +90,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN_STAGING }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
@@ -152,8 +155,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN_STAGING }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
@@ -240,8 +242,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN_STAGING }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Wait for service to be ready

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -35,6 +35,10 @@ env:
   ECS_SERVICE_API: arrakis-production-api
   ECS_SERVICE_WORKER: arrakis-production-worker
 
+permissions:
+  id-token: write   # REQUIRED for OIDC role assumption
+  contents: read
+
 jobs:
   # ===========================================================================
   # Build and Push
@@ -54,8 +58,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN_PROD }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
@@ -110,8 +113,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN_PROD }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
@@ -260,8 +262,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN_PROD }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Get ALB DNS

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -57,6 +57,10 @@ env:
   ECS_SERVICE_WORKER: arrakis-staging-worker
   ECS_SERVICE_DIXIE: arrakis-staging-dixie
 
+permissions:
+  id-token: write   # REQUIRED for OIDC role assumption
+  contents: read
+
 jobs:
   # ===========================================================================
   # Build and Push
@@ -86,8 +90,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN_STAGING }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
@@ -147,8 +150,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN_STAGING }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Run freeside migration
@@ -227,8 +229,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN_STAGING }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
@@ -291,8 +292,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN_STAGING }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
@@ -352,8 +352,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN_STAGING }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
@@ -425,8 +424,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN_STAGING }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Wait for services stability (parallel)

--- a/infrastructure/terraform/github-oidc-ci-deploy.tf
+++ b/infrastructure/terraform/github-oidc-ci-deploy.tf
@@ -1,0 +1,147 @@
+# GitHub Actions OIDC deploy roles — replaces the long-lived AWS keys that were
+# stored (and removed 2026-08-19) as Actions secrets in this PUBLIC repo.
+#
+# WHY: a public repo must never hold long-lived cloud credentials. OIDC issues a
+# short-lived STS token per workflow run, scoped by the GitHub identity's `sub`
+# claim, with nothing stored. This follows the existing fleet convention
+# (arrakis-{env}-{service}-ci-deploy; cf. the dixie/finn/world-* deploy roles).
+#
+# APPLY ORDERING (operator): apply THIS with a valid credential FIRST, then set
+# the two repo variables (AWS_DEPLOY_ROLE_ARN_STAGING / _PROD) to the role ARNs,
+# then the converted workflows self-sustain. Deploys stay fail-closed until then.
+
+data "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+locals {
+  # SCOPING DECISION — operator confirm: trust is limited to this repo's default
+  # branch. If production deploys actually run from the PRIVATE fork
+  # (hosaka-fm/freeside), add "repo:hosaka-fm/freeside:ref:refs/heads/main" to the
+  # relevant role's subs and REMOVE whichever repo does not deploy (least privilege).
+  ci_repo = "0xHoneyJar/loa-freeside"
+
+  # Operations enumerated from the workflows (2026-08-19): ECR login/push +
+  # lifecycle, ECS register/update/run/describe/exec. Deliberately NOT the broad
+  # arrakis-deployer grant — this is scoped to what CI actually calls.
+  ecr_actions = [
+    "ecr:GetAuthorizationToken", "ecr:BatchCheckLayerAvailability",
+    "ecr:GetDownloadUrlForLayer", "ecr:BatchGetImage", "ecr:DescribeImages",
+    "ecr:DescribeRepositories", "ecr:InitiateLayerUpload", "ecr:UploadLayerPart",
+    "ecr:CompleteLayerUpload", "ecr:PutImage", "ecr:CreateRepository",
+    "ecr:PutLifecyclePolicy",
+  ]
+  ecs_actions = [
+    "ecs:RegisterTaskDefinition", "ecs:DeregisterTaskDefinition",
+    "ecs:DescribeTaskDefinition", "ecs:UpdateService", "ecs:DescribeServices",
+    "ecs:DescribeTasks", "ecs:ListTasks", "ecs:RunTask", "ecs:ExecuteCommand",
+  ]
+}
+
+# Trust policy factory — one per environment, scoped to the CI repo's main ref.
+data "aws_iam_policy_document" "ci_deploy_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [data.aws_iam_openid_connect_provider.github.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${local.ci_repo}:ref:refs/heads/main"]
+    }
+  }
+}
+
+# ── Staging deploy role (deploy-staging / -ingestor / -gp-worker / build-base-image) ──
+resource "aws_iam_role" "ci_deploy_staging" {
+  name               = "arrakis-staging-freeside-ci-deploy"
+  assume_role_policy = data.aws_iam_policy_document.ci_deploy_trust.json
+  tags               = local.common_tags
+}
+
+data "aws_iam_policy_document" "ci_deploy_staging" {
+  statement {
+    sid       = "EcrPushAndRead"
+    effect    = "Allow"
+    actions   = local.ecr_actions
+    resources = ["*"] # ECR GetAuthorizationToken requires "*"; tighten push actions to arrakis-staging-* repos if desired
+  }
+  statement {
+    sid       = "EcsStagingDeploy"
+    effect    = "Allow"
+    actions   = local.ecs_actions
+    resources = ["*"] # operator: scope to arn:aws:ecs:us-east-1:<acct>:*/arrakis-staging-* once verified
+  }
+  statement {
+    sid       = "PassTaskRolesStaging"
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
+    resources = ["*"] # REQUIRED by RegisterTaskDefinition/RunTask; MUST be tightened to the arrakis-staging task/exec role ARNs before merge
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "ci_deploy_staging" {
+  name   = "arrakis-staging-freeside-ci-deploy"
+  role   = aws_iam_role.ci_deploy_staging.id
+  policy = data.aws_iam_policy_document.ci_deploy_staging.json
+}
+
+# ── Production deploy role (deploy-production only) ──
+resource "aws_iam_role" "ci_deploy_production" {
+  name               = "arrakis-production-freeside-ci-deploy"
+  assume_role_policy = data.aws_iam_policy_document.ci_deploy_trust.json
+  tags               = local.common_tags
+}
+
+data "aws_iam_policy_document" "ci_deploy_production" {
+  statement {
+    sid       = "EcrReadAndPush"
+    effect    = "Allow"
+    actions   = local.ecr_actions
+    resources = ["*"]
+  }
+  statement {
+    sid       = "EcsProductionDeploy"
+    effect    = "Allow"
+    actions   = local.ecs_actions
+    resources = ["*"] # operator: scope to arrakis-production-* once verified
+  }
+  statement {
+    sid       = "PassTaskRolesProduction"
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
+    resources = ["*"] # tighten to arrakis-production task/exec role ARNs before merge
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "ci_deploy_production" {
+  name   = "arrakis-production-freeside-ci-deploy"
+  role   = aws_iam_role.ci_deploy_production.id
+  policy = data.aws_iam_policy_document.ci_deploy_production.json
+}
+
+output "ci_deploy_role_arns" {
+  description = "Set these as repo variables AWS_DEPLOY_ROLE_ARN_STAGING / _PROD (Settings > Actions > Variables). ARNs contain the account id and are NOT stored in source - variables keep them out of the public tree."
+  value = {
+    staging    = aws_iam_role.ci_deploy_staging.arn
+    production = aws_iam_role.ci_deploy_production.arn
+  }
+}


### PR DESCRIPTION
**Draft for review.** Completes the 2026-08-19 security remediation. The exposed `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` were deleted from this **public** repo; this replaces them with **keyless GitHub OIDC** so nothing long-lived is ever stored here again.

Follows the pattern this repo **already uses** in `dns-drift-check.yml` and `agent-key-rotation.yml` (`role-to-assume` + OIDC), and the fleet convention `arrakis-{env}-{service}-ci-deploy` (cf. the dixie/finn/world-* deploy roles).

## Workflows — 5 converted
`deploy-staging`, `deploy-ingestor`, `deploy-gp-worker`, `build-base-image` → `vars.AWS_DEPLOY_ROLE_ARN_STAGING`; `deploy-production` → `vars.AWS_DEPLOY_ROLE_ARN_PROD`. Each gains `permissions: id-token: write`. Verified: **zero** `secrets.AWS_ACCESS_KEY_ID` references remain, all 5 YAML-valid. Role ARN via a **variable** (not hardcoded) to keep the account ID out of the public source tree, consistent with #515.

## IAM — `infrastructure/terraform/github-oidc-ci-deploy.tf`
Two roles (staging/production separated for blast radius), trust scoped to `repo:0xHoneyJar/loa-freeside:ref:refs/heads/main` + `aud: sts.amazonaws.com`, permissions scoped to the **actual** ECR+ECS operations the workflows invoke — deliberately **not** the broad `arrakis-deployer` grant.

## ⚠️ Operator review gates before this is relied on
1. **`iam:PassRole` is `*`** with an `ecs-tasks.amazonaws.com` condition — **narrow to the real task/exec role ARNs before merge.**
2. **ECS/ECR resources are `*`** — scope to `arrakis-{staging,production}-*` once exact ARNs confirmed.
3. **Trust is loa-freeside main only.** If production deploys actually run from the **private fork** `hosaka-fm/freeside`, add its `sub` and drop whichever repo doesn't deploy.
4. **Apply order**: apply the terraform with a restored credential **first**, set the two repo variables to the output ARNs, **then** deploys self-sustain. Fail-closed until then (accepted).

Does **not** apply the IAM role or touch state — trust-policy scoping is an operator decision, per the incident record (`ridden` PR #825).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
